### PR TITLE
KAN-1268 feat(domain): ensure_prefix_rows_exist rejects a card naming an unbacked namespace

### DIFF
--- a/.changeset/kan-1268-ensure-prefix-rows-exist.md
+++ b/.changeset/kan-1268-ensure-prefix-rows-exist.md
@@ -1,0 +1,4 @@
+---
+bump: patch
+---
+domain: internal groundwork for prefix referential integrity - a shared check that rejects a write leaving a card naming a namespace with no prefix row, reporting the offending card deterministically. No user-visible behaviour changes yet.

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -73,7 +73,7 @@ pub use prefix_backfill::{
     plan_prefix_backfill, BackfillBoard, BackfillRow, BackfillSprint, DEFAULT_CARD_PREFIX,
     DEFAULT_SPRINT_PREFIX,
 };
-pub use prefix_integrity::unbacked_namespaces;
+pub use prefix_integrity::{ensure_prefix_rows_exist, unbacked_namespaces};
 pub use prefix_resolution::{resolve as resolve_prefix, PrefixAxis};
 pub use query::{
     count_filtered_cards, filter_and_sort_boards, filter_and_sort_cards, resolve_board_sort,

--- a/crates/kanban-domain/src/prefix_integrity.rs
+++ b/crates/kanban-domain/src/prefix_integrity.rs
@@ -26,7 +26,7 @@ pub fn unbacked_namespaces(cards: &[Card], rows: &[Prefix]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use crate::card_factory::CardRecord;
-    use crate::{Card, CardPriority, CardStatus, Prefix};
+    use crate::{Card, CardPriority, CardStatus, DomainError, KanbanError, Prefix};
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -93,5 +93,50 @@ mod tests {
         let cards = vec![card_with_prefix("KAN", 1), card_with_prefix("kan", 2)];
         let result = super::unbacked_namespaces(&cards, &[]);
         assert_eq!(result, vec!["kan".to_string()]);
+    }
+
+    #[test]
+    fn test_a_card_naming_an_unbacked_namespace_is_rejected() {
+        let cards = vec![card_with_prefix("KAN", 1)];
+        let err = super::ensure_prefix_rows_exist(&cards, &[]).unwrap_err();
+        assert!(matches!(
+            err,
+            KanbanError::Domain(DomainError::PrefixNotBacked { card_number: 1, ref prefix }) if prefix == "KAN"
+        ));
+        assert_eq!(
+            err.to_string(),
+            "card 1 names prefix 'KAN', which has no row"
+        );
+    }
+
+    #[test]
+    fn test_the_same_card_is_accepted_once_the_row_exists() {
+        let cards = vec![card_with_prefix("kan", 1)];
+        let rows = vec![Prefix::new("kan")];
+        assert!(super::ensure_prefix_rows_exist(&cards, &rows).is_ok());
+    }
+
+    #[test]
+    fn test_configured_casing_is_backed_by_the_normalised_row() {
+        let cards = vec![card_with_prefix("KAN", 1)];
+        let rows = vec![Prefix::new("kan")];
+        assert!(super::ensure_prefix_rows_exist(&cards, &rows).is_ok());
+    }
+
+    #[test]
+    fn test_the_reported_offender_is_deterministic() {
+        let cards = vec![card_with_prefix("aaa", 7), card_with_prefix("zzz", 3)];
+        let err = super::ensure_prefix_rows_exist(&cards, &[]).unwrap_err();
+        assert!(matches!(
+            err,
+            KanbanError::Domain(DomainError::PrefixNotBacked { card_number: 3, ref prefix }) if prefix == "zzz"
+        ));
+
+        let cards = vec![card_with_prefix("zzz", 3), card_with_prefix("aaa", 7)];
+        let err = super::ensure_prefix_rows_exist(&cards, &[]).unwrap_err();
+        assert!(matches!(
+            err,
+            KanbanError::Domain(DomainError::PrefixNotBacked { card_number: 3, ref prefix }) if prefix == "zzz"
+        ));
     }
 }

--- a/crates/kanban-domain/src/prefix_integrity.rs
+++ b/crates/kanban-domain/src/prefix_integrity.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashSet;
 
-use crate::{Card, Prefix};
+use crate::{Card, DomainError, KanbanResult, Prefix};
 
 /// Namespaces named by `cards` (via [`Card::prefix`]) that have no matching
 /// row in `rows`. Comparison is on [`Prefix::normalize`] for both sides, so
@@ -21,6 +21,33 @@ pub fn unbacked_namespaces(cards: &[Card], rows: &[Prefix]) -> Vec<String> {
     result.sort();
     result.dedup();
     result
+}
+
+/// Rejects a card naming a namespace with no matching row in `rows`. When
+/// more than one card offends, the one with the lowest `card_number` is
+/// reported (ties broken by normalised prefix name), with the prefix as
+/// stored on that card.
+pub fn ensure_prefix_rows_exist(cards: &[Card], rows: &[Prefix]) -> KanbanResult<()> {
+    let unbacked: HashSet<String> = unbacked_namespaces(cards, rows).into_iter().collect();
+    if unbacked.is_empty() {
+        return Ok(());
+    }
+    let offender = cards
+        .iter()
+        .filter(|c| unbacked.contains(&Prefix::normalize(&c.prefix)))
+        .min_by(|a, b| {
+            a.card_number
+                .cmp(&b.card_number)
+                .then_with(|| Prefix::normalize(&a.prefix).cmp(&Prefix::normalize(&b.prefix)))
+        });
+    match offender {
+        Some(card) => Err(DomainError::PrefixNotBacked {
+            card_number: card.card_number,
+            prefix: card.prefix.clone(),
+        }
+        .into()),
+        None => Ok(()),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `ensure_prefix_rows_exist(cards: &[Card], rows: &[Prefix]) -> KanbanResult<()>` to `crates/kanban-domain/src/prefix_integrity.rs`, a write-boundary guard built on top of KAN-1267's `unbacked_namespaces`.
- On an unbacked namespace, fails with `DomainError::PrefixNotBacked`, naming the offending card deterministically: lowest `card_number` among offenders, ties broken by normalised prefix name, error message carries the card's configured (as-stored) casing.
- Re-exports the new function from `kanban-domain`'s crate root alongside `unbacked_namespaces`.
- This is purely additive: no call sites are wired here. Consumers land in KAN-1271/1272/1273/1277. Per KAN-1260's verification, an unbacked namespace is not reachable through any current production write path, so this change fixes no present data corruption.

## Test plan

- [x] `cargo test -p kanban-domain` — 9/9 tests pass in `prefix_integrity::tests` (5 pre-existing + 4 new)
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: replaced the `min_by` offender selection with `.next()` (input-order pick), confirmed `test_the_reported_offender_is_deterministic` fails, then restored