### PR TITLE
KAN-1236 feat(api): expose the owning board on CardResponse

### DIFF
--- a/.changeset/kan-1236-card-response-board-id.md
+++ b/.changeset/kan-1236-card-response-board-id.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+api: card read responses now carry the owning board's id, so a client reading a card over HTTP no longer needs a second request to find out which board it belongs to.

--- a/crates/kanban-api/src/v1/cards/response.rs
+++ b/crates/kanban-api/src/v1/cards/response.rs
@@ -20,6 +20,9 @@ use uuid::Uuid;
 pub struct CardResponse {
     pub id: Uuid,
     pub column_id: Uuid,
+    /// The owning board, carried directly rather than resolved through
+    /// `column_id`, so it stays answerable after the column is deleted.
+    pub board_id: Uuid,
     /// The namespace half of the card's identifier, stored at creation.
     pub prefix: String,
     pub title: String,
@@ -58,7 +61,7 @@ impl From<&Card> for CardResponse {
         let Card {
             id,
             column_id,
-            board_id: _,
+            board_id,
             title,
             description,
             priority,
@@ -77,6 +80,7 @@ impl From<&Card> for CardResponse {
         Self {
             id: *id,
             column_id: *column_id,
+            board_id: *board_id,
             prefix: prefix.clone(),
             title: title.clone(),
             description: description.clone(),

--- a/crates/kanban-api/src/v1/cards/response.rs
+++ b/crates/kanban-api/src/v1/cards/response.rs
@@ -210,4 +210,33 @@ mod tests {
         assert_eq!(dto.prefix, "KAN", "casing included: this renders KAN-5");
         assert_eq!(dto.card_number, 5);
     }
+
+    #[test]
+    fn test_card_response_from_card_exposes_board_id() {
+        let card = sample_card();
+        let dto = CardResponse::from(&card);
+        assert_eq!(dto.board_id, card.board_id);
+        assert_ne!(dto.board_id, dto.column_id);
+        assert_ne!(dto.board_id, dto.id);
+    }
+
+    #[test]
+    fn test_card_response_serde_round_trip_includes_board_id() {
+        let card = sample_card();
+        let dto = CardResponse::from(&card);
+        let value = serde_json::to_value(&dto).unwrap();
+        assert_eq!(value["board_id"], serde_json::json!(card.board_id));
+        let json = serde_json::to_string(&dto).unwrap();
+        let back: CardResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, dto);
+    }
+
+    #[test]
+    fn test_card_response_with_archived_at_preserves_board_id() {
+        let card = sample_card();
+        let at = Utc::now();
+        let dto = CardResponse::with_archived_at(&card, Some(at));
+        assert_eq!(dto.board_id, card.board_id);
+        assert_eq!(dto.archived_at, Some(at));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `board_id: Uuid` to `CardResponse`, populated from the domain `Card.board_id`
- Every HTTP/CLI/MCP consumer of card reads (`GET /v1/cards/{id}`, `kanban card get`, MCP `tool_get_card`) can now name the owning board without a second round trip
- `CardSummary` (list/relation-children DTO) is intentionally unchanged: three integration tests assert the absence of `board_id` there, so `kanban relation children` output is unaffected by this card

## Test plan
- [x] Red: three new tests added, confirmed failing to compile (E0609) before the struct change
- [x] Green: `cargo test -p kanban-api` and `cargo test -p kanban-server -p kanban-cli -p kanban-mcp` pass
- [x] Mutation check: reverted the `board_id` binding to a placeholder, confirmed `test_card_response_from_card_exposes_board_id` fails, restored
- [x] `cargo test --workspace` green
- [x] `bash scripts/check-factory-compile-lock.sh` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Changeset added