### PR TITLE
KAN-1234 refactor(api): construct SprintResponse from a resolved name instead of the owning board

### DIFF
--- a/.changeset/kan-1234-sprint-response-self-resolving.md
+++ b/.changeset/kan-1234-sprint-response-self-resolving.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+api: `SprintResponse` no longer requires the owning `Board` to construct — `SprintResponse::new(sprint, resolved_name)` takes an already-resolved name, so a sprint read never forces a second board fetch just to project it onto the wire

--- a/.changeset/kan-1234-sprint-response-self-resolving.md
+++ b/.changeset/kan-1234-sprint-response-self-resolving.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-api: `SprintResponse::new(sprint, name)` builds the wire projection from an already-resolved name instead of the owning `Board`. server: the sprint routes now resolve a sprint's name through `kanban-service` rather than fetching the board themselves.
+api: a sprint's wire response is now built from the sprint plus its already-resolved display name, so reading one sprint no longer structurally requires loading its board; the board lookup moved once into the service layer (`kanban_service::resolve_sprint_name`/`resolve_sprint_names`), and the server, CLI, and MCP sprint-list paths still read the owning board only once.

--- a/.changeset/kan-1234-sprint-response-self-resolving.md
+++ b/.changeset/kan-1234-sprint-response-self-resolving.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-api: `SprintResponse` no longer requires the owning `Board` to construct — `SprintResponse::new(sprint, resolved_name)` takes an already-resolved name, so a sprint read never forces a second board fetch just to project it onto the wire
+api: `SprintResponse::new(sprint, name)` builds the wire projection from an already-resolved name instead of the owning `Board`. server: the sprint routes now resolve a sprint's name through `kanban-service` rather than fetching the board themselves.

--- a/crates/kanban-api/src/v1/sprints/response.rs
+++ b/crates/kanban-api/src/v1/sprints/response.rs
@@ -111,6 +111,17 @@ mod tests {
     }
 
     #[test]
