### PR TITLE
KAN-1220 feat(tui): a structured read-op log on CountingBackend

### DIFF
--- a/.changeset/kan-1220-read-op-recorder.md
+++ b/.changeset/kan-1220-read-op-recorder.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: internal test infrastructure so the suite can assert which entities a screen actually read from storage, not just how many reads happened.

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -7,7 +7,7 @@ use kanban_tui::App;
 use std::sync::atomic::Ordering;
 
 fn wrap_backend(app: &mut App) -> std::sync::Arc<std::sync::atomic::AtomicUsize> {
-    let (backend, reads) = CountingBackend::wrap(app.ctx.backend());
+    let (backend, reads, _ops) = CountingBackend::wrap(app.ctx.backend());
     app.ctx.replace_backend(backend);
     reads
 }

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -10,8 +10,31 @@ use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::app::ExportDialogState;
 use kanban_tui::App;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use uuid::Uuid;
+
+/// One recorded store read: which method was called, and the id(s) it was
+/// called with. Empty for collection-shaped reads such as `list_boards`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadOp {
+    pub method: &'static str,
+    pub ids: Vec<Uuid>,
+}
+
+pub type ReadOpLog = Arc<Mutex<Vec<ReadOp>>>;
+
+pub type WrappedBackend = (Arc<dyn KanbanBackend>, Arc<AtomicUsize>, ReadOpLog);
+
+/// Asserts `log` holds exactly `expected`, in order. A log that is a strict
+/// superset or subset of `expected` fails.
+pub fn assert_ops(log: &Mutex<Vec<ReadOp>>, expected: &[ReadOp]) {
+    let actual = log.lock().unwrap().clone();
+    assert_eq!(
+        actual.as_slice(),
+        expected,
+        "read op log mismatch\n  expected: {expected:?}\n  actual:   {actual:?}"
+    );
+}
 
 /// A `KanbanBackend` decorator that counts every DataStore/CommandStore READ
 /// method invoked, delegating all reads and writes verbatim to `inner`.
@@ -20,41 +43,45 @@ use uuid::Uuid;
 pub struct CountingBackend {
     inner: Arc<dyn KanbanBackend>,
     reads: Arc<AtomicUsize>,
+    ops: ReadOpLog,
 }
 
 impl CountingBackend {
-    pub fn wrap(inner: Arc<dyn KanbanBackend>) -> (Arc<dyn KanbanBackend>, Arc<AtomicUsize>) {
+    pub fn wrap(inner: Arc<dyn KanbanBackend>) -> WrappedBackend {
         let reads = Arc::new(AtomicUsize::new(0));
+        let ops: ReadOpLog = Arc::new(Mutex::new(Vec::new()));
         let backend: Arc<dyn KanbanBackend> = Arc::new(Self {
             inner,
             reads: reads.clone(),
+            ops: ops.clone(),
         });
-        (backend, reads)
+        (backend, reads, ops)
     }
 
-    fn record(&self) {
+    fn record(&self, method: &'static str, ids: Vec<Uuid>) {
         self.reads.fetch_add(1, Ordering::SeqCst);
+        self.ops.lock().unwrap().push(ReadOp { method, ids });
     }
 }
 
 impl DataStore for CountingBackend {
     fn get_prefix(&self, name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
-        self.record();
+        self.record("get_prefix", vec![]);
         self.inner.get_prefix(name)
     }
     fn list_prefixes(&self) -> KanbanResult<Vec<kanban_domain::Prefix>> {
-        self.record();
+        self.record("list_prefixes", vec![]);
         self.inner.list_prefixes()
     }
     fn upsert_prefix(&self, prefix: kanban_domain::Prefix) -> KanbanResult<()> {
         self.inner.upsert_prefix(prefix)
     }
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
-        self.record();
+        self.record("get_board", vec![id]);
         self.inner.get_board(id)
     }
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
-        self.record();
+        self.record("list_boards", vec![]);
         self.inner.list_boards()
     }
     fn upsert_board(&self, board: Board) -> KanbanResult<()> {
@@ -64,15 +91,15 @@ impl DataStore for CountingBackend {
         self.inner.delete_board(id)
     }
     fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
-        self.record();
+        self.record("get_column", vec![id]);
         self.inner.get_column(id)
     }
     fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
-        self.record();
+        self.record("list_columns_by_board", vec![board_id]);
         self.inner.list_columns_by_board(board_id)
     }
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
-        self.record();
+        self.record("list_all_columns", vec![]);
         self.inner.list_all_columns()
     }
     fn upsert_column(&self, column: Column) -> KanbanResult<()> {
@@ -85,23 +112,23 @@ impl DataStore for CountingBackend {
         self.inner.delete_columns_by_board(board_id)
     }
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
-        self.record();
+        self.record("get_card", vec![id]);
         self.inner.get_card(id)
     }
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
-        self.record();
+        self.record("list_all_cards", vec![]);
         self.inner.list_all_cards()
     }
     fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
