### PR TITLE
KAN-1279 test(service): hold every durable backend to one prefix referential-integrity spec

### DIFF
--- a/.changeset/kan-1279-referential-contract-spec.md
+++ b/.changeset/kan-1279-referential-contract-spec.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+persistence-json: reject a snapshot whose cards name a prefix namespace it drops, matching what the SQLite backend already did

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -396,6 +396,7 @@ impl DataStore for JsonDataStore {
         self.with_read(|s| s.snapshot())
     }
     fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+        kanban_domain::ensure_prefix_rows_exist(&snapshot.cards, &snapshot.prefixes)?;
         self.with_mutate(|s| s.apply_snapshot(snapshot))
     }
 }

--- a/crates/kanban-persistence-json/tests/contract.rs
+++ b/crates/kanban-persistence-json/tests/contract.rs
@@ -16,4 +16,5 @@ mod tier1 {
 
 mod tier2 {
     kanban_service::context_contract_tests!(super::json_backend_factory);
+    kanban_service::durable_prefix_contract_tests!(super::json_backend_factory);
 }

--- a/crates/kanban-service/src/test_helpers/contract/prefix.rs
+++ b/crates/kanban-service/src/test_helpers/contract/prefix.rs
@@ -268,12 +268,13 @@ pub async fn test_a_rejected_create_does_not_consume_a_card_number(factory: &Bac
     );
 }
 
