### PR TITLE
KAN-1256 refactor(domain,persistence-sqlite,api): remove the legacy card and sprint counter fields

### DIFF
--- a/crates/kanban-api/src/v1/boards/response.rs
+++ b/crates/kanban-api/src/v1/boards/response.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Response body for board reads. Omits internal allocation state
-/// (`card_counter`, `next_sprint_number`, `sprint_counters`, `sprint_names`,
-/// `sprint_name_used_count`); `active_sprint_id`/`position` are read-only.
+/// (`next_sprint_number`, `sprint_names`, `sprint_name_used_count`);
+/// `active_sprint_id`/`position` are read-only.
 /// Enums use the decoupled wire mirrors (snake_case); ids are plain `Uuid`.
 /// `Deserialize` is derived intentionally (test round-trips / client use); the
 /// server only serializes it.
@@ -89,9 +89,7 @@ mod tests {
         assert_eq!(resp.name, "Test");
         let json = serde_json::to_string(&resp).unwrap();
         for hidden in [
-            "card_counter",
             "next_sprint_number",
-            "sprint_counters",
             "sprint_names",
             "sprint_name_used_count",
         ] {

--- a/crates/kanban-domain/src/board.rs
+++ b/crates/kanban-domain/src/board.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::field_update::FieldUpdate;
@@ -137,8 +136,6 @@ pub struct Board {
     pub next_sprint_number: u32,
     pub active_sprint_id: Option<Uuid>,
     pub task_list_view: TaskListView,
-    pub card_counter: u32,
-    pub sprint_counters: HashMap<String, u32>,
     pub position: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -173,8 +170,6 @@ impl Board {
             next_sprint_number: 1,
             active_sprint_id: None,
             task_list_view: TaskListView::default(),
-            card_counter: 1,
-            sprint_counters: HashMap::new(),
             position: 0,
             created_at: now,
             updated_at: now,
@@ -244,80 +239,6 @@ impl Board {
     pub fn update_task_list_view(&mut self, view: TaskListView) {
         self.task_list_view = view;
         self.updated_at = Utc::now();
-    }
-
-    /// Get the next card number and increment the counter.
-    pub fn get_next_card_number(&mut self) -> u32 {
-        let number = self.card_counter;
-        self.card_counter += 1;
-        self.updated_at = Utc::now();
-        number
-    }
-
-    /// Set the card counter to a specific start value (used for import/migration).
-    pub fn initialize_card_counter(&mut self, start: u32) {
-        self.card_counter = start;
-        self.updated_at = Utc::now();
-    }
-
-    /// Get the current card counter value (next number to be assigned).
-    pub fn get_card_counter(&self) -> u32 {
-        self.card_counter
-    }
-
-    pub fn get_next_sprint_number(&mut self, prefix: &str) -> u32 {
-        let counter = self.sprint_counters.entry(prefix.to_string()).or_insert(1);
-        let number = *counter;
-        *counter += 1;
-        self.updated_at = Utc::now();
-        number
-    }
-
-    pub fn initialize_sprint_counter(&mut self, prefix: &str, start: u32) {
-        self.sprint_counters.insert(prefix.to_string(), start);
-        self.updated_at = Utc::now();
-    }
-
-    pub fn get_sprint_counters(&self) -> &HashMap<String, u32> {
-        &self.sprint_counters
-    }
-
-    pub fn get_sprint_counter(&self, prefix: &str) -> Option<u32> {
-        self.sprint_counters.get(prefix).copied()
-    }
-
-    pub fn ensure_sprint_counter_initialized(
-        &mut self,
-        prefix: &str,
-        all_sprints: &[crate::Sprint],
-    ) {
-        // If counter already exists for this prefix, don't reinitialize
-        if self.sprint_counters.contains_key(prefix) {
-            return;
-        }
-
-        // Find the highest sprint number with this prefix FOR THIS BOARD
-        let max_number = all_sprints
-            .iter()
-            .filter(|sprint| {
-                // Only consider sprints for this board
-                if sprint.board_id != self.id {
-                    return false;
-                }
-
-                let sprint_prefix = sprint
-                    .prefix
-                    .as_deref()
-                    .unwrap_or_else(|| self.sprint_prefix.as_deref().unwrap_or("sprint"));
-                sprint_prefix == prefix
-            })
-            .map(|sprint| sprint.sprint_number)
-            .max()
-            .unwrap_or(0);
-
-        // Initialize counter to one more than the max, or 1 if no sprints exist
-        let next_number = max_number + 1;
-        self.initialize_sprint_counter(prefix, next_number);
     }
 
     /// Update board with partial changes
@@ -555,34 +476,6 @@ mod tests {
     }
 
     #[test]
-    fn test_board_new_card_counter_initialized_to_one() {
-        let board = Board::new("Test", None::<String>);
-        assert_eq!(board.card_counter, 1);
-    }
-
-    #[test]
-    fn test_board_get_next_card_number_increments_without_prefix() {
-        let mut board = Board::new("Test", None::<String>);
-        assert_eq!(board.get_next_card_number(), 1);
-        assert_eq!(board.get_next_card_number(), 2);
-        assert_eq!(board.get_next_card_number(), 3);
-        assert_eq!(board.card_counter, 4);
-    }
-
-    #[test]
-    fn test_board_initialize_card_counter_sets_value_and_get_next_returns_it() {
-        let mut board = Board::new("Test", None::<String>);
-        board.initialize_card_counter(10);
-        assert_eq!(board.get_card_counter(), 10);
-        assert_eq!(board.get_next_card_number(), 10);
-        assert_eq!(board.get_card_counter(), 11);
-    }
-
-    // The four card-counter migration tests moved to `board_factory.rs` as
-    // `test_board_record_deserialize_*`, since the migration logic now lives on
-    // `BoardRecord`'s hand-written `Deserialize` (`Board` no longer deserializes).
-
-    #[test]
     fn test_update_sprint_prefix() {
         let mut board = Board::new("Test", None::<String>);
         assert_eq!(board.sprint_prefix, None);
@@ -629,77 +522,6 @@ mod tests {
         let mut board = Board::new("Test", None::<String>);
         board.update_sprint_prefix(Some("custom"));
         assert_eq!(board.effective_branch_prefix("default"), "custom");
-    }
-
-    #[test]
-    fn test_sprint_counter_initialization() {
-        let mut board = Board::new("Test", None::<String>);
-        assert_eq!(board.get_sprint_counter("sprint"), None);
-
-        let num = board.get_next_sprint_number("sprint");
-        assert_eq!(num, 1);
-        assert_eq!(board.get_sprint_counter("sprint"), Some(2));
-    }
-
-    #[test]
-    fn test_shared_sprint_sequence() {
-        let mut board = Board::new("Test", None::<String>);
-
-        let num1 = board.get_next_sprint_number("SPRINT");
-        assert_eq!(num1, 1);
-
-        let num2 = board.get_next_sprint_number("SPRINT");
-        assert_eq!(num2, 2);
-
-        let num3 = board.get_next_sprint_number("SPRINT");
-        assert_eq!(num3, 3);
-
-        assert_eq!(board.get_sprint_counter("SPRINT"), Some(4));
-    }
-
-    #[test]
-    fn test_initialize_sprint_counter() {
-        let mut board = Board::new("Test", None::<String>);
-        board.initialize_sprint_counter("RELEASE", 5);
-
-        let num = board.get_next_sprint_number("RELEASE");
-        assert_eq!(num, 5);
-        assert_eq!(board.get_sprint_counter("RELEASE"), Some(6));
-    }
-
-    #[test]
-    fn test_ensure_sprint_counter_initialized_with_existing_sprints() {
-        use crate::Sprint;
-
-        let mut board = Board::new("Test", None::<String>);
-
-        let sprint1 = Sprint::new(board.id, 1, None, None::<String>);
-        let sprint2 = Sprint::new(board.id, 2, None, None::<String>);
-        let sprint3 = Sprint::new(board.id, 3, None, None::<String>);
-
-        let sprints = vec![sprint1, sprint2, sprint3];
-
-        assert_eq!(board.get_sprint_counter("sprint"), None);
-        board.ensure_sprint_counter_initialized("sprint", &sprints);
-        assert_eq!(board.get_sprint_counter("sprint"), Some(4));
-
-        let next = board.get_next_sprint_number("sprint");
-        assert_eq!(next, 4);
-    }
-
-    #[test]
-    fn test_ensure_sprint_counter_not_reinitialize() {
-        use crate::Sprint;
-
-        let mut board = Board::new("Test", None::<String>);
-        board.initialize_sprint_counter("test", 10);
-
-        let sprint1 = Sprint::new(board.id, 1, None, Some("test"));
-        let sprint2 = Sprint::new(board.id, 2, None, Some("test"));
-        let sprints = vec![sprint1, sprint2];
-
-        board.ensure_sprint_counter_initialized("test", &sprints);
-        assert_eq!(board.get_sprint_counter("test"), Some(10));
     }
 }
 

--- a/crates/kanban-domain/src/board_factory.rs
+++ b/crates/kanban-domain/src/board_factory.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use uuid::Uuid;
@@ -45,8 +43,6 @@ pub struct BoardRecord {
     pub next_sprint_number: u32,
     pub active_sprint_id: Option<Uuid>,
     pub task_list_view: TaskListView,
-    pub card_counter: u32,
-    pub sprint_counters: HashMap<String, u32>,
     pub position: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -84,14 +80,6 @@ impl<'de> Deserialize<'de> for BoardRecord {
             pub active_sprint_id: Option<Uuid>,
             #[serde(default)]
             pub task_list_view: TaskListView,
-            /// New field: single card counter
-            #[serde(default)]
-            pub card_counter: u32,
-            /// Legacy field for migration: prefix-keyed counters
-            #[serde(default)]
-            pub prefix_counters: HashMap<String, u32>,
-            #[serde(default)]
-            pub sprint_counters: HashMap<String, u32>,
             /// Pre-V12 key: parsed so a hand-rolled payload does not
             /// hard-fail, then discarded. The V12 migration is the supported
             /// upgrade path.
@@ -105,33 +93,10 @@ impl<'de> Deserialize<'de> for BoardRecord {
             pub position: i32,
             pub created_at: DateTime<Utc>,
             pub updated_at: DateTime<Utc>,
-            /// Very old field for migration
-            #[serde(default)]
-            pub next_card_number: u32,
         }
 
         let helper = BoardHelper::deserialize(deserializer)?;
         let sprint_prefix = helper.sprint_prefix.or(helper.branch_prefix);
-
-        // Resolve card_counter from migration chain (all legacy paths):
-        // 1. If card_counter already set (V3 format) → use it
-        // 2. Else if prefix_counters non-empty (V2 format) → use matching prefix counter or max
-        // 3. Else if next_card_number > 1 (V1 format) → use that
-        // 4. Else default to 1 (no cards)
-        let card_counter = if helper.card_counter > 0 {
-            helper.card_counter
-        } else if !helper.prefix_counters.is_empty() {
-            let matching_key = helper.card_prefix.as_deref().unwrap_or("task");
-            helper
-                .prefix_counters
-                .get(matching_key)
-                .copied()
-                .unwrap_or_else(|| helper.prefix_counters.values().copied().max().unwrap_or(1))
-        } else if helper.next_card_number > 1 {
-            helper.next_card_number
-        } else {
-            1
-        };
 
         Ok(BoardRecord {
             id: helper.id,
@@ -147,8 +112,6 @@ impl<'de> Deserialize<'de> for BoardRecord {
             next_sprint_number: helper.next_sprint_number,
             active_sprint_id: helper.active_sprint_id,
             task_list_view: helper.task_list_view,
-            card_counter,
-            sprint_counters: helper.sprint_counters,
             position: helper.position,
             created_at: helper.created_at,
             updated_at: helper.updated_at,
@@ -178,8 +141,6 @@ impl Board {
             next_sprint_number: 1,
             active_sprint_id: None,
             task_list_view: spec.task_list_view.unwrap_or_default(),
-            card_counter: 1,
-            sprint_counters: HashMap::new(),
             position: 0,
             created_at: now,
             updated_at: now,
@@ -203,8 +164,6 @@ impl Board {
             next_sprint_number,
             active_sprint_id,
             task_list_view,
-            card_counter,
-            sprint_counters,
             position,
             created_at,
             updated_at,
@@ -231,8 +190,6 @@ impl Board {
             next_sprint_number,
             active_sprint_id,
             task_list_view,
-            card_counter,
-            sprint_counters,
             position,
             created_at,
             updated_at,
@@ -256,8 +213,6 @@ impl From<&Board> for BoardRecord {
             next_sprint_number,
             active_sprint_id,
             task_list_view,
-            card_counter,
-            sprint_counters,
             position,
             created_at,
             updated_at,
@@ -276,8 +231,6 @@ impl From<&Board> for BoardRecord {
             next_sprint_number: *next_sprint_number,
             active_sprint_id: *active_sprint_id,
             task_list_view: *task_list_view,
-            card_counter: *card_counter,
-            sprint_counters: sprint_counters.clone(),
             position: *position,
             created_at: *created_at,
             updated_at: *updated_at,
@@ -403,13 +356,11 @@ mod factory_tests {
         let id = Uuid::new_v4();
         let now = Utc::now();
         let board = Board::create(full_spec(), id, now)?;
-        assert_eq!(board.card_counter, 1);
         assert_eq!(board.next_sprint_number, 1);
         assert_eq!(board.sprint_name_used_count, 0);
         assert_eq!(board.position, 0);
         assert_eq!(board.active_sprint_id, None);
         assert!(board.sprint_names.is_empty());
-        assert!(board.sprint_counters.is_empty());
         Ok(())
     }
 
@@ -494,17 +445,14 @@ mod factory_tests {
     #[test]
     fn test_new_board_spec_has_no_server_managed_fields() -> KanbanResult<()> {
         // NewBoard cannot set id/counters: the struct has no such fields, so an
-        // attempt to set a card_counter field on NewBoard would not compile.
+        // attempt to set a next_sprint_number field on NewBoard would not compile.
         // Positive assertion: created counters are minted by `create`, not passed.
         let board = Board::create(full_spec(), Uuid::new_v4(), Utc::now())?;
-        assert_eq!(board.card_counter, 1);
         assert_eq!(board.next_sprint_number, 1);
         Ok(())
     }
 
     fn populated_record() -> BoardRecord {
-        let mut sprint_counters = HashMap::new();
-        sprint_counters.insert("SPR".to_string(), 7);
         BoardRecord {
             id: Uuid::new_v4(),
             name: "Persisted".to_string(),
@@ -519,8 +467,6 @@ mod factory_tests {
             next_sprint_number: 9,
             active_sprint_id: Some(Uuid::new_v4()),
             task_list_view: TaskListView::GroupedByColumn,
-            card_counter: 42,
-            sprint_counters,
             position: 3,
             created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
             updated_at: "2024-02-02T00:00:00Z".parse().unwrap(),
@@ -548,8 +494,6 @@ mod factory_tests {
         assert_eq!(board.next_sprint_number, expected.next_sprint_number);
         assert_eq!(board.active_sprint_id, expected.active_sprint_id);
         assert_eq!(board.task_list_view, expected.task_list_view);
-        assert_eq!(board.card_counter, expected.card_counter);
-        assert_eq!(board.sprint_counters, expected.sprint_counters);
         assert_eq!(board.position, expected.position);
         assert_eq!(board.created_at, expected.created_at);
         assert_eq!(board.updated_at, expected.updated_at);
@@ -577,108 +521,6 @@ mod factory_tests {
     }
 
     #[test]
-    fn test_board_record_deserialize_migrates_prefix_counters() {
-        let json = r#"{
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "name": "Test Board",
-            "description": null,
-            "created_at": "2024-01-01T00:00:00Z",
-            "updated_at": "2024-01-01T00:00:00Z",
-            "sprint_prefix": null,
-            "card_prefix": "feat",
-            "task_sort_field": "Default",
-            "task_sort_order": "Ascending",
-            "active_sprint_id": null,
-            "sprint_duration_days": null,
-            "sprint_names": [],
-            "next_sprint_number": 1,
-            "sprint_name_used_count": 0,
-            "prefix_counters": {"feat": 42, "other": 5},
-            "sprint_counters": {},
-            "task_list_view": "Flat"
-        }"#;
-        let rec: BoardRecord = serde_json::from_str(json).expect("Should deserialize");
-        assert_eq!(rec.card_counter, 42);
-    }
-
-    #[test]
-    fn test_board_record_deserialize_migrates_next_card_number() {
-        let json = r#"{
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "name": "Test Board",
-            "description": null,
-            "created_at": "2024-01-01T00:00:00Z",
-            "updated_at": "2024-01-01T00:00:00Z",
-            "sprint_prefix": null,
-            "card_prefix": null,
-            "task_sort_field": "Default",
-            "task_sort_order": "Ascending",
-            "active_sprint_id": null,
-            "sprint_duration_days": null,
-            "sprint_names": [],
-            "next_sprint_number": 1,
-            "sprint_name_used_count": 0,
-            "prefix_counters": {},
-            "sprint_counters": {},
-            "task_list_view": "Flat",
-            "next_card_number": 42
-        }"#;
-        let rec: BoardRecord = serde_json::from_str(json).expect("Should deserialize");
-        assert_eq!(rec.card_counter, 42);
-    }
-
-    #[test]
-    fn test_board_record_deserialize_card_counter_takes_priority() {
-        let json = r#"{
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "name": "Test Board",
-            "description": null,
-            "created_at": "2024-01-01T00:00:00Z",
-            "updated_at": "2024-01-01T00:00:00Z",
-            "sprint_prefix": null,
-            "card_prefix": null,
-            "task_sort_field": "Default",
-            "task_sort_order": "Ascending",
-            "active_sprint_id": null,
-            "sprint_duration_days": null,
-            "sprint_names": [],
-            "next_sprint_number": 1,
-            "sprint_name_used_count": 0,
-            "card_counter": 100,
-            "prefix_counters": {"task": 50},
-            "sprint_counters": {},
-            "task_list_view": "Flat"
-        }"#;
-        let rec: BoardRecord = serde_json::from_str(json).expect("Should deserialize");
-        assert_eq!(rec.card_counter, 100);
-    }
-
-    #[test]
-    fn test_board_record_deserialize_prefix_counters_uses_max() {
-        let json = r#"{
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "name": "Test Board",
-            "description": null,
-            "created_at": "2024-01-01T00:00:00Z",
-            "updated_at": "2024-01-01T00:00:00Z",
-            "sprint_prefix": null,
-            "card_prefix": null,
-            "task_sort_field": "Default",
-            "task_sort_order": "Ascending",
-            "active_sprint_id": null,
-            "sprint_duration_days": null,
-            "sprint_names": [],
-            "next_sprint_number": 1,
-            "sprint_name_used_count": 0,
-            "prefix_counters": {"FEAT": 20, "BUG": 30},
-            "sprint_counters": {},
-            "task_list_view": "Flat"
-        }"#;
-        let rec: BoardRecord = serde_json::from_str(json).expect("Should deserialize");
-        assert_eq!(rec.card_counter, 30);
-    }
-
-    #[test]
     fn test_board_record_deserialize_branch_prefix_alias_maps_to_sprint_prefix() {
         let json = r#"{
             "id": "550e8400-e29b-41d4-a716-446655440000",
@@ -695,8 +537,6 @@ mod factory_tests {
             "sprint_names": [],
             "next_sprint_number": 1,
             "sprint_name_used_count": 0,
-            "card_counter": 1,
-            "sprint_counters": {},
             "task_list_view": "Flat"
         }"#;
         let rec: BoardRecord = serde_json::from_str(json).expect("Should deserialize");

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -102,7 +102,7 @@ pub struct CreateCard {
 impl CreateCard {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
         context.check_wip_limit(self.column_id, 1, &[])?;
-        let mut board = context.get_board(self.board_id)?;
+        let board = context.get_board(self.board_id)?;
 
         let now = self.timestamp;
         // Funnel construction through the factory (no `Card { .. }` literal nor a
@@ -140,10 +140,6 @@ impl CreateCard {
         )?;
         card.position = self.position;
 
-        if board.card_counter <= self.card_number {
-            board.card_counter = self.card_number + 1;
-        }
-
         if let Some(sprint_id) = self.options.sprint_id {
             let sprint = context.get_sprint(sprint_id)?;
             if sprint.board_id != self.board_id {
@@ -178,9 +174,8 @@ impl CreateCard {
 
     /// Inverse: delete the new card. `DeleteCard` is polymorphic over
     /// live / archived so it cleanly removes a freshly-created live
-    /// card without leaving an archive trail. The board's
-    /// `card_counter` stays bumped; redo via the original forward
-    /// reproduces the same id and number.
+    /// card without leaving an archive trail. Redo via the original
+    /// forward reproduces the same id and number.
     pub fn capture_inverse(&self, _store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         Ok(vec![Command::Card(CardCommand::Delete(DeleteCard {
             card_id: self.id,

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -270,23 +270,8 @@ impl CreateSprint {
             .or_else(|| board.sprint_prefix.clone())
             .unwrap_or_else(|| self.default_sprint_prefix.clone());
 
-        // The prefix row is the source of truth; the board's map is written
-        // behind it only until KAN-1216 removes it. The old
-        // `ensure_sprint_counter_initialized` scan is deliberately gone: it
-        // seeded a counter from MAX(sprint_number) FOR THIS BOARD, which is
-        // exactly what lets two boards sharing a namespace both hand out 1.
         let sprint_number =
             crate::prefix::allocate_sprint_number(context.store, &effective_prefix)?;
-        // The legacy map holds the NEXT number, the row holds the last used.
-        // Clamped upward only, matching how `CreateCard` maintains
-        // `board.card_counter`: the row steers allocation now, so dragging
-        // this back down would discard a value nothing re-derives.
-        if board
-            .get_sprint_counter(&effective_prefix)
-            .is_none_or(|next| next <= sprint_number)
-        {
-            board.initialize_sprint_counter(&effective_prefix, sprint_number + 1);
-        }
         let name_index = match &self.name {
             Some(name) if !name.trim().is_empty() => {
                 Some(board.add_sprint_name_at_used_index(name.clone()))
@@ -320,9 +305,9 @@ impl CreateSprint {
     }
 
     /// Inverse: delete the newly-created sprint. The board's
-    /// sprint_counter and sprint_name_used_count stay bumped — display
-    /// numbering drifts for *future* sprints only, redo of this one
-    /// reproduces the same sprint id.
+    /// sprint_name_used_count stays bumped — display numbering drifts
+    /// for *future* sprints only, redo of this one reproduces the same
+    /// sprint id.
     pub fn capture_inverse(&self, _store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         Ok(vec![Command::Sprint(SprintCommand::Delete(DeleteSprint {
             sprint_id: self.id,

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -172,11 +172,8 @@ mod tests {
         use crate::board_factory::BoardRecord;
         use crate::task_list_view::TaskListView;
         use crate::{SortField, SortOrder};
-        use std::collections::HashMap;
         use uuid::Uuid;
 
-        let mut sprint_counters = HashMap::new();
-        sprint_counters.insert("SPR".to_string(), 4);
         let record = BoardRecord {
             id: Uuid::new_v4(),
             name: "Populated".to_string(),
@@ -191,8 +188,6 @@ mod tests {
             next_sprint_number: 12,
             active_sprint_id: Some(Uuid::new_v4()),
             task_list_view: TaskListView::GroupedByColumn,
-            card_counter: 99,
-            sprint_counters,
             position: 5,
             created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
             updated_at: "2024-02-02T00:00:00Z".parse().unwrap(),
@@ -217,36 +212,6 @@ mod tests {
 
         assert_eq!(restored.boards.len(), 1);
         assert_eq!(restored.boards[0], board);
-    }
-
-    #[test]
-    fn test_json_board_legacy_v_migration_still_round_trips() {
-        // A V2-shaped board: prefix_counters set, no card_counter. The boards
-        // field routes through BoardRecord's migration Deserialize.
-        let json = r#"{
-            "boards": [{
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "name": "Legacy",
-                "description": null,
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z",
-                "sprint_prefix": null,
-                "card_prefix": "feat",
-                "task_sort_field": "Default",
-                "task_sort_order": "Ascending",
-                "active_sprint_id": null,
-                "sprint_duration_days": null,
-                "sprint_names": [],
-                "next_sprint_number": 1,
-                "sprint_name_used_count": 0,
-                "prefix_counters": {"feat": 42, "other": 5},
-                "sprint_counters": {},
-                "task_list_view": "Flat"
-            }]
-        }"#;
-        let snapshot: Snapshot = serde_json::from_str(json).unwrap();
-        assert_eq!(snapshot.boards.len(), 1);
-        assert_eq!(snapshot.boards[0].card_counter, 42);
     }
 
     #[test]

--- a/crates/kanban-domain/src/snapshot.rs
+++ b/crates/kanban-domain/src/snapshot.rs
@@ -628,4 +628,48 @@ mod tests {
         ));
         assert!(!snap.is_empty());
     }
+
+    /// A board payload written by an old version still carries
+    /// `prefix_counters`, `card_counter` and `next_card_number`. Those fields
+    /// are gone from `BoardRecord`, and nothing deserializes them any more --
+    /// which is only safe because serde ignores unknown keys rather than
+    /// rejecting them.
+    ///
+    /// That is the whole argument for dropping the legacy resolution without a
+    /// migration in front of it, so it is asserted rather than assumed. The
+    /// test this replaces also checked the resolved counter value, which no
+    /// longer exists; what survives here is the part that still means
+    /// something.
+    #[test]
+    fn test_a_legacy_board_payload_still_deserializes() {
+        let json = r#"{
+            "boards": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "name": "Legacy",
+                "description": null,
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "sprint_prefix": null,
+                "card_prefix": "feat",
+                "task_sort_field": "Default",
+                "task_sort_order": "Ascending",
+                "active_sprint_id": null,
+                "sprint_duration_days": null,
+                "sprint_names": [],
+                "next_sprint_number": 1,
+                "sprint_name_used_count": 0,
+                "prefix_counters": {"feat": 42, "other": 5},
+                "card_counter": 42,
+                "next_card_number": 7,
+                "sprint_counters": {"feat": 3},
+                "task_list_view": "Flat"
+            }]
+        }"#;
+
+        let snapshot: Snapshot = serde_json::from_str(json)
+            .expect("a payload carrying the removed counter keys must not hard-fail");
+        assert_eq!(snapshot.boards.len(), 1);
+        assert_eq!(snapshot.boards[0].name, "Legacy");
+        assert_eq!(snapshot.boards[0].card_prefix.as_deref(), Some("feat"));
+    }
 }

--- a/crates/kanban-domain/tests/board_commands.rs
+++ b/crates/kanban-domain/tests/board_commands.rs
@@ -25,7 +25,6 @@ fn test_create_board_command_funnels_through_factory_with_injected_id() {
     assert_eq!(board.card_prefix, Some("KAN".to_string()));
     // Server-managed position applied verbatim, counters seeded by the factory:
     assert_eq!(board.position, 3);
-    assert_eq!(board.card_counter, 1);
     assert_eq!(board.next_sprint_number, 1);
     // Factory uses a single clock for both timestamps:
     assert_eq!(board.created_at, board.updated_at);

--- a/crates/kanban-domain/tests/card_create.rs
+++ b/crates/kanban-domain/tests/card_create.rs
@@ -10,11 +10,10 @@ use uuid::Uuid;
 #[test]
 fn test_create_card_command_funnels_through_factory_seeds_defaults() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let board_id = board.id;
     let column_id = col.id;
-    board.card_counter = 1;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
 
@@ -48,19 +47,15 @@ fn test_create_card_command_funnels_through_factory_seeds_defaults() {
         card.updated_at, card.created_at,
         "no observable intermediate update — one Card::create call"
     );
-    // Board counter bumped past the minted number (sibling-entity write):
-    let bumped = tc.store.get_board(board_id).unwrap().unwrap();
-    assert_eq!(bumped.card_counter, 2);
 }
 
 #[test]
 fn test_create_card_sets_board_id() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let board_id = board.id;
     let column_id = col.id;
-    board.card_counter = 1;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
 
@@ -191,14 +186,12 @@ fn test_create_card_below_wip_limit_succeeds() {
 #[test]
 fn test_create_card_with_sprint_id_assigns_card_to_sprint() {
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let sprint = kanban_domain::Sprint::new(board.id, 1, None, None::<String>);
     let board_id = board.id;
     let column_id = col.id;
     let sprint_id = sprint.id;
-    // Bump card_counter so upsert_board doesn't reset it; mirrors real usage.
-    board.card_counter = 1;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
     tc.store.upsert_sprint(sprint).unwrap();
@@ -330,13 +323,12 @@ fn test_create_card_with_options_and_sprint_uses_embedded_timestamp() {
     use chrono::TimeZone;
 
     let tc = TestContext::new();
-    let mut board = kanban_domain::Board::new("B", Some("TST"));
+    let board = kanban_domain::Board::new("B", Some("TST"));
     let col = kanban_domain::Column::new(board.id, "Col", 0);
     let sprint = kanban_domain::Sprint::new(board.id, 1, None, None::<String>);
     let board_id = board.id;
     let column_id = col.id;
     let sprint_id = sprint.id;
-    board.card_counter = 1;
     tc.store.upsert_board(board).unwrap();
     tc.store.upsert_column(col).unwrap();
     tc.store.upsert_sprint(sprint).unwrap();

--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -1146,8 +1146,7 @@ mod tests {
                 "boards": [{"id": "550e8400-e29b-41d4-a716-446655440001", "name": "B",
                     "task_sort_field": "Default", "task_sort_order": "Ascending",
                     "sprint_name_used_count": 0, "next_sprint_number": 1,
-                    "task_list_view": "Flat", "prefix_counters": {}, "sprint_counters": {},
-                    "card_counter": 0, "position": 0,
+                    "task_list_view": "Flat", "position": 0,
                     "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"}],
                 "columns": [], "cards": [], "archived_cards": [], "sprints": [],
                 "graph": { "cards": { "edges": [] } }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/conversions.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use kanban_domain::{
     ArchiveMetadata, Archived, ArchivedCard, Board, BoardRecord, Card, CardRecord,
     CardRestoreContext, Column, ColumnRecord, KanbanResult, Sprint, SprintLog, SprintRecord,
@@ -9,11 +7,7 @@ use sqlx::Row;
 
 use super::helpers::{db_err, p_dt, p_enum, p_uuid, ser_err};
 
-pub(crate) fn row_to_board(
-    row: &SqliteRow,
-    sprint_names: Vec<String>,
-    sprint_counters: HashMap<String, u32>,
-) -> KanbanResult<Board> {
+pub(crate) fn row_to_board(row: &SqliteRow, sprint_names: Vec<String>) -> KanbanResult<Board> {
     let id_str: String = row.try_get("id").map_err(db_err)?;
     let active_sprint_id_str: Option<String> = row.try_get("active_sprint_id").map_err(db_err)?;
     let task_sort_field_str: String = row.try_get("task_sort_field").map_err(db_err)?;
@@ -42,8 +36,6 @@ pub(crate) fn row_to_board(
             .map_err(db_err)? as u32,
         active_sprint_id: active_sprint_id_str.as_deref().map(p_uuid).transpose()?,
         task_list_view: p_enum(&task_list_view_str, "task_list_view")?,
-        card_counter: row.try_get::<i32, _>("card_counter").map_err(db_err)? as u32,
-        sprint_counters,
         position: row.try_get::<i32, _>("position").map_err(db_err)?,
         created_at: p_dt(&created_at_str)?,
         updated_at: p_dt(&updated_at_str)?,

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -103,7 +103,6 @@ impl DataStore for SqliteStore {
                     "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
                             task_sort_order, sprint_duration_days, sprint_name_used_count,
                             next_sprint_number, active_sprint_id, task_list_view,
-                            COALESCE(card_counter, 1) as card_counter,
                             position, created_at, updated_at
                      FROM boards
                      WHERE id = ?",
@@ -115,9 +114,8 @@ impl DataStore for SqliteStore {
 
                 match row {
                     Some(row) => {
-                        let (names, counters) =
-                            SqliteStore::fetch_board_aux_with_conn(conn, &id_str).await?;
-                        Ok(Some(row_to_board(&row, names, counters)?))
+                        let names = SqliteStore::fetch_board_aux_with_conn(conn, &id_str).await?;
+                        Ok(Some(row_to_board(&row, names)?))
                     }
                     None => Ok(None),
                 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/entities/board.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/entities/board.rs
@@ -10,7 +10,7 @@ impl SqliteStore {
     pub(crate) async fn fetch_board_aux_with_conn(
         conn: &mut sqlx::SqliteConnection,
         board_id: &str,
-    ) -> KanbanResult<(Vec<String>, HashMap<String, u32>)> {
+    ) -> KanbanResult<Vec<String>> {
         let name_rows =
             sqlx::query("SELECT name FROM board_sprint_names WHERE board_id = ? ORDER BY position")
                 .bind(board_id)
@@ -22,20 +22,7 @@ impl SqliteStore {
             .map(|r| r.try_get("name").map_err(db_err))
             .collect::<KanbanResult<_>>()?;
 
-        let counter_rows =
-            sqlx::query("SELECT prefix, counter FROM board_sprint_counters WHERE board_id = ?")
-                .bind(board_id)
-                .fetch_all(&mut *conn)
-                .await
-                .map_err(db_err)?;
-        let mut sprint_counters = HashMap::new();
-        for row in &counter_rows {
-            let prefix: String = row.try_get("prefix").map_err(db_err)?;
-            let counter: i32 = row.try_get("counter").map_err(db_err)?;
-            sprint_counters.insert(prefix, counter as u32);
-        }
-
-        Ok((sprint_names, sprint_counters))
+        Ok(sprint_names)
     }
 
     pub(crate) async fn write_board_with_conn(
@@ -49,9 +36,9 @@ impl SqliteStore {
             "INSERT INTO boards (id, name, description, sprint_prefix, card_prefix,
                 task_sort_field, task_sort_order, sprint_duration_days,
                 sprint_name_used_count, next_sprint_number, active_sprint_id,
-                task_list_view, card_counter, position,
+                task_list_view, position,
                 created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
                 name=excluded.name, description=excluded.description,
                 sprint_prefix=excluded.sprint_prefix, card_prefix=excluded.card_prefix,
@@ -60,7 +47,7 @@ impl SqliteStore {
                 sprint_name_used_count=excluded.sprint_name_used_count,
                 next_sprint_number=excluded.next_sprint_number,
                 active_sprint_id=excluded.active_sprint_id,
-                task_list_view=excluded.task_list_view, card_counter=excluded.card_counter,
+                task_list_view=excluded.task_list_view,
                 position=excluded.position,
                 updated_at=excluded.updated_at",
         )
@@ -76,7 +63,6 @@ impl SqliteStore {
         .bind(rec.next_sprint_number as i32)
         .bind(rec.active_sprint_id.map(|id| id.to_string()))
         .bind(format!("{:?}", rec.task_list_view))
-        .bind(rec.card_counter as i32)
         .bind(rec.position)
         .bind(fmt_dt(&rec.created_at))
         .bind(fmt_dt(&rec.updated_at))
@@ -101,23 +87,6 @@ impl SqliteStore {
             .map_err(db_err)?;
         }
 
-        sqlx::query("DELETE FROM board_sprint_counters WHERE board_id = ?")
-            .bind(&id)
-            .execute(&mut *conn)
-            .await
-            .map_err(db_err)?;
-        for (prefix, counter) in &rec.sprint_counters {
-            sqlx::query(
-                "INSERT INTO board_sprint_counters (board_id, prefix, counter) VALUES (?, ?, ?)",
-            )
-            .bind(&id)
-            .bind(prefix)
-            .bind(*counter as i32)
-            .execute(&mut *conn)
-            .await
-            .map_err(db_err)?;
-        }
-
         Ok(())
     }
 
@@ -131,10 +100,7 @@ impl SqliteStore {
 
     pub(crate) async fn fetch_all_board_aux_with_conn(
         conn: &mut sqlx::SqliteConnection,
-    ) -> KanbanResult<(
-        HashMap<String, Vec<String>>,
-        HashMap<String, HashMap<String, u32>>,
-    )> {
+    ) -> KanbanResult<HashMap<String, Vec<String>>> {
         let name_rows = sqlx::query(
             "SELECT board_id, name FROM board_sprint_names ORDER BY board_id, position",
         )
@@ -148,22 +114,6 @@ impl SqliteStore {
             names_map.entry(board_id).or_default().push(name);
         }
 
-        let counter_rows =
-            sqlx::query("SELECT board_id, prefix, counter FROM board_sprint_counters")
-                .fetch_all(&mut *conn)
-                .await
-                .map_err(db_err)?;
-        let mut counters_map: HashMap<String, HashMap<String, u32>> = HashMap::new();
-        for row in &counter_rows {
-            let board_id: String = row.try_get("board_id").map_err(db_err)?;
-            let prefix: String = row.try_get("prefix").map_err(db_err)?;
-            let counter: i32 = row.try_get("counter").map_err(db_err)?;
-            counters_map
-                .entry(board_id)
-                .or_default()
-                .insert(prefix, counter as u32);
-        }
-
-        Ok((names_map, counters_map))
+        Ok(names_map)
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/lists.rs
@@ -13,7 +13,6 @@ impl SqliteStore {
                     "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
                             task_sort_order, sprint_duration_days, sprint_name_used_count,
                             next_sprint_number, active_sprint_id, task_list_view,
-                            COALESCE(card_counter, 1) as card_counter,
                             position, created_at, updated_at
                      FROM boards
                      WHERE NOT EXISTS (SELECT 1 FROM board_archival ba WHERE ba.board_id = boards.id)
@@ -23,14 +22,13 @@ impl SqliteStore {
                 .await
                 .map_err(db_err)?;
 
-                let (mut names_map, mut counters_map) = Self::fetch_all_board_aux_with_conn(conn).await?;
+                let mut names_map = Self::fetch_all_board_aux_with_conn(conn).await?;
 
                 let mut boards = Vec::with_capacity(rows.len());
                 for row in &rows {
                     let id_str: String = row.try_get("id").map_err(db_err)?;
                     let names = names_map.remove(&id_str).unwrap_or_default();
-                    let counters = counters_map.remove(&id_str).unwrap_or_default();
-                    boards.push(row_to_board(row, names, counters)?);
+                    boards.push(row_to_board(row, names)?);
                 }
                 Ok(boards)
             })
@@ -49,7 +47,6 @@ impl SqliteStore {
                     "SELECT id, name, description, sprint_prefix, card_prefix, task_sort_field,
                             task_sort_order, sprint_duration_days, sprint_name_used_count,
                             next_sprint_number, active_sprint_id, task_list_view,
-                            COALESCE(card_counter, 1) as card_counter,
                             position, created_at, updated_at
                      FROM boards
                      ORDER BY position ASC, created_at ASC, id ASC",
@@ -58,15 +55,13 @@ impl SqliteStore {
                 .await
                 .map_err(db_err)?;
 
-                let (mut names_map, mut counters_map) =
-                    Self::fetch_all_board_aux_with_conn(conn).await?;
+                let mut names_map = Self::fetch_all_board_aux_with_conn(conn).await?;
 
                 let mut boards = Vec::with_capacity(rows.len());
                 for row in &rows {
                     let id_str: String = row.try_get("id").map_err(db_err)?;
                     let names = names_map.remove(&id_str).unwrap_or_default();
-                    let counters = counters_map.remove(&id_str).unwrap_or_default();
-                    boards.push(row_to_board(row, names, counters)?);
+                    boards.push(row_to_board(row, names)?);
                 }
                 Ok(boards)
             })

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
@@ -91,10 +91,6 @@ impl SqliteStore {
             .execute(&mut *tx)
             .await
             .map_err(db_err)?;
-        sqlx::query("DELETE FROM board_sprint_counters")
-            .execute(&mut *tx)
-            .await
-            .map_err(db_err)?;
         sqlx::query("DELETE FROM columns")
             .execute(&mut *tx)
             .await

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/boards.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/boards.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{Board, BoardRecord, SortField, SortOrder};
 use tempfile::TempDir;
@@ -12,8 +10,6 @@ use super::make_rt;
 /// completion_column_id) so the round-trip does not trip the boards table's
 /// foreign-key constraints.
 fn fully_populated_board() -> Board {
-    let mut sprint_counters = HashMap::new();
-    sprint_counters.insert("SPR".to_string(), 4);
     let record = BoardRecord {
         id: Uuid::new_v4(),
         name: "Populated".to_string(),
@@ -28,8 +24,6 @@ fn fully_populated_board() -> Board {
         next_sprint_number: 12,
         active_sprint_id: None,
         task_list_view: kanban_domain::task_list_view::TaskListView::GroupedByColumn,
-        card_counter: 99,
-        sprint_counters,
         position: 5,
         created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
         updated_at: "2024-02-02T00:00:00Z".parse().unwrap(),
@@ -66,7 +60,6 @@ fn test_sqlite_side_tables_sourced_from_record() {
 
         let loaded = store.get_board(id).unwrap().expect("board should load");
         assert_eq!(loaded.sprint_names, board.sprint_names);
-        assert_eq!(loaded.sprint_counters, board.sprint_counters);
     });
 }
 

--- a/crates/kanban-persistence-sqlite/tests/data_store.rs
+++ b/crates/kanban-persistence-sqlite/tests/data_store.rs
@@ -31,14 +31,12 @@ async fn test_sqlite_upsert_and_get_board() {
     let (store, _dir) = make_store().await;
     let mut board = make_board("Test Board");
     board.sprint_names = vec!["Alpha".to_string(), "Beta".to_string()];
-    board.sprint_counters.insert("SP".to_string(), 5);
     let id = board.id;
     store.upsert_board(board).unwrap();
 
     let fetched = store.get_board(id).unwrap().unwrap();
     assert_eq!(fetched.name, "Test Board");
     assert_eq!(fetched.sprint_names, vec!["Alpha", "Beta"]);
-    assert_eq!(fetched.sprint_counters.get("SP"), Some(&5));
 }
 
 // multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime

--- a/crates/kanban-persistence/src/test_helpers/helpers.rs
+++ b/crates/kanban-persistence/src/test_helpers/helpers.rs
@@ -27,12 +27,6 @@ pub fn fully_populated_snapshot() -> Snapshot {
         next_sprint_number: 3,
         active_sprint_id: Some(sprint_id),
         task_list_view: kanban_domain::task_list_view::TaskListView::GroupedByColumn,
-        card_counter: 4,
-        sprint_counters: {
-            let mut m = std::collections::HashMap::new();
-            m.insert("sprint".into(), 3u32);
-            m
-        },
         position: 0,
         created_at: now,
         updated_at: now,

--- a/crates/kanban-service/src/test_helpers/contract/board.rs
+++ b/crates/kanban-service/src/test_helpers/contract/board.rs
@@ -95,32 +95,6 @@ pub async fn test_board_sprint_names_roundtrip(factory: &BackendFactory) {
     assert_eq!(b.sprint_name_used_count, 1);
 }
 
-pub async fn test_board_card_counter_roundtrip(factory: &BackendFactory) {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("test.store");
-    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
-        .await
-        .unwrap();
-
-    let board = ctx
-        .create_board("Board".into(), Some("PFX".into()))
-        .unwrap();
-
-    let mut b = ctx.data_store().get_board(board.id).unwrap().unwrap();
-    b.card_counter = 10;
-    b.sprint_counters.insert("SP".into(), 3);
-    b.sprint_counters.insert("SPRINT".into(), 7);
-    ctx.data_store().upsert_board(b).unwrap();
-
-    ctx.save().await.unwrap();
-    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
-
-    let b = ctx.get_board(board.id).unwrap().unwrap();
-    assert_eq!(b.card_counter, 10);
-    assert_eq!(b.sprint_counters.get("SP"), Some(&3));
-    assert_eq!(b.sprint_counters.get("SPRINT"), Some(&7));
-}
-
 pub async fn test_board_next_sprint_number_roundtrip(factory: &BackendFactory) {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.store");

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -167,8 +167,6 @@ pub async fn test_full_populated_context_roundtrip(factory: &BackendFactory) -> 
         let mut b = ctx.data_store().get_board(board.id).unwrap().unwrap();
         b.sprint_names = vec!["Alpha".into(), "Beta".into()];
         b.sprint_name_used_count = 1;
-        b.card_counter = 10;
-        b.sprint_counters.insert("SP".into(), 5);
         ctx.data_store().upsert_board(b).unwrap();
     }
 
@@ -326,15 +324,6 @@ pub async fn test_full_populated_context_roundtrip(factory: &BackendFactory) -> 
     assert_eq!(b.active_sprint_id, Some(sprint.id));
     assert_eq!(b.sprint_names, vec!["Alpha", "Beta"]);
     assert_eq!(b.sprint_name_used_count, 1);
-    // Seeded to 10 above and unchanged by the four cards created since:
-    // numbers now come from the prefix row, and the legacy counter is only
-    // clamped UPWARD past a number actually issued. Seeding it directly no
-    // longer steers allocation -- for a real workspace the migration seeds the
-    // prefix row FROM this field, so the two agree from the start.
-    assert_eq!(b.card_counter, 10);
-    // Same story on the sprint axis: seeded to 5 above and left there by the
-    // sprint created since, which drew number 1 from the "sp" prefix row.
-    assert_eq!(b.sprint_counters.get("SP"), Some(&5));
 
     let cols = loaded.list_columns(board.id).unwrap();
     assert_eq!(cols.len(), 2);

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -61,10 +61,6 @@ macro_rules! context_contract_tests {
             $crate::test_helpers::contract::board::test_board_sprint_names_roundtrip(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_board_card_counter_roundtrip() {
-            $crate::test_helpers::contract::board::test_board_card_counter_roundtrip(&$factory_fn()).await;
-        }
-        #[tokio::test(flavor = "multi_thread")]
         async fn test_board_next_sprint_number_roundtrip() {
             $crate::test_helpers::contract::board::test_board_next_sprint_number_roundtrip(&$factory_fn()).await;
         }

--- a/crates/kanban-service/tests/command_replay.rs
+++ b/crates/kanban-service/tests/command_replay.rs
@@ -61,10 +61,6 @@ async fn test_replay_from_baseline_reproduces_state() -> KanbanResult<()> {
         assert_eq!(a.name, b.name, "board name must match");
         assert_eq!(a.card_prefix, b.card_prefix, "board card_prefix must match");
         assert_eq!(a.position, b.position, "board position must match");
-        assert_eq!(
-            a.card_counter, b.card_counter,
-            "board card_counter must match"
-        );
     }
 
     assert_eq!(

--- a/crates/kanban-service/tests/create_board_from_spec.rs
+++ b/crates/kanban-service/tests/create_board_from_spec.rs
@@ -49,7 +49,6 @@ async fn test_create_board_from_spec_applies_all_content_fields() {
     assert_eq!(fetched.sprint_duration_days, Some(21));
     assert_eq!(fetched.task_list_view, TaskListView::GroupedByColumn);
     // Server-managed: counters minted, not accepted; position == prior list len (0).
-    assert_eq!(fetched.card_counter, 1);
     assert_eq!(fetched.next_sprint_number, 1);
     assert_eq!(fetched.position, 0);
 }
@@ -137,7 +136,6 @@ async fn test_create_or_replace_board_creates_when_absent_reports_created() {
     assert!(outcome.created, "absent id must report created");
     assert_eq!(outcome.board.id, id);
     assert_eq!(outcome.board.name, "Fresh");
-    assert_eq!(outcome.board.card_counter, 1);
     assert_eq!(outcome.board.position, 0);
     assert_eq!(ctx.get_board(id).unwrap().unwrap().name, "Fresh");
 }
@@ -216,6 +214,5 @@ async fn test_create_board_shim_delegates_to_spec_path() {
     let fetched = ctx.get_board(board.id).unwrap().unwrap();
     assert_eq!(fetched.name, "Shimmed");
     assert_eq!(fetched.card_prefix, Some("SHM".to_string()));
-    assert_eq!(fetched.card_counter, 1);
     assert_eq!(fetched.position, 0);
 }

--- a/crates/kanban-service/tests/create_card_from_spec.rs
+++ b/crates/kanban-service/tests/create_card_from_spec.rs
@@ -58,10 +58,7 @@ async fn test_create_card_funnels_through_factory_seeds_defaults() {
     assert_eq!(card.status, CardStatus::Todo);
     assert_eq!(card.completed_at, None);
     assert_eq!(card.position, 0, "first card appended at position 0");
-    // card_number minted from board.card_counter (seeded at 1), board bumped.
     assert_eq!(card.card_number, 1);
-    let bumped = ctx.get_board(board.id).unwrap().unwrap();
-    assert_eq!(bumped.card_counter, 2, "board counter incremented by 1");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -79,12 +76,6 @@ async fn test_create_card_mints_card_number_sequentially_across_creates() {
 
     assert_eq!(first.card_number, 1, "first card minted card_number 1");
     assert_eq!(second.card_number, 2, "second card minted card_number 2");
-
-    let bumped = ctx.get_board(board.id).unwrap().unwrap();
-    assert_eq!(
-        bumped.card_counter, 3,
-        "board card_counter advanced past both creates"
-    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -172,9 +163,7 @@ async fn test_create_card_with_duplicate_archived_id_returns_conflict() {
 async fn test_create_card_with_missing_column_returns_not_found() {
     let (_d, mut ctx) = ctx().await;
     let board = ctx.create_board("Board".into(), None).unwrap();
-    // Real column so the board counter is observable; we create against a bogus one.
     ctx.create_column(board.id, "Todo".into(), None).unwrap();
-    let before = ctx.get_board(board.id).unwrap().unwrap().card_counter;
 
     let bogus = Uuid::new_v4();
     let err = ctx
@@ -182,11 +171,6 @@ async fn test_create_card_with_missing_column_returns_not_found() {
         .unwrap_err();
 
     assert!(err.is_not_found(), "expected NotFound, got: {err:?}");
-    assert_eq!(
-        ctx.get_board(board.id).unwrap().unwrap().card_counter,
-        before,
-        "board counter unchanged on a rejected create"
-    );
     assert_eq!(ctx.list_all_cards().unwrap().len(), 0);
 }
 

--- a/crates/kanban-service/tests/prefix_allocation.rs
+++ b/crates/kanban-service/tests/prefix_allocation.rs
@@ -141,28 +141,6 @@ async fn test_a_sprint_override_allocates_from_the_sprints_namespace() {
     );
 }
 
-/// KAN-1216 removes `boards.card_counter` only once KAN-1215 reads through the
-/// prefix row. Until then both move together, and deleting this test is what
-/// that card does.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_legacy_board_counter_still_moves_in_lockstep() {
-    let dir = TempDir::new().unwrap();
-    let mut c = ctx(&dir.path().join("s.db")).await;
-
-    let board = c.create_board("B".into(), Some("KAN".into())).unwrap();
-    let col = c.create_column(board.id, "Todo".into(), None).unwrap();
-    let before = c.get_board(board.id).unwrap().unwrap().card_counter;
-
-    c.create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
-        .unwrap();
-
-    assert_eq!(
-        c.get_board(board.id).unwrap().unwrap().card_counter,
-        before + 1,
-        "the legacy counter stays in sync until KAN-1216 removes it"
-    );
-}
-
 /// Allocation moved ahead of `CreateCard::execute`, but the WIP check lives
 /// inside it, so a rejected create used to bump the counter and then fail.
 ///

--- a/crates/kanban-service/tests/sprint_allocation.rs
+++ b/crates/kanban-service/tests/sprint_allocation.rs
@@ -142,28 +142,6 @@ async fn test_a_sprint_prefix_override_allocates_from_its_own_namespace() {
     assert_eq!(sprint_counter(&c, "rel"), 1);
 }
 
-/// KAN-1216 removes `board.sprint_counters` only once this read path has
-/// proven itself. Until then both move together, and deleting this test is
-/// what that card does.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_legacy_board_sprint_counter_still_moves_in_lockstep() {
-    let dir = TempDir::new().unwrap();
-    let mut c = ctx(&dir.path().join("s.db")).await;
-
-    let board = c.create_board("B".into(), None).unwrap();
-    c.create_sprint(board.id, None, None).unwrap();
-
-    assert_eq!(
-        c.get_board(board.id)
-            .unwrap()
-            .unwrap()
-            .get_sprint_counter("sprint"),
-        Some(2),
-        "the legacy map stores the NEXT number and stays in sync until KAN-1216 \
-         removes it"
-    );
-}
-
 /// Numbers must be contiguous across the point where allocation moved onto the
 /// prefix row. A row seeded with the legacy next-to-hand-out instead of the
 /// last-used would make this skip.

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -929,7 +929,6 @@ mod tests {
             .find(|b| b.name == "Roadmap")
             .expect("created board present in store");
         // Factory seeds these; a hand-built create must not diverge.
-        assert_eq!(board.card_counter, 1);
         assert_eq!(board.next_sprint_number, 1);
         assert_eq!(board.position, 0);
 

--- a/crates/kanban-view/src/panel_titles.rs
+++ b/crates/kanban-view/src/panel_titles.rs
@@ -111,9 +111,10 @@ mod tests {
         let mut board = Board::new("Test Board", None::<String>);
         let sprints: Vec<Sprint> = names
             .iter()
-            .map(|name| {
+            .enumerate()
+            .map(|(i, name)| {
                 let name_index = board.add_sprint_name_at_used_index(*name);
-                let number = board.get_next_sprint_number("sprint");
+                let number = i as u32 + 1;
                 Sprint::new(board.id, number, Some(name_index), None::<String>)
             })
             .collect();


### PR DESCRIPTION
`Board.card_counter` and `Board.sprint_counters` have been dead weight since numbering moved to the prefix row. KAN-1255 closed the last path that still minted from the legacy counter (the TUI), so nothing reads them for allocation any more.

This removes the in-memory and wire representation. **KAN-1257 removes them from disk** — the SQLite column, the `board_sprint_counters` table, and the JSON envelope keys.

That ordering is forced, not stylistic: `lists.rs` and `entities/board.rs` name `card_counter` in their SELECT and INSERT, so dropping the column first would break them. The column is `NOT NULL DEFAULT 1`, so once the code stops naming it, it sits unused and inserts still succeed. `schema.sql` and every migration file are untouched here.

## Removed

- The two `Board` fields and their accessors, including `ensure_sprint_counter_initialized`, already dead since KAN-1214 removed its only caller
- The dual-write clamps in `CreateCard::execute` and `CreateSprint::execute`
- `board_factory`'s `card_counter` migration-chain resolution (V3 `card_counter` → V2 `prefix_counters` → V1 `next_card_number`) and its helper fields. Safe because it existed only to populate the removed field, and the V15 prefix backfill seeds the rows by projecting off the raw `Value` earlier in the chain
- `card_counter` from the SQLite SELECT/INSERT and the `board_sprint_counters` read/write; the JSON fixture keys; the API doc comment and hidden-field entries

## Tests

Deleted: the two lockstep tests written to be removed by this card, the `board.rs` unit tests for the removed accessors, the `board_factory` resolution tests, and the per-backend `card_counter` round-trip.

One deletion was walked back. `test_json_board_legacy_v_migration_still_round_trips` was mostly about the resolved counter value, which is gone — but it *also* proved that a payload still carrying `prefix_counters` / `card_counter` / `next_card_number` deserializes rather than hard-failing. That property is the entire reason the resolution could be dropped without a migration in front of it: serde ignores unknown keys. It is now asserted directly by `test_a_legacy_board_payload_still_deserializes` instead of being assumed.

Numbering behaviour is unchanged — `prefix_allocation.rs` and `sprint_allocation.rs` pass untouched apart from the two intentional deletions, as does the all-backend `test_a_rejected_create_does_not_consume_a_card_number`.

- `cargo test --workspace --all-features` green, 191 suites
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all` applied