-        self.record();
+        self.record("list_cards_by_column", vec![column_id]);
         self.inner.list_cards_by_column(column_id)
     }
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
-        self.record();
+        self.record("list_cards_by_sprint", vec![sprint_id]);
         self.inner.list_cards_by_sprint(sprint_id)
     }
     fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
-        self.record();
+        self.record("list_cards_by_columns", column_ids.to_vec());
         self.inner.list_cards_by_columns(column_ids)
     }
     fn list_cards_by_column_filtered(
@@ -109,12 +136,12 @@ impl DataStore for CountingBackend {
         column_id: Uuid,
         archived: kanban_domain::ArchivedFilter,
     ) -> KanbanResult<Vec<Card>> {
-        self.record();
+        self.record("list_cards_by_column_filtered", vec![column_id]);
         self.inner
             .list_cards_by_column_filtered(column_id, archived)
     }
     fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
-        self.record();
+        self.record("count_cards_in_column", vec![column_id]);
         self.inner.count_cards_in_column(column_id)
     }
     fn count_cards_in_column_filtered(
@@ -122,7 +149,7 @@ impl DataStore for CountingBackend {
         column_id: Uuid,
         archived: kanban_domain::ArchivedFilter,
     ) -> KanbanResult<usize> {
-        self.record();
+        self.record("count_cards_in_column_filtered", vec![column_id]);
         self.inner
             .count_cards_in_column_filtered(column_id, archived)
     }
@@ -131,7 +158,7 @@ impl DataStore for CountingBackend {
         column_id: Uuid,
         exclude_ids: &[Uuid],
     ) -> KanbanResult<usize> {
-        self.record();
+        self.record("count_cards_in_column_excluding", vec![column_id]);
         self.inner
             .count_cards_in_column_excluding(column_id, exclude_ids)
     }
@@ -152,15 +179,15 @@ impl DataStore for CountingBackend {
         self.inner.clear_sprint_from_cards(sprint_id, cleared_at)
     }
     fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
-        self.record();
+        self.record("get_archived_card", vec![card_id]);
         self.inner.get_archived_card(card_id)
     }
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
-        self.record();
+        self.record("list_archived_cards", vec![]);
         self.inner.list_archived_cards()
     }
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
-        self.record();
+        self.record("list_archived_cards_by_board", vec![board_id]);
         self.inner.list_archived_cards_by_board(board_id)
     }
     fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
@@ -178,11 +205,11 @@ impl DataStore for CountingBackend {
             .clear_sprint_from_archived_cards(sprint_id, cleared_at)
     }
     fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
-        self.record();
+        self.record("get_archived_board", vec![board_id]);
         self.inner.get_archived_board(board_id)
     }
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
-        self.record();
+        self.record("list_archived_boards", vec![]);
         self.inner.list_archived_boards()
     }
     fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
