### PR TITLE
KAN-1231 test(tui): pin zero-read navigation and single-read cold start

### DIFF
--- a/.changeset/kan-1231-navigation-no-reload.md
+++ b/.changeset/kan-1231-navigation-no-reload.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: starting the TUI now reads the workspace once instead of twice, and navigation, scrolling and selection keys are permanently held to zero store reads by a keybinding-level regression guard.

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -148,7 +148,7 @@ impl App {
         }
     }
 
-    pub(in crate::app) fn execute_action(&mut self, action: &crate::keybindings::KeybindingAction) {
+    pub fn execute_action(&mut self, action: &crate::keybindings::KeybindingAction) {
         use crate::keybindings::KeybindingAction;
         use crossterm::event::KeyCode;
 

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -16,19 +16,26 @@ impl App {
     pub async fn load_initial_state(&mut self) {
         // Trigger the lazy data load eagerly so file errors are caught here.
         // On error, clear save_file to avoid writing back to a broken file.
-        if let Err(e) = self.ctx.snapshot() {
-            tracing::warn!("Failed to load initial state from file: {e}");
-            self.persistence.save_file = None;
-            self.set_error(format!("Failed to read data file: {e}"));
-            return;
-        }
-        self.migrate_sprint_logs();
+        let snapshot = match self.ctx.snapshot() {
+            Ok(snapshot) => snapshot,
+            Err(e) => {
+                tracing::warn!("Failed to load initial state from file: {e}");
+                self.persistence.save_file = None;
+                self.set_error(format!("Failed to read data file: {e}"));
+                return;
+            }
+        };
+        let migrated = self.migrate_sprint_logs();
         // Migration is a transparent startup operation, not a user change.
         // mark_clean so the startup flush doesn't trigger the conflict popup.
         self.ctx.mark_clean();
         // `prepare_frame` resyncs `board_list`, which auto-selects the first
         // board when none was previously highlighted and boards exist.
-        self.reload_model();
+        if migrated > 0 {
+            self.reload_model();
+        } else {
+            self.model.load_from_snapshot(snapshot);
+        }
         self.prepare_frame();
         self.check_ended_sprints();
     }

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -29,9 +29,13 @@ impl App {
         }
     }
 
-    pub(in crate::app) fn migrate_sprint_logs(&mut self) {
-        if let Err(e) = self.ctx.migrate_sprint_logs() {
-            tracing::error!("Failed to migrate sprint logs: {}", e);
+    pub(in crate::app) fn migrate_sprint_logs(&mut self) -> usize {
+        match self.ctx.migrate_sprint_logs() {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::error!("Failed to migrate sprint logs: {}", e);
+                0
+            }
         }
     }
 }

--- a/crates/kanban-tui/tests/cold_start_reload_tests.rs
+++ b/crates/kanban-tui/tests/cold_start_reload_tests.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering;
 #[tokio::test]
 async fn test_cold_start_reads_the_whole_workspace_once() {
     let dir = tempfile::tempdir().unwrap();
-    let path = create_test_json_file(&dir.path(), "source.json", &["Board"]).await;
+    let path = create_test_json_file(dir.path(), "source.json", &["Board"]).await;
     let (mut app, _rx) = App::new(Some(path)).await.unwrap();
 
     let (backend, snapshot_reads) = SnapshotCountingBackend::wrap(app.ctx.backend());

--- a/crates/kanban-tui/tests/cold_start_reload_tests.rs
+++ b/crates/kanban-tui/tests/cold_start_reload_tests.rs
@@ -1,0 +1,77 @@
+mod helpers;
+
+use helpers::{create_test_json_file, SnapshotCountingBackend};
+use kanban_domain::{Column, Snapshot, Sprint};
+use kanban_tui::App;
+use std::sync::atomic::Ordering;
+
+#[tokio::test]
+async fn test_cold_start_reads_the_whole_workspace_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = create_test_json_file(&dir.path(), "source.json", &["Board"]).await;
+    let (mut app, _rx) = App::new(Some(path)).await.unwrap();
+
+    let (backend, snapshot_reads) = SnapshotCountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+
+    app.load_initial_state().await;
+
+    assert_eq!(
+        snapshot_reads.load(Ordering::SeqCst),
+        1,
+        "cold start must read the whole workspace exactly once"
+    );
+    let board_present = app.model.boards().iter().any(|b| b.name == "Board");
+    assert!(board_present, "the model must reflect the seeded board");
+}
+
+#[tokio::test]
+async fn test_cold_start_after_a_sprint_log_migration_loads_the_migrated_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("migrate.json");
+    let path_str = path.to_str().unwrap().to_string();
+
+    let store = kanban_persistence_json::JsonFileStore::new(&path_str);
+    let board = kanban_domain::Board::new("Board".to_string(), None::<String>);
+    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+    let mut card = kanban_domain::Card::new(board.id, column.id, "Card".to_string(), 0);
+    card.sprint_id = Some(sprint.id);
+    assert!(
+        card.sprint_logs.is_empty(),
+        "precondition: seeded card has no sprint log yet"
+    );
+
+    let snapshot = Snapshot {
+        archived_boards: Vec::new(),
+        boards: vec![board],
+        columns: vec![column],
+        cards: vec![card.clone()],
+        archived_cards: vec![],
+        sprints: vec![sprint],
+        graph: Default::default(),
+        prefixes: Vec::new(),
+    };
+
+    use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
+    let store_snapshot = StoreSnapshot {
+        data: serde_json::to_vec(&snapshot).unwrap(),
+        metadata: PersistenceMetadata::new(store.instance_id()),
+    };
+    store.save(store_snapshot).await.unwrap();
+
+    let (mut app, _rx) = App::new(Some(path_str)).await.unwrap();
+    app.load_initial_state().await;
+
+    let migrated_log_present = app
+        .model
+        .all_cards()
+        .iter()
+        .find(|c| c.id == card.id)
+        .map(|c| !c.sprint_logs.is_empty())
+        .unwrap_or(false);
+    assert!(
+        migrated_log_present,
+        "cold start must serve the migrated sprint log, not the stale pre-migration probe snapshot"
+    );
+}

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -1,6 +1,6 @@
 mod helpers;
 
-use helpers::CountingBackend;
+use helpers::{assert_ops, CountingBackend, ReadOpLog};
 use kanban_domain::KanbanOperations;
 use kanban_tui::app::focus::Focus;
 use kanban_tui::App;
@@ -10,6 +10,12 @@ fn wrap_backend(app: &mut App) -> std::sync::Arc<std::sync::atomic::AtomicUsize>
     let (backend, reads, _ops) = CountingBackend::wrap(app.ctx.backend());
     app.ctx.replace_backend(backend);
     reads
+}
+
+fn wrap_backend_with_ops(app: &mut App) -> ReadOpLog {
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+    ops
 }
 
 #[test]
