### PR TITLE
KAN-1280 test(persistence-sqlite): hold both prefix repairs to identical row order

### DIFF
--- a/.changeset/kan-1280-cross-backend-repair-equality.md
+++ b/.changeset/kan-1280-cross-backend-repair-equality.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+persistence-json: the prefix rows written when a workspace is upgraded are now stored in name order, so a JSON and a SQLite workspace holding the same content list their naming prefixes identically.

--- a/crates/kanban-persistence-json/src/migration/v18_prefix_rows.rs
+++ b/crates/kanban-persistence-json/src/migration/v18_prefix_rows.rs
@@ -7,7 +7,8 @@
 //! shared `kanban_domain` functions the SQLite backend uses
 //! (`resolve_card_prefix_by_ids`, `counters_implied_by`,
 //! `merge_counter_rows`), so the two backends cannot derive different rows
-//! for identical logical content.
+//! for identical logical content. The repaired rows are written in
+//! ascending name order, matching how SQLite's `list_prefixes` reads them.
 
 use std::path::Path;
 
@@ -228,6 +229,13 @@ fn repair_unbacked_card_namespaces(envelope: &mut Value) -> PersistenceResult<()
             }
         }
     }
+
+    rows.sort_by(|a, b| {
+        a.get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .cmp(b.get("name").and_then(Value::as_str).unwrap_or_default())
+    });
 
     Ok(())
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cross_backend_repair_agreement.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cross_backend_repair_agreement.rs
@@ -1,0 +1,631 @@
+//! Executes BOTH the SQLite v12 -> v13 stamp/repair chain and the JSON
+//! V17 -> V18 prefix-row repair, live and in one process, over a single
+//! shared scenario, and asserts the two produce byte-identical results:
+//! the same prefix rows (name, `card_counter`, `sprint_counter`), IN THE
+//! SAME ORDER, and the same stamped prefix on every card.
+//!
+//! SQLite is read canonically with `ORDER BY name ASC`, exactly what
+//! `list_prefixes` reads. The JSON side is read from `data.prefixes` in
+//! array order, unsorted -- so this module pins the migration-boundary
+//! ordering contract rather than the general (and backend-divergent)
+//! runtime `list_prefixes()` ordering.
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{Pool, Sqlite};
+use std::path::Path;
+use tempfile::TempDir;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+struct BoardSpec {
+    id: &'static str,
+    card_prefix: Option<&'static str>,
+}
+
+struct ColumnSpec {
+    id: &'static str,
+    board_id: &'static str,
+}
+
+struct SprintSpec {
+    id: &'static str,
+    board_id: &'static str,
+    card_prefix: Option<&'static str>,
+}
+
+struct CardSpec {
+    id: &'static str,
+    column_id: &'static str,
+    board_id: &'static str,
+    sprint_id: Option<&'static str>,
+    prefix: &'static str,
+    number: i64,
+}
+
+struct PrefixSpec {
+    name: &'static str,
+    card_counter: i64,
+    sprint_counter: i64,
+}
+
+struct Scenario {
+    boards: Vec<BoardSpec>,
+    columns: Vec<ColumnSpec>,
+    sprints: Vec<SprintSpec>,
+    cards: Vec<CardSpec>,
+    /// Declared in the order the fixture must store the pre-existing rows.
+    prefixes: Vec<PrefixSpec>,
+}
+
+/// A repaired prefix row: name and its counters, in read order.
+type Row = (String, i64, i64);
+/// A card's id and its stored prefix, always sorted by id before comparing.
+type Stamp = (String, String);
+
+const TS: &str = "2024-01-01T00:00:00Z";
+
+async fn raw(path: &Path) -> Pool<Sqlite> {
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap()
+}
+
+async fn seed_v12(scenario: &Scenario, path: &Path) {
+    {
+        let store = SqliteStore::open(path).await.unwrap();
+        store.pool().close().await;
+    }
+
+    let pool = raw(path).await;
+    let index_ddl: Vec<(String,)> = sqlx::query_as(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'cards' AND sql IS NOT NULL",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    sqlx::raw_sql(
+        "PRAGMA foreign_keys = OFF;
+        BEGIN;
+        CREATE TABLE cards_legacy (
+            id TEXT PRIMARY KEY,
+            column_id TEXT NOT NULL,
+            board_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            priority TEXT NOT NULL DEFAULT 'Medium',
+            status TEXT NOT NULL DEFAULT 'Todo',
+            position INTEGER NOT NULL,
+            due_date TEXT,
+            points INTEGER CHECK (points >= 0 AND points <= 255),
+            card_number INTEGER NOT NULL DEFAULT 0,
+            prefix TEXT NOT NULL DEFAULT '',
+            sprint_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT,
+            FOREIGN KEY (sprint_id) REFERENCES sprints(id) ON DELETE SET NULL
+        );
+        DROP TABLE cards;
+        ALTER TABLE cards_legacy RENAME TO cards;
+        COMMIT;
+        PRAGMA foreign_keys = ON;",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    for (sql,) in index_ddl {
+        sqlx::raw_sql(&sql).execute(&pool).await.unwrap();
+    }
+
+    sqlx::raw_sql("UPDATE metadata SET schema_version = 12;")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    for b in &scenario.boards {
+        sqlx::query(
+            "INSERT INTO boards (id, name, card_prefix, created_at, updated_at)
+             VALUES (?, 'Board', ?, ?, ?)",
+        )
+        .bind(b.id)
+        .bind(b.card_prefix)
+        .bind(TS)
+        .bind(TS)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    for c in &scenario.columns {
+        sqlx::query(
+            "INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+             VALUES (?, ?, 'Todo', 0, ?, ?)",
+        )
+        .bind(c.id)
+        .bind(c.board_id)
+        .bind(TS)
+        .bind(TS)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    for s in &scenario.sprints {
+        sqlx::query(
+            "INSERT INTO sprints (id, board_id, sprint_number, status, card_prefix, created_at, updated_at)
+             VALUES (?, ?, 1, 'Planning', ?, ?, ?)",
+        )
+        .bind(s.id)
+        .bind(s.board_id)
+        .bind(s.card_prefix)
+        .bind(TS)
+        .bind(TS)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    for p in &scenario.prefixes {
+        sqlx::query(
+            "INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES (?, ?, ?)",
+        )
+        .bind(p.name)
+        .bind(p.card_counter)
+        .bind(p.sprint_counter)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    for c in &scenario.cards {
+        sqlx::query(
+            "INSERT INTO cards (id, column_id, board_id, title, position, priority, status,
+                                card_number, prefix, sprint_id, created_at, updated_at)
+             VALUES (?, ?, ?, 'Card', 0, 'medium', 'todo', ?, ?, ?, ?, ?)",
+        )
+        .bind(c.id)
+        .bind(c.column_id)
+        .bind(c.board_id)
+        .bind(c.number)
+        .bind(c.prefix)
+        .bind(c.sprint_id)
+        .bind(TS)
+        .bind(TS)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    pool.close().await;
+}
+
+async fn sqlite_repair(scenario: &Scenario) -> Result<(Vec<Row>, Vec<Stamp>), String> {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v12.db");
+    seed_v12(scenario, &path).await;
+
+    let store = SqliteStore::open(&path).await.map_err(|e| e.to_string())?;
+    let pool = store.pool();
+
+    let rows: Vec<Row> =
+        sqlx::query_as("SELECT name, card_counter, sprint_counter FROM prefixes ORDER BY name ASC")
+            .fetch_all(pool)
+            .await
+            .unwrap();
+
+    let mut stamps: Vec<Stamp> = sqlx::query_as("SELECT id, prefix FROM cards")
+        .fetch_all(pool)
+        .await
+        .unwrap();
+    stamps.sort();
+
+    Ok((rows, stamps))
+}
+
+fn json_envelope(scenario: &Scenario) -> serde_json::Value {
+    let boards: Vec<serde_json::Value> = scenario
+        .boards
+        .iter()
+        .map(|b| {
+            serde_json::json!({
+                "id": b.id,
+                "name": "Board",
+                "card_prefix": b.card_prefix,
+            })
+        })
+        .collect();
+    let columns: Vec<serde_json::Value> = scenario
+        .columns
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "id": c.id,
+                "board_id": c.board_id,
+                "name": "Todo",
+            })
+        })
+        .collect();
+    let sprints: Vec<serde_json::Value> = scenario
+        .sprints
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "id": s.id,
+                "board_id": s.board_id,
+                "card_prefix": s.card_prefix,
+            })
+        })
+        .collect();
+    let cards: Vec<serde_json::Value> = scenario
+        .cards
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "id": c.id,
+                "column_id": c.column_id,
+                "board_id": c.board_id,
+                "sprint_id": c.sprint_id,
+                "prefix": c.prefix,
+                "card_number": c.number,
+            })
+        })
+        .collect();
+    let prefixes: Vec<serde_json::Value> = scenario
+        .prefixes
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "name": p.name,
+                "card_counter": p.card_counter,
+                "sprint_counter": p.sprint_counter,
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "version": 17,
+        "metadata": {
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "saved_at": TS
+        },
+        "data": {
+            "boards": boards,
+            "columns": columns,
+            "cards": cards,
+            "sprints": sprints,
+            "prefixes": prefixes,
+            "archived_cards": [],
+            "archived_boards": [],
+            "graph": {
+                "spawns": { "edges": [] },
+                "blocks": { "edges": [] },
+                "relates": { "edges": [] }
+            }
+        }
+    })
+}
+
+fn json_repair(scenario: &Scenario) -> Result<(Vec<Row>, Vec<Stamp>), String> {
+    let mut env = json_envelope(scenario);
+    kanban_persistence_json::migration_test_support::try_transform_v17_to_v18(&mut env)
+        .map_err(|e| e.to_string())?;
+
+    let rows: Vec<Row> = env["data"]["prefixes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                r["name"].as_str().unwrap().to_string(),
+                r["card_counter"].as_i64().unwrap(),
+                r["sprint_counter"].as_i64().unwrap(),
+            )
+        })
+        .collect();
+
+    let mut stamps: Vec<Stamp> = env["data"]["cards"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| {
+            (
+                c["id"].as_str().unwrap().to_string(),
+                c["prefix"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    stamps.sort();
+
+    Ok((rows, stamps))
+}
+
+fn assert_backends_agree(scenario: &Scenario, what: &str) {
+    let rt = make_rt();
+    let sqlite = rt.block_on(sqlite_repair(scenario));
+    let json = json_repair(scenario);
+
+    match (&sqlite, &json) {
+        (Ok((s_rows, s_stamps)), Ok((j_rows, j_stamps))) => {
+            assert_eq!(
+                s_rows, j_rows,
+                "{what}: prefix rows disagree (name/counter/order).\nsqlite: {s_rows:#?}\njson:   {j_rows:#?}"
+            );
+            assert_eq!(
+                s_stamps, j_stamps,
+                "{what}: stamped card prefixes disagree.\nsqlite: {s_stamps:#?}\njson:   {j_stamps:#?}"
+            );
+        }
+        (Err(se), Err(je)) => {
+            let _ = (se, je);
+        }
+        (Ok((s_rows, _)), Err(je)) => panic!(
+            "{what}: the SQLite repair succeeded but the JSON one rejected the same input.\n\
+             sqlite: {s_rows:#?}\njson error: {je}"
+        ),
+        (Err(se), Ok((j_rows, _))) => panic!(
+            "{what}: the JSON repair succeeded but the SQLite one rejected the same input.\n\
+             json: {j_rows:#?}\nsqlite error: {se}"
+        ),
+    }
+}
+
+const B1: &str = "11111111-1111-1111-1111-111111111111";
+const B2: &str = "22222222-2222-2222-2222-222222222222";
+const B3: &str = "33333333-3333-3333-3333-333333333333";
+const C1: &str = "00000000-0000-0000-0000-0000000000c1";
+const C2: &str = "00000000-0000-0000-0000-0000000000c2";
+const C3: &str = "00000000-0000-0000-0000-0000000000c3";
+const S1: &str = "aaaaaaaa-1111-1111-1111-111111111111";
+const A1: &str = "00000000-0000-0000-0000-0000000000a1";
+const A2: &str = "00000000-0000-0000-0000-0000000000a2";
+const A3: &str = "00000000-0000-0000-0000-0000000000a3";
+const A4: &str = "00000000-0000-0000-0000-0000000000a4";
+const A5: &str = "00000000-0000-0000-0000-0000000000a5";
+const A6: &str = "00000000-0000-0000-0000-0000000000a6";
+
+#[test]
+fn test_both_backends_repair_an_orphaned_namespace_identically() {
+    assert_backends_agree(
+        &Scenario {
+            boards: vec![BoardSpec {
+                id: B1,
+                card_prefix: Some("KAN"),
+            }],
+            columns: vec![ColumnSpec {
+                id: C1,
+                board_id: B1,
+            }],
+            sprints: vec![],
+            prefixes: vec![],
+            cards: vec![
+                CardSpec {
+                    id: A1,
+                    column_id: C1,
+                    board_id: B1,
+                    sprint_id: None,
+                    prefix: "KAN",
+                    number: 7,
+                },
+                CardSpec {
+                    id: A2,
+                    column_id: C1,
+                    board_id: B1,
+                    sprint_id: None,
+                    prefix: "kan",
+                    number: 3,
+                },
+                CardSpec {
+                    id: A3,
+                    column_id: C1,
+                    board_id: B1,
+                    sprint_id: None,
+                    prefix: "ops",
+                    number: 2,
+                },
+            ],
+        },
+        "unbacked namespaces named by several cards with mixed casing",
+    );
+}
+
+#[test]
+fn test_both_backends_stamp_empty_prefix_cards_identically() {
+    assert_backends_agree(
+        &Scenario {
+            boards: vec![
+                BoardSpec {
+                    id: B1,
+                    card_prefix: Some("KAN"),
+                },
+                BoardSpec {
+                    id: B2,
+                    card_prefix: None,
+                },
+            ],
+            columns: vec![
+                ColumnSpec {
+                    id: C1,
+                    board_id: B1,
+                },
+                ColumnSpec {
+                    id: C2,
+                    board_id: B2,
+                },
+            ],
+            sprints: vec![SprintSpec {
+                id: S1,
+                board_id: B1,
+                card_prefix: Some("AUTH"),
+            }],
+            prefixes: vec![],
+            cards: vec![
+                CardSpec {
+                    id: A1,
+                    column_id: C1,
+                    board_id: B1,
+                    sprint_id: None,
+                    prefix: "",
+                    number: 5,
+                },
+                CardSpec {
+                    id: A2,
+                    column_id: C2,
+                    board_id: B2,
+                    sprint_id: None,
+                    prefix: "",
+                    number: 2,
+                },
+                CardSpec {
+                    id: A3,
+                    column_id: C1,
+                    board_id: B1,
+                    sprint_id: Some(S1),
+                    prefix: "",
+                    number: 4,
+                },
+            ],
+        },
+        "empty-prefix cards under a board default, a missing default, and a sprint override",
+    );
+}
+
+#[test]
+fn test_both_backends_raise_a_lagging_namespace_identically() {
+    assert_backends_agree(
+        &Scenario {
+            boards: vec![BoardSpec {
+                id: B1,
+                card_prefix: Some("KAN"),
+            }],
+            columns: vec![ColumnSpec {
+                id: C1,
+                board_id: B1,
+            }],
+            sprints: vec![],
+            prefixes: vec![PrefixSpec {
+                name: "kan",
+                card_counter: 3,
+                sprint_counter: 5,
+            }],
+            cards: vec![CardSpec {
+                id: A1,
+                column_id: C1,
+                board_id: B1,
+                sprint_id: None,
+                prefix: "KAN",
+                number: 9,
+            }],
+        },
+        "a backed namespace whose row lags the card that names it",
+    );
+}
+
+#[test]
+fn test_both_backends_agree_on_the_full_repair_including_row_order() {
+    assert_backends_agree(
+        &Scenario {
+            boards: vec![
+                BoardSpec {
+                    id: B1,
+                    card_prefix: Some("KAN"),
+                },
+                BoardSpec {
+                    id: B2,
+                    card_prefix: Some("ZETA"),
+                },
+                BoardSpec {
+                    id: B3,
+                    card_prefix: None,
+                },
+            ],
+            columns: vec![
+                ColumnSpec {
+                    id: C1,
+                    board_id: B1,
+                },
+                ColumnSpec {
+                    id: C2,
+                    board_id: B2,
+                },
+                ColumnSpec {
+                    id: C3,
+                    board_id: B3,
+                },
+            ],
+            sprints: vec![SprintSpec {
+                id: S1,
+                board_id: B1,
+                card_prefix: Some("AUTH"),
+            }],
+            prefixes: vec![
+                PrefixSpec {
+                    name: "zeta",
+                    card_counter: 4,
+                    sprint_counter: 0,
+                },
+                PrefixSpec {
+                    name: "kan",
+                    card_counter: 3,
+                    sprint_counter: 1,
+                },
+            ],
+            cards: vec![
+                CardSpec {
+                    id: A1,
+                    column_id: C1,
+                    board_id: B1,
+                    sprint_id: None,
+                    prefix: "KAN",
+                    number: 9,
+                },
+                CardSpec {
+                    id: A2,
+                    column_id: C1,
+                    board_id: B1,
+                    sprint_id: None,
+                    prefix: "kan",
+                    number: 4,
+                },
+                CardSpec {
+                    id: A3,
+                    column_id: C2,
+                    board_id: B2,
+                    sprint_id: None,
+                    prefix: "ZETA",
+                    number: 2,
+                },
+                CardSpec {
+                    id: A4,
+                    column_id: C2,
+                    board_id: B2,
+                    sprint_id: None,
+                    prefix: "ops",
+                    number: 6,
+                },
+                CardSpec {
+                    id: A5,
+                    column_id: C3,
+                    board_id: B3,
+                    sprint_id: None,
+                    prefix: "",
+                    number: 3,
+                },
+                CardSpec {
+                    id: A6,
+                    column_id: C1,
+                    board_id: B1,
+                    sprint_id: Some(S1),
+                    prefix: "",
+                    number: 8,
+                },
+            ],
+        },
+        "a full scenario with pre-existing rows stored out of name order",
+    );
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cross_backend_repair_agreement.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/cross_backend_repair_agreement.rs
@@ -173,15 +173,13 @@ async fn seed_v12(scenario: &Scenario, path: &Path) {
         .unwrap();
     }
     for p in &scenario.prefixes {
-        sqlx::query(
-            "INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES (?, ?, ?)",
-        )
-        .bind(p.name)
-        .bind(p.card_counter)
-        .bind(p.sprint_counter)
-        .execute(&pool)
-        .await
-        .unwrap();
+        sqlx::query("INSERT INTO prefixes (name, card_counter, sprint_counter) VALUES (?, ?, ?)")
+            .bind(p.name)
+            .bind(p.card_counter)
+            .bind(p.sprint_counter)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
     for c in &scenario.cards {
         sqlx::query(

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -7,6 +7,7 @@ mod command_log;
 mod composite_indexes;
 mod cross_backend_card_stamp_agreement;
 mod cross_backend_prefix_agreement;
+mod cross_backend_repair_agreement;
 mod empty_prefix_stamp;
 mod entities;
 mod filtered_reads;


### PR DESCRIPTION
## Summary

- Adds `cross_backend_repair_agreement.rs`, driving the SQLite v12->v13 stamp/repair chain and the JSON V17->V18 prefix-row repair over one shared `Scenario`, live and in one process, and asserting the full ordered `prefixes` rows and every card's stamped prefix agree between the two backends.
- Both repairs already route through the same `kanban-domain` functions (`resolve_card_prefix_by_ids`, `counters_implied_by`, `merge_counter_rows`), so name/counter equality was green on arrival for three of the four scenarios; only array ORDER diverged.
- Fixes the divergence: `v18_prefix_rows.rs::repair_unbacked_card_namespaces` now sorts the repaired `prefixes` array by name before returning, matching what SQLite's `list_prefixes` reads (`ORDER BY name ASC`).

## Red evidence

`test_both_backends_agree_on_the_full_repair_including_row_order` failed before the fix:

```
left:  [("auth", 8, 0), ("kan", 9, 1), ("ops", 6, 0), ("task", 3, 0), ("zeta", 4, 0)]
right: [("zeta", 4, 0), ("kan", 9, 1), ("auth", 8, 0), ("ops", 6, 0), ("task", 3, 0)]
```

SQLite reads rows sorted by name; the JSON repair updated existing rows in place and appended new ones, so pre-existing rows stored out of name order stayed out of order.

The other three tests were green on arrival (both repairs derive from the same domain functions), so each was mutation-verified against a deliberately broken repair and confirmed to fail, then the mutation was reverted:

- `test_both_backends_raise_a_lagging_namespace_identically`: made the JSON repair's existing-row branch a no-op (insert-only) -> failed with `kan@3` (json) vs `kan@9` (sqlite).
- `test_both_backends_repair_an_orphaned_namespace_identically`: limited the SQLite `stamped_cards` query to one row -> failed on a missing namespace.
- `test_both_backends_stamp_empty_prefix_cards_identically`: made the JSON stamp step ignore a card's sprint override -> failed on a mismatched stamped prefix for the sprint-scoped card.

## Out-of-scope findings (noted on KAN-1280, not fixed here)

- The general runtime `list_prefixes()` ordering divergence between SQLite (always sorted) and the JSON/in-memory backend (insertion order, re-unsorted after any `upsert_prefix`) is a separate, broader change outside this card's scope.
- SQLite's `ON CONFLICT` never rewrites an existing row's name casing, while the JSON in-memory store normalizes to lowercase on load; no production path can create a non-normalized row today, so this divergence is unreachable and was deliberately not pinned by a test.

## Test plan

- `cargo test -p kanban-persistence-sqlite --all-features cross_backend_repair_agreement`
- `cargo test -p kanban-persistence-json --all-features`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`