### PR TITLE
KAN-1273 test(domain,service): sweep every production card writer for prefix write-order

### DIFF
--- a/.changeset/kan-1273-sweep-card-writers.md
+++ b/.changeset/kan-1273-sweep-card-writers.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain,service: test-only sweep pinning that no card is ever written while the namespace its prefix names has no row (no user-visible change; every production writer already held this invariant)

--- a/crates/kanban-domain/tests/common/mod.rs
+++ b/crates/kanban-domain/tests/common/mod.rs
@@ -2,6 +2,8 @@
 //! subset, so unused items would otherwise warn as dead code per-binary.
 #![allow(dead_code)]
 
+pub mod prefix_write_order;
+
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::commands::CommandContext;
 

--- a/crates/kanban-domain/tests/common/prefix_write_order.rs
+++ b/crates/kanban-domain/tests/common/prefix_write_order.rs
@@ -1,0 +1,200 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::{
+    ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanResult,
+    Prefix, Snapshot, Sprint,
+};
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// Records any card written while the namespace its prefix names has no row.
+pub struct PrefixWriteOrderStore {
+    inner: InMemoryStore,
+    unbacked_at_write: Mutex<Vec<(u32, String)>>,
+    swallow_prefix_writes: bool,
+}
+
+impl PrefixWriteOrderStore {
+    pub fn new() -> Self {
+        Self {
+            inner: InMemoryStore::default(),
+            unbacked_at_write: Mutex::new(Vec::new()),
+            swallow_prefix_writes: false,
+        }
+    }
+
+    pub fn with_prefix_writes_swallowed() -> Self {
+        Self {
+            inner: InMemoryStore::default(),
+            unbacked_at_write: Mutex::new(Vec::new()),
+            swallow_prefix_writes: true,
+        }
+    }
+
+    pub fn unbacked_at_write(&self) -> Vec<(u32, String)> {
+        self.unbacked_at_write.lock().unwrap().clone()
+    }
+}
+
+impl Default for PrefixWriteOrderStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DataStore for PrefixWriteOrderStore {
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        self.inner.get_board(id)
+    }
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        self.inner.list_boards()
+    }
+    fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+        self.inner.upsert_board(board)
+    }
+    fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_board(id)
+    }
+
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<Prefix>> {
+        self.inner.get_prefix(name)
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<Prefix>> {
+        self.inner.list_prefixes()
+    }
+    fn upsert_prefix(&self, prefix: Prefix) -> KanbanResult<()> {
+        if self.swallow_prefix_writes {
+            return Ok(());
+        }
+        self.inner.upsert_prefix(prefix)
+    }
+
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        self.inner.get_column(id)
+    }
+    fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        self.inner.list_columns_by_board(board_id)
+    }
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.inner.list_all_columns()
+    }
+    fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+        self.inner.upsert_column(column)
+    }
+    fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_column(id)
+    }
+    fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_columns_by_board(board_id)
+    }
+
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        self.inner.get_card(id)
+    }
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.inner.list_all_cards()
+    }
+    fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_column(column_id)
+    }
+    fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_sprint(sprint_id)
+    }
+    fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+        self.inner.count_cards_in_column(column_id)
+    }
+    fn count_cards_in_column_excluding(
+        &self,
+        column_id: Uuid,
+        exclude: &[Uuid],
+    ) -> KanbanResult<usize> {
+        self.inner
+            .count_cards_in_column_excluding(column_id, exclude)
+    }
+    fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+        if !card.prefix.is_empty() {
+            let normalized = Prefix::normalize(&card.prefix);
+            if self.inner.get_prefix(&normalized)?.is_none() {
+                self.unbacked_at_write
+                    .lock()
+                    .unwrap()
+                    .push((card.card_number, card.prefix.clone()));
+            }
+        }
+        self.inner.upsert_card(card)
+    }
+    fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_card(id)
+    }
+    fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+        self.inner.delete_cards_by_columns(column_ids)
+    }
+    fn clear_sprint_from_cards(
+        &self,
+        sprint_id: Uuid,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner.clear_sprint_from_cards(sprint_id, timestamp)
+    }
+
+    fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        self.inner.get_archived_card(card_id)
+    }
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        self.inner.list_archived_cards()
+    }
+    fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+        self.inner.insert_archived_card(ac)
+    }
+    fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_card(card_id)
+    }
+
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        self.inner.get_archived_board(board_id)
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.inner.list_archived_boards()
+    }
+    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        self.inner.insert_archived_board(ab)
+    }
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_board(board_id)
+    }
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.unarchive_board(board_id)
+    }
+
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        self.inner.get_sprint(id)
+    }
+    fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        self.inner.list_sprints_by_board(board_id)
+    }
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.inner.list_all_sprints()
+    }
+    fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+        self.inner.upsert_sprint(sprint)
+    }
+    fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprint(id)
+    }
+    fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprints_by_board(board_id)
+    }
+
+    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+        self.inner.get_graph()
+    }
+    fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+        self.inner.set_graph(graph)
+    }
+
+    fn snapshot(&self) -> KanbanResult<Snapshot> {
+        self.inner.snapshot()
+    }
+    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+        self.inner.apply_snapshot(snapshot)
+    }
+}

