### PR TITLE
KAN-1267 feat(domain,api): unbacked_namespaces and the prefix integrity errors

### DIFF
--- a/.changeset/kan-1267-unbacked-namespaces.md
+++ b/.changeset/kan-1267-unbacked-namespaces.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: internal groundwork for prefix referential integrity - a shared rule for detecting cards whose namespace has no prefix row, and the two errors that will report it. No user-visible behaviour changes yet.

--- a/crates/kanban-api/src/v1/error_mapping.rs
+++ b/crates/kanban-api/src/v1/error_mapping.rs
@@ -150,6 +150,20 @@ mod tests {
                 ErrorCode::SprintBoardMismatch,
             ),
             (
+                d(DomainError::PrefixNotBacked {
+                    card_number: 1,
+                    prefix: "kan".into(),
+                }),
+                ErrorCode::ValidationFailed,
+            ),
+            (
+                d(DomainError::NamespaceStillReferenced {
+                    prefix: "kan".into(),
+                    count: 1,
+                }),
+                ErrorCode::ValidationFailed,
+            ),
+            (
                 KanbanError::Io(std::io::Error::other("disk gone")),
                 ErrorCode::IoError,
             ),

--- a/crates/kanban-api/src/v1/error_mapping.rs
+++ b/crates/kanban-api/src/v1/error_mapping.rs
@@ -31,6 +31,8 @@ impl From<&KanbanError> for ApiError {
                 },
                 DomainError::WipLimitExceeded { .. } => ErrorCode::WipLimitExceeded,
                 DomainError::SprintBoardMismatch { .. } => ErrorCode::SprintBoardMismatch,
+                DomainError::PrefixNotBacked { .. } => ErrorCode::ValidationFailed,
+                DomainError::NamespaceStillReferenced { .. } => ErrorCode::ValidationFailed,
             },
             KanbanError::Io(_) => ErrorCode::IoError,
             KanbanError::Serialization(_) => ErrorCode::SerializationError,

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -440,6 +440,30 @@ mod tests {
     }
 
     #[test]
