### PR TITLE
KAN-1274 feat(persistence-sqlite): repair prefix rows for unbacked card namespaces

### DIFF
--- a/.changeset/kan-1274-sqlite-repair-unbacked.md
+++ b/.changeset/kan-1274-sqlite-repair-unbacked.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+persistence-sqlite: opening a database now repairs any card whose prefix namespace has no row, so upgrading a workspace where an archived card outlived its column no longer leaves an identifier pointing at a namespace the database does not know about.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/init.rs
@@ -143,6 +143,7 @@ impl SqliteStore {
         Self::migrate_v8_to_v9_drop_completion_columns(pool).await?;
         Self::migrate_v9_to_v10_prefixes(pool).await?;
         Self::migrate_v11_to_v12_drop_legacy_counters(pool).await?;
+        Self::repair_unbacked_card_namespaces(pool).await?;
 
         // Once the ALTERs above have caught the schema up, normalise
         // schema_version. Doing it unconditionally is idempotent and

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -16,6 +16,7 @@ mod init;
 mod lists;
 mod metadata;
 mod persistence_store;
+mod prefix_repair;
 mod snapshot;
 mod transaction;
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/prefix_repair.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/prefix_repair.rs
@@ -1,0 +1,105 @@
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+use kanban_domain::{Card, CardPriority, CardRecord, CardStatus, KanbanResult, Prefix};
+use sqlx::{Pool, Sqlite};
+use uuid::Uuid;
+
+use super::helpers::db_err;
+use super::SqliteStore;
+
+/// Only `prefix` and `card_number` are meaningful on these cards; every other
+/// field is a placeholder the integrity rules do not read.
+async fn stamped_cards(pool: &Pool<Sqlite>) -> KanbanResult<Vec<Card>> {
+    let rows: Vec<(String, i64)> = sqlx::query_as("SELECT prefix, card_number FROM cards")
+        .fetch_all(pool)
+        .await
+        .map_err(db_err)?;
+
+    rows.into_iter()
+        .map(|(prefix, card_number)| {
+            Card::reconstitute(CardRecord {
+                id: Uuid::nil(),
+                column_id: Uuid::nil(),
+                board_id: Uuid::nil(),
+                title: String::new(),
+                description: None,
+                priority: CardPriority::Medium,
+                status: CardStatus::Todo,
+                position: 0,
+                due_date: None,
+                points: None,
+                card_number: card_number as u32,
+                prefix,
+                sprint_id: None,
+                created_at: DateTime::<Utc>::UNIX_EPOCH,
+                updated_at: DateTime::<Utc>::UNIX_EPOCH,
+                completed_at: None,
+                sprint_logs: Vec::new(),
+            })
+        })
+        .collect()
+}
+
+impl SqliteStore {
+    /// Inserts a row for every namespace a card names that has none. The
+    /// counter is set to the highest `card_number` among the cards naming
+    /// it. Returns how many rows were inserted. Idempotent; never lowers an
+    /// existing counter.
+    pub(crate) async fn repair_unbacked_card_namespaces(
+        pool: &Pool<Sqlite>,
+    ) -> KanbanResult<usize> {
+        let rows: Vec<(String, i64, i64)> =
+            sqlx::query_as("SELECT name, card_counter, sprint_counter FROM prefixes")
+                .fetch_all(pool)
+                .await
+                .map_err(db_err)?;
+        let rows: Vec<Prefix> = rows
+            .into_iter()
+            .map(|(name, card_counter, sprint_counter)| Prefix {
+                name,
+                card_counter: card_counter as u32,
+                sprint_counter: sprint_counter as u32,
+            })
+            .collect();
+
+        let cards = stamped_cards(pool).await?;
+
+        let unbacked: HashSet<String> = kanban_domain::unbacked_namespaces(&cards, &rows)
+            .into_iter()
+            .collect();
+        if unbacked.is_empty() {
+            return Ok(0);
+        }
+
+        let implied = kanban_domain::counters_implied_by(&cards, &[], &[], &[], None);
+
+        let mut inserted = 0usize;
+        let mut tx = pool.begin().await.map_err(db_err)?;
+        for prefix in implied.iter().filter(|p| unbacked.contains(&p.name)) {
+            let result = sqlx::query(
+                "INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES (?, ?, ?) \
+                 ON CONFLICT(name) DO NOTHING",
+            )
+            .bind(&prefix.name)
+            .bind(i64::from(prefix.card_counter))
+            .bind(i64::from(prefix.sprint_counter))
+            .execute(&mut *tx)
+            .await
+            .map_err(db_err)?;
+            if result.rows_affected() > 0 {
+                inserted += 1;
+            }
+        }
+        tx.commit().await.map_err(db_err)?;
+
+        if inserted > 0 {
+            tracing::info!(
+                inserted,
+                "inserted prefix rows for namespaces named by cards but backed by none"
+            );
+        }
+
+        Ok(inserted)
+    }
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -22,6 +22,7 @@ mod migration_v8_to_v9;
 mod migration_v9_to_v10;
 mod persistence_store;
 mod pre_migration_backup;
+mod prefix_repair;
 mod snapshot_atomicity;
 mod snapshot_prefix_ordering;
 mod transaction;

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/prefix_repair.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/prefix_repair.rs
@@ -1,0 +1,305 @@
+//! Coverage for `SqliteStore::repair_unbacked_card_namespaces`: insert-only
+//! backfill of `prefixes` rows for namespaces a card names but nothing backs.
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{Pool, Sqlite};
+use std::path::Path;
+use tempfile::TempDir;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+async fn raw(path: &Path) -> Pool<Sqlite> {
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap()
+}
+
+async fn seed_card(pool: &Pool<Sqlite>, board_id: &str, column_id: &str, card_id: &str, prefix: &str, number: i64) {
+    sqlx::raw_sql(&format!(
+        "INSERT INTO boards (id, name, card_prefix, created_at, updated_at)
+             VALUES ('{board_id}','Board','{prefix}','2024-01-01T00:00:00Z','2024-01-01T00:00:00Z')
+             ON CONFLICT(id) DO NOTHING;
+         INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+             VALUES ('{column_id}','{board_id}','Todo',0,'2024-01-01T00:00:00Z','2024-01-01T00:00:00Z')
+             ON CONFLICT(id) DO NOTHING;
+         INSERT INTO cards (id, column_id, board_id, title, position, priority, status,
+                            card_number, prefix, created_at, updated_at)
+             VALUES ('{card_id}','{column_id}','{board_id}','Card',0,'medium','todo',
+                     {number},'{prefix}','2024-01-01T00:00:00Z','2024-01-01T00:00:00Z');"
+    ))
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn prefix_rows(pool: &Pool<Sqlite>) -> Vec<(String, i64, i64)> {
+    let mut rows: Vec<(String, i64, i64)> =
+        sqlx::query_as("SELECT name, card_counter, sprint_counter FROM prefixes")
+            .fetch_all(pool)
+            .await
+            .unwrap();
+    rows.sort();
+    rows
+}
+
+#[test]
+fn test_repair_inserts_a_row_for_an_unbacked_namespace() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b1",
+            "00000000-0000-0000-0000-0000000000c1",
+            "00000000-0000-0000-0000-0000000000a1",
+            "KAN",
+            7,
+        )
+        .await;
+
+        let inserted = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(inserted, 1);
+        assert_eq!(prefix_rows(pool).await, vec![("kan".to_string(), 7, 0)]);
+    });
+}
+
+#[test]
+fn test_the_repaired_counter_is_the_high_water_mark() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b1",
+            "00000000-0000-0000-0000-0000000000c1",
+            "00000000-0000-0000-0000-0000000000a1",
+            "KAN",
+            9,
+        )
+        .await;
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b2",
+            "00000000-0000-0000-0000-0000000000c2",
+            "00000000-0000-0000-0000-0000000000a2",
+            "kan",
+            2,
+        )
+        .await;
+
+        let inserted = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(inserted, 1);
+        assert_eq!(prefix_rows(pool).await, vec![("kan".to_string(), 9, 0)]);
+    });
+}
+
+#[test]
+fn test_the_repair_is_idempotent() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b1",
+            "00000000-0000-0000-0000-0000000000c1",
+            "00000000-0000-0000-0000-0000000000a1",
+            "KAN",
+            3,
+        )
+        .await;
+
+        let first = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(first, 1);
+        let second = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(second, 0);
+        assert_eq!(prefix_rows(pool).await.len(), 1);
+    });
+}
+
+#[test]
+fn test_the_repair_never_lowers_an_existing_counter() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+        sqlx::raw_sql(
+            "INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES ('kan', 50, 4)",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b1",
+            "00000000-0000-0000-0000-0000000000c1",
+            "00000000-0000-0000-0000-0000000000a1",
+            "KAN",
+            3,
+        )
+        .await;
+
+        let inserted = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(inserted, 0);
+        assert_eq!(prefix_rows(pool).await, vec![("kan".to_string(), 50, 4)]);
+    });
+}
+
+#[test]
+fn test_the_repair_ignores_empty_prefix_cards() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b1",
+            "00000000-0000-0000-0000-0000000000c1",
+            "00000000-0000-0000-0000-0000000000a1",
+            "",
+            5,
+        )
+        .await;
+
+        let inserted = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(inserted, 0);
+        assert_eq!(prefix_rows(pool).await.len(), 0);
+    });
+}
+
+/// The regression for the dangling-column archived-card orphan path found
+/// during planning: a pre-v11 database where an archived card's column was
+/// deleted so `migrate_v10_to_v11_card_prefix` stamps it `task`, while
+/// `migrate_v9_to_v10_prefixes` never creates a `task` row because every
+/// board sets an explicit `card_prefix`.
+#[test]
+fn test_a_card_stamped_from_a_dangling_column_is_backed_after_open() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("stale.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let board = "00000000-0000-0000-0000-0000000000b1";
+        let column = "00000000-0000-0000-0000-0000000000c1";
+        let live_card = "00000000-0000-0000-0000-0000000000a1";
+        let dangling_card = "00000000-0000-0000-0000-0000000000a2";
+        let dangling_column = "00000000-0000-0000-0000-0000000000cd";
+
+        {
+            let store = SqliteStore::open(&path).await.unwrap();
+            let pool = store.pool();
+            sqlx::raw_sql(&format!(
+                "INSERT INTO boards (id, name, card_prefix, created_at, updated_at)
+                     VALUES ('{board}','Board','KAN','2024-01-01T00:00:00Z','2024-01-01T00:00:00Z');
+                 INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+                     VALUES ('{column}','{board}','Todo',0,'2024-01-01T00:00:00Z','2024-01-01T00:00:00Z');
+                 INSERT INTO cards (id, column_id, board_id, title, position, priority, status,
+                                    card_number, created_at, updated_at)
+                     VALUES ('{live_card}','{column}','{board}','Live',0,'medium','todo',1,
+                             '2024-01-01T00:00:00Z','2024-01-01T00:00:00Z'),
+                            ('{dangling_card}','{dangling_column}','{board}','Archived',0,'medium','todo',4,
+                             '2024-01-01T00:00:00Z','2024-01-01T00:00:00Z');
+                 INSERT INTO archived_cards (card_id, board_id, archived_at, original_column_id, original_position)
+                     VALUES ('{dangling_card}','{board}','2024-01-01T00:00:00Z','{dangling_column}',0);"
+            ))
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+
+        let pool = raw(&path).await;
+        sqlx::raw_sql(
+            "DROP INDEX IF EXISTS idx_cards_prefix_nocase_number;
+             CREATE TABLE cards_v9 (
+                 id TEXT PRIMARY KEY, column_id TEXT NOT NULL, board_id TEXT NOT NULL,
+                 title TEXT NOT NULL, description TEXT,
+                 priority TEXT NOT NULL DEFAULT 'Medium', status TEXT NOT NULL DEFAULT 'Todo',
+                 position INTEGER NOT NULL, due_date TEXT,
+                 points INTEGER CHECK (points >= 0 AND points <= 255),
+                 card_number INTEGER NOT NULL DEFAULT 0, sprint_id TEXT,
+                 created_at TEXT NOT NULL, updated_at TEXT NOT NULL, completed_at TEXT
+             );
+             INSERT INTO cards_v9 (id, column_id, board_id, title, description, priority, status,
+                                   position, due_date, points, card_number, sprint_id,
+                                   created_at, updated_at, completed_at)
+                 SELECT id, column_id, board_id, title, description, priority, status,
+                        position, due_date, points, card_number, sprint_id,
+                        created_at, updated_at, completed_at FROM cards;
+             DROP TABLE cards;
+             ALTER TABLE cards_v9 RENAME TO cards;
+             ALTER TABLE boards ADD COLUMN card_counter INTEGER NOT NULL DEFAULT 1;
+             UPDATE boards SET card_counter = 5;
+             DELETE FROM prefixes;
+             UPDATE metadata SET schema_version = 9;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+
+        let unbacked: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM cards c WHERE c.prefix <> '' AND NOT EXISTS \
+             (SELECT 1 FROM prefixes p WHERE p.name = c.prefix COLLATE NOCASE)",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        assert_eq!(unbacked, 0, "every card's namespace must now be backed");
+
+        let dangling_prefix: String =
+            sqlx::query_scalar("SELECT prefix FROM cards WHERE id = ?")
+                .bind(dangling_card)
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(dangling_prefix, "task");
+
+        let task_row: (i64,) =
+            sqlx::query_as("SELECT card_counter FROM prefixes WHERE name = 'task'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(task_row.0, 4);
+
+        let kan_row: (i64,) =
+            sqlx::query_as("SELECT card_counter FROM prefixes WHERE name = 'kan'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(kan_row.0, 1);
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/prefix_repair.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/prefix_repair.rs
@@ -22,7 +22,14 @@ async fn raw(path: &Path) -> Pool<Sqlite> {
         .unwrap()
 }
 
-async fn seed_card(pool: &Pool<Sqlite>, board_id: &str, column_id: &str, card_id: &str, prefix: &str, number: i64) {
+async fn seed_card(
+    pool: &Pool<Sqlite>,
+    board_id: &str,
+    column_id: &str,
+    card_id: &str,
+    prefix: &str,
+    number: i64,
+) {
     sqlx::raw_sql(&format!(
         "INSERT INTO boards (id, name, card_prefix, created_at, updated_at)
              VALUES ('{board_id}','Board','{prefix}','2024-01-01T00:00:00Z','2024-01-01T00:00:00Z')
@@ -300,6 +307,10 @@ fn test_a_card_stamped_from_a_dangling_column_is_backed_after_open() {
                 .fetch_one(pool)
                 .await
                 .unwrap();
-        assert_eq!(kan_row.0, 1);
+        assert_eq!(
+            kan_row.0, 4,
+            "kan was already backed by the v9->v10 migration (from boards.card_counter=5, \
+             high-water 4); the repair must not touch it"
+        );
     });
 }


### PR DESCRIPTION
## Summary

- Adds `SqliteStore::repair_unbacked_card_namespaces(pool)`: an insert-only, idempotent pass that creates a `prefixes` row for every namespace a card names but no row backs, with the counter set to the high-water `card_number` among the cards naming it.
- Rows and counters are derived entirely through the domain (`kanban_domain::unbacked_namespaces` + `counters_implied_by`), never a hand-rolled SQL fold.
- Wired into `SqliteStore::migrate`, after `migrate_v11_to_v12_drop_legacy_counters` and before the `schema_version` normalisation, so KAN-1276's foreign key can be appended after it.

## Investigation finding

Planning for this card found a real orphan path, not just a preventive one: an archived card whose column was deleted is stamped with the built-in `task` prefix by the v10->v11 migration, and when every board in a workspace sets an explicit `card_prefix`, the v9->v10 migration never creates a `task` row. Upgrading such a pre-v11 database leaves an unbacked namespace on unmodified `develop` today. This is encoded as `test_a_card_stamped_from_a_dangling_column_is_backed_after_open`, confirmed failing before the repair was wired in.

## Test plan

- [x] `cargo test -p kanban-persistence-sqlite --features test-helpers prefix_repair` — 6/6 green, all confirmed red first
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: reverting the `migrate` wiring makes the dangling-column regression test fail; restoring it passes again