### PR TITLE
KAN-1281 feat(persistence-sqlite): raise a backed prefix counter to cover its cards

### DIFF
--- a/.changeset/kan-1281-repair-raises-backed-counter.md
+++ b/.changeset/kan-1281-repair-raises-backed-counter.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+persistence-sqlite: opening a database now also raises a naming prefix's counter when a card already carries a higher number, so the next card created in that namespace cannot re-use an identifier a live card already holds.

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/prefix_repair.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/prefix_repair.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use kanban_domain::{
@@ -137,10 +137,10 @@ impl SqliteStore {
         Ok(stamped)
     }
 
-    /// Inserts a row for every namespace a card names that has none. The
-    /// counter is set to the highest `card_number` among the cards naming
-    /// it. Returns how many rows were inserted. Idempotent; never lowers an
-    /// existing counter.
+    /// Inserts a row for every namespace a card names that has none, and
+    /// raises an existing row's counters to cover the cards naming it.
+    /// Returns how many rows were written. Idempotent; never lowers a
+    /// counter and never renames a row.
     pub(crate) async fn repair_unbacked_card_namespaces(
         pool: &Pool<Sqlite>,
     ) -> KanbanResult<usize> {
@@ -149,7 +149,7 @@ impl SqliteStore {
                 .fetch_all(pool)
                 .await
                 .map_err(db_err)?;
-        let rows: Vec<Prefix> = rows
+        let existing: Vec<Prefix> = rows
             .into_iter()
             .map(|(name, card_counter, sprint_counter)| Prefix {
                 name,
@@ -157,44 +157,52 @@ impl SqliteStore {
                 sprint_counter: sprint_counter as u32,
             })
             .collect();
+        let stored: HashMap<String, (u32, u32)> = existing
+            .iter()
+            .map(|p| {
+                (
+                    Prefix::normalize(&p.name),
+                    (p.card_counter, p.sprint_counter),
+                )
+            })
+            .collect();
 
         let cards = stamped_cards(pool).await?;
 
-        let unbacked: HashSet<String> = kanban_domain::unbacked_namespaces(&cards, &rows)
-            .into_iter()
-            .collect();
-        if unbacked.is_empty() {
-            return Ok(0);
-        }
+        let mut target = kanban_domain::counters_implied_by(&cards, &[], &[], &[], None);
+        kanban_domain::merge_counter_rows(&mut target, &existing);
 
-        let implied = kanban_domain::counters_implied_by(&cards, &[], &[], &[], None);
-
-        let mut inserted = 0usize;
+        let mut repaired = 0usize;
         let mut tx = pool.begin().await.map_err(db_err)?;
-        for prefix in implied.iter().filter(|p| unbacked.contains(&p.name)) {
-            let result = sqlx::query(
+        for row in &target {
+            if let Some((card_counter, sprint_counter)) = stored.get(&row.name) {
+                if row.card_counter <= *card_counter && row.sprint_counter <= *sprint_counter {
+                    continue;
+                }
+            }
+            sqlx::query(
                 "INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES (?, ?, ?) \
-                 ON CONFLICT(name) DO NOTHING",
+                 ON CONFLICT(name) DO UPDATE SET \
+                 card_counter = MAX(card_counter, excluded.card_counter), \
+                 sprint_counter = MAX(sprint_counter, excluded.sprint_counter)",
             )
-            .bind(&prefix.name)
-            .bind(i64::from(prefix.card_counter))
-            .bind(i64::from(prefix.sprint_counter))
+            .bind(&row.name)
+            .bind(i64::from(row.card_counter))
+            .bind(i64::from(row.sprint_counter))
             .execute(&mut *tx)
             .await
             .map_err(db_err)?;
-            if result.rows_affected() > 0 {
-                inserted += 1;
-            }
+            repaired += 1;
         }
         tx.commit().await.map_err(db_err)?;
 
-        if inserted > 0 {
+        if repaired > 0 {
             tracing::info!(
-                inserted,
-                "inserted prefix rows for namespaces named by cards but backed by none"
+                repaired,
+                "repaired prefix rows for namespaces named by cards"
             );
         }
 
-        Ok(inserted)
+        Ok(repaired)
     }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/prefix_repair.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/prefix_repair.rs
@@ -1,5 +1,6 @@
-//! Coverage for `SqliteStore::repair_unbacked_card_namespaces`: insert-only
-//! backfill of `prefixes` rows for namespaces a card names but nothing backs.
+//! Coverage for `SqliteStore::repair_unbacked_card_namespaces`: inserts a row
+//! for an unbacked namespace and raises a backed row's counters to cover the
+//! cards naming it.
 
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Pool, Sqlite};
@@ -312,5 +313,208 @@ fn test_a_card_stamped_from_a_dangling_column_is_backed_after_open() {
             "kan was already backed by the v9->v10 migration (from boards.card_counter=5, \
              high-water 4); the repair must not touch it"
         );
+    });
+}
+
+#[test]
+fn test_the_repair_raises_a_backed_counter_to_cover_its_cards() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+        sqlx::raw_sql(
+            "INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES ('task', 3, 0)",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b1",
+            "00000000-0000-0000-0000-0000000000c1",
+            "00000000-0000-0000-0000-0000000000a1",
+            "task",
+            7,
+        )
+        .await;
+
+        let repaired = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(repaired, 1);
+        assert_eq!(prefix_rows(pool).await, vec![("task".to_string(), 7, 0)]);
+    });
+}
+
+#[test]
+fn test_the_repair_raises_and_inserts_in_one_pass() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+        sqlx::raw_sql(
+            "INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES ('task', 3, 0)",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b1",
+            "00000000-0000-0000-0000-0000000000c1",
+            "00000000-0000-0000-0000-0000000000a1",
+            "task",
+            7,
+        )
+        .await;
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b2",
+            "00000000-0000-0000-0000-0000000000c2",
+            "00000000-0000-0000-0000-0000000000a2",
+            "ops",
+            2,
+        )
+        .await;
+
+        let repaired = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(repaired, 2);
+        assert_eq!(
+            prefix_rows(pool).await,
+            vec![("ops".to_string(), 2, 0), ("task".to_string(), 7, 0)]
+        );
+    });
+}
+
+#[test]
+fn test_the_raise_is_idempotent() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fresh.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+        sqlx::raw_sql(
+            "INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES ('task', 3, 0)",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        seed_card(
+            pool,
+            "00000000-0000-0000-0000-0000000000b1",
+            "00000000-0000-0000-0000-0000000000c1",
+            "00000000-0000-0000-0000-0000000000a1",
+            "task",
+            7,
+        )
+        .await;
+
+        let first = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(first, 1);
+        let second = SqliteStore::repair_unbacked_card_namespaces(pool)
+            .await
+            .unwrap();
+        assert_eq!(second, 0);
+        assert_eq!(prefix_rows(pool).await, vec![("task".to_string(), 7, 0)]);
+    });
+}
+
+#[test]
+fn test_a_dangling_column_card_raises_an_already_backed_default_namespace() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("stale.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let b1 = "00000000-0000-0000-0000-0000000001b1";
+        let b2 = "00000000-0000-0000-0000-0000000001b2";
+        let c1 = "00000000-0000-0000-0000-0000000001c1";
+        let c2 = "00000000-0000-0000-0000-0000000001c2";
+        let live_card = "00000000-0000-0000-0000-0000000001a1";
+        let dangling_card = "00000000-0000-0000-0000-0000000001a2";
+        let dangling_column = "00000000-0000-0000-0000-0000000001cd";
+
+        {
+            let store = SqliteStore::open(&path).await.unwrap();
+            let pool = store.pool();
+            sqlx::raw_sql(&format!(
+                "INSERT INTO boards (id, name, card_prefix, created_at, updated_at)
+                     VALUES ('{b1}','Board1','KAN','2024-01-01T00:00:00Z','2024-01-01T00:00:00Z'),
+                            ('{b2}','Board2','task','2024-01-01T00:00:00Z','2024-01-01T00:00:00Z');
+                 INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+                     VALUES ('{c1}','{b1}','Todo',0,'2024-01-01T00:00:00Z','2024-01-01T00:00:00Z'),
+                            ('{c2}','{b2}','Todo',0,'2024-01-01T00:00:00Z','2024-01-01T00:00:00Z');
+                 INSERT INTO cards (id, column_id, board_id, title, position, priority, status,
+                                    card_number, created_at, updated_at)
+                     VALUES ('{live_card}','{c1}','{b1}','Live',0,'medium','todo',1,
+                             '2024-01-01T00:00:00Z','2024-01-01T00:00:00Z'),
+                            ('{dangling_card}','{dangling_column}','{b1}','Archived',0,'medium','todo',7,
+                             '2024-01-01T00:00:00Z','2024-01-01T00:00:00Z');
+                 INSERT INTO archived_cards (card_id, board_id, archived_at, original_column_id, original_position)
+                     VALUES ('{dangling_card}','{b1}','2024-01-01T00:00:00Z','{dangling_column}',0);"
+            ))
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+
+        let pool = raw(&path).await;
+        sqlx::raw_sql(
+            "DROP INDEX IF EXISTS idx_cards_prefix_nocase_number;
+             CREATE TABLE cards_v9 (
+                 id TEXT PRIMARY KEY, column_id TEXT NOT NULL, board_id TEXT NOT NULL,
+                 title TEXT NOT NULL, description TEXT,
+                 priority TEXT NOT NULL DEFAULT 'Medium', status TEXT NOT NULL DEFAULT 'Todo',
+                 position INTEGER NOT NULL, due_date TEXT,
+                 points INTEGER CHECK (points >= 0 AND points <= 255),
+                 card_number INTEGER NOT NULL DEFAULT 0, sprint_id TEXT,
+                 created_at TEXT NOT NULL, updated_at TEXT NOT NULL, completed_at TEXT
+             );
+             INSERT INTO cards_v9 (id, column_id, board_id, title, description, priority, status,
+                                   position, due_date, points, card_number, sprint_id,
+                                   created_at, updated_at, completed_at)
+                 SELECT id, column_id, board_id, title, description, priority, status,
+                        position, due_date, points, card_number, sprint_id,
+                        created_at, updated_at, completed_at FROM cards;
+             DROP TABLE cards;
+             ALTER TABLE cards_v9 RENAME TO cards;
+             ALTER TABLE boards ADD COLUMN card_counter INTEGER NOT NULL DEFAULT 1;
+             UPDATE boards SET card_counter = 11 WHERE id = '{b1}';
+             UPDATE boards SET card_counter = 4 WHERE id = '{b2}';
+             DELETE FROM prefixes;
+             UPDATE metadata SET schema_version = 9;"
+                .replace("{b1}", b1)
+                .replace("{b2}", b2)
+                .as_str(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+
+        let task_row: (i64,) =
+            sqlx::query_as("SELECT card_counter FROM prefixes WHERE name = 'task'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(task_row.0, 7);
+
+        let kan_row: (i64,) =
+            sqlx::query_as("SELECT card_counter FROM prefixes WHERE name = 'kan'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(kan_row.0, 10);
     });
 }


### PR DESCRIPTION
## Summary

- `SqliteStore::repair_unbacked_card_namespaces` now inserts a row for an unbacked namespace AND raises a backed row's `card_counter`/`sprint_counter` to cover the cards naming it, in one pass. Previously it was insert-only, so a `prefixes` row that lagged behind the cards naming its namespace (e.g. from a stale legacy backfill) was never repaired, leaving the next allocation from that namespace free to re-mint an identifier a live card already holds.
- The raise semantic is `kanban_domain::counters_implied_by` + `kanban_domain::merge_counter_rows`; no max/high-water fold is hand-rolled in the SQLite crate, beyond a defensive `MAX(...)` in the upsert's `ON CONFLICT` clause.
- A counter already ahead of its cards is never lowered, and a row is never renamed (the `COLLATE NOCASE` primary key means an upsert on a lowercase name updates a differently-cased stored row in place, not by renaming it).
- The return value counts rows actually changed; a second consecutive call returns 0 and leaves the table byte-identical.

## Scope

SQLite only. The card's JSON-side step and its cross-backend acceptance criterion are deferred: neither KAN-1278 (JSON repair) nor KAN-1280 (cross-backend equality) has merged, so there is nothing on the JSON side to raise or compare against. `SUPPORTED_SCHEMA_VERSION` is unchanged at 12; no schema change, no new migration.

## Test plan

- [x] Four new red tests observed failing before the implementation commit
- [x] `cargo test -p kanban-persistence-sqlite --features test-helpers` — all 190 tests green, including the six pre-existing tests in `prefix_repair.rs`, which never went red
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: removing the never-lower skip guard turned 3 tests red; restored