@@ -52,7 +58,7 @@ fn test_navigation_performs_no_store_reads() {
     app.reload_model();
     app.prepare_frame();
 
-    let reads = wrap_backend(&mut app);
+    let ops = wrap_backend_with_ops(&mut app);
 
     app.focus.active = Focus::Boards;
     app.handle_selection_activate();
@@ -65,12 +71,20 @@ fn test_navigation_performs_no_store_reads() {
     app.handle_jump_to_bottom();
     app.handle_toggle_archived_boards_view();
     app.handle_toggle_archived_boards_view();
+    app.handle_escape_key();
+    app.handle_column_or_focus_switch(0);
+    app.handle_column_or_focus_switch(1);
+    app.handle_jump_half_viewport_up();
+    app.handle_jump_half_viewport_down();
+    app.handle_focus_switch(Focus::Cards);
+    app.handle_selection_activate();
+    app.handle_toggle_archived_cards_view();
+    app.handle_toggle_archived_cards_view();
+    app.handle_card_selection_toggle();
+    app.handle_clear_card_selection();
+    app.handle_select_all_cards_in_view();
 
-    assert_eq!(
-        reads.load(Ordering::SeqCst),
-        0,
-        "pure navigation must not touch the store"
-    );
+    assert_ops(&ops, &[]);
 }
 
 #[test]

--- a/crates/kanban-tui/tests/keybinding_store_io_tests.rs
+++ b/crates/kanban-tui/tests/keybinding_store_io_tests.rs
@@ -1,0 +1,150 @@
+mod helpers;
+
+use helpers::{assert_ops, CountingBackend};
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::keybindings::{KeybindingAction, KeybindingRegistry};
+use kanban_tui::App;
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Purity {
+    Pure,
+    Mutating,
+}
+
+fn classify(action: &KeybindingAction) -> Purity {
+    use KeybindingAction::*;
+    match action {
+        NavigateDown | NavigateUp | NavigateLeft | NavigateRight | SelectItem | Escape
+        | FocusPanel(_) | JumpToTop | JumpToBottom | JumpHalfViewportUp | JumpHalfViewportDown
+        | ToggleArchivedView | ToggleArchivedBoardsView | ToggleCardSelection
+        | ClearCardSelection | SelectAllCards | ShowHelp | EditCard | Search => Purity::Pure,
+
+        CreateCard | CreateBoard | CreateSprint | CreateColumn | RenameBoard | RenameColumn
+        | SetColumnDefaultStatus | EditBoard | ToggleCompletion | AssignToSprint | ArchiveCard
+        | RestoreCard | DeleteCard | MoveCardLeft | MoveCardRight | MoveColumnUp
+        | MoveColumnDown | DeleteColumn | DeleteBoard | ExportBoard | ExportAll | ImportBoard
+        | OrderCards | OrderBoards | ToggleSortOrder | ToggleFilter | ToggleHideAssigned
+        | RestoreBoard | DeleteArchivedBoard | ToggleBoardsSortOrder | ToggleTaskListView
+        | SetCardPriority | SetSelectedCardsPriority | ManageParents | ManageChildren
+        | CarryOver | Undo | Redo | OpenSettings | ExportBoards | CopyBranchName
+        | CopyGitCheckoutCommand | ConfirmPrefixCollision | RejectPrefixCollision
+        | CancelPrefixCollision | ForceOverwriteConflict | TakeTheirsConflict
+        | CancelConflictResolution | ReloadDiscardLocal | KeepLocalChanges
+        | DismissExternalChange => Purity::Mutating,
+    }
+}
+
+fn seeded_app() -> App {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    for i in 0..3 {
+        app.ctx
+            .create_card(
+                board.id,
+                column.id,
+                format!("Card {i}"),
+                kanban_domain::CreateCardOptions::default(),
+            )
+            .unwrap();
+    }
+    app.reload_model();
+    app.prepare_frame();
+    app.selection.active_board_id = Some(board.id);
+    app
+}
+
+fn advertised_actions_for(app: &App) -> Vec<KeybindingAction> {
+    KeybindingRegistry::get_provider(app)
+        .get_context()
+        .bindings
+        .into_iter()
+        .map(|b| b.action)
+        .collect()
+}
+
+fn advertised_actions() -> Vec<(&'static str, Vec<KeybindingAction>)> {
+    let mut normal_boards = seeded_app();
+    normal_boards.mode = AppMode::Normal;
+    normal_boards.focus.active = kanban_tui::app::focus::Focus::Boards;
+
+    let mut normal_cards = seeded_app();
+    normal_cards.mode = AppMode::Normal;
+    normal_cards.focus.active = kanban_tui::app::focus::Focus::Cards;
+
+    let mut archived_boards = seeded_app();
+    archived_boards.mode = AppMode::ArchivedBoardsView;
+    archived_boards.focus.active = kanban_tui::app::focus::Focus::Boards;
+
+    let mut archived_cards = seeded_app();
+    archived_cards.mode = AppMode::ArchivedCardsView;
+
+    vec![
+        ("Normal/Boards", advertised_actions_for(&normal_boards)),
+        ("Normal/Cards", advertised_actions_for(&normal_cards)),
+        (
+            "ArchivedBoardsView",
+            advertised_actions_for(&archived_boards),
+        ),
+        ("ArchivedCardsView", advertised_actions_for(&archived_cards)),
+    ]
+}
+
+#[test]
+fn test_every_advertised_keybinding_action_is_classified() {
+    let modes = advertised_actions();
+    for (mode, actions) in &modes {
+        assert!(
+            !actions.is_empty(),
+            "mode {mode} advertised zero keybindings; a provider regression can silently hide this"
+        );
+        for action in actions {
+            let _ = classify(action);
+        }
+    }
+}
+
+#[test]
+fn test_every_advertised_navigation_keybinding_performs_no_store_reads() {
+    let modes = advertised_actions();
+    let mut seen: HashSet<&'static str> = HashSet::new();
+    for (mode, actions) in &modes {
+        for action in actions {
+            if classify(action) != Purity::Pure {
+                continue;
+            }
+            let key = match action {
+                KeybindingAction::FocusPanel(n) => {
+                    Box::leak(format!("FocusPanel({n})").into_boxed_str()) as &str
+                }
+                other => Box::leak(format!("{other:?}").into_boxed_str()) as &str,
+            };
+            if !seen.insert(key) {
+                continue;
+            }
+
+            let mut app = seeded_app();
+            match *mode {
+                "Normal/Cards" => app.focus.active = kanban_tui::app::focus::Focus::Cards,
+                "ArchivedBoardsView" => app.mode = AppMode::ArchivedBoardsView,
+                "ArchivedCardsView" => app.mode = AppMode::ArchivedCardsView,
+                _ => {}
+            }
+
+            let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+            app.ctx.replace_backend(backend);
+
+            app.execute_action(action);
+
+            assert_ops(
+                &ops,
+                &[],
+            );
+        }
+    }
+}

--- a/crates/kanban-tui/tests/keybinding_store_io_tests.rs
+++ b/crates/kanban-tui/tests/keybinding_store_io_tests.rs
@@ -16,22 +16,76 @@ enum Purity {
 fn classify(action: &KeybindingAction) -> Purity {
     use KeybindingAction::*;
     match action {
-        NavigateDown | NavigateUp | NavigateLeft | NavigateRight | SelectItem | Escape
-        | FocusPanel(_) | JumpToTop | JumpToBottom | JumpHalfViewportUp | JumpHalfViewportDown
-        | ToggleArchivedView | ToggleArchivedBoardsView | ToggleCardSelection
-        | ClearCardSelection | SelectAllCards | ShowHelp | EditCard | Search => Purity::Pure,
+        NavigateDown
+        | NavigateUp
+        | NavigateLeft
+        | NavigateRight
+        | SelectItem
+        | Escape
+        | FocusPanel(_)
+        | JumpToTop
+        | JumpToBottom
+        | JumpHalfViewportUp
+        | JumpHalfViewportDown
+        | ToggleArchivedView
+        | ToggleArchivedBoardsView
+        | ToggleCardSelection
+        | ClearCardSelection
+        | SelectAllCards
+        | ShowHelp
+        | EditCard
+        | Search => Purity::Pure,
 
-        CreateCard | CreateBoard | CreateSprint | CreateColumn | RenameBoard | RenameColumn
-        | SetColumnDefaultStatus | EditBoard | ToggleCompletion | AssignToSprint | ArchiveCard
-        | RestoreCard | DeleteCard | MoveCardLeft | MoveCardRight | MoveColumnUp
-        | MoveColumnDown | DeleteColumn | DeleteBoard | ExportBoard | ExportAll | ImportBoard
-        | OrderCards | OrderBoards | ToggleSortOrder | ToggleFilter | ToggleHideAssigned
-        | RestoreBoard | DeleteArchivedBoard | ToggleBoardsSortOrder | ToggleTaskListView
-        | SetCardPriority | SetSelectedCardsPriority | ManageParents | ManageChildren
-        | CarryOver | Undo | Redo | OpenSettings | ExportBoards | CopyBranchName
-        | CopyGitCheckoutCommand | ConfirmPrefixCollision | RejectPrefixCollision
-        | CancelPrefixCollision | ForceOverwriteConflict | TakeTheirsConflict
-        | CancelConflictResolution | ReloadDiscardLocal | KeepLocalChanges
+        CreateCard
+        | CreateBoard
+        | CreateSprint
+        | CreateColumn
+        | RenameBoard
+        | RenameColumn
+        | SetColumnDefaultStatus
+        | EditBoard
+        | ToggleCompletion
+        | AssignToSprint
+        | ArchiveCard
+        | RestoreCard
+        | DeleteCard
+        | MoveCardLeft
+        | MoveCardRight
+        | MoveColumnUp
+        | MoveColumnDown
+        | DeleteColumn
+        | DeleteBoard
+        | ExportBoard
+        | ExportAll
+        | ImportBoard
+        | OrderCards
+        | OrderBoards
+        | ToggleSortOrder
+        | ToggleFilter
+        | ToggleHideAssigned
+        | RestoreBoard
+        | DeleteArchivedBoard
+        | ToggleBoardsSortOrder
+        | ToggleTaskListView
+        | SetCardPriority
+        | SetSelectedCardsPriority
+        | ManageParents
+        | ManageChildren
+        | CarryOver
+        | Undo
+        | Redo
+        | OpenSettings
+        | ExportBoards
+        | CopyBranchName
+        | CopyGitCheckoutCommand
+        | ConfirmPrefixCollision
+        | RejectPrefixCollision
+        | CancelPrefixCollision
+        | ForceOverwriteConflict
+        | TakeTheirsConflict
+        | CancelConflictResolution
+        | ReloadDiscardLocal
+        | KeepLocalChanges
         | DismissExternalChange => Purity::Mutating,
     }
 }
@@ -141,10 +195,7 @@ fn test_every_advertised_navigation_keybinding_performs_no_store_reads() {
 
             app.execute_action(action);
 
-            assert_ops(
-                &ops,
-                &[],
-            );
+            assert_ops(&ops, &[]);
         }
     }
 }