@@ -195,15 +222,15 @@ impl DataStore for CountingBackend {
         self.inner.unarchive_board(board_id)
     }
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
-        self.record();
+        self.record("get_sprint", vec![id]);
         self.inner.get_sprint(id)
     }
     fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
-        self.record();
+        self.record("list_sprints_by_board", vec![board_id]);
         self.inner.list_sprints_by_board(board_id)
     }
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
-        self.record();
+        self.record("list_all_sprints", vec![]);
         self.inner.list_all_sprints()
     }
     fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
@@ -216,18 +243,18 @@ impl DataStore for CountingBackend {
         self.inner.delete_sprints_by_board(board_id)
     }
     fn get_graph(&self) -> KanbanResult<DependencyGraph> {
-        self.record();
+        self.record("get_graph", vec![]);
         self.inner.get_graph()
     }
     fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
         self.inner.set_graph(graph)
     }
     fn modify_graph(&self, f: kanban_domain::GraphMutFn) -> KanbanResult<()> {
-        self.record();
+        self.record("modify_graph", vec![]);
         self.inner.modify_graph(f)
     }
     fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.record();
+        self.record("snapshot", vec![]);
         self.inner.snapshot()
     }
     fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
@@ -240,11 +267,11 @@ impl CommandStore for CountingBackend {
         self.inner.append_batch(batch)
     }
     fn batch_count(&self) -> KanbanResult<u64> {
-        self.record();
+        self.record("batch_count", vec![]);
         self.inner.batch_count()
     }
     fn load_batches(&self, offset: u64, limit: u64) -> KanbanResult<Vec<CommandBatch>> {
-        self.record();
+        self.record("load_batches", vec![]);
         self.inner.load_batches(offset, limit)
     }
 }

