### PR TITLE
KAN-1269 feat(domain): ensure_namespace_unreferenced refuses to remove a referenced namespace

### DIFF
--- a/.changeset/kan-1269-ensure-namespace-unreferenced.md
+++ b/.changeset/kan-1269-ensure-namespace-unreferenced.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: internal groundwork for prefix referential integrity - a shared rule that refuses to remove a namespace any card still names, matched case-insensitively and reporting how many cards reference it. No user-visible behaviour changes yet; nothing can remove a namespace today.

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -73,7 +73,9 @@ pub use prefix_backfill::{
     plan_prefix_backfill, BackfillBoard, BackfillRow, BackfillSprint, DEFAULT_CARD_PREFIX,
     DEFAULT_SPRINT_PREFIX,
 };
-pub use prefix_integrity::{ensure_prefix_rows_exist, unbacked_namespaces};
+pub use prefix_integrity::{
+    ensure_namespace_unreferenced, ensure_prefix_rows_exist, unbacked_namespaces,
+};
 pub use prefix_resolution::{resolve as resolve_prefix, PrefixAxis};
 pub use query::{
     count_filtered_cards, filter_and_sort_boards, filter_and_sort_cards, resolve_board_sort,

--- a/crates/kanban-domain/src/prefix_integrity.rs
+++ b/crates/kanban-domain/src/prefix_integrity.rs
@@ -166,4 +166,63 @@ mod tests {
             KanbanError::Domain(DomainError::PrefixNotBacked { card_number: 3, ref prefix }) if prefix == "zzz"
         ));
     }
+
+    #[test]
+    fn test_a_namespace_named_by_a_card_cannot_be_removed() {
+        let cards = vec![card_with_prefix("kan", 1)];
+        let err = super::ensure_namespace_unreferenced("kan", &cards).unwrap_err();
+        assert!(matches!(
+            err,
+            KanbanError::Domain(DomainError::NamespaceStillReferenced { count: 1, ref prefix }) if prefix == "kan"
+        ));
+        assert_eq!(
+            err.to_string(),
+            "prefix 'kan' still names 1 card(s) and cannot be removed"
+        );
+    }
+
+    #[test]
+    fn test_the_error_reports_how_many_cards_still_name_it() {
+        let cards = vec![
+            card_with_prefix("kan", 1),
+            card_with_prefix("kan", 2),
+            card_with_prefix("kan", 3),
+            card_with_prefix("ops", 4),
+        ];
+        let err = super::ensure_namespace_unreferenced("kan", &cards).unwrap_err();
+        assert!(matches!(
+            err,
+            KanbanError::Domain(DomainError::NamespaceStillReferenced { count: 3, .. })
+        ));
+    }
+
+    #[test]
+    fn test_an_unreferenced_namespace_can_be_removed() {
+        let cards = vec![card_with_prefix("kan", 1)];
+        assert!(super::ensure_namespace_unreferenced("ops", &cards).is_ok());
+        assert!(super::ensure_namespace_unreferenced("kan", &[]).is_ok());
+    }
+
+    #[test]
+    fn test_removal_is_blocked_regardless_of_casing() {
+        let cards = vec![card_with_prefix("KAN", 1)];
+        let err = super::ensure_namespace_unreferenced("kan", &cards).unwrap_err();
+        assert!(matches!(
+            err,
+            KanbanError::Domain(DomainError::NamespaceStillReferenced { count: 1, ref prefix }) if prefix == "kan"
+        ));
+
+        let cards = vec![card_with_prefix("kan", 1)];
+        let err = super::ensure_namespace_unreferenced("KAN", &cards).unwrap_err();
+        assert!(matches!(
+            err,
+            KanbanError::Domain(DomainError::NamespaceStillReferenced { count: 1, ref prefix }) if prefix == "KAN"
+        ));
+    }
+
+    #[test]
+    fn test_cards_with_an_empty_prefix_do_not_block_removing_the_empty_name() {
+        let cards = vec![card_with_prefix("", 1)];
+        assert!(super::ensure_namespace_unreferenced("", &cards).is_ok());
+    }
 }