+    fn test_sprint_response_from_sprint_resolves_name_via_board() {
+        let mut board = Board::new("Test", Some("KAN"));
+        let idx = board.add_sprint_name_at_used_index("Gamma");
+        let sprint = Sprint::new(board.id, 4, Some(idx), Some("SPR"));
+
+        let resp = SprintResponse::from_sprint(&sprint, &board);
+        assert_eq!(resp.name, Some("Gamma".to_string()));
+        assert_eq!(resp.id, sprint.id);
+    }
+
+    #[test]
     fn test_sprint_response_new_builds_from_sprint_and_resolved_name() {
         let sprint = Sprint::new(Uuid::new_v4(), 3, None, Some("SPR"));
         let resp = SprintResponse::new(&sprint, Some("Denormalised".to_string()));

--- a/crates/kanban-api/src/v1/sprints/response.rs
+++ b/crates/kanban-api/src/v1/sprints/response.rs
@@ -5,12 +5,12 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Response body for sprint reads. Hides the internal allocation state
-/// (`name_index`); instead it exposes the resolved sprint `name`, looked up
-/// against the owning board at projection time. `sprint_number` IS exposed (it
-/// is the human-facing read-only identifier, unlike a board's hidden counters).
-/// Lifecycle (`status`/dates) is exposed read-only; transitions go through
-/// dedicated activate/complete/cancel endpoints. `Deserialize` is derived
-/// intentionally (test round-trips / client use); the server only serializes it.
+/// (`name_index`); instead it exposes the resolved sprint `name`. `sprint_number`
+/// IS exposed (it is the human-facing read-only identifier, unlike a board's
+/// hidden counters). Lifecycle (`status`/dates) is exposed read-only;
+/// transitions go through dedicated activate/complete/cancel endpoints.
+/// `Deserialize` is derived intentionally (test round-trips / client use); the
+/// server only serializes it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SprintResponse {
     pub id: Uuid,
@@ -27,11 +27,11 @@ pub struct SprintResponse {
 }
 
 impl SprintResponse {
-    /// Project a sprint into its wire response, resolving the `name` against the
-    /// owning `board`'s name pool (`name_index` is never exposed). Exhaustive
-    /// destructure — no `..` — so a new `Sprint` field is a compile error here.
-    pub fn from_sprint(sprint: &Sprint, board: &Board) -> Self {
-        let name = sprint.get_name(board).map(str::to_string);
+    /// Project a sprint into its wire response given an already-resolved
+    /// `name` (`name_index` is never exposed). Exhaustive destructure — no
+    /// `..` — so a new `Sprint` field is a compile error here. Takes no
+    /// `Board`: the caller supplies the already-resolved `name`.
+    pub fn new(sprint: &Sprint, name: Option<String>) -> Self {
         let Sprint {
             id,
             board_id,
@@ -58,6 +58,11 @@ impl SprintResponse {
             created_at: *created_at,
             updated_at: *updated_at,
         }
+    }
+
+    /// Convenience wrapper for callers that already hold the owning `board`.
+    pub fn from_sprint(sprint: &Sprint, board: &Board) -> Self {
+        Self::new(sprint, sprint.get_name(board).map(str::to_string))
     }
 }
 

--- a/crates/kanban-api/src/v1/sprints/response.rs
+++ b/crates/kanban-api/src/v1/sprints/response.rs
@@ -1,6 +1,6 @@
 use super::super::enums::SprintStatusDto;
 use chrono::{DateTime, Utc};
-use kanban_domain::{Board, Sprint};
+use kanban_domain::Sprint;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -57,11 +57,6 @@ impl SprintResponse {
             created_at: *created_at,
             updated_at: *updated_at,
         }
-    }
-
-    /// Convenience wrapper for callers that already hold the owning `board`.
-    pub fn from_sprint(sprint: &Sprint, board: &Board) -> Self {
-        Self::new(sprint, sprint.get_name(board).map(str::to_string))
     }
 }
 

--- a/crates/kanban-api/src/v1/sprints/response.rs
+++ b/crates/kanban-api/src/v1/sprints/response.rs
@@ -73,7 +73,7 @@ mod tests {
         let mut sprint = Sprint::new(board.id, 1, Some(idx), Some("SPR"));
         sprint.card_prefix = Some("KAN".to_string());
 
-        let resp = SprintResponse::from_sprint(&sprint, &board);
+        let resp = SprintResponse::new(&sprint, sprint.get_name(&board).map(str::to_string));
         assert_eq!(resp.name, Some("Alpha".to_string()));
         assert_eq!(resp.sprint_number, 1);
         assert_eq!(resp.board_id, board.id);
@@ -91,7 +91,7 @@ mod tests {
         let mut sprint = Sprint::new(board.id, 1, None, None::<String>);
         sprint.status = SprintStatus::Active;
 
-        let resp = SprintResponse::from_sprint(&sprint, &board);
+        let resp = SprintResponse::new(&sprint, sprint.get_name(&board).map(str::to_string));
         assert_eq!(resp.status, SprintStatusDto::Active);
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"status\":\"active\""), "json: {json}");
@@ -101,7 +101,16 @@ mod tests {
     fn test_sprint_response_resolves_no_name_when_name_index_absent() {
         let board = Board::new("Test", Some("KAN"));
         let sprint = Sprint::new(board.id, 2, None, None::<String>);
-        let resp = SprintResponse::from_sprint(&sprint, &board);
+        let resp = SprintResponse::new(&sprint, sprint.get_name(&board).map(str::to_string));
         assert_eq!(resp.name, None);
+    }
+
+    #[test]
+    fn test_sprint_response_new_builds_from_sprint_and_resolved_name() {
+        let sprint = Sprint::new(Uuid::new_v4(), 3, None, Some("SPR"));
+        let resp = SprintResponse::new(&sprint, Some("Denormalised".to_string()));
+        assert_eq!(resp.name, Some("Denormalised".to_string()));
+        assert_eq!(resp.id, sprint.id);
+        assert_eq!(resp.sprint_number, 3);
     }
 }

--- a/crates/kanban-api/src/v1/sprints/response.rs
+++ b/crates/kanban-api/src/v1/sprints/response.rs
@@ -28,9 +28,8 @@ pub struct SprintResponse {
 
 impl SprintResponse {
     /// Project a sprint into its wire response given an already-resolved
-    /// `name` (`name_index` is never exposed). Exhaustive destructure — no
-    /// `..` — so a new `Sprint` field is a compile error here. Takes no
-    /// `Board`: the caller supplies the already-resolved `name`.
+    /// `name` (`name_index` is never exposed). Exhaustive destructure, no
+    /// `..`, so a new `Sprint` field is a compile error here.
     pub fn new(sprint: &Sprint, name: Option<String>) -> Self {
         let Sprint {
             id,
@@ -72,16 +71,41 @@ mod tests {
     use kanban_domain::SprintStatus;
 
     #[test]
-    fn test_sprint_response_hides_name_index_and_exposes_resolved_name() {
-        let mut board = Board::new("Test", Some("KAN"));
-        let idx = board.add_sprint_name_at_used_index("Alpha");
-        let mut sprint = Sprint::new(board.id, 1, Some(idx), Some("SPR"));
-        sprint.card_prefix = Some("KAN".to_string());
+    fn test_sprint_response_new_carries_the_supplied_resolved_name() {
+        let sprint = Sprint::new(Uuid::new_v4(), 1, Some(0), Some("SPR"));
 
-        let resp = SprintResponse::new(&sprint, sprint.get_name(&board).map(str::to_string));
+        let resp = SprintResponse::new(&sprint, Some("Alpha".to_string()));
         assert_eq!(resp.name, Some("Alpha".to_string()));
         assert_eq!(resp.sprint_number, 1);
-        assert_eq!(resp.board_id, board.id);
+        assert_eq!(resp.board_id, sprint.board_id);
+
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(
+            !json.contains("name_index"),
+            "SprintResponse leaked name_index: {json}"
+        );
+    }
+
+    #[test]
+    fn test_sprint_response_new_with_no_resolved_name_leaves_name_none() {
+        let sprint = Sprint::new(Uuid::new_v4(), 2, None, None::<String>);
+
+        let resp = SprintResponse::new(&sprint, None);
+        assert_eq!(resp.name, None);
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"name\":null"), "json: {json}");
+    }
+
+    #[test]
+    fn test_sprint_response_hides_name_index_and_exposes_resolved_name() {
+        let board_id = Uuid::new_v4();
+        let mut sprint = Sprint::new(board_id, 1, Some(0), Some("SPR"));
+        sprint.card_prefix = Some("KAN".to_string());
+
+        let resp = SprintResponse::new(&sprint, Some("Alpha".to_string()));
+        assert_eq!(resp.name, Some("Alpha".to_string()));
+        assert_eq!(resp.sprint_number, 1);
+        assert_eq!(resp.board_id, board_id);
 
         let json = serde_json::to_string(&resp).unwrap();
         assert!(
@@ -92,11 +116,10 @@ mod tests {
 
     #[test]
     fn test_sprint_response_uses_snake_case_status() {
-        let board = Board::new("Test", Some("KAN"));
-        let mut sprint = Sprint::new(board.id, 1, None, None::<String>);
+        let mut sprint = Sprint::new(Uuid::new_v4(), 1, None, None::<String>);
         sprint.status = SprintStatus::Active;
 
-        let resp = SprintResponse::new(&sprint, sprint.get_name(&board).map(str::to_string));
+        let resp = SprintResponse::new(&sprint, None);
         assert_eq!(resp.status, SprintStatusDto::Active);
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"status\":\"active\""), "json: {json}");
@@ -104,29 +127,8 @@ mod tests {
 
     #[test]
     fn test_sprint_response_resolves_no_name_when_name_index_absent() {
-        let board = Board::new("Test", Some("KAN"));
-        let sprint = Sprint::new(board.id, 2, None, None::<String>);
-        let resp = SprintResponse::new(&sprint, sprint.get_name(&board).map(str::to_string));
+        let sprint = Sprint::new(Uuid::new_v4(), 2, None, None::<String>);
+        let resp = SprintResponse::new(&sprint, None);
         assert_eq!(resp.name, None);
-    }
-
-    #[test]
-    fn test_sprint_response_from_sprint_resolves_name_via_board() {
-        let mut board = Board::new("Test", Some("KAN"));
-        let idx = board.add_sprint_name_at_used_index("Gamma");
-        let sprint = Sprint::new(board.id, 4, Some(idx), Some("SPR"));
-
-        let resp = SprintResponse::from_sprint(&sprint, &board);
-        assert_eq!(resp.name, Some("Gamma".to_string()));
-        assert_eq!(resp.id, sprint.id);
-    }
-
-    #[test]
-    fn test_sprint_response_new_builds_from_sprint_and_resolved_name() {
-        let sprint = Sprint::new(Uuid::new_v4(), 3, None, Some("SPR"));
-        let resp = SprintResponse::new(&sprint, Some("Denormalised".to_string()));
-        assert_eq!(resp.name, Some("Denormalised".to_string()));
-        assert_eq!(resp.id, sprint.id);
-        assert_eq!(resp.sprint_number, 3);
     }
 }

--- a/crates/kanban-cli/src/handlers/sprint.rs
+++ b/crates/kanban-cli/src/handlers/sprint.rs
@@ -4,15 +4,14 @@ use crate::output;
 use kanban_core::{parse_datetime_input, resolve_page_params, PaginatedList};
 use kanban_domain::{FieldUpdate, KanbanOperations, Sprint, SprintUpdate};
 use kanban_service::api::SprintResponse;
+use kanban_service::resolve_sprint_name;
 
 /// Project a domain `Sprint` into its wire `SprintResponse`, resolving the
-/// `name` against the owning board (fetched here) so the JSON edge never leaks
-/// the internal `name_index` or non-snake-case enum reprs.
+/// `name` against the owning board via the shared service helper so the JSON
+/// edge never leaks the internal `name_index` or non-snake-case enum reprs.
 fn sprint_response(ctx: &CliContext, sprint: &Sprint) -> anyhow::Result<SprintResponse> {
-    let board = ctx
-        .get_board(sprint.board_id)?
-        .ok_or_else(|| anyhow::anyhow!("Board not found: {}", sprint.board_id))?;
-    Ok(SprintResponse::from_sprint(sprint, &board))
+    let name = resolve_sprint_name(ctx, sprint)?;
+    Ok(SprintResponse::new(sprint, name))
 }
 
 pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Result<()> {
@@ -43,12 +42,11 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
                 Err(e) => return output::output_error(&e.to_string()),
             };
             let sprints = ctx.list_sprints(board_uuid)?;
-            let board = ctx
-                .get_board(board_uuid)?
-                .ok_or_else(|| anyhow::anyhow!("Board not found: {}", board_uuid))?;
+            let names = kanban_service::resolve_sprint_names(ctx, board_uuid, &sprints)?;
             let responses: Vec<SprintResponse> = sprints
                 .iter()
-                .map(|s| SprintResponse::from_sprint(s, &board))
+                .zip(names)
+                .map(|(s, name)| SprintResponse::new(s, name))
                 .collect();
             let (page, page_size) = resolve_page_params(page, page_size)?;
             output::output_success(PaginatedList::paginate(responses, page, page_size)?);

--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -1,7 +1,8 @@
 use crate::context::McpContext;
 use crate::helpers::error_mapping::kanban_err_to_mcp;
-use kanban_domain::{CardSummary, KanbanError, KanbanOperations, Sprint};
+use kanban_domain::{CardSummary, KanbanOperations, Sprint};
 use kanban_service::api::SprintResponse;
+use kanban_service::resolve_sprint_name;
 use rmcp::model::ErrorData as McpError;
 use uuid::Uuid;
 
@@ -92,16 +93,13 @@ pub(crate) fn card_board(ctx: &McpContext, card_id: Uuid) -> Result<Uuid, McpErr
     Ok(column.board_id)
 }
 
-/// Project a domain `Sprint` into its v1 `SprintResponse`, resolving the
-/// owning board so the wire `name` can be looked up against the board's name
-/// pool (the internal `name_index` is never exposed). Used by the sprint
-/// mutating tools, whose service calls return a raw `Sprint`.
+/// Project a domain `Sprint` into its v1 `SprintResponse`, resolving the wire
+/// `name` through the shared service helper (the internal `name_index` is
+/// never exposed). Used by the sprint mutating tools, whose service calls
+/// return a raw `Sprint`.
 pub(crate) fn project_sprint(ctx: &McpContext, sprint: Sprint) -> Result<SprintResponse, McpError> {
-    let board = ctx
-        .get_board(sprint.board_id)
-        .map_err(kanban_err_to_mcp)?
-        .ok_or_else(|| kanban_err_to_mcp(KanbanError::not_found("Board", sprint.board_id)))?;
-    Ok(SprintResponse::from_sprint(&sprint, &board))
+    let name = resolve_sprint_name(ctx, &sprint).map_err(kanban_err_to_mcp)?;
+    Ok(SprintResponse::new(&sprint, name))
 }
 
 #[cfg(test)]

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -9,8 +9,9 @@ use crate::requests::sprint::{
 };
 use crate::KanbanMcpServer;
 use kanban_core::{resolve_page_params, PaginatedList};
-use kanban_domain::{FieldUpdate, KanbanError, KanbanOperations, SprintUpdate};
+use kanban_domain::{FieldUpdate, KanbanOperations, SprintUpdate};
 use kanban_service::api::SprintResponse;
+use kanban_service::{resolve_sprint_name, resolve_sprint_names};
 use rmcp::{
     handler::server::wrapper::Parameters,
     model::{CallToolResult, ErrorData as McpError},
@@ -34,11 +35,8 @@ impl KanbanMcpServer {
             let sprint = ctx
                 .create_sprint_from_spec(board_id, content.id, content.name, content.prefix)
                 .map_err(kanban_err_to_mcp)?;
-            let board = ctx
-                .get_board(board_id)
-                .map_err(kanban_err_to_mcp)?
-                .ok_or_else(|| kanban_err_to_mcp(KanbanError::not_found("Board", board_id)))?;
-            Ok(SprintResponse::from_sprint(&sprint, &board))
+            let name = resolve_sprint_name(ctx, &sprint).map_err(kanban_err_to_mcp)?;
+            Ok(SprintResponse::new(&sprint, name))
         })
         .await?;
         to_call_tool_result(&response)
@@ -54,13 +52,11 @@ impl KanbanMcpServer {
         let responses = locked_read(&self.ctx, |ctx| -> Result<_, McpError> {
             let board_id = ctx.mcp_resolve_board(&req.board)?;
             let sprints = ctx.list_sprints(board_id).map_err(kanban_err_to_mcp)?;
-            let board = ctx
-                .get_board(board_id)
-                .map_err(kanban_err_to_mcp)?
-                .ok_or_else(|| kanban_err_to_mcp(KanbanError::not_found("Board", board_id)))?;
+            let names = resolve_sprint_names(ctx, board_id, &sprints).map_err(kanban_err_to_mcp)?;
             Ok(sprints
                 .iter()
-                .map(|s| SprintResponse::from_sprint(s, &board))
+                .zip(names)
+                .map(|(s, name)| SprintResponse::new(s, name))
                 .collect::<Vec<_>>())
         })
         .await?;
@@ -80,13 +76,8 @@ impl KanbanMcpServer {
             let Some(sprint) = ctx.get_sprint(id).map_err(kanban_err_to_mcp)? else {
                 return Ok(None);
             };
-            let board = ctx
-                .get_board(sprint.board_id)
-                .map_err(kanban_err_to_mcp)?
-                .ok_or_else(|| {
-                    kanban_err_to_mcp(KanbanError::not_found("Board", sprint.board_id))
-                })?;
-            Ok(Some(SprintResponse::from_sprint(&sprint, &board)))
+            let name = resolve_sprint_name(ctx, &sprint).map_err(kanban_err_to_mcp)?;
+            Ok(Some(SprintResponse::new(&sprint, name)))
         })
         .await?;
         to_call_tool_result(&response)

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -82,5 +82,6 @@ fn project(
         .get_board(sprint.board_id)
         .map_err(|e| ApiError::from(&e))?
         .ok_or_else(|| ApiError::from(&KanbanError::not_found("Board", sprint.board_id)))?;
-    Ok((SprintResponse::from_sprint(&sprint, &board), created))
+    let name = sprint.get_name(&board).map(str::to_string);
+    Ok((SprintResponse::new(&sprint, name), created))
 }

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -11,12 +11,10 @@
 //! replaced (`false`, 200). A re-PUT of a client-supplied id that already exists
 //! on the POST path is a conflict -> 409 (mapped from `AlreadyExists` by
 //! [`ApiError`]). The resulting domain `Sprint` is projected onto the wire
-//! [`SprintResponse`] via `KanbanContext::get_sprint_with_name`, which resolves
-//! the sprint `name` against the owning board inside kanban-service — this
-//! handler never fetches `Board` itself.
+//! [`SprintResponse`] via `kanban_service::resolve_sprint_name`.
 
 use kanban_service::api::{ApiError, CreateSprintRequest, ReplaceSprintRequest, SprintResponse};
-use kanban_service::{KanbanContext, KanbanError, KanbanOperations};
+use kanban_service::{resolve_sprint_name, KanbanContext, KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 /// `POST /v1/boards/:board_id/sprints`: create a sprint under the path-supplied
@@ -73,17 +71,13 @@ pub fn create_or_replace_sprint(
     project(ctx, outcome.sprint, outcome.created)
 }
 
-/// Project the created/replaced domain sprint onto its wire response,
-/// resolving the sprint `name` through the service-level name resolver
-/// instead of fetching the owning `Board` here.
+/// Project the created/replaced domain sprint onto its wire response with
+/// its `name` resolved by the service.
 fn project(
     ctx: &KanbanContext,
     sprint: kanban_service::Sprint,
     created: bool,
 ) -> Result<(SprintResponse, bool), ApiError> {
-    let (sprint, name) = ctx
-        .get_sprint_with_name(sprint.id)
-        .map_err(|e| ApiError::from(&e))?
-        .ok_or_else(|| ApiError::from(&KanbanError::not_found("Sprint", sprint.id)))?;
+    let name = resolve_sprint_name(ctx, &sprint).map_err(|e| ApiError::from(&e))?;
     Ok((SprintResponse::new(&sprint, name), created))
 }

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -11,7 +11,9 @@
 //! replaced (`false`, 200). A re-PUT of a client-supplied id that already exists
 //! on the POST path is a conflict -> 409 (mapped from `AlreadyExists` by
 //! [`ApiError`]). The resulting domain `Sprint` is projected onto the wire
-//! [`SprintResponse`], whose `name` is resolved against the owning board.
+//! [`SprintResponse`] via `KanbanContext::get_sprint_with_name`, which resolves
+//! the sprint `name` against the owning board inside kanban-service — this
+//! handler never fetches `Board` itself.
 
 use kanban_service::api::{ApiError, CreateSprintRequest, ReplaceSprintRequest, SprintResponse};
 use kanban_service::{KanbanContext, KanbanError, KanbanOperations};
@@ -71,17 +73,17 @@ pub fn create_or_replace_sprint(
     project(ctx, outcome.sprint, outcome.created)
 }
 
-/// Project the created/replaced domain sprint onto its wire response, resolving
-/// the sprint `name` against the owning board's name pool.
+/// Project the created/replaced domain sprint onto its wire response,
+/// resolving the sprint `name` through the service-level name resolver
+/// instead of fetching the owning `Board` here.
 fn project(
     ctx: &KanbanContext,
     sprint: kanban_service::Sprint,
     created: bool,
 ) -> Result<(SprintResponse, bool), ApiError> {
-    let board = ctx
-        .get_board(sprint.board_id)
+    let (sprint, name) = ctx
+        .get_sprint_with_name(sprint.id)
         .map_err(|e| ApiError::from(&e))?
-        .ok_or_else(|| ApiError::from(&KanbanError::not_found("Board", sprint.board_id)))?;
-    let name = sprint.get_name(&board).map(str::to_string);
+        .ok_or_else(|| ApiError::from(&KanbanError::not_found("Sprint", sprint.id)))?;
     Ok((SprintResponse::new(&sprint, name), created))
 }

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -175,43 +175,6 @@ impl KanbanContext {
         self.backend.get_sprint(id)
     }
 
-    /// Fetch a sprint and resolve its `name` against the owning board, in one
-    /// service-level call. Callers get the denormalised name back without
-    /// ever naming `Board` themselves.
-    pub fn get_sprint_with_name(&self, id: Uuid) -> KanbanResult<Option<(Sprint, Option<String>)>> {
-        let Some(sprint) = self.get_sprint_impl(id)? else {
-            return Ok(None);
-        };
-        let name = self.resolve_sprint_name(&sprint)?;
-        Ok(Some((sprint, name)))
-    }
-
-    /// List a board's sprints with each `name` resolved against the owning
-    /// board, in one service-level call.
-    pub fn list_sprints_with_names(
-        &self,
-        board_id: Uuid,
-    ) -> KanbanResult<Vec<(Sprint, Option<String>)>> {
-        let sprints = self.list_sprints_impl(board_id)?;
-        let board = self
-            .get_board_impl(board_id)?
-            .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
-        Ok(sprints
-            .into_iter()
-            .map(|sprint| {
-                let name = sprint.get_name(&board).map(str::to_string);
-                (sprint, name)
-            })
-            .collect())
-    }
-
-    fn resolve_sprint_name(&self, sprint: &Sprint) -> KanbanResult<Option<String>> {
-        let board = self
-            .get_board_impl(sprint.board_id)?
-            .ok_or_else(|| KanbanError::not_found("Board", sprint.board_id))?;
-        Ok(sprint.get_name(&board).map(str::to_string))
-    }
-
     pub(super) fn update_sprint_impl(
         &mut self,
         id: Uuid,

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -175,6 +175,43 @@ impl KanbanContext {
         self.backend.get_sprint(id)
     }
 
+    /// Fetch a sprint and resolve its `name` against the owning board, in one
+    /// service-level call. Callers get the denormalised name back without
+    /// ever naming `Board` themselves.
+    pub fn get_sprint_with_name(&self, id: Uuid) -> KanbanResult<Option<(Sprint, Option<String>)>> {
+        let Some(sprint) = self.get_sprint_impl(id)? else {
+            return Ok(None);
+        };
+        let name = self.resolve_sprint_name(&sprint)?;
+        Ok(Some((sprint, name)))
+    }
+
+    /// List a board's sprints with each `name` resolved against the owning
+    /// board, in one service-level call.
+    pub fn list_sprints_with_names(
+        &self,
+        board_id: Uuid,
+    ) -> KanbanResult<Vec<(Sprint, Option<String>)>> {
+        let sprints = self.list_sprints_impl(board_id)?;
+        let board = self
+            .get_board_impl(board_id)?
+            .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
+        Ok(sprints
+            .into_iter()
+            .map(|sprint| {
+                let name = sprint.get_name(&board).map(str::to_string);
+                (sprint, name)
+            })
+            .collect())
+    }
+
+    fn resolve_sprint_name(&self, sprint: &Sprint) -> KanbanResult<Option<String>> {
+        let board = self
+            .get_board_impl(sprint.board_id)?
+            .ok_or_else(|| KanbanError::not_found("Board", sprint.board_id))?;
+        Ok(sprint.get_name(&board).map(str::to_string))
+    }
+
     pub(super) fn update_sprint_impl(
         &mut self,
         id: Uuid,

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -18,6 +18,7 @@ mod cascade;
 pub mod config;
 mod context;
 mod path;
+mod sprint_name;
 mod store_adapter;
 mod store_manager;
 pub mod undo_stack;
@@ -30,6 +31,7 @@ pub use kanban_backend::KanbanBackend;
 pub use kanban_backend::RemoteWrites;
 pub use kanban_backend::TransactionFn;
 pub use path::validate_path;
+pub use sprint_name::{resolve_sprint_name, resolve_sprint_names};
 pub use store_manager::StoreManager;
 
 #[cfg(feature = "test-helpers")]

--- a/crates/kanban-service/src/sprint_name.rs
+++ b/crates/kanban-service/src/sprint_name.rs
@@ -1,0 +1,31 @@
+//! Resolves a sprint's display `name` against its owning board.
+
+use kanban_domain::{KanbanError, KanbanOperations, KanbanResult, Sprint};
+use uuid::Uuid;
+
+pub fn resolve_sprint_name<O: KanbanOperations + ?Sized>(
+    ops: &O,
+    sprint: &Sprint,
+) -> KanbanResult<Option<String>> {
+    let board = ops
+        .get_board(sprint.board_id)?
+        .ok_or_else(|| KanbanError::not_found("Board", sprint.board_id))?;
+    Ok(sprint.get_name(&board).map(str::to_string))
+}
+
+/// Resolves every sprint's `name` against a single read of `board_id`'s
+/// board. Every sprint in `sprints` must belong to `board_id`; this does not
+/// re-check each sprint's `board_id`.
+pub fn resolve_sprint_names<O: KanbanOperations + ?Sized>(
+    ops: &O,
+    board_id: Uuid,
+    sprints: &[Sprint],
+) -> KanbanResult<Vec<Option<String>>> {
+    let board = ops
+        .get_board(board_id)?
+        .ok_or_else(|| KanbanError::not_found("Board", board_id))?;
+    Ok(sprints
+        .iter()
+        .map(|s| s.get_name(&board).map(str::to_string))
+        .collect())
+}

--- a/crates/kanban-service/tests/sprint_name_resolution.rs
+++ b/crates/kanban-service/tests/sprint_name_resolution.rs
@@ -1,0 +1,87 @@
+//! Service-tier integration tests for the name-resolving sprint accessors
+//! (`KanbanContext::get_sprint_with_name` / `list_sprints_with_names`): the
+//! `Board` lookup + `Sprint::get_name` denormalisation happen once inside
+//! kanban-service, so callers get the resolved name back without touching
+//! `Board` themselves.
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use std::sync::Arc;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+fn make_json_backend(path: &std::path::Path) -> Arc<dyn KanbanBackend> {
+    Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))))
+}
+
+fn ctx_with_board(path: &std::path::Path) -> (KanbanContext, Uuid) {
+    let mut ctx = KanbanContext::open_deferred(make_json_backend(path), AppConfig::default());
+    let board = ctx
+        .create_board("Roadmap".to_string(), Some("KAN".to_string()))
+        .unwrap();
+    (ctx, board.id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_with_name_resolves_denormalised_name() {
+    let dir = tempdir().unwrap();
+    let (mut ctx, board_id) = ctx_with_board(&dir.path().join("get.json"));
+
+    let sprint = ctx
+        .create_sprint_from_spec(
+            board_id,
+            None,
+            Some("Alpha".to_string()),
+            Some("SPR".to_string()),
+            false,
+        )
+        .unwrap();
+
+    let (resolved, name) = ctx.get_sprint_with_name(sprint.id).unwrap().unwrap();
+    assert_eq!(resolved.id, sprint.id);
+    assert_eq!(name, Some("Alpha".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_with_name_returns_none_for_missing_sprint() {
+    let dir = tempdir().unwrap();
+    let (ctx, _board_id) = ctx_with_board(&dir.path().join("missing.json"));
+
+    let result = ctx.get_sprint_with_name(Uuid::new_v4()).unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_with_names_resolves_every_sprint_in_board() {
+    let dir = tempdir().unwrap();
+    let (mut ctx, board_id) = ctx_with_board(&dir.path().join("list.json"));
+
+    ctx.create_sprint_from_spec(
+        board_id,
+        None,
+        Some("Alpha".to_string()),
+        Some("SPR".to_string()),
+        false,
+    )
+    .unwrap();
+    ctx.create_sprint_from_spec(
+        board_id,
+        None,
+        Some("Beta".to_string()),
+        Some("SPR".to_string()),
+        false,
+    )
+    .unwrap();
+
+    let mut names: Vec<Option<String>> = ctx
+        .list_sprints_with_names(board_id)
+        .unwrap()
+        .into_iter()
+        .map(|(_, name)| name)
+        .collect();
+    names.sort();
+
+    assert_eq!(
+        names,
+        vec![Some("Alpha".to_string()), Some("Beta".to_string())]
+    );
+}

--- a/crates/kanban-service/tests/sprint_name_resolution.rs
+++ b/crates/kanban-service/tests/sprint_name_resolution.rs
@@ -1,10 +1,13 @@
-//! Service-tier integration tests for the name-resolving sprint accessors
-//! (`KanbanContext::get_sprint_with_name` / `list_sprints_with_names`): the
-//! `Board` lookup + `Sprint::get_name` denormalisation happen once inside
-//! kanban-service, so callers get the resolved name back without touching
-//! `Board` themselves.
+//! Service-tier integration tests for the free-function sprint-name
+//! resolvers (`kanban_service::resolve_sprint_name` /
+//! `resolve_sprint_names`): the `Board` lookup + `Sprint::get_name`
+//! denormalisation happen once inside kanban-service, so callers get the
+//! resolved name back without touching `Board` themselves.
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
-use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use kanban_service::{
+    resolve_sprint_name, resolve_sprint_names, AppConfig, KanbanBackend, KanbanContext,
+    KanbanOperations, Sprint,
+};
 use std::sync::Arc;
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -22,7 +25,7 @@ fn ctx_with_board(path: &std::path::Path) -> (KanbanContext, Uuid) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_sprint_with_name_resolves_denormalised_name() {
+async fn test_resolve_sprint_name_returns_the_owning_boards_pool_name() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("get.json"));
 
@@ -36,22 +39,38 @@ async fn test_get_sprint_with_name_resolves_denormalised_name() {
         )
         .unwrap();
 
-    let (resolved, name) = ctx.get_sprint_with_name(sprint.id).unwrap().unwrap();
-    assert_eq!(resolved.id, sprint.id);
+    let name = resolve_sprint_name(&ctx, &sprint).unwrap();
     assert_eq!(name, Some("Alpha".to_string()));
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_sprint_with_name_returns_none_for_missing_sprint() {
+async fn test_resolve_sprint_name_returns_none_when_sprint_has_no_name_index() {
     let dir = tempdir().unwrap();
-    let (ctx, _board_id) = ctx_with_board(&dir.path().join("missing.json"));
+    let (mut ctx, board_id) = ctx_with_board(&dir.path().join("no_name.json"));
 
-    let result = ctx.get_sprint_with_name(Uuid::new_v4()).unwrap();
-    assert!(result.is_none());
+    let sprint = ctx
+        .create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
+        .unwrap();
+
+    let name = resolve_sprint_name(&ctx, &sprint).unwrap();
+    assert_eq!(name, None);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_sprints_with_names_resolves_every_sprint_in_board() {
+async fn test_resolve_sprint_name_missing_board_returns_not_found() {
+    let dir = tempdir().unwrap();
+    let (ctx, _board_id) = ctx_with_board(&dir.path().join("missing.json"));
+
+    let missing_board_id = Uuid::new_v4();
+    let sprint = Sprint::new(missing_board_id, 1, Some(0), None::<String>);
+
+    let err = resolve_sprint_name(&ctx, &sprint).expect_err("board does not exist");
+    assert!(err.is_not_found());
+    assert!(err.to_string().contains(&missing_board_id.to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_sprint_names_maps_each_sprint_to_its_own_pool_name() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("list.json"));
 
@@ -63,25 +82,22 @@ async fn test_list_sprints_with_names_resolves_every_sprint_in_board() {
         false,
     )
     .unwrap();
+    ctx.create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
+        .unwrap();
     ctx.create_sprint_from_spec(
         board_id,
         None,
-        Some("Beta".to_string()),
+        Some("Gamma".to_string()),
         Some("SPR".to_string()),
         false,
     )
     .unwrap();
 
-    let mut names: Vec<Option<String>> = ctx
-        .list_sprints_with_names(board_id)
-        .unwrap()
-        .into_iter()
-        .map(|(_, name)| name)
-        .collect();
-    names.sort();
+    let sprints = ctx.list_sprints(board_id).unwrap();
+    let names = resolve_sprint_names(&ctx, board_id, &sprints).unwrap();
 
     assert_eq!(
         names,
-        vec![Some("Alpha".to_string()), Some("Beta".to_string())]
+        vec![Some("Alpha".to_string()), None, Some("Gamma".to_string())]
     );
 }


### PR DESCRIPTION
## Summary
- `SprintResponse::new(sprint, name)` builds the wire projection from a `Sprint` and an already-resolved `name`. `SprintResponse::from_sprint(sprint, board)` is removed; the DTO no longer names `kanban_domain::Board` at all.
- Added `kanban_service::resolve_sprint_name` / `resolve_sprint_names`: free functions generic over `KanbanOperations` that do the `Board` lookup + `Sprint::get_name` resolution once, inside the service. Free functions (not inherent `KanbanContext` methods) so `CliContext` and `McpContext`, which hold a private `inner: KanbanContext`, can call them without extra delegation.
- `resolve_sprint_names` reads the owning board once and resolves every sprint's name against it, so a sprint list stays a single board read.
- Rewired every former `SprintResponse::from_sprint` call site onto the new helpers: `kanban-server`'s sprint-create seam, the CLI sprint handler (all actions, including the `List` arm via the batch resolver), and the MCP sprint tools (create/list/get) plus the shared `project_sprint` helper used by update/activate/complete/cancel.
- User-visible text change: the CLI's missing-board message for the sprint paths changes from `Board not found: <id>` to the `KanbanError::not_found` Display. No test asserts the old string on this path.

## Test plan
- [x] `cargo test -p kanban-api` green: DTO tests build sprints without a `Board`
- [x] `cargo test -p kanban-service --test sprint_name_resolution` green: resolver, not-found, and batch coverage
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `bash scripts/check-factory-compile-lock.sh` clean
- [x] Mutation-checked `resolve_sprint_names`: hardcoded it to return `None` for every sprint, confirmed `test_resolve_sprint_names_maps_each_sprint_to_its_own_pool_name` fails, then restored