--- a/crates/kanban-tui/tests/lifecycle_reload_tests.rs
+++ b/crates/kanban-tui/tests/lifecycle_reload_tests.rs
@@ -1,0 +1,83 @@
+mod helpers;
+
+use kanban_tui::App;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_import_board_from_file_refreshes_the_whole_model_without_a_further_reload() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("import.json");
+
+    let json = r#"{
+        "boards": [{
+            "board": {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "name": "Imported Board",
+                "description": null,
+                "created_at": "2025-01-01T00:00:00Z",
+                "updated_at": "2025-01-01T00:00:00Z"
+            },
+            "columns": [{
+                "id": "00000000-0000-0000-0000-000000000002",
+                "board_id": "00000000-0000-0000-0000-000000000001",
+                "name": "Todo",
+                "position": 0,
+                "wip_limit": null,
+                "created_at": "2025-01-01T00:00:00Z",
+                "updated_at": "2025-01-01T00:00:00Z"
+            }],
+            "cards": [{
+                "id": "00000000-0000-0000-0000-000000000003",
+                "column_id": "00000000-0000-0000-0000-000000000002",
+                "title": "Imported Task",
+                "description": null,
+                "priority": "Medium",
+                "status": "Todo",
+                "position": 0,
+                "due_date": null,
+                "points": null,
+                "created_at": "2025-01-01T00:00:00Z",
+                "updated_at": "2025-01-01T00:00:00Z"
+            }],
+            "archived_cards": [],
+            "sprints": []
+        }]
+    }"#;
+
+    fs::write(&file_path, json).unwrap();
+
+    let mut app = App::test_default();
+    app.import_board_from_file(file_path.to_str().unwrap())
+        .unwrap();
+
+    assert_eq!(app.model.boards().len(), 1);
+    assert_eq!(app.model.boards()[0].name, "Imported Board");
+    assert_eq!(app.model.columns().len(), 1);
+    assert_eq!(app.model.all_cards().len(), 1);
+    assert_eq!(app.model.all_cards()[0].title, "Imported Task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_storage_location_change_refreshes_the_model_without_a_further_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut app = helpers::setup_app_with_json_file(dir.path()).await;
+    assert_eq!(app.model.boards()[0].name, "OriginalBoard");
+
+    let sqlite_path =
+        helpers::create_test_sqlite_file(dir.path(), "other.db", &["SqliteBoard"]).await;
+
+    let old_config = app.app_config.clone();
+    let old_storage_location = app.app_config.effective_storage_location();
+    app.app_config.storage_location = Some(sqlite_path.clone());
+
+    app.apply_storage_location_change(old_config, &old_storage_location);
+    app.await_migration().await;
+
+    assert_eq!(app.model.boards().len(), 1);
+    assert_eq!(app.model.boards()[0].name, "SqliteBoard");
+    assert_eq!(
+        app.persistence.save_file.as_deref(),
+        Some(sqlite_path.as_str())
+    );
+}