-fn snapshot_with_one_card(prefixes: Vec<Prefix>) -> Snapshot {
-    let board = Board::new("B", Some("KAN"));
+fn seed_graph(prefix: &str, card_number: u32) -> (Snapshot, uuid::Uuid) {
+    let board = Board::new("B", Some(prefix));
     let column = Column::new(board.id, "Todo", 0);
     let mut card = Card::new(board.id, column.id, "one", 0);
-    card.prefix = "KAN".to_string();
-    card.card_number = 7;
+    card.prefix = prefix.to_string();
+    card.card_number = card_number;
+    let card_id = card.id;
 
     let mut snapshot = Snapshot::from_data(
         vec![board],
@@ -283,6 +284,16 @@ fn snapshot_with_one_card(prefixes: Vec<Prefix>) -> Snapshot {
         Vec::new(),
         Default::default(),
     );
+    snapshot.prefixes = vec![Prefix {
+        name: Prefix::normalize(prefix),
+        card_counter: card_number,
+        sprint_counter: 0,
+    }];
+    (snapshot, card_id)
+}
+
+fn snapshot_with_one_card(prefixes: Vec<Prefix>) -> Snapshot {
+    let (mut snapshot, _) = seed_graph("KAN", 7);
     snapshot.prefixes = prefixes;
     snapshot
 }
@@ -510,4 +521,281 @@ pub async fn test_restoring_an_archived_card_leaves_its_namespace_backed(factory
         .unwrap()
         .expect("the restored card must survive the reload");
     assert_eq!(reread.prefix, card.prefix);
+}
+
+/// A namespace a live card still names must survive on every durable backend,
+/// on every write path -- including `apply_snapshot`, not just a card upsert.
+pub async fn test_a_referenced_namespace_cannot_be_removed_on_every_backend(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let (mut seed, _card_id) = seed_graph("KAN", 7);
+    seed.prefixes.push(Prefix {
+        name: "ops".to_string(),
+        card_counter: 0,
+        sprint_counter: 0,
+    });
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+    backend
+        .as_data_store()
+        .apply_snapshot(seed.clone())
+        .unwrap();
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    // Negative half: dropping the `kan` row while a card still names it must
+    // be rejected, and the row must still be there after the rejected write.
+    let mut without_kan = seed.clone();
+    without_kan.prefixes.clear();
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+    let err = backend
+        .as_data_store()
+        .apply_snapshot(without_kan)
+        .unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            kanban_domain::KanbanError::Domain(kanban_domain::DomainError::PrefixNotBacked {
+                card_number: 7,
+                prefix,
+            }) if prefix == "KAN"
+        ),
+        "expected PrefixNotBacked for card 7 / KAN, got {err:?}"
+    );
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    let prefix = reopened
+        .get_prefix("kan")
+        .unwrap()
+        .expect("the `kan` row must survive a rejected apply_snapshot");
+    assert_eq!(prefix.card_counter, 7);
+    let cards = reopened.as_data_store().list_all_cards().unwrap();
+    let card = cards
+        .into_iter()
+        .find(|c| c.card_number == 7)
+        .expect("the card must still be present");
+    assert_eq!(card.prefix, "KAN");
+    drop(reopened);
+
+    // Positive half: dropping the extra, unreferenced `ops` row must succeed.
+    let mut without_ops = seed.clone();
+    without_ops.prefixes.retain(|p| p.name != "ops");
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+    backend.as_data_store().apply_snapshot(without_ops).unwrap();
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    let mut names: Vec<String> = reopened
+        .list_prefixes()
+        .unwrap()
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["kan".to_string()]);
+}
+
+/// A card naming a namespace with no row must be rejected on the write path
+/// itself, on every durable backend.
+pub async fn test_an_unbacked_namespace_is_rejected_on_every_backend(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+
+    let board = Board::new("B", Some("ZZZ"));
+    let column = Column::new(board.id, "Todo", 0);
+    backend.as_data_store().upsert_board(board.clone()).unwrap();
+    backend
+        .as_data_store()
+        .upsert_column(column.clone())
+        .unwrap();
+
+    let mut card = Card::new(board.id, column.id, "one", 0);
+    card.prefix = "ZZZ".to_string();
+    card.card_number = 4;
+
+    let store = backend.as_data_store();
+    let result = backend.with_transaction(Box::new(|| store.upsert_card(card.clone())));
+    let err = result.unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            kanban_domain::KanbanError::Domain(kanban_domain::DomainError::PrefixNotBacked {
+                card_number: 4,
+                prefix,
+            }) if prefix == "ZZZ"
+        ),
+        "expected PrefixNotBacked for card 4 / ZZZ, got {err:?}"
+    );
+
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    assert!(
+        reopened
+            .as_data_store()
+            .list_all_cards()
+            .unwrap()
+            .is_empty(),
+        "the rejected card must not have reached durable storage"
+    );
+    assert!(
+        reopened.list_prefixes().unwrap().is_empty(),
+        "no prefix row should have been created for the rejected card"
+    );
+}
+
+/// A card whose casing differs from the row's stored, normalised name must
+/// still be accepted, on every durable backend.
+pub async fn test_configured_casing_is_backed_by_the_normalised_row_on_every_backend(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+
+    backend
+        .as_data_store()
+        .upsert_prefix(Prefix::new("kan"))
+        .unwrap();
+    let board = Board::new("B", Some("KAN"));
+    let column = Column::new(board.id, "Todo", 0);
+    backend.as_data_store().upsert_board(board.clone()).unwrap();
+    backend
+        .as_data_store()
+        .upsert_column(column.clone())
+        .unwrap();
+
+    let mut card = Card::new(board.id, column.id, "one", 0);
+    card.prefix = "KAN".to_string();
+    card.card_number = 3;
+
+    let store = backend.as_data_store();
+    backend
+        .with_transaction(Box::new(|| store.upsert_card(card.clone())))
+        .unwrap();
+
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    let reread = reopened
+        .get_card(card.id)
+        .unwrap()
+        .expect("the card must survive the reload");
+    assert_eq!(
+        reread.prefix, "KAN",
+        "casing must be kept verbatim on the card"
+    );
+    assert!(reopened.get_prefix("kan").unwrap().is_some());
+    assert!(reopened.get_prefix("KAN").unwrap().is_some());
+    let all = reopened.list_prefixes().unwrap();
+    assert_eq!(all.len(), 1, "expected exactly one prefix row: {all:?}");
+    assert_eq!(all[0].name, "kan");
+}
+
+/// A rejected write must leave every backend byte-identical, before AND after
+/// a reload, so a failed batch cannot have partially reached disk.
+pub async fn test_a_rejected_write_leaves_every_backend_unchanged(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+
+    let backend = factory(&path);
+    backend.reload().await.unwrap();
+
+    backend
+        .as_data_store()
+        .upsert_prefix(Prefix {
+            name: "kan".to_string(),
+            card_counter: 1,
+            sprint_counter: 0,
+        })
+        .unwrap();
+    let board = Board::new("B", Some("KAN"));
+    let column = Column::new(board.id, "Todo", 0);
+    backend.as_data_store().upsert_board(board.clone()).unwrap();
+    backend
+        .as_data_store()
+        .upsert_column(column.clone())
+        .unwrap();
+
+    let mut good_card = Card::new(board.id, column.id, "good", 0);
+    good_card.prefix = "KAN".to_string();
+    good_card.card_number = 1;
+    {
+        let store = backend.as_data_store();
+        let card = good_card.clone();
+        backend
+            .with_transaction(Box::new(|| store.upsert_card(card)))
+            .unwrap();
+    }
+    backend.flush().await.unwrap();
+
+    let capture = |backend: &std::sync::Arc<dyn crate::KanbanBackend>| {
+        let store = backend.as_data_store();
+        let mut boards = store.list_boards().unwrap();
+        boards.sort_by_key(|b| b.id);
+        let mut columns = store.list_all_columns().unwrap();
+        columns.sort_by_key(|c| c.id);
+        let mut cards = store.list_all_cards().unwrap();
+        cards.sort_by_key(|c| c.id);
+        let mut prefixes = store.list_prefixes().unwrap();
+        prefixes.sort_by(|a, b| a.name.cmp(&b.name));
+        (boards, columns, cards, prefixes)
+    };
+
+    let before = capture(&backend);
+
+    let mut second_card = Card::new(board.id, column.id, "second", 0);
+    second_card.prefix = "KAN".to_string();
+    second_card.card_number = 2;
+    let mut bad_card = Card::new(board.id, column.id, "bad", 0);
+    bad_card.prefix = "ZZZ".to_string();
+    bad_card.card_number = 9;
+
+    let store = backend.as_data_store();
+    let second = second_card.clone();
+    let bad = bad_card.clone();
+    let result = backend.with_transaction(Box::new(move || {
+        store.upsert_card(second)?;
+        store.upsert_card(bad)
+    }));
+    assert!(result.is_err(), "the transaction must fail");
+
+    assert_eq!(
+        capture(&backend),
+        before,
+        "a rejected batch must leave every collection unchanged before reload"
+    );
+
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = factory(&path);
+    reopened.reload().await.unwrap();
+    assert_eq!(
+        capture(&reopened),
+        before,
+        "a rejected batch must not have reached disk"
+    );
 }

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -66,6 +66,10 @@ macro_rules! context_contract_tests {
         async fn test_restoring_an_archived_card_leaves_its_namespace_backed() {
             $crate::test_helpers::contract::prefix::test_restoring_an_archived_card_leaves_its_namespace_backed(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_configured_casing_is_backed_by_the_normalised_row_on_every_backend() {
+            $crate::test_helpers::contract::prefix::test_configured_casing_is_backed_by_the_normalised_row_on_every_backend(&$factory_fn()).await;
+        }
 
         // Board tests
         #[tokio::test(flavor = "multi_thread")]
@@ -385,5 +389,28 @@ macro_rules! context_contract_tests {
         // has no persistence layer to conflict on, and the SQLite backend shares a
         // live DB connection rather than snapshot-versioning. It is invoked
         // directly for the JSON backend by the F4 registration test instead.
+    };
+}
+
+/// Prefix referential-integrity enforcement (a card's namespace must be
+/// backed by a durable row, and a still-referenced namespace cannot be
+/// removed) lives on a durable backend's persistence write path. The
+/// in-memory backend has no such path -- it is snapshot/restore only -- so
+/// these cases are registered separately and never invoked for it.
+#[macro_export]
+macro_rules! durable_prefix_contract_tests {
+    ($factory_fn:expr) => {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_referenced_namespace_cannot_be_removed_on_every_backend() {
+            $crate::test_helpers::contract::prefix::test_a_referenced_namespace_cannot_be_removed_on_every_backend(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_an_unbacked_namespace_is_rejected_on_every_backend() {
+            $crate::test_helpers::contract::prefix::test_an_unbacked_namespace_is_rejected_on_every_backend(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_rejected_write_leaves_every_backend_unchanged() {
+            $crate::test_helpers::contract::prefix::test_a_rejected_write_leaves_every_backend_unchanged(&$factory_fn()).await;
+        }
     };
 }

--- a/crates/kanban-service/tests/archival_contract.rs
+++ b/crates/kanban-service/tests/archival_contract.rs
@@ -80,10 +80,12 @@ mod in_memory {
 
 mod json {
     kanban_service::context_contract_tests!(super::json_backend_factory);
+    kanban_service::durable_prefix_contract_tests!(super::json_backend_factory);
 }
 
 mod sqlite {
     kanban_service::context_contract_tests!(super::sqlite_backend_factory);
+    kanban_service::durable_prefix_contract_tests!(super::sqlite_backend_factory);
 }
 
 /// Optimistic-concurrency conflict detection is a FILE-store feature (it versions


### PR DESCRIPTION
## Summary
- Adds four cases to the shared prefix contract suite: a still-referenced namespace cannot be removed via `apply_snapshot`, an unbacked namespace is rejected on the write path, a card whose casing differs from the row's stored name is still accepted, and a rejected batch leaves every collection unchanged before and after a reload.
- The referenced-namespace and unbacked-namespace and rejected-write cases are registered in a new `durable_prefix_contract_tests!` macro, invoked only for the JSON and SQLite backends (the in-memory backend has no persistence write path to enforce this on and is deliberately excluded, matching KAN-1272's pinned "apply_snapshot must not guard prefix rows" test).
- The casing case is registered in the existing shared `context_contract_tests!` macro since it asserts a write succeeds and all three backends satisfy it.
- `JsonDataStore::apply_snapshot` now calls `kanban_domain::ensure_prefix_rows_exist` before mutating, matching what `SqliteStore::apply_snapshot` already did. This was the one genuine divergence: JSON silently accepted a snapshot whose cards outran their prefix rows.

## Test plan
- [x] `cargo test -p kanban-service --features test-helpers --test archival_contract` — all backends green, red observed on JSON before the fix
- [x] `cargo test --workspace --all-features` — green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Mutation check: reverted the `apply_snapshot` guard, confirmed the JSON case fails, restored it