--- a/crates/kanban-domain/src/prefix_integrity.rs
+++ b/crates/kanban-domain/src/prefix_integrity.rs
@@ -50,6 +50,31 @@ pub fn ensure_prefix_rows_exist(cards: &[Card], rows: &[Prefix]) -> KanbanResult
     }
 }
 
+/// Rejects removing a namespace that any card in `cards` still names.
+/// Matching is on [`Prefix::normalize`] for both sides, so `KAN` on a card
+/// blocks removing `kan`. The error echoes `name` as the caller spelled it.
+/// Cards with an empty prefix name no namespace and are never counted.
+/// `cards` is the universe the caller wants protected; `DataStore::list_all_cards`
+/// excludes archived cards, which still name their namespace.
+pub fn ensure_namespace_unreferenced(name: &str, cards: &[Card]) -> KanbanResult<()> {
+    let target = Prefix::normalize(name);
+    if target.is_empty() {
+        return Ok(());
+    }
+    let count = cards
+        .iter()
+        .filter(|c| Prefix::normalize(&c.prefix) == target)
+        .count();
+    if count == 0 {
+        return Ok(());
+    }
+    Err(DomainError::NamespaceStillReferenced {
+        prefix: name.to_string(),
+        count,
+    }
+    .into())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::card_factory::CardRecord;


### PR DESCRIPTION
## Summary

- Adds `ensure_namespace_unreferenced(name: &str, cards: &[Card]) -> KanbanResult<()>` to `crates/kanban-domain/src/prefix_integrity.rs`, the second half of the referential rule started in KAN-1267/1268: a namespace still named by any card cannot be removed. Matching is on `Prefix::normalize` on both sides, so a card stored as `KAN` blocks removing `kan` and vice versa; the returned `DomainError::NamespaceStillReferenced { prefix, count }` echoes the caller's spelling of `name` and reports how many cards in the given slice name that namespace.
- Re-exports the new function from `kanban-domain::lib`.
- This is purely preventive. `grep -rn "delete_prefix|remove_prefix" crates/` still returns nothing on this branch, so there is no removal path to guard yet and this PR fixes no present data corruption. The deliverable is a shared rule ready for the caller that eventually needs it.

## Deviations from the card

- Signature is `(name: &str, cards: &[Card])`, not `(&str, &dyn DataStore)` as the card's Target block stated. Its sibling `ensure_prefix_rows_exist` in the same file already landed slice-based for the same reason: it needs one fact, not the whole trait. There's also a correctness trap with the store-taking shape: `DataStore::list_all_cards()` excludes archived cards, but under the reference-marker model an archived card is a live row plus a marker and still names its namespace, so a store-based implementation would silently under-count. The pure form puts the card universe at the call site where it's visible. Recorded on KAN-1269.
- `DataStore::delete_prefix` was not added, matching the card's stated default. KAN-1272 has not yet shown it necessary, and it would mean a no-default trait method hand-implemented across three backends for an operation the product doesn't offer today. Recorded on KAN-1269.
- Refactor step deliberately skipped: `Prefix::normalize` is already the module's single normalise-and-compare site across all three functions; extracting a helper for these few call sites would add an abstraction with no gain.

## Test plan

- [x] `cargo test -p kanban-domain` — all 14 `prefix_integrity` tests pass, including 5 new ones covering: single-card block, count filtered to the requested namespace (not `cards.len()`), unreferenced namespace allowed, case-insensitive blocking in both directions, and empty-prefix cards never blocking removal of the empty name
- [x] Mutation check: broke the central `count == 0` guard, confirmed 3 tests failed, reverted
- [x] `cargo test --workspace`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check` all green
- [x] `git diff --stat origin/develop` touches exactly `crates/kanban-domain/src/prefix_integrity.rs`, `crates/kanban-domain/src/lib.rs`, and the changeset