### PR DESCRIPTION
## Summary

Re-verification against current develop (0d452dec) found the card's 11-production-site count for `reload_model()` still correct, the animation-tick acceptance criterion already satisfied by an existing test file, three of the card's proposed tests unwritable, and one genuine defect: cold start performs two full-workspace snapshot reads where one suffices.

## Changes

- `load_initial_state` now performs exactly one full-workspace snapshot read on the common path. It keeps the probe snapshot it already fetches for error handling and reuses it to build the model, falling back to a full `reload_model()` only when the sprint-log migration that runs between the probe and the model load actually changed data (otherwise the probe would serve stale sprint logs).
- `migrate_sprint_logs` now returns the migrated-card count instead of discarding it, so `load_initial_state` can make that decision.
- `App::execute_action` (the terminal-free keybinding dispatch table) is widened from `pub(in crate::app)` to `pub`, so a test can drive every advertised keybinding action directly instead of duplicating a second `DataStore` decorator.

## Tests added

- `cold_start_reload_tests.rs`: `test_cold_start_reads_the_whole_workspace_once` (failed before the fix with `left: 2, right: 1`) and `test_cold_start_after_a_sprint_log_migration_loads_the_migrated_state`, which pins that a migration is never served from the stale pre-migration probe.
- `keybinding_store_io_tests.rs`: an exhaustive, no-wildcard `classify(&KeybindingAction) -> Purity` match (so a new action variant fails to compile until classified), and `test_every_advertised_navigation_keybinding_performs_no_store_reads`, which enumerates every action advertised by the Normal/Boards, Normal/Cards, ArchivedBoardsView and ArchivedCardsView keybinding providers and asserts the Pure ones touch the store zero times. This test failed to compile before the visibility change (`error[E0624]: method `execute_action` is private`).
- `frame_reload_tests.rs::test_navigation_performs_no_store_reads` extended to cover ten additional navigation/selection handlers (escape, column/focus switch, half-viewport jumps, the Cards branch of selection-activate, archived-cards toggle, multi-select toggle/clear/select-all) found by a coverage diff against the advertised keybinding surface, and switched from a bare read counter to `assert_ops(&ops, &[])` so a failure names the offending store method.
- `lifecycle_reload_tests.rs`: two characterization tests pinning that `import_board_from_file` and the storage-location-change path (`handle_migration_complete`) already refresh the model without a further explicit reload.