--- a/crates/kanban-tui/tests/read_op_log_tests.rs
+++ b/crates/kanban-tui/tests/read_op_log_tests.rs
@@ -1,0 +1,166 @@
+mod helpers;
+
+use helpers::{assert_ops, CountingBackend, ReadOp};
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::{Board, Card, Column, DataStore};
+use std::sync::Arc;
+use uuid::Uuid;
+
+fn seeded_store() -> (Arc<InMemoryStore>, Uuid, Uuid) {
+    let store = Arc::new(InMemoryStore::new());
+    let board_a = Board::new("Board A", None::<String>);
+    let board_b = Board::new("Board B", None::<String>);
+    let column = Column::new(board_a.id, "Todo", 0);
+    let card = Card::new(board_a.id, column.id, "Card A", 0);
+    let (board_a_id, card_id) = (board_a.id, card.id);
+    store.upsert_board(board_a).unwrap();
+    store.upsert_board(board_b).unwrap();
+    store.upsert_column(column).unwrap();
+    store.upsert_card(card).unwrap();
+    (store, board_a_id, card_id)
+}
+
+#[test]
+fn test_read_op_log_records_get_card_with_its_id() {
+    let (store, _board_id, card_id) = seeded_store();
+    let (backend, _reads, ops) = CountingBackend::wrap(store);
+
+    backend.as_data_store().get_card(card_id).unwrap();
+
+    assert_ops(
+        &ops,
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![card_id],
+        }],
+    );
+}
+
+#[test]
+fn test_read_op_log_records_collection_reads_with_empty_ids() {
+    let (store, _board_id, _card_id) = seeded_store();
+    let (backend, _reads, ops) = CountingBackend::wrap(store);
+
+    backend.as_data_store().list_boards().unwrap();
+
+    assert_ops(
+        &ops,
+        &[ReadOp {
+            method: "list_boards",
+            ids: vec![],
+        }],
+    );
+}
+
+#[test]
+fn test_read_op_log_preserves_call_order() {
+    let (store, _board_id, card_id) = seeded_store();
+    let (backend, _reads, ops) = CountingBackend::wrap(store);
+
+    backend.as_data_store().get_card(card_id).unwrap();
+    backend.as_data_store().list_boards().unwrap();
+
+    assert_ops(
+        &ops,
+        &[
+            ReadOp {
+                method: "get_card",
+                ids: vec![card_id],
+            },
+            ReadOp {
+                method: "list_boards",
+                ids: vec![],
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_read_op_log_ignores_writes() {
+    let (store, board_id, card_id) = seeded_store();
+    let (backend, _reads, ops) = CountingBackend::wrap(store);
+
+    let card = Card::new(board_id, Uuid::new_v4(), "Card B", 1);
+    backend.as_data_store().upsert_card(card).unwrap();
+    backend.as_data_store().delete_card(card_id).unwrap();
+
+    assert_ops(&ops, &[]);
+}
+
+#[test]
+fn test_assert_ops_accepts_an_exactly_matching_log() {
+    let (store, _board_id, card_id) = seeded_store();
+    let (backend, _reads, ops) = CountingBackend::wrap(store);
+
+    backend.as_data_store().get_card(card_id).unwrap();
+
+    assert_ops(
+        &ops,
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![card_id],
+        }],
+    );
+}
+
+#[test]
+fn test_assert_ops_rejects_an_unexpected_extra_op() {
+    let (store, _board_id, card_id) = seeded_store();
+    let (backend, _reads, ops) = CountingBackend::wrap(store);
+
+    backend.as_data_store().get_card(card_id).unwrap();
+    backend.as_data_store().list_boards().unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_ops(
+            &ops,
+            &[ReadOp {
+                method: "get_card",
+                ids: vec![card_id],
+            }],
+        );
+    }));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_assert_ops_rejects_a_missing_expected_op() {
+    let (store, _board_id, card_id) = seeded_store();
+    let (backend, _reads, ops) = CountingBackend::wrap(store);
+
+    backend.as_data_store().get_card(card_id).unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_ops(
+            &ops,
+            &[
+                ReadOp {
+                    method: "get_card",
+                    ids: vec![card_id],
+                },
+                ReadOp {
+                    method: "list_boards",
+                    ids: vec![],
+                },
+            ],
+        );
+    }));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_counting_backend_counter_still_counts_every_recorded_read() {
+    use std::sync::atomic::Ordering;
+
+    let (store, board_id, card_id) = seeded_store();
+    let (backend, reads, _ops) = CountingBackend::wrap(store);
+
+    backend.as_data_store().get_card(card_id).unwrap();
+    backend.as_data_store().list_boards().unwrap();
+    let card = Card::new(board_id, Uuid::new_v4(), "Card C", 2);
+    backend.as_data_store().upsert_card(card).unwrap();
+
+    assert_eq!(reads.load(Ordering::SeqCst), 2);
+}


### PR DESCRIPTION
## Summary
- Upgrades `CountingBackend` (test-only, `crates/kanban-tui/tests/helpers.rs`) from a bare `Arc<AtomicUsize>` counter into a structured `ReadOp { method, ids }` log recorded alongside the counter
- Adds `assert_ops`, an exact ordered-match helper so tests can assert "exactly these entities were read, in this order, and nothing else"
- All 29 existing `self.record()` call sites are converted to pass the enclosing method's name and the id(s) it was called with; collection-shaped reads record an empty `ids` vec
- `CountingBackend::wrap` now returns a 3-tuple; the counter stays the second element with unchanged semantics
- `SnapshotCountingBackend` is untouched

This is entirely test infrastructure for epic KAN-1218 (lazy per-entity model loading); no production crate is touched.

## Test plan
- [x] `cargo test -p kanban-tui --test read_op_log_tests`, 8 new tests pass
- [x] `cargo test -p kanban-tui --test frame_reload_tests`, all pre-existing assertions unchanged and green
- [x] `cargo test -p kanban-tui --test '*'`, full kanban-tui test suite green
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: weakened `assert_ops` to a `contains`-based match, confirmed `test_assert_ops_rejects_an_unexpected_extra_op` fails, reverted
