### PR TITLE
KAN-1219 feat(domain): LoadState and Resolved for per-entity lazy loading

### DIFF
--- a/.changeset/kan-1219-load-state.md
+++ b/.changeset/kan-1219-load-state.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: internal groundwork so a later release can tell "this list has not been loaded yet" apart from "this list is empty", instead of rendering both the same way.

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -22,12 +22,14 @@ pub mod export;
 pub mod field_update;
 pub mod filter;
 pub mod graph_operations;
+pub mod load_state;
 pub mod operations;
 pub mod prefix;
 pub mod prefix_backfill;
 pub mod prefix_integrity;
 pub mod prefix_resolution;
 pub mod query;
+pub mod resolved;
 pub mod search;
 pub mod snapshot;
 pub mod sort;
@@ -65,6 +67,7 @@ pub use export::{AllBoardsExport, BoardExport, BoardExporter, BoardImporter, Imp
 pub use field_update::FieldUpdate;
 pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
+pub use load_state::LoadState;
 pub use operations::KanbanOperations;
 pub use prefix::{
     allocate_card_number, allocate_sprint_number, effective_card_prefix, effective_prefixes,
@@ -86,6 +89,7 @@ pub use query::{
     },
     ArchivedFilter, BoardListFilter, CardListFilter, CardQueryBuilder,
 };
+pub use resolved::Resolved;
 pub use search::{
     find_boards_by_name, find_cards_by_identifier, find_columns_by_name,
     find_sprints_by_query_global, find_sprints_by_query_on_board, format_ambiguous_matches,

--- a/crates/kanban-domain/src/load_state.rs
+++ b/crates/kanban-domain/src/load_state.rs
@@ -2,12 +2,66 @@ use std::sync::Arc;
 
 use crate::error::KanbanError;
 
-#[derive(Debug)]
+/// Per-entity load status. `NotLoaded` is the only non-terminal state.
+#[derive(Debug, Clone, Default)]
 pub enum LoadState<T> {
+    #[default]
     NotLoaded,
     Loaded(T),
     Missing,
     Failed(Arc<KanbanError>),
+}
+
+impl<T> LoadState<T> {
+    pub fn as_ref(&self) -> LoadState<&T> {
+        match self {
+            LoadState::NotLoaded => LoadState::NotLoaded,
+            LoadState::Loaded(v) => LoadState::Loaded(v),
+            LoadState::Missing => LoadState::Missing,
+            LoadState::Failed(e) => LoadState::Failed(Arc::clone(e)),
+        }
+    }
+
+    pub fn loaded(&self) -> Option<&T> {
+        match self {
+            LoadState::Loaded(v) => Some(v),
+            LoadState::NotLoaded | LoadState::Missing | LoadState::Failed(_) => None,
+        }
+    }
+
+    pub fn is_loaded(&self) -> bool {
+        matches!(self, LoadState::Loaded(_))
+    }
+
+    pub fn is_not_loaded(&self) -> bool {
+        matches!(self, LoadState::NotLoaded)
+    }
+
+    pub fn is_missing(&self) -> bool {
+        matches!(self, LoadState::Missing)
+    }
+
+    pub fn is_failed(&self) -> bool {
+        matches!(self, LoadState::Failed(_))
+    }
+
+    /// True once a fetch has produced a result. Only a non-terminal state is
+    /// requestable by a fetch round.
+    pub fn is_terminal(&self) -> bool {
+        match self {
+            LoadState::NotLoaded => false,
+            LoadState::Loaded(_) | LoadState::Missing | LoadState::Failed(_) => true,
+        }
+    }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> LoadState<U> {
+        match self {
+            LoadState::NotLoaded => LoadState::NotLoaded,
+            LoadState::Loaded(v) => LoadState::Loaded(f(v)),
+            LoadState::Missing => LoadState::Missing,
+            LoadState::Failed(e) => LoadState::Failed(e),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-domain/src/load_state.rs
+++ b/crates/kanban-domain/src/load_state.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+
+use crate::error::KanbanError;
+
+#[derive(Debug)]
+pub enum LoadState<T> {
+    NotLoaded,
+    Loaded(T),
+    Missing,
+    Failed(Arc<KanbanError>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_loadstate_default_is_not_loaded() {
+        let state = LoadState::<u32>::default();
+        assert!(state.is_not_loaded());
+    }
+
+    #[test]
+    fn test_loadstate_loaded_returns_some_via_loaded_accessor() {
+        let state = LoadState::Loaded(5);
+        assert_eq!(state.loaded(), Some(&5));
+    }
+
+    #[test]
+    fn test_loadstate_not_loaded_and_failed_return_none_via_loaded_accessor() {
+        let not_loaded: LoadState<u32> = LoadState::NotLoaded;
+        let failed: LoadState<u32> = LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
+        assert_eq!(not_loaded.loaded(), None);
+        assert_eq!(failed.loaded(), None);
+    }
+
+    #[test]
+    fn test_loadstate_missing_returns_none_via_loaded_accessor() {
+        let missing: LoadState<u32> = LoadState::Missing;
+        assert_eq!(missing.loaded(), None);
+    }
+
+    #[test]
+    fn test_loadstate_is_loaded_is_failed_is_not_loaded_are_mutually_exclusive() {
+        let not_loaded: LoadState<u32> = LoadState::NotLoaded;
+        let loaded: LoadState<u32> = LoadState::Loaded(1);
+        let failed: LoadState<u32> = LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
+
+        assert!(not_loaded.is_not_loaded() && !not_loaded.is_loaded() && !not_loaded.is_failed());
+        assert!(loaded.is_loaded() && !loaded.is_not_loaded() && !loaded.is_failed());
+        assert!(failed.is_failed() && !failed.is_loaded() && !failed.is_not_loaded());
+    }
+
+    #[test]
+    fn test_loadstate_missing_is_missing_and_not_the_other_three_variants() {
+        let missing: LoadState<u32> = LoadState::Missing;
+        assert!(missing.is_missing());
+        assert!(!missing.is_loaded() && !missing.is_not_loaded() && !missing.is_failed());
+    }
+
+    #[test]
+    fn test_loadstate_map_transforms_loaded_value_only() {
+        let loaded: LoadState<i32> = LoadState::Loaded(2);
+        assert!(matches!(loaded.map(|x| x * 2), LoadState::Loaded(4)));
+
+        let not_loaded: LoadState<i32> = LoadState::NotLoaded;
+        assert!(not_loaded.map(|x| x * 2).is_not_loaded());
+
+        let failed: LoadState<i32> = LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
+        assert!(failed.map(|x| x * 2).is_failed());
+    }
+
+    #[test]
+    fn test_loadstate_map_preserves_missing_without_invoking_closure() {
+        let missing: LoadState<i32> = LoadState::Missing;
+        let mapped = missing.map(|x| -> i32 {
+            panic!("map must not invoke its closure on Missing, got {x}");
+        });
+        assert!(mapped.is_missing());
+    }
+
+    #[test]
+    fn test_loadstate_failed_arc_clone_is_cheap_and_shares_the_same_error() {
+        let state: LoadState<u32> = LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
+        let cloned = state.clone();
+
+        match (&state, &cloned) {
+            (LoadState::Failed(a), LoadState::Failed(b)) => assert!(Arc::ptr_eq(a, b)),
+            _ => panic!("expected Failed variant"),
+        }
+    }
+
+    #[test]
+    fn test_loadstate_as_ref_preserves_variant() {
+        let loaded: LoadState<u32> = LoadState::Loaded(7);
+        assert!(matches!(loaded.as_ref(), LoadState::Loaded(v) if *v == 7));
+
+        let not_loaded: LoadState<u32> = LoadState::NotLoaded;
+        assert!(not_loaded.as_ref().is_not_loaded());
+
+        let failed: LoadState<u32> = LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
+        match (&failed, failed.as_ref()) {
+            (LoadState::Failed(a), LoadState::Failed(b)) => assert!(Arc::ptr_eq(a, &b)),
+            _ => panic!("expected Failed variant"),
+        }
+    }
+
+    #[test]
+    fn test_loadstate_as_ref_preserves_missing_variant() {
+        let missing: LoadState<u32> = LoadState::Missing;
+        assert!(missing.as_ref().is_missing());
+    }
+
+    #[test]
+    fn test_loadstate_only_not_loaded_is_non_terminal() {
+        let not_loaded: LoadState<u32> = LoadState::NotLoaded;
+        let loaded: LoadState<u32> = LoadState::Loaded(1);
+        let missing: LoadState<u32> = LoadState::Missing;
+        let failed: LoadState<u32> = LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
+
+        assert!(!not_loaded.is_terminal());
+        assert!(loaded.is_terminal());
+        assert!(missing.is_terminal());
+        assert!(failed.is_terminal());
+    }
+}
+
+#[cfg(test)]
+mod design_validation {
+    use super::*;
+    use crate::card::Card;
+
+    #[derive(Clone)]
+    struct Holder {
+        #[allow(dead_code)]
+        cards: LoadState<Vec<Card>>,
+    }
+
+    #[test]
+    fn test_struct_holding_loadstate_can_derive_clone() {
+        let holder = Holder {
+            cards: LoadState::NotLoaded,
+        };
+        let _cloned = holder.clone();
+    }
+}

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -1,0 +1,60 @@
+pub struct Resolved {}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::error::KanbanError;
+    use crate::load_state::LoadState;
+
+    #[test]
+    fn test_resolved_default_mentions_no_entity_kind() {
+        let resolved = Resolved::default();
+        assert!(resolved.boards.is_not_loaded());
+        assert!(resolved.graph.is_not_loaded());
+        assert!(resolved.columns.is_empty());
+        assert!(resolved.cards.is_empty());
+        assert!(resolved.sprints.is_empty());
+    }
+
+    #[test]
+    fn test_resolved_distinguishes_a_loaded_empty_board_list_from_an_unmentioned_one() {
+        let loaded_empty = Resolved {
+            boards: LoadState::Loaded(vec![]),
+            ..Default::default()
+        };
+        assert!(loaded_empty.boards.is_loaded());
+        assert!(loaded_empty.boards.loaded().unwrap().is_empty());
+
+        let unmentioned = Resolved::default();
+        assert!(unmentioned.boards.is_not_loaded());
+    }
+
+    #[test]
+    fn test_resolved_carries_per_entity_missing_for_a_card_the_backend_did_not_have() {
+        let id = Uuid::new_v4();
+        let mut resolved = Resolved::default();
+        resolved.cards.insert(id, LoadState::Missing);
+
+        assert!(resolved.cards[&id].is_missing());
+        assert!(resolved.cards[&id].is_terminal());
+    }
+
+    #[test]
+    fn test_resolved_clone_shares_the_same_failed_error() {
+        let id = Uuid::new_v4();
+        let mut resolved = Resolved::default();
+        resolved
+            .cards
+            .insert(id, LoadState::Failed(Arc::new(KanbanError::unsupported("x"))));
+
+        let cloned = resolved.clone();
+        match (&resolved.cards[&id], &cloned.cards[&id]) {
+            (LoadState::Failed(a), LoadState::Failed(b)) => assert!(Arc::ptr_eq(a, b)),
+            _ => panic!("expected Failed variant"),
+        }
+    }
+}

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -1,4 +1,25 @@
-pub struct Resolved {}
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use crate::board::Board;
+use crate::card::Card;
+use crate::column::Column;
+use crate::dependencies::DependencyGraph;
+use crate::load_state::LoadState;
+use crate::sprint::Sprint;
+
+/// The outcome of one resolve pass. A `NotLoaded` field or an absent map key
+/// means the pass did not touch that entity, and applying the result must
+/// leave it as it was.
+#[derive(Debug, Clone, Default)]
+pub struct Resolved {
+    pub boards: LoadState<Vec<Board>>,
+    pub graph: LoadState<DependencyGraph>,
+    pub columns: HashMap<Uuid, LoadState<Column>>,
+    pub cards: HashMap<Uuid, LoadState<Card>>,
+    pub sprints: HashMap<Uuid, LoadState<Sprint>>,
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -68,9 +68,10 @@ mod tests {
     fn test_resolved_clone_shares_the_same_failed_error() {
         let id = Uuid::new_v4();
         let mut resolved = Resolved::default();
-        resolved
-            .cards
-            .insert(id, LoadState::Failed(Arc::new(KanbanError::unsupported("x"))));
+        resolved.cards.insert(
+            id,
+            LoadState::Failed(Arc::new(KanbanError::unsupported("x"))),
+        );
 
         let cloned = resolved.clone();
         match (&resolved.cards[&id], &cloned.cards[&id]) {


### PR DESCRIPTION
## Summary

- Adds `LoadState<T>` to kanban-domain: a four-state per-entity load status (`NotLoaded` / `Loaded(T)` / `Missing` / `Failed(Arc<KanbanError>)`) that distinguishes "not fetched" from "fetched and empty" and "fetched but the backend does not have it".
- Adds `Resolved` to kanban-domain: the payload one `EntityCache::resolve` pass returns, carrying whole-collection `LoadState` for boards and the dependency graph plus per-id `HashMap<Uuid, LoadState<T>>` maps for columns, cards, and sprints.
- Both types are re-exported at the crate root and are purely additive with zero consumers outside kanban-domain, so the change is inert everywhere else in the workspace.

## Test plan

- [x] `cargo test -p kanban-domain --lib` — 17 new tests pass (13 for `LoadState`, 4 for `Resolved`), full crate suite green (554 tests)
- [x] `cargo test --workspace` — green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace --all-targets` — proves the addition is inert outside kanban-domain
- [x] `git grep` confirms zero consumers of `LoadState`/`Resolved` outside kanban-domain (aside from two pre-existing unrelated comment hits in kanban-tui)
- [x] Mutation check on `is_terminal`: flipped `NotLoaded => false` to `true`, confirmed `test_loadstate_only_not_loaded_is_non_terminal` failed, reverted