### PR TITLE
KAN-1272 fix(domain,backend-memory): normalise and collapse the prefix rows apply_snapshot writes, ahead of the cards that name them

### DIFF
--- a/.changeset/kan-1272-apply-snapshot-prefix-ordering.md
+++ b/.changeset/kan-1272-apply-snapshot-prefix-ordering.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+persistence: replacing a workspace's contents from a snapshot now stores one prefix row per namespace with a normalised name on every backend, so a file that recorded `KAN` and `kan` separately no longer reads back as two namespaces able to hand out the same card number.

--- a/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
@@ -265,6 +265,31 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_snapshot_accepts_a_snapshot_whose_cards_outrun_its_prefix_rows() {
+        let store = InMemoryStore::new();
+        let board = make_board("B");
+        let col = make_column(board.id, "C", 0);
+        let mut card = make_card(&board, col.id, "Card", 0);
+        card.prefix = "KAN".to_string();
+
+        let snap = Snapshot::from_data(
+            vec![board],
+            vec![col],
+            vec![card],
+            vec![],
+            vec![],
+            DependencyGraph::new(),
+        );
+        let result = store.apply_snapshot(snap);
+        assert!(result.is_ok(), "apply_snapshot must not guard prefix rows: {result:?}");
+        assert_eq!(store.list_all_cards().unwrap().len(), 1);
+        assert!(
+            store.list_prefixes().unwrap().is_empty(),
+            "apply_snapshot must not invent a repair row for an unbacked prefix"
+        );
+    }
+
+    #[test]
     fn test_apply_snapshot_replaces_existing_data() {
         let store = InMemoryStore::new();
         let board_old = make_board("Old");

--- a/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
@@ -44,6 +44,7 @@ impl InMemoryStore {
 
     pub fn apply_snapshot_impl(&self, snapshot: Snapshot) -> KanbanResult<()> {
         let mut state = self.write_state()?;
+        state.prefixes = kanban_domain::normalize_prefix_rows(snapshot.prefixes);
         state.boards = snapshot.boards.into_iter().map(|b| (b.id, b)).collect();
         state.columns = snapshot.columns.into_iter().map(|c| (c.id, c)).collect();
         // F3b (KAN-884): `snapshot.cards` already carries every card (live AND
@@ -63,7 +64,6 @@ impl InMemoryStore {
             .collect();
         state.sprints = snapshot.sprints.into_iter().map(|s| (s.id, s)).collect();
         state.graph = snapshot.graph;
-        state.prefixes = snapshot.prefixes;
         Ok(())
     }
 }
@@ -281,7 +281,10 @@ mod tests {
             DependencyGraph::new(),
         );
         let result = store.apply_snapshot(snap);
-        assert!(result.is_ok(), "apply_snapshot must not guard prefix rows: {result:?}");
+        assert!(
+            result.is_ok(),
+            "apply_snapshot must not guard prefix rows: {result:?}"
+        );
         assert_eq!(store.list_all_cards().unwrap().len(), 1);
         assert!(
             store.list_prefixes().unwrap().is_empty(),

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -67,7 +67,8 @@ pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use operations::KanbanOperations;
 pub use prefix::{
-    allocate_card_number, allocate_sprint_number, effective_card_prefix, effective_prefixes, Prefix,
+    allocate_card_number, allocate_sprint_number, effective_card_prefix, effective_prefixes,
+    normalize_prefix_rows, Prefix,
 };
 pub use prefix_backfill::{
     plan_prefix_backfill, BackfillBoard, BackfillRow, BackfillSprint, DEFAULT_CARD_PREFIX,

--- a/crates/kanban-domain/src/prefix.rs
+++ b/crates/kanban-domain/src/prefix.rs
@@ -140,6 +140,28 @@ impl Prefix {
     }
 }
 
+/// Normalises every row's `name` and collapses rows that share a normalised
+/// name into one, keeping the position of its first appearance and the
+/// counters of its last. A row with an empty name passes through unchanged.
+pub fn normalize_prefix_rows(rows: Vec<Prefix>) -> Vec<Prefix> {
+    let mut result: Vec<Prefix> = Vec::with_capacity(rows.len());
+    let mut index_by_name: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+
+    for mut row in rows {
+        row.name = Prefix::normalize(&row.name);
+        match index_by_name.get(&row.name) {
+            Some(&idx) => result[idx] = row,
+            None => {
+                index_by_name.insert(row.name.clone(), result.len());
+                result.push(row);
+            }
+        }
+    }
+
+    result
+}
+
 /// Computes the set of normalised prefix names a workspace would currently
 /// hand out to new cards: every board's effective prefix (falling back to
 /// `default_card_prefix` when unset), plus every sprint's override. A board
@@ -172,5 +194,66 @@ mod tests {
     fn test_normalize_lowercases_prefix() {
         assert_eq!(Prefix::normalize("KAN"), Prefix::normalize("kan"));
         assert_eq!(Prefix::normalize("KAN"), "kan");
+    }
+
+    #[test]
+    fn test_normalize_prefix_rows_lowercases_every_name() {
+        let rows = normalize_prefix_rows(vec![Prefix {
+            name: "KAN".to_string(),
+            card_counter: 3,
+            sprint_counter: 1,
+        }]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "kan");
+        assert_eq!(rows[0].card_counter, 3);
+        assert_eq!(rows[0].sprint_counter, 1);
+    }
+
+    #[test]
+    fn test_normalize_prefix_rows_collapses_two_spellings_keeping_the_later_counters() {
+        let rows = normalize_prefix_rows(vec![
+            Prefix {
+                name: "kan".to_string(),
+                card_counter: 1,
+                sprint_counter: 0,
+            },
+            Prefix {
+                name: "KAN".to_string(),
+                card_counter: 9,
+                sprint_counter: 2,
+            },
+            Prefix {
+                name: "ops".to_string(),
+                card_counter: 4,
+                sprint_counter: 0,
+            },
+        ]);
+        assert_eq!(rows.len(), 2);
+        let kan = rows.iter().find(|p| p.name == "kan").unwrap();
+        assert_eq!(kan.card_counter, 9);
+        assert_eq!(kan.sprint_counter, 2);
+    }
+
+    #[test]
+    fn test_normalize_prefix_rows_keeps_the_first_appearance_position() {
+        let rows = normalize_prefix_rows(vec![
+            Prefix {
+                name: "ops".to_string(),
+                card_counter: 1,
+                sprint_counter: 0,
+            },
+            Prefix {
+                name: "kan".to_string(),
+                card_counter: 2,
+                sprint_counter: 0,
+            },
+            Prefix {
+                name: "KAN".to_string(),
+                card_counter: 9,
+                sprint_counter: 0,
+            },
+        ]);
+        let names: Vec<&str> = rows.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["ops", "kan"]);
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -23,6 +23,7 @@ mod migration_v9_to_v10;
 mod persistence_store;
 mod pre_migration_backup;
 mod snapshot_atomicity;
+mod snapshot_prefix_ordering;
 mod transaction;
 
 /// Ordered `board_completion_columns.column_id`s for a board, straight from

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_prefix_ordering.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_prefix_ordering.rs
@@ -1,0 +1,84 @@
+use tempfile::TempDir;
+
+use super::super::SqliteStore;
+use super::make_rt;
+use kanban_domain::{ArchivedCard, Board, Card, Column, DataStore, Prefix};
+
+#[test]
+fn test_apply_snapshot_never_deletes_a_prefix_row_while_a_card_names_it() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefix_order.sqlite3");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+
+        store
+            .upsert_prefix(Prefix {
+                name: "kan".to_string(),
+                card_counter: 3,
+                sprint_counter: 0,
+            })
+            .unwrap();
+
+        let board = Board::new("Existing", Some("KAN"));
+        let column = Column::new(board.id, "Todo", 0);
+        let mut card = Card::new(board.id, column.id, "Existing card", 0);
+        card.prefix = "KAN".to_string();
+        card.card_number = 3;
+        let mut second = Card::new(board.id, column.id, "Second card", 1);
+        second.prefix = "KAN".to_string();
+        second.card_number = 2;
+
+        store.upsert_board(board.clone()).unwrap();
+        store.upsert_column(column).unwrap();
+        store.upsert_card(card).unwrap();
+        store.upsert_card(second.clone()).unwrap();
+        store
+            .insert_archived_card(ArchivedCard::new(second.id, board.id))
+            .unwrap();
+
+        let snap = store.snapshot().unwrap();
+
+        sqlx::query(
+            "CREATE TRIGGER prefix_delete_restrict_probe \
+             BEFORE DELETE ON prefixes FOR EACH ROW \
+             WHEN EXISTS (SELECT 1 FROM cards WHERE cards.prefix = OLD.name COLLATE NOCASE) \
+             BEGIN SELECT RAISE(ABORT, 'prefix still referenced by a card'); END;",
+        )
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "CREATE TRIGGER card_prefix_restrict_probe \
+             BEFORE INSERT ON cards FOR EACH ROW \
+             WHEN NEW.prefix <> '' AND NOT EXISTS (SELECT 1 FROM prefixes WHERE name = NEW.prefix COLLATE NOCASE) \
+             BEGIN SELECT RAISE(ABORT, 'card names an unbacked prefix'); END;",
+        )
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+        let result = store.apply_snapshot(snap);
+        assert!(
+            result.is_ok(),
+            "apply_snapshot must not delete a prefix row while a card still \
+             names it, nor insert a card before its prefix row exists: {result:?}"
+        );
+
+        let unbacked: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM cards c WHERE c.prefix <> '' AND NOT EXISTS \
+             (SELECT 1 FROM prefixes p WHERE p.name = c.prefix COLLATE NOCASE)",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(unbacked, 0);
+
+        let card_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cards")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(card_count, 2);
+    });
+}