--- a/crates/kanban-domain/tests/import_prefix_ordering.rs
+++ b/crates/kanban-domain/tests/import_prefix_ordering.rs
@@ -1,199 +1,9 @@
-use kanban_backend_memory::InMemoryStore;
+mod common;
+
+use common::prefix_write_order::PrefixWriteOrderStore;
 use kanban_domain::commands::board_commands::ImportEntities;
 use kanban_domain::commands::CommandContext;
-use kanban_domain::{
-    ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, DomainError,
-    KanbanError, KanbanResult, Prefix, Snapshot, Sprint,
-};
-use std::sync::Mutex;
-use uuid::Uuid;
-
-/// Records any card written while the namespace its prefix names has no row.
-struct PrefixOrderStore {
-    inner: InMemoryStore,
-    unbacked_at_write: Mutex<Vec<(u32, String)>>,
-    swallow_prefix_writes: bool,
-}
-
-impl PrefixOrderStore {
-    fn new() -> Self {
-        Self {
-            inner: InMemoryStore::default(),
-            unbacked_at_write: Mutex::new(Vec::new()),
-            swallow_prefix_writes: false,
-        }
-    }
-
-    fn with_prefix_writes_swallowed() -> Self {
-        Self {
-            inner: InMemoryStore::default(),
-            unbacked_at_write: Mutex::new(Vec::new()),
-            swallow_prefix_writes: true,
-        }
-    }
-
-    fn unbacked_at_write(&self) -> Vec<(u32, String)> {
-        self.unbacked_at_write.lock().unwrap().clone()
-    }
-}
-
-impl DataStore for PrefixOrderStore {
-    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
-        self.inner.get_board(id)
-    }
-    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
-        self.inner.list_boards()
-    }
-    fn upsert_board(&self, board: Board) -> KanbanResult<()> {
-        self.inner.upsert_board(board)
-    }
-    fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_board(id)
-    }
-
-    fn get_prefix(&self, name: &str) -> KanbanResult<Option<Prefix>> {
-        self.inner.get_prefix(name)
-    }
-    fn list_prefixes(&self) -> KanbanResult<Vec<Prefix>> {
-        self.inner.list_prefixes()
-    }
-    fn upsert_prefix(&self, prefix: Prefix) -> KanbanResult<()> {
-        if self.swallow_prefix_writes {
-            return Ok(());
-        }
-        self.inner.upsert_prefix(prefix)
-    }
-
-    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
-        self.inner.get_column(id)
-    }
-    fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
-        self.inner.list_columns_by_board(board_id)
-    }
-    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
-        self.inner.list_all_columns()
-    }
-    fn upsert_column(&self, column: Column) -> KanbanResult<()> {
-        self.inner.upsert_column(column)
-    }
-    fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_column(id)
-    }
-    fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_columns_by_board(board_id)
-    }
-
-    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
-        self.inner.get_card(id)
-    }
-    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
-        self.inner.list_all_cards()
-    }
-    fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
-        self.inner.list_cards_by_column(column_id)
-    }
-    fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
-        self.inner.list_cards_by_sprint(sprint_id)
-    }
-    fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
-        self.inner.count_cards_in_column(column_id)
-    }
-    fn count_cards_in_column_excluding(
-        &self,
-        column_id: Uuid,
-        exclude: &[Uuid],
-    ) -> KanbanResult<usize> {
-        self.inner
-            .count_cards_in_column_excluding(column_id, exclude)
-    }
-    fn upsert_card(&self, card: Card) -> KanbanResult<()> {
-        if !card.prefix.is_empty() {
-            let normalized = Prefix::normalize(&card.prefix);
-            if self.inner.get_prefix(&normalized)?.is_none() {
-                self.unbacked_at_write
-                    .lock()
-                    .unwrap()
-                    .push((card.card_number, card.prefix.clone()));
-            }
-        }
-        self.inner.upsert_card(card)
-    }
-    fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_card(id)
-    }
-    fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
-        self.inner.delete_cards_by_columns(column_ids)
-    }
-    fn clear_sprint_from_cards(
-        &self,
-        sprint_id: Uuid,
-        timestamp: chrono::DateTime<chrono::Utc>,
-    ) -> KanbanResult<()> {
-        self.inner.clear_sprint_from_cards(sprint_id, timestamp)
-    }
-
-    fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
-        self.inner.get_archived_card(card_id)
-    }
-    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
-        self.inner.list_archived_cards()
-    }
-    fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
-        self.inner.insert_archived_card(ac)
-    }
-    fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_archived_card(card_id)
-    }
-
-    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
-        self.inner.get_archived_board(board_id)
-    }
-    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
-        self.inner.list_archived_boards()
-    }
-    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
-        self.inner.insert_archived_board(ab)
-    }
-    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_archived_board(board_id)
-    }
-    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
-        self.inner.unarchive_board(board_id)
-    }
-
-    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
-        self.inner.get_sprint(id)
-    }
-    fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
-        self.inner.list_sprints_by_board(board_id)
-    }
-    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
-        self.inner.list_all_sprints()
-    }
-    fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
-        self.inner.upsert_sprint(sprint)
-    }
-    fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_sprint(id)
-    }
-    fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
-        self.inner.delete_sprints_by_board(board_id)
-    }
-
-    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
-        self.inner.get_graph()
-    }
-    fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
-        self.inner.set_graph(graph)
-    }
-
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
-    }
-}
+use kanban_domain::{Board, Card, Column, DataStore, DomainError, KanbanError};
 
 fn legacy_import_payload() -> ImportEntities {
     let board = Board::new("B", Some("KAN"));
@@ -210,7 +20,7 @@ fn legacy_import_payload() -> ImportEntities {
 
 #[test]
 fn test_import_writes_the_prefix_row_before_the_cards_that_name_it() {
-    let store = PrefixOrderStore::new();
+    let store = PrefixWriteOrderStore::new();
     let context = CommandContext { store: &store };
     legacy_import_payload().execute(&context).unwrap();
 
@@ -229,7 +39,7 @@ fn test_import_writes_the_prefix_row_before_the_cards_that_name_it() {
 
 #[test]
 fn test_import_rejects_a_card_whose_prefix_row_failed_to_land() {
-    let store = PrefixOrderStore::with_prefix_writes_swallowed();
+    let store = PrefixWriteOrderStore::with_prefix_writes_swallowed();
     let context = CommandContext { store: &store };
     let result = legacy_import_payload().execute(&context);
 

--- a/crates/kanban-domain/tests/prefix_write_order.rs
+++ b/crates/kanban-domain/tests/prefix_write_order.rs
@@ -196,9 +196,21 @@ fn test_moving_a_card_cross_board_leaves_its_namespace_backed() {
 #[test]
 fn test_compacting_column_positions_leaves_its_namespace_backed() {
     let store = PrefixWriteOrderStore::new();
-    let (_board, column, _card) = seed_board_column_card(&store, "KAN");
-    let context = CommandContext { store: &store };
+    let (board, column, _card) = seed_board_column_card(&store, "KAN");
 
+    let (display, card_number) = kanban_domain::prefix::allocate_card_number(
+        &store,
+        board.card_prefix.as_deref(),
+        None,
+        None,
+    )
+    .unwrap();
+    let mut second = Card::new(board.id, column.id, "C2", 5);
+    second.card_number = card_number;
+    second.prefix = display;
+    store.upsert_card(second.clone()).unwrap();
+
+    let context = CommandContext { store: &store };
     Command::Card(CardCommand::CompactPositions(CompactColumnPositions {
         column_id: column.id,
     }))
@@ -206,6 +218,14 @@ fn test_compacting_column_positions_leaves_its_namespace_backed() {
     .unwrap();
 
     assert_all_backed(&store);
+    let mut positions: Vec<i32> = store
+        .list_cards_by_column(column.id)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.position)
+        .collect();
+    positions.sort();
+    assert_eq!(positions, vec![0, 1]);
 }
 
 #[test]
@@ -306,12 +326,19 @@ fn test_clear_sprint_from_archived_cards_default_leaves_its_namespace_backed() {
     updated.sprint_id = Some(sprint.id);
     store.upsert_card(updated).unwrap();
 
+    let context = CommandContext { store: &store };
+    Command::Card(CardCommand::Archive(ArchiveCards { ids: vec![card.id] }))
+        .execute(&context)
+        .unwrap();
+
     let dyn_store: &dyn DataStore = &store;
     dyn_store
         .clear_sprint_from_archived_cards(sprint.id, chrono::Utc::now())
         .unwrap();
 
     assert_all_backed(&store);
+    let after = store.get_card(card.id).unwrap().unwrap();
+    assert_eq!(after.sprint_id, None);
 }
 
 #[test]

--- a/crates/kanban-domain/tests/prefix_write_order.rs
+++ b/crates/kanban-domain/tests/prefix_write_order.rs
@@ -1,0 +1,340 @@
+mod common;
+
+use common::prefix_write_order::PrefixWriteOrderStore;
+use kanban_domain::commands::card::{
+    ApplyCardMetadata, ArchiveCards, AssignCardsToSprint, CardCommand, CompactColumnPositions,
+    CreateCard, MoveCard, RestoreCard, UnassignCardFromSprint, UpdateCard,
+};
+use kanban_domain::commands::dependency_commands::CreateSubcardCommand;
+use kanban_domain::commands::{cascade_commands::SetArchivedCardsSprint, Command, CommandContext};
+use kanban_domain::editable::CardMetadataDto;
+use kanban_domain::{
+    Board, Card, CardUpdate, Column, CreateCardOptions, DataStore, Prefix, Sprint,
+};
+use uuid::Uuid;
+
+fn seed_board_column_card(store: &PrefixWriteOrderStore, prefix: &str) -> (Board, Column, Card) {
+    let board = Board::new("B", Some(prefix));
+    let column = Column::new(board.id, "Todo", 0);
+    let (display, card_number) = kanban_domain::prefix::allocate_card_number(
+        store,
+        board.card_prefix.as_deref(),
+        None,
+        None,
+    )
+    .unwrap();
+    let mut card = Card::new(board.id, column.id, "C", 0);
+    card.card_number = card_number;
+    card.prefix = display;
+
+    store.upsert_board(board.clone()).unwrap();
+    store.upsert_column(column.clone()).unwrap();
+    store.upsert_card(card.clone()).unwrap();
+    (board, column, card)
+}
+
+fn assert_all_backed(store: &PrefixWriteOrderStore) {
+    let violations = store.unbacked_at_write();
+    assert!(
+        violations.is_empty(),
+        "cards written while their namespace had no prefix row: {violations:?}"
+    );
+}
+
+#[test]
+fn test_creating_a_card_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let board = Board::new("B", Some("KAN"));
+    let column = Column::new(board.id, "Todo", 0);
+    store.upsert_board(board.clone()).unwrap();
+    store.upsert_column(column.clone()).unwrap();
+
+    let default_card_prefix = "task".to_string();
+    let (_display, card_number) = kanban_domain::prefix::allocate_card_number(
+        &store,
+        board.card_prefix.as_deref(),
+        None,
+        Some(&default_card_prefix),
+    )
+    .unwrap();
+
+    let cmd = Command::Card(CardCommand::Create(CreateCard {
+        id: Uuid::new_v4(),
+        card_number,
+        board_id: board.id,
+        column_id: column.id,
+        title: "New card".to_string(),
+        position: 0,
+        options: CreateCardOptions::default(),
+        timestamp: chrono::Utc::now(),
+        default_card_prefix,
+    }));
+    let context = CommandContext { store: &store };
+    cmd.execute(&context).unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_creating_a_subcard_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let board = Board::new("B", Some("KAN"));
+    let column = Column::new(board.id, "Todo", 0);
+    let parent = Card::new(board.id, column.id, "Parent", 0);
+    store.upsert_board(board.clone()).unwrap();
+    store.upsert_column(column.clone()).unwrap();
+    store.upsert_card(parent.clone()).unwrap();
+
+    let cmd = Command::Dependency(kanban_domain::commands::DependencyCommand::CreateSubcard(
+        CreateSubcardCommand {
+            id: Uuid::new_v4(),
+            parent_id: parent.id,
+            board_id: board.id,
+            column_id: column.id,
+            title: "Subcard".to_string(),
+            description: None,
+            position: 0,
+            default_card_prefix: "task".to_string(),
+        },
+    ));
+    let context = CommandContext { store: &store };
+    cmd.execute(&context).unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_restoring_an_archived_card_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (_board, column, card) = seed_board_column_card(&store, "KAN");
+
+    let context = CommandContext { store: &store };
+    Command::Card(CardCommand::Archive(ArchiveCards { ids: vec![card.id] }))
+        .execute(&context)
+        .unwrap();
+
+    let prefix_before = store.get_prefix("kan").unwrap().unwrap();
+
+    Command::Card(CardCommand::Restore(RestoreCard {
+        card_id: card.id,
+        column_id: column.id,
+        position: 0,
+        timestamp: chrono::Utc::now(),
+    }))
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+    let prefix_after = store.get_prefix("kan").unwrap().unwrap();
+    assert_eq!(prefix_before.card_counter, prefix_after.card_counter);
+}
+
+#[test]
+fn test_updating_a_card_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (_board, _column, card) = seed_board_column_card(&store, "KAN");
+    let context = CommandContext { store: &store };
+
+    Command::Card(CardCommand::Update(UpdateCard {
+        card_id: card.id,
+        updates: CardUpdate {
+            title: Some("Renamed".to_string()),
+            ..Default::default()
+        },
+    }))
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_applying_card_metadata_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (_board, _column, card) = seed_board_column_card(&store, "KAN");
+    let context = CommandContext { store: &store };
+
+    Command::Card(CardCommand::ApplyMetadata(ApplyCardMetadata {
+        card_id: card.id,
+        dto: CardMetadataDto {
+            priority: "High".to_string(),
+            status: "InProgress".to_string(),
+            points: Some(3),
+            due_date: None,
+        },
+    }))
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_moving_a_card_cross_board_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (_board, _column, card) = seed_board_column_card(&store, "KAN");
+
+    let other_board = Board::new("Other", Some("OTH"));
+    let other_column = Column::new(other_board.id, "Todo", 0);
+    store.upsert_board(other_board.clone()).unwrap();
+    store.upsert_column(other_column.clone()).unwrap();
+
+    let context = CommandContext { store: &store };
+    Command::Card(CardCommand::Move(MoveCard {
+        card_id: card.id,
+        new_column_id: other_column.id,
+        new_position: 0,
+    }))
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+    let moved = store.get_card(card.id).unwrap().unwrap();
+    assert_eq!(moved.prefix, card.prefix);
+}
+
+#[test]
+fn test_compacting_column_positions_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (_board, column, _card) = seed_board_column_card(&store, "KAN");
+    let context = CommandContext { store: &store };
+
+    Command::Card(CardCommand::CompactPositions(CompactColumnPositions {
+        column_id: column.id,
+    }))
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_assigning_cards_to_a_sprint_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (board, _column, card) = seed_board_column_card(&store, "KAN");
+    let mut sprint = Sprint::new(board.id, 1, None, Some("SPR"));
+    sprint.card_prefix = Some("SPR".to_string());
+    store.upsert_sprint(sprint.clone()).unwrap();
+
+    let context = CommandContext { store: &store };
+    Command::Card(CardCommand::AssignToSprint(AssignCardsToSprint {
+        ids: vec![card.id],
+        sprint_id: sprint.id,
+    }))
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+    let updated = store.get_card(card.id).unwrap().unwrap();
+    assert_eq!(updated.prefix, card.prefix);
+}
+
+#[test]
+fn test_unassigning_a_card_from_a_sprint_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (board, _column, card) = seed_board_column_card(&store, "KAN");
+    let sprint = Sprint::new(board.id, 1, None, Some("SPR"));
+    store.upsert_sprint(sprint.clone()).unwrap();
+    let context = CommandContext { store: &store };
+    Command::Card(CardCommand::AssignToSprint(AssignCardsToSprint {
+        ids: vec![card.id],
+        sprint_id: sprint.id,
+    }))
+    .execute(&context)
+    .unwrap();
+
+    Command::Card(CardCommand::UnassignFromSprint(UnassignCardFromSprint {
+        card_id: card.id,
+        timestamp: chrono::Utc::now(),
+    }))
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_restoring_a_card_sprint_attachment_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (_board, _column, card) = seed_board_column_card(&store, "KAN");
+    let context = CommandContext { store: &store };
+
+    Command::Card(CardCommand::RestoreSprintAttachment(
+        kanban_domain::commands::card::RestoreCardSprintAttachment {
+            card_id: card.id,
+            sprint_id: None,
+            sprint_logs: vec![],
+            updated_at: chrono::Utc::now(),
+        },
+    ))
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_set_archived_cards_sprint_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (board, _column, card) = seed_board_column_card(&store, "KAN");
+    let sprint = Sprint::new(board.id, 1, None, Some("SPR"));
+    store.upsert_sprint(sprint.clone()).unwrap();
+    let context = CommandContext { store: &store };
+
+    Command::Cascade(
+        kanban_domain::commands::cascade_commands::CascadeCommand::SetArchivedCardsSprint(
+            SetArchivedCardsSprint {
+                archived_card_ids: vec![card.id],
+                sprint_id: sprint.id,
+            },
+        ),
+    )
+    .execute(&context)
+    .unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_clear_sprint_from_archived_cards_default_leaves_its_namespace_backed() {
+    let store = PrefixWriteOrderStore::new();
+    let (board, _column, card) = seed_board_column_card(&store, "KAN");
+    let sprint = Sprint::new(board.id, 1, None, Some("SPR"));
+    store.upsert_sprint(sprint.clone()).unwrap();
+
+    let mut updated = card.clone();
+    updated.sprint_id = Some(sprint.id);
+    store.upsert_card(updated).unwrap();
+
+    let dyn_store: &dyn DataStore = &store;
+    dyn_store
+        .clear_sprint_from_archived_cards(sprint.id, chrono::Utc::now())
+        .unwrap();
+
+    assert_all_backed(&store);
+}
+
+#[test]
+fn test_the_probe_reports_a_card_written_before_its_prefix_row() {
+    let store = PrefixWriteOrderStore::new();
+    let mut card = Card::new(Uuid::new_v4(), Uuid::new_v4(), "C", 0);
+    card.card_number = 7;
+    card.prefix = "KAN".to_string();
+    store.upsert_card(card).unwrap();
+    assert_eq!(store.unbacked_at_write(), vec![(7, "KAN".to_string())]);
+
+    let store2 = PrefixWriteOrderStore::new();
+    store2.upsert_prefix(Prefix::new("kan")).unwrap();
+    let mut card2 = Card::new(Uuid::new_v4(), Uuid::new_v4(), "C", 0);
+    card2.card_number = 8;
+    card2.prefix = "KAN".to_string();
+    store2.upsert_card(card2).unwrap();
+    assert!(store2.unbacked_at_write().is_empty());
+
+    let store3 = PrefixWriteOrderStore::new();
+    let mut card3 = Card::new(Uuid::new_v4(), Uuid::new_v4(), "C", 0);
+    card3.card_number = 9;
+    card3.prefix = String::new();
+    store3.upsert_card(card3).unwrap();
+    assert!(store3.unbacked_at_write().is_empty());
+}

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -554,4 +554,222 @@ mod tests {
         );
         Ok(())
     }
+
+    /// Records any card written while the namespace its prefix names has no
+    /// row, mirroring `kanban-domain`'s `PrefixWriteOrderStore` — kept local
+    /// rather than shared cross-crate since it wraps `InMemoryStore` the same
+    /// way `NoWholeStoreReads` does.
+    struct PrefixWriteOrderProbe {
+        inner: InMemoryStore,
+        unbacked_at_write: std::sync::Mutex<Vec<(u32, String)>>,
+    }
+
+    impl PrefixWriteOrderProbe {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryStore::new(),
+                unbacked_at_write: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn unbacked_at_write(&self) -> Vec<(u32, String)> {
+            self.unbacked_at_write.lock().unwrap().clone()
+        }
+    }
+
+    impl DataStore for PrefixWriteOrderProbe {
+        fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
+            self.inner.get_prefix(name)
+        }
+        fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
+            self.inner.list_prefixes()
+        }
+        fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
+            self.inner.upsert_prefix(prefix)
+        }
+        fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+            self.inner.get_board(id)
+        }
+        fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+            self.inner.list_boards()
+        }
+        fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+            self.inner.upsert_board(board)
+        }
+        fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_board(id)
+        }
+        fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+            self.inner.get_column(id)
+        }
+        fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+            self.inner.list_columns_by_board(board_id)
+        }
+        fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+            self.inner.list_all_columns()
+        }
+        fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+            self.inner.upsert_column(column)
+        }
+        fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_column(id)
+        }
+        fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_columns_by_board(board_id)
+        }
+        fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+            self.inner.get_card(id)
+        }
+        fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+            self.inner.list_all_cards()
+        }
+        fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+            self.inner.list_cards_by_column(column_id)
+        }
+        fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+            self.inner.list_cards_by_sprint(sprint_id)
+        }
+        fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+            self.inner.count_cards_in_column(column_id)
+        }
+        fn count_cards_in_column_excluding(
+            &self,
+            column_id: Uuid,
+            exclude: &[Uuid],
+        ) -> KanbanResult<usize> {
+            self.inner
+                .count_cards_in_column_excluding(column_id, exclude)
+        }
+        fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+            if !card.prefix.is_empty() {
+                let normalized = kanban_domain::Prefix::normalize(&card.prefix);
+                if self.inner.get_prefix(&normalized)?.is_none() {
+                    self.unbacked_at_write
+                        .lock()
+                        .unwrap()
+                        .push((card.card_number, card.prefix.clone()));
+                }
+            }
+            self.inner.upsert_card(card)
+        }
+        fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_card(id)
+        }
+        fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+            self.inner.delete_cards_by_columns(column_ids)
+        }
+        fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+            self.inner.list_archived_cards()
+        }
+        fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+            self.inner.insert_archived_card(ac)
+        }
+        fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+            self.inner.get_archived_card(card_id)
+        }
+        fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_archived_card(card_id)
+        }
+        fn get_archived_board(
+            &self,
+            board_id: Uuid,
+        ) -> KanbanResult<Option<kanban_domain::ArchivedBoard>> {
+            self.inner.get_archived_board(board_id)
+        }
+        fn list_archived_boards(&self) -> KanbanResult<Vec<kanban_domain::ArchivedBoard>> {
+            self.inner.list_archived_boards()
+        }
+        fn insert_archived_board(&self, ab: kanban_domain::ArchivedBoard) -> KanbanResult<()> {
+            self.inner.insert_archived_board(ab)
+        }
+        fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_archived_board(board_id)
+        }
+        fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+            self.inner.get_sprint(id)
+        }
+        fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+            self.inner.list_sprints_by_board(board_id)
+        }
+        fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+            self.inner.list_all_sprints()
+        }
+        fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+            self.inner.upsert_sprint(sprint)
+        }
+        fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_sprint(id)
+        }
+        fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+            self.inner.delete_sprints_by_board(board_id)
+        }
+        fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+            self.inner.get_graph()
+        }
+        fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+            self.inner.set_graph(graph)
+        }
+        fn clear_sprint_from_cards(
+            &self,
+            sprint_id: Uuid,
+            timestamp: chrono::DateTime<chrono::Utc>,
+        ) -> KanbanResult<()> {
+            self.inner.clear_sprint_from_cards(sprint_id, timestamp)
+        }
+        fn snapshot(&self) -> KanbanResult<Snapshot> {
+            panic!("write_full_snapshot must compose per-entity writes, not call apply_snapshot()")
+        }
+        fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
+            panic!("write_full_snapshot must compose per-entity writes, not call apply_snapshot()")
+        }
+    }
+
+    fn snapshot_with_one_card(prefix: &str, card_number: u32) -> Snapshot {
+        let board = Board::new("B", Some(prefix));
+        let column = Column::new(board.id, "Todo", 0);
+        let mut card = Card::new(board.id, column.id, "C", 0);
+        card.card_number = card_number;
+        card.prefix = prefix.to_string();
+
+        let mut snapshot = Snapshot::new();
+        snapshot.boards = vec![board];
+        snapshot.columns = vec![column];
+        snapshot.cards = vec![card];
+        snapshot
+    }
+
+    #[test]
+    fn test_the_snapshot_probe_reports_a_card_whose_prefix_row_is_missing_from_the_snapshot(
+    ) -> KanbanResult<()> {
+        let probe = PrefixWriteOrderProbe::new();
+        let snapshot = snapshot_with_one_card("KAN", 7);
+
+        write_full_snapshot(&probe, snapshot)?;
+
+        assert_eq!(probe.unbacked_at_write(), vec![(7, "KAN".to_string())]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_full_snapshot_writes_the_prefix_rows_before_the_cards_that_name_them(
+    ) -> KanbanResult<()> {
+        use kanban_domain::Prefix;
+
+        let probe = PrefixWriteOrderProbe::new();
+        let mut snapshot = snapshot_with_one_card("KAN", 7);
+        snapshot.prefixes = vec![Prefix {
+            name: "kan".into(),
+            card_counter: 7,
+            sprint_counter: 0,
+        }];
+
+        write_full_snapshot(&probe, snapshot)?;
+
+        assert!(
+            probe.unbacked_at_write().is_empty(),
+            "no card should ever be recorded as unbacked when its prefix row \
+             is present in the same snapshot"
+        );
+        Ok(())
+    }
 }

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -555,10 +555,7 @@ mod tests {
         Ok(())
     }
 
-    /// Records any card written while the namespace its prefix names has no
-    /// row, mirroring `kanban-domain`'s `PrefixWriteOrderStore` — kept local
-    /// rather than shared cross-crate since it wraps `InMemoryStore` the same
-    /// way `NoWholeStoreReads` does.
+    /// Records any card written while the namespace its prefix names has no row.
     struct PrefixWriteOrderProbe {
         inner: InMemoryStore,
         unbacked_at_write: std::sync::Mutex<Vec<(u32, String)>>,

--- a/crates/kanban-service/src/test_helpers/contract/prefix.rs
+++ b/crates/kanban-service/src/test_helpers/contract/prefix.rs
@@ -370,3 +370,144 @@ pub async fn test_apply_snapshot_collapses_two_spellings_of_one_namespace(
     reopened.reload().await.unwrap();
     assert_collapsed(&reopened);
 }
+
+/// A created card's namespace must be backed by a durable prefix row on
+/// every backend, and the card must keep its own prefix across a reload.
+pub async fn test_creating_a_card_leaves_its_namespace_backed(factory: &BackendFactory) {
+    use kanban_domain::{CreateCardOptions, KanbanOperations};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = crate::KanbanContext::open(factory(&path), kanban_core::AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+
+    ctx.backend().flush().await.unwrap();
+    drop(ctx);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    let prefix = reopened
+        .get_prefix("kan")
+        .unwrap()
+        .expect("the namespace the card names must be backed by a durable row");
+    assert!(
+        prefix.card_counter >= card.card_number,
+        "the row's counter must have advanced at least as far as the card it minted"
+    );
+    let reread = reopened
+        .get_card(card.id)
+        .unwrap()
+        .expect("the card must survive the reload");
+    assert_eq!(reread.prefix, card.prefix);
+}
+
+/// A subcard allocates its own number from its own namespace, independent
+/// of any pre-allocation by the caller, and must be backed the same way.
+pub async fn test_creating_a_subcard_leaves_its_namespace_backed(factory: &BackendFactory) {
+    use kanban_domain::commands::{
+        dependency_commands::CreateSubcardCommand, Command, DependencyCommand,
+    };
+    use kanban_domain::{CreateCardOptions, KanbanOperations};
+    use uuid::Uuid;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = crate::KanbanContext::open(factory(&path), kanban_core::AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let parent = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "parent".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let subcard_id = Uuid::new_v4();
+    ctx.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+        CreateSubcardCommand {
+            id: subcard_id,
+            parent_id: parent.id,
+            board_id: board.id,
+            column_id: col.id,
+            title: "subcard".into(),
+            description: None,
+            position: 0,
+            default_card_prefix: "task".into(),
+        },
+    ))])
+    .unwrap();
+
+    ctx.backend().flush().await.unwrap();
+    drop(ctx);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    let subcard = reopened
+        .get_card(subcard_id)
+        .unwrap()
+        .expect("the subcard must survive the reload");
+    let prefix = reopened
+        .get_prefix("kan")
+        .unwrap()
+        .expect("the subcard's namespace must be backed by a durable row");
+    assert!(prefix.card_counter >= subcard.card_number);
+}
+
+/// Restoring an archived card must not leave its namespace un-backed, and
+/// must not disturb the counter the card's own number was minted from.
+pub async fn test_restoring_an_archived_card_leaves_its_namespace_backed(factory: &BackendFactory) {
+    use kanban_domain::{CreateCardOptions, KanbanOperations};
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = crate::KanbanContext::open(factory(&path), kanban_core::AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+
+    let counter_before = ctx
+        .backend()
+        .get_prefix("kan")
+        .unwrap()
+        .unwrap()
+        .card_counter;
+
+    ctx.archive_card(card.id).unwrap();
+    let restored = ctx.restore_card(card.id, None).unwrap();
+
+    ctx.backend().flush().await.unwrap();
+    drop(ctx);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    let prefix = reopened
+        .get_prefix("kan")
+        .unwrap()
+        .expect("the restored card's namespace must still be backed by a durable row");
+    assert_eq!(
+        prefix.card_counter, counter_before,
+        "restore must not mint or lose numbers from the namespace's counter"
+    );
+    let reread = reopened
+        .get_card(restored.id)
+        .unwrap()
+        .expect("the restored card must survive the reload");
+    assert_eq!(reread.prefix, card.prefix);
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -54,6 +54,18 @@ macro_rules! context_contract_tests {
         async fn test_apply_snapshot_collapses_two_spellings_of_one_namespace() {
             $crate::test_helpers::contract::prefix::test_apply_snapshot_collapses_two_spellings_of_one_namespace(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_creating_a_card_leaves_its_namespace_backed() {
+            $crate::test_helpers::contract::prefix::test_creating_a_card_leaves_its_namespace_backed(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_creating_a_subcard_leaves_its_namespace_backed() {
+            $crate::test_helpers::contract::prefix::test_creating_a_subcard_leaves_its_namespace_backed(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_restoring_an_archived_card_leaves_its_namespace_backed() {
+            $crate::test_helpers::contract::prefix::test_restoring_an_archived_card_leaves_its_namespace_backed(&$factory_fn()).await;
+        }
 
         // Board tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Sweeps every production `upsert_card` caller and pins, with a write-order
probe, that no card is ever written while the namespace its prefix names has
no row. **No production writer was found unsafe** (this PR fixes nothing and
guards everything, matching KAN-1260's verification note). It is a test-only
change; no production source file outside `#[cfg(test)]` is modified.

## Enumeration (all 15 production `upsert_card` call sites, origin/develop)

| Site | Command | Prefix handling |
|---|---|---|
| `commands/card/lifecycle.rs:25` | `UpdateCard` | PRESERVES |
| `commands/card/lifecycle.rs:169` | `CreateCard` | STAMPS (from allocation done by its caller) |
| `commands/card/lifecycle.rs:234` | `RestoreCard` | PRESERVES |
| `commands/card/metadata.rs:20` | `ApplyCardMetadata` | PRESERVES |
| `commands/card/positioning.rs:27` | `MoveCard` | PRESERVES (incl. cross-board) |
| `commands/card/positioning.rs:65` | `CompactColumnPositions` | PRESERVES |
| `commands/card/sprint_binding.rs:28` | `RestoreCardSprintAttachment` | PRESERVES |
| `commands/card/sprint_binding.rs:103` | `AssignCardsToSprint` | PRESERVES |
| `commands/card/sprint_binding.rs:131` | `UnassignCardFromSprint` | PRESERVES |
| `commands/cascade_commands.rs:263` | `SetArchivedCardsSprint` | PRESERVES |
| `commands/dependency_commands.rs:488` | `CreateSubcardCommand` | STAMPS (self-allocates) |
| `commands/board_commands.rs:742` | `ImportEntities` | STAMPS (already guarded by `ensure_prefix_rows_exist`, KAN-1271) |
| `data_store.rs:217` | `clear_sprint_from_archived_cards` (trait default) | PRESERVES |
| `kanban-service/src/store_adapter.rs:81` | `write_full_snapshot` | STAMPS (prefixes written first, at :67-69) |
| `kanban-service/src/context/persistence.rs:35` | `migrate_sprint_logs` | PRESERVES |

## Changes

- Extracted the write-order probe (`PrefixOrderStore` renamed `PrefixWriteOrderStore`) out of `kanban-domain/tests/import_prefix_ordering.rs`'s private copy into a shared `tests/common/prefix_write_order.rs`.
- `kanban-domain/tests/prefix_write_order.rs`: one guard per production domain command writer (11 commands plus the `clear_sprint_from_archived_cards` trait default), plus a negative-control test proving the probe actually detects an unbacked write. The `CompactColumnPositions` guard seeds a non-compact column so the writer's `if card.position != i` branch actually runs, and the `clear_sprint_from_archived_cards` guard archives its card through the real command first so the default's loop body has a marker to iterate, with both asserting the write's effect (compacted positions, cleared sprint) on top of the probe.
- `kanban-service/src/store_adapter.rs`: a local write-order probe (mirroring the domain one) plus a negative control and an ordering guard on `write_full_snapshot`.
- `kanban-service/src/test_helpers/contract/prefix.rs` (plus registration in `test_helpers::mod`): three all-backend contract cases (creating a card, creating a subcard, restoring an archived card), each driven through a real `KanbanContext`, reopened from disk, and asserted against in-memory, JSON, and SQLite.
- `.changeset/kan-1273-sweep-card-writers.md` (patch, no user-facing behavior change).

## Scope notes (deliberately not done here)

- `CreateCard`/`CreateSubcardCommand` do **not** get an in-command `ensure_prefix_rows_exist` guard the way `ImportEntities` does. `ImportEntities` earned it because it derives prefixes from an untrusted payload with no allocator in the loop; `CreateCard`/`CreateSubcardCommand` trust their allocator, and adding self-validation there would flip 34 existing direct-construction tests red for a design decision that belongs on the root spec, not this sweep. Reported as an observation for KAN-1260/KAN-1276.
- A theoretical (currently unreachable) redo hole: `KanbanContext::redo` re-executes the forward batch, so `CreateCard::execute` re-derives its prefix at redo time rather than reusing the number's original namespace. It's unreachable today because `UndoStack::push` truncates the redo tail, so nothing can change a prefix between an undo and its redo. Flagged for the root spec, not fixed here.

## Verification

- `cargo test --workspace`: green.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Mutation-checked: broke the probe's detection (domain and service), broke `write_full_snapshot`'s write order, broke `CreateSubcardCommand`'s allocation, broke `CompactColumnPositions`'s write, and broke `clear_sprint_from_archived_cards`'s write. Each mutation was caught by the relevant new test, then reverted.
