### PR TITLE
KAN-1277 feat(persistence-json): enforce prefix backing at the batch boundary

### DIFF
--- a/.changeset/kan-1277-json-write-enforcement.md
+++ b/.changeset/kan-1277-json-write-enforcement.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+persistence-json: a JSON workspace now refuses a change that would create a card whose prefix namespace has no record, and rolls the whole change back, so a JSON store cannot drift into a shape the SQLite backend would reject.

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -13,7 +13,7 @@ use kanban_persistence::{
 };
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, RwLock,
+    Arc, Mutex, MutexGuard, RwLock,
 };
 use uuid::Uuid;
 
@@ -32,6 +32,8 @@ pub struct JsonDataStore {
     /// diagnostics panel.
     last_metadata: RwLock<Option<PersistenceMetadata>>,
     dirty: AtomicBool,
+    /// Cards written since the current batch opened; `None` outside a batch.
+    batch_cards: Mutex<Option<Vec<Card>>>,
 }
 
 impl JsonDataStore {
@@ -41,6 +43,7 @@ impl JsonDataStore {
             inner: RwLock::new(None),
             last_metadata: RwLock::new(None),
             dirty: AtomicBool::new(false),
+            batch_cards: Mutex::new(None),
         }
     }
 
@@ -157,6 +160,37 @@ impl JsonDataStore {
         self.dirty.store(true, Ordering::Release);
         Ok(result)
     }
+
+    fn lock_batch(&self) -> KanbanResult<MutexGuard<'_, Option<Vec<Card>>>> {
+        self.batch_cards
+            .lock()
+            .map_err(|_| KanbanError::Internal("json_backend: batch_cards Mutex poisoned".into()))
+    }
+
+    fn record_batch_card(&self, card: &Card) -> KanbanResult<()> {
+        if let Some(v) = self.lock_batch()?.as_mut() {
+            v.push(card.clone());
+        }
+        Ok(())
+    }
+
+    fn ensure_batch_namespaces_backed(&self) -> KanbanResult<()> {
+        let cards = self
+            .lock_batch()?
+            .as_mut()
+            .map(std::mem::take)
+            .unwrap_or_default();
+        if cards.is_empty() {
+            return Ok(());
+        }
+        let mut rows = Vec::new();
+        for name in kanban_domain::unbacked_namespaces(&cards, &[]) {
+            if let Some(row) = self.get_prefix(&name)? {
+                rows.push(row);
+            }
+        }
+        kanban_domain::ensure_prefix_rows_exist(&cards, &rows)
+    }
 }
 
 // ─── DataStore ────────────────────────────────────────────────────────────────
@@ -269,7 +303,9 @@ impl DataStore for JsonDataStore {
         self.with_read(|s| s.count_cards_in_column_filtered(column_id, archived))
     }
     fn upsert_card(&self, card: Card) -> KanbanResult<()> {
-        self.with_mutate(|s| s.upsert_card(card))
+        let recorded = card.clone();
+        self.with_mutate(|s| s.upsert_card(card))?;
+        self.record_batch_card(&recorded)
     }
     fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
         self.with_mutate(|s| s.delete_card(id))