--- a/crates/kanban-service/src/test_helpers/contract/prefix.rs
+++ b/crates/kanban-service/src/test_helpers/contract/prefix.rs
@@ -10,7 +10,7 @@
 //! already carry.
 
 use super::super::BackendFactory;
-use kanban_domain::{DataStore, Prefix};
+use kanban_domain::{Board, Card, Column, DataStore, Prefix, Snapshot};
 use tempfile::TempDir;
 
 /// Writes through one backend instance, then reads through a fresh one over
@@ -266,4 +266,107 @@ pub async fn test_a_rejected_create_does_not_consume_a_card_number(factory: &Bac
         first.card_number + 1,
         "and numbering stays contiguous"
     );
+}
+
+fn snapshot_with_one_card(prefixes: Vec<Prefix>) -> Snapshot {
+    let board = Board::new("B", Some("KAN"));
+    let column = Column::new(board.id, "Todo", 0);
+    let mut card = Card::new(board.id, column.id, "one", 0);
+    card.prefix = "KAN".to_string();
+    card.card_number = 7;
+
+    let mut snapshot = Snapshot::from_data(
+        vec![board],
+        vec![column],
+        vec![card],
+        Vec::new(),
+        Vec::new(),
+        Default::default(),
+    );
+    snapshot.prefixes = prefixes;
+    snapshot
+}
+
+pub async fn test_apply_snapshot_stores_prefix_rows_normalised(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let snapshot = snapshot_with_one_card(vec![Prefix {
+        name: "KAN".to_string(),
+        card_counter: 7,
+        sprint_counter: 2,
+    }]);
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+    backend.as_data_store().apply_snapshot(snapshot).unwrap();
+
+    let assert_normalised = |backend: &std::sync::Arc<dyn crate::KanbanBackend>| {
+        let all = backend.list_prefixes().unwrap();
+        assert_eq!(all.len(), 1, "expected exactly one prefix row: {all:?}");
+        assert_eq!(
+            all[0].name, "kan",
+            "`Prefix::name` is documented as always normalised, but apply_snapshot \
+             stored the caller's casing verbatim: {all:?}"
+        );
+        assert_eq!(all[0].card_counter, 7);
+        assert_eq!(all[0].sprint_counter, 2);
+        assert!(backend.get_prefix("kan").unwrap().is_some());
+        assert!(backend.get_prefix("KAN").unwrap().is_some());
+    };
+
+    assert_normalised(&backend);
+
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    assert_normalised(&reopened);
+}
+
+pub async fn test_apply_snapshot_collapses_two_spellings_of_one_namespace(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let snapshot = snapshot_with_one_card(vec![
+        Prefix {
+            name: "kan".to_string(),
+            card_counter: 1,
+            sprint_counter: 0,
+        },
+        Prefix {
+            name: "KAN".to_string(),
+            card_counter: 9,
+            sprint_counter: 2,
+        },
+    ]);
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+    backend.as_data_store().apply_snapshot(snapshot).unwrap();
+
+    let assert_collapsed = |backend: &std::sync::Arc<dyn crate::KanbanBackend>| {
+        let all = backend.list_prefixes().unwrap();
+        assert_eq!(
+            all.len(),
+            1,
+            "`kan` and `KAN` are one namespace; a second row would let two owners \
+             allocate the same number: {all:?}"
+        );
+        assert_eq!(all[0].name, "kan");
+        assert_eq!(all[0].card_counter, 9, "the later write wins");
+        assert_eq!(all[0].sprint_counter, 2);
+    };
+
+    assert_collapsed(&backend);
+
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    assert_collapsed(&reopened);
 }

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -46,6 +46,14 @@ macro_rules! context_contract_tests {
         async fn test_a_rejected_create_does_not_consume_a_card_number() {
             $crate::test_helpers::contract::prefix::test_a_rejected_create_does_not_consume_a_card_number(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_apply_snapshot_stores_prefix_rows_normalised() {
+            $crate::test_helpers::contract::prefix::test_apply_snapshot_stores_prefix_rows_normalised(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_apply_snapshot_collapses_two_spellings_of_one_namespace() {
+            $crate::test_helpers::contract::prefix::test_apply_snapshot_collapses_two_spellings_of_one_namespace(&$factory_fn()).await;
+        }
 
         // Board tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- Proves the SQLite `apply_snapshot` delete/rewrite order is already FK-safe, closing the card's "cascade" premise as stale: `apply_snapshot_async` deletes every table explicitly (there is no cascade to rely on), and `PRAGMA defer_foreign_keys = ON` defers all FK checking to COMMIT regardless of statement order anyway. Pinned by a trigger-based probe test on a real `SqliteStore` (`test_apply_snapshot_never_deletes_a_prefix_row_while_a_card_names_it`), mutation-checked in both directions.
- Adds `kanban_domain::normalize_prefix_rows`, a pure function that normalises row names and collapses rows that share a normalised name (keeping first-appearance position, last-write counters).
- Fixes the real defect: `InMemoryStore::apply_snapshot_impl` (and by extension the JSON backend, which routes through it) assigned `state.prefixes = snapshot.prefixes` verbatim, bypassing normalisation and namespace collapsing that SQLite already performs via its `COLLATE NOCASE` primary key and `write_prefix_with_conn`. A snapshot carrying both `KAN` and `kan` used to survive as two separate rows on in-memory/JSON, diverging from SQLite and violating `Prefix::name`'s documented "always normalised" contract.
- Records the guard decision explicitly on KAN-1272: `apply_snapshot` deliberately does not run `ensure_prefix_rows_exist` on any backend (it's the rollback/whole-store-save primitive and cannot itself introduce an unbacked namespace), with a follow-up noted on KAN-1276 for FK-error mapping once that constraint lands.

## Mutation-check evidence (manual, not committed)

- Moving `DELETE FROM prefixes` before `DELETE FROM cards` in `apply_snapshot_async` made the trigger probe fail with: `prefix still referenced by a card`.
- Moving the prefix-row insert loop after the card-insert loop made it fail with: `card names an unbacked prefix`.
- Both reverted; no net change to `snapshot.rs`.

## Test plan

- [x] `cargo test --workspace --all-features` — all green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New contract cases (`test_apply_snapshot_stores_prefix_rows_normalised`, `test_apply_snapshot_collapses_two_spellings_of_one_namespace`) observed failing on in-memory and JSON, passing on SQLite, before the fix; all three green after
- [x] SQLite trigger probe green before and after (regression pin, not a behaviour change)
- [x] In-memory no-guard pin (`test_apply_snapshot_accepts_a_snapshot_whose_cards_outrun_its_prefix_rows`) green before and after