## Findings recorded, not fixed here

- `navigation_handlers.rs` and `app/keybindings.rs` both have zero production `reload_model()` sites (all hits are in `#[cfg(test)]` blocks), confirmed by inspection and now guarded by the keybinding test.
- Undo/redo (`view_management.rs`) stay wholesale on purpose: narrowing them needs `KanbanContext::undo`/`redo` to surface the executed command's affected-id set, which is out of this card's scope.
- `file_io.rs` (2 sites), `main_loop.rs:185` (inline in the crossterm event loop) and `reload_watch.rs:9` are accounted for by inspection only, no terminal-free/loop-free seam exists to test them from `tests/`.
- 'Take theirs' conflict resolution is implemented twice (inline in `main_loop.rs` and again in `handle_conflict_resolution_popup`, which is what the keybinding actually dispatches to). Not touched here; flagged for a follow-up.

## Mutation checks (all reverted, none committed)

- Duplicating the `reload_model()` call inside `handle_animation_tick`'s guarded branch broke `test_animation_tick_mixed_archive_delete_restore_reads_the_store_once`.
- Removing the `reload_model()` call at the end of the storage-location-change handler broke `test_storage_location_change_refreshes_the_model_without_a_further_reload`.
- Injecting `self.ctx.snapshot().ok();` into `handle_navigation_down` broke `test_navigation_performs_no_store_reads`, naming `snapshot` as the offending read.

## Test plan

- [x] `cargo test -p kanban-tui --test cold_start_reload_tests` green; red observed as `left: 2, right: 1` before the fix
- [x] `cargo test -p kanban-tui --test keybinding_store_io_tests` green; red observed as `error[E0624]: method `execute_action` is private` before the visibility change
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check --workspace --all-targets` clean