@@ -430,7 +466,13 @@ impl KanbanBackend for JsonDataStore {
 
     fn with_transaction(&self, f: kanban_backend::TransactionFn<'_>) -> KanbanResult<()> {
         let before = self.with_read(|s| s.snapshot_impl())?;
-        match f() {
+        *self.lock_batch()? = Some(Vec::new());
+        let outcome = match f() {
+            Ok(()) => self.ensure_batch_namespaces_backed(),
+            Err(e) => Err(e),
+        };
+        *self.lock_batch()? = None;
+        match outcome {
             Ok(()) => Ok(()),
             Err(e) => match self.with_mutate(|s| s.apply_snapshot_impl(before)) {
                 Err(rollback_err) => Err(kanban_backend::rollback_failed(e, rollback_err)),

--- a/crates/kanban-persistence-json/tests/prefix_write_enforcement.rs
+++ b/crates/kanban-persistence-json/tests/prefix_write_enforcement.rs
@@ -1,0 +1,233 @@
+use kanban_backend::KanbanBackend;
+use kanban_domain::{Board, Card, Column, DataStore, DomainError, KanbanError, Prefix};
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn make_store(path: &std::path::Path) -> JsonDataStore {
+    JsonDataStore::new(Arc::new(JsonFileStore::new(path)))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_writing_a_card_with_an_unbacked_namespace_is_rejected() {
+    let dir = tempdir().unwrap();
+    let jds = make_store(&dir.path().join("t.json"));
+    let board = Board::new("Board", None::<String>);
+    jds.upsert_board(board.clone()).unwrap();
+    let col = Column::new(board.id, "Col", 0);
+    jds.upsert_column(col.clone()).unwrap();
+
+    let result = jds.with_transaction(Box::new(|| {
+        let mut card = Card::new(board.id, col.id, "C", 0);
+        card.prefix = "KAN".into();
+        card.card_number = 1;
+        jds.upsert_card(card)
+    }));
+
+    assert!(result.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_rejected_batch_leaves_the_store_unchanged() {
+    let dir = tempdir().unwrap();
+    let jds = make_store(&dir.path().join("t.json"));
+    let board = Board::new("Board", None::<String>);
+    jds.upsert_board(board.clone()).unwrap();
+    let col = Column::new(board.id, "Col", 0);
+    jds.upsert_column(col.clone()).unwrap();
+    jds.upsert_prefix(Prefix::new("kan")).unwrap();
+    let mut existing = Card::new(board.id, col.id, "Existing", 0);
+    existing.prefix = "KAN".into();
+    existing.card_number = 1;
+    jds.upsert_card(existing.clone()).unwrap();
+    let sprint = kanban_domain::Sprint::new(board.id, 1, None, None::<String>);
+    jds.upsert_sprint(sprint).unwrap();
+    let mut archived_source = Card::new(board.id, col.id, "Archived", 1);
+    archived_source.prefix = "KAN".into();
+    archived_source.card_number = 2;
+    jds.upsert_card(archived_source.clone()).unwrap();
+    jds.insert_archived_card(kanban_domain::ArchivedCard::new(
+        archived_source.id,
+        board.id,
+    ))
+    .unwrap();
+    let mut other_source = Card::new(board.id, col.id, "Other", 2);
+    other_source.prefix = "KAN".into();
+    other_source.card_number = 3;
+    jds.upsert_card(other_source.clone()).unwrap();
+    jds.modify_graph(Box::new(move |graph| {
+        graph.set_block(existing.id, other_source.id)
+    }))
+    .unwrap();
+
+    let before = jds.snapshot().unwrap();
+
+    let injected = Board::new("Injected", None::<String>);
+    let injected_id = injected.id;
+    let offender_id = uuid::Uuid::new_v4();
+    let result = jds.with_transaction(Box::new(|| {
+        jds.upsert_board(injected.clone())?;
+        let mut offender = Card::new(board.id, col.id, "Offender", 3);
+        offender.id = offender_id;
+        offender.prefix = "OPS".into();
+        offender.card_number = 99;
+        jds.upsert_card(offender)
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(jds.snapshot().unwrap(), before);
+    assert!(jds.get_card(offender_id).unwrap().is_none());
+    assert!(jds.get_board(injected_id).unwrap().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_the_rejection_is_the_prefix_not_backed_error() {
+    let dir = tempdir().unwrap();
+    let jds = make_store(&dir.path().join("t.json"));
+    let board = Board::new("Board", None::<String>);
+    jds.upsert_board(board.clone()).unwrap();
+    let col = Column::new(board.id, "Col", 0);
+    jds.upsert_column(col.clone()).unwrap();
+
+    let result = jds.with_transaction(Box::new(|| {
+        let mut card_a = Card::new(board.id, col.id, "A", 0);
+        card_a.prefix = "aaa".into();
+        card_a.card_number = 7;
+        jds.upsert_card(card_a)?;
+        let mut card_b = Card::new(board.id, col.id, "B", 1);
+        card_b.prefix = "ZZZ".into();
+        card_b.card_number = 3;
+        jds.upsert_card(card_b)
+    }));
+
+    let err = result.unwrap_err();
+    assert!(matches!(
+        &err,
+        KanbanError::Domain(DomainError::PrefixNotBacked { card_number: 3, prefix })
+            if prefix == "ZZZ"
+    ));
+    assert_eq!(
+        err.to_string(),
+        "card 3 names prefix 'ZZZ', which has no row"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_partly_backed_batch_is_rejected_whole() {
+    let dir = tempdir().unwrap();
+    let jds = make_store(&dir.path().join("t.json"));
+    let board = Board::new("Board", None::<String>);
+    jds.upsert_board(board.clone()).unwrap();
+    let col = Column::new(board.id, "Col", 0);
+    jds.upsert_column(col.clone()).unwrap();
+
+    let kan_card_id = uuid::Uuid::new_v4();
+    let ops_card_id = uuid::Uuid::new_v4();
+    let result = jds.with_transaction(Box::new(|| {
+        jds.upsert_prefix(Prefix::new("kan"))?;
+        let mut kan_card = Card::new(board.id, col.id, "K", 0);
+        kan_card.id = kan_card_id;
+        kan_card.prefix = "KAN".into();
+        kan_card.card_number = 1;
+        jds.upsert_card(kan_card)?;
+        let mut ops_card = Card::new(board.id, col.id, "O", 1);
+        ops_card.id = ops_card_id;
+        ops_card.prefix = "OPS".into();
+        ops_card.card_number = 2;
+        jds.upsert_card(ops_card)
+    }));
+
+    let err = result.unwrap_err();
+    assert!(matches!(
+        &err,
+        KanbanError::Domain(DomainError::PrefixNotBacked { prefix, .. }) if prefix == "OPS"
+    ));
+    assert!(jds.get_card(kan_card_id).unwrap().is_none());
+    assert!(jds.get_card(ops_card_id).unwrap().is_none());
+    assert!(jds.get_prefix("kan").unwrap().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_batch_whose_namespace_is_backed_commits() {
+    let dir = tempdir().unwrap();
+    let jds = make_store(&dir.path().join("t.json"));
+    let board = Board::new("Board", None::<String>);
+    jds.upsert_board(board.clone()).unwrap();
+    let col = Column::new(board.id, "Col", 0);
+    jds.upsert_column(col.clone()).unwrap();
+    jds.upsert_prefix(Prefix::new("kan")).unwrap();
+
+    let card_id = uuid::Uuid::new_v4();
+    let result = jds.with_transaction(Box::new(|| {
+        let mut card = Card::new(board.id, col.id, "C", 0);
+        card.id = card_id;
+        card.prefix = "KAN".into();
+        card.card_number = 1;
+        jds.upsert_card(card)
+    }));
+
+    assert!(result.is_ok());
+    assert!(jds.get_card(card_id).unwrap().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_row_created_earlier_in_the_same_batch_backs_the_card() {
+    let dir = tempdir().unwrap();
+    let jds = make_store(&dir.path().join("t.json"));
+    let board = Board::new("Board", None::<String>);
+    jds.upsert_board(board.clone()).unwrap();
+    let col = Column::new(board.id, "Col", 0);
+    jds.upsert_column(col.clone()).unwrap();
+
+    let card_id = uuid::Uuid::new_v4();
+    let result = jds.with_transaction(Box::new(|| {
+        jds.upsert_prefix(Prefix::new("kan"))?;
+        let mut card = Card::new(board.id, col.id, "C", 0);
+        card.id = card_id;
+        card.prefix = "KAN".into();
+        card.card_number = 1;
+        jds.upsert_card(card)
+    }));
+
+    assert!(result.is_ok());
+    assert!(jds.get_card(card_id).unwrap().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_card_with_an_empty_prefix_is_accepted() {
+    let dir = tempdir().unwrap();
+    let jds = make_store(&dir.path().join("t.json"));
+    let board = Board::new("Board", None::<String>);
+    jds.upsert_board(board.clone()).unwrap();
+    let col = Column::new(board.id, "Col", 0);
+    jds.upsert_column(col.clone()).unwrap();
+
+    let card_id = uuid::Uuid::new_v4();
+    let result = jds.with_transaction(Box::new(|| {
+        let mut card = Card::new(board.id, col.id, "C", 0);
+        card.id = card_id;
+        jds.upsert_card(card)
+    }));
+
+    assert!(result.is_ok());
+    assert!(jds.get_card(card_id).unwrap().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_direct_upsert_outside_a_batch_is_not_rejected() {
+    let dir = tempdir().unwrap();
+    let jds = make_store(&dir.path().join("t.json"));
+    let board = Board::new("Board", None::<String>);
+    jds.upsert_board(board.clone()).unwrap();
+    let col = Column::new(board.id, "Col", 0);
+    jds.upsert_column(col.clone()).unwrap();
+
+    let mut card = Card::new(board.id, col.id, "C", 0);
+    card.prefix = "KAN".into();
+    card.card_number = 1;
+    let card_id = card.id;
+    let result = jds.upsert_card(card);
+
+    assert!(result.is_ok());
+    assert!(jds.get_card(card_id).unwrap().is_some());
+}


### PR DESCRIPTION
## Summary
- Wire `kanban_domain::ensure_prefix_rows_exist` into `JsonDataStore::with_transaction`, the real batch/commit boundary, so a batch that writes a card into a namespace with no prefix row is rejected with `DomainError::PrefixNotBacked` and the whole batch is rolled back.
- `upsert_card` now records the cards it writes into a per-batch buffer (`batch_cards`); `with_transaction` validates the distinct namespaces named by those cards once at commit, resolving one `get_prefix` per namespace rather than calling `list_prefixes()`.
- Cards written outside a batch (direct `upsert_card`, migration/load paths, the tier-2 contract suite) are unaffected, the check only fires inside `with_transaction`.

## Test plan
- [x] `cargo test -p kanban-persistence-json --test prefix_write_enforcement`, 8 new tests (4 red-turned-green + 4 guard tests) pass
- [x] Mutation check: neutralized the new check inline, confirmed the 4 rejection tests fail, restored it
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `.changeset/kan-1277-json-write-enforcement.md` added