+    fn test_prefix_not_backed_names_the_card_and_its_prefix() {
+        let err = DomainError::PrefixNotBacked {
+            card_number: 42,
+            prefix: "KAN".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "card 42 names prefix 'KAN', which has no row"
+        );
+    }
+
+    #[test]
+    fn test_namespace_still_referenced_names_the_namespace_and_the_count() {
+        let err = DomainError::NamespaceStillReferenced {
+            prefix: "kan".into(),
+            count: 3,
+        };
+        assert_eq!(
+            err.to_string(),
+            "prefix 'kan' still names 3 card(s) and cannot be removed"
+        );
+    }
+
+    #[test]
     fn test_is_cycle_detected_returns_true() {
         let err = KanbanError::from(DependencyError::CycleDetected);
         assert!(err.is_cycle_detected());

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -148,6 +148,12 @@ pub enum DomainError {
         sprint_board: Uuid,
         card_board: Uuid,
     },
+
+    #[error("card {card_number} names prefix '{prefix}', which has no row")]
+    PrefixNotBacked { card_number: u32, prefix: String },
+
+    #[error("prefix '{prefix}' still names {count} card(s) and cannot be removed")]
+    NamespaceStillReferenced { prefix: String, count: usize },
 }
 
 impl DomainError {

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -73,6 +73,7 @@ pub use prefix_backfill::{
     plan_prefix_backfill, BackfillBoard, BackfillRow, BackfillSprint, DEFAULT_CARD_PREFIX,
     DEFAULT_SPRINT_PREFIX,
 };
+pub use prefix_integrity::unbacked_namespaces;
 pub use prefix_resolution::{resolve as resolve_prefix, PrefixAxis};
 pub use query::{
     count_filtered_cards, filter_and_sort_boards, filter_and_sort_cards, resolve_board_sort,

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -25,6 +25,7 @@ pub mod graph_operations;
 pub mod operations;
 pub mod prefix;
 pub mod prefix_backfill;
+pub mod prefix_integrity;
 pub mod prefix_resolution;
 pub mod query;
 pub mod search;

--- a/crates/kanban-domain/src/prefix_integrity.rs
+++ b/crates/kanban-domain/src/prefix_integrity.rs
@@ -1,0 +1,76 @@
+//! Referential-integrity rules between cards and prefix rows: is a namespace
+//! a card names actually backed by a row, and is a namespace still
+//! referenced by a card.
+
+#[cfg(test)]
+mod tests {
+    use crate::card_factory::CardRecord;
+    use crate::{Card, CardPriority, CardStatus, Prefix};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn card_with_prefix(prefix: &str, number: u32) -> Card {
+        let now = Utc::now();
+        Card::reconstitute(CardRecord {
+            id: Uuid::new_v4(),
+            column_id: Uuid::new_v4(),
+            board_id: Uuid::new_v4(),
+            title: "c".into(),
+            description: None,
+            priority: CardPriority::Medium,
+            status: CardStatus::Todo,
+            position: 0,
+            due_date: None,
+            points: None,
+            card_number: number,
+            prefix: prefix.into(),
+            sprint_id: None,
+            created_at: now,
+            updated_at: now,
+            completed_at: None,
+            sprint_logs: Vec::new(),
+        })
+        .expect("valid record")
+    }
+
+    #[test]
+    fn test_a_card_with_no_matching_row_is_reported_unbacked() {
+        let cards = vec![card_with_prefix("kan", 1)];
+        let result = super::unbacked_namespaces(&cards, &[]);
+        assert_eq!(result, vec!["kan".to_string()]);
+    }
+
+    #[test]
+    fn test_a_row_differing_only_in_case_backs_the_card() {
+        let cards = vec![card_with_prefix("KAN", 1)];
+        let rows = vec![Prefix::new("kan")];
+        let result = super::unbacked_namespaces(&cards, &rows);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_a_row_whose_name_bypassed_normalisation_still_backs_the_card() {
+        let cards = vec![card_with_prefix("kan", 1)];
+        let rows = vec![Prefix {
+            name: "KAN".into(),
+            card_counter: 0,
+            sprint_counter: 0,
+        }];
+        let result = super::unbacked_namespaces(&cards, &rows);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_a_card_with_an_empty_prefix_is_not_reported() {
+        let cards = vec![card_with_prefix("", 1)];
+        let result = super::unbacked_namespaces(&cards, &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_several_cards_sharing_an_unbacked_namespace_report_it_once() {
+        let cards = vec![card_with_prefix("KAN", 1), card_with_prefix("kan", 2)];
+        let result = super::unbacked_namespaces(&cards, &[]);
+        assert_eq!(result, vec!["kan".to_string()]);
+    }
+}

--- a/crates/kanban-domain/src/prefix_integrity.rs
+++ b/crates/kanban-domain/src/prefix_integrity.rs
@@ -2,6 +2,27 @@
 //! a card names actually backed by a row, and is a namespace still
 //! referenced by a card.
 
+use std::collections::HashSet;
+
+use crate::{Card, Prefix};
+
+/// Namespaces named by `cards` (via [`Card::prefix`]) that have no matching
+/// row in `rows`. Comparison is on [`Prefix::normalize`] for both sides, so
+/// the result is normalised, sorted, and deduplicated. Cards with an empty
+/// prefix are not reported.
+pub fn unbacked_namespaces(cards: &[Card], rows: &[Prefix]) -> Vec<String> {
+    let backed: HashSet<String> = rows.iter().map(|r| Prefix::normalize(&r.name)).collect();
+    let mut result: Vec<String> = cards
+        .iter()
+        .filter(|c| !c.prefix.is_empty())
+        .map(|c| Prefix::normalize(&c.prefix))
+        .filter(|name| !backed.contains(name))
+        .collect();
+    result.sort();
+    result.dedup();
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use crate::card_factory::CardRecord;


### PR DESCRIPTION
## Summary

- Adds `kanban_domain::unbacked_namespaces(cards, rows) -> Vec<String>`, a pure function that reports normalised, sorted, deduped card prefixes with no matching `Prefix` row. Empty-prefix cards are not reported (parked for KAN-1275).
- Adds two `DomainError` variants: `PrefixNotBacked { card_number, prefix }` and `NamespaceStillReferenced { prefix, count }`.
- Classifies both new variants in `kanban-api`'s exhaustive `DomainError -> ErrorCode` match (`error_mapping.rs`) as `ErrorCode::ValidationFailed`. This is a deliberate call, not a compile fix: nothing returns either variant yet, so no wire contract is exercised, and `ValidationFailed` already echoes the `Display` message to clients. A distinct wire code can be introduced later by whichever card starts returning `NamespaceStillReferenced` for real.

This is groundwork for prefix referential integrity (KAN-1260). It does not change any runtime behaviour - nothing yet calls `unbacked_namespaces` or returns the new errors.

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Red commit (`test(domain,api): ...`) confirmed failing to compile before the green commit
- [x] Mutation check: reverted the `unbacked_namespaces` filter to a no-op, confirmed the case-normalisation tests failed, restored