### PR TITLE
KAN-1237 refactor(server,service): list_cards returns CardResponse

### DIFF
--- a/.changeset/kan-1237-list-cards-dto.md
+++ b/.changeset/kan-1237-list-cards-dto.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+server: `GET /v1/boards/{board_id}/cards` now returns the same `CardResponse` objects as `GET /v1/boards/{board_id}/cards/{id}` instead of a narrower summary shape. List items now carry `board_id`, `prefix` and `description`, and `priority`/`status` are serialized in snake_case (`"in_progress"`) to match every other card endpoint.

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -4,7 +4,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
-use kanban_domain::{Card, CardListFilter, CardSummary};
+use kanban_domain::{Card, CardListFilter};
 use kanban_service::api::ArchivedFilterDto;
 use kanban_service::api::CardResponse;
 use kanban_service::api::{CreateCardRequest, UpdateCardRequest};
@@ -25,7 +25,7 @@ async fn list_cards(
     State(state): State<AppState>,
     Path(board_id): Path<Uuid>,
     Query(q): Query<CardQuery>,
-) -> Result<Json<Vec<CardSummary>>, AppError> {
+) -> Result<Json<Vec<CardResponse>>, AppError> {
     let filter = CardListFilter {
         board_id: Some(board_id),
         column_id: q.column_id,
@@ -34,8 +34,15 @@ async fn list_cards(
         ..Default::default()
     };
     let ctx = state.ctx.lock().await;
-    let cards = ctx.list_cards(filter).map_err(|e| AppError::from(&e))?;
-    Ok(Json(cards))
+    let cards = ctx
+        .list_cards_detailed(filter)
+        .map_err(|e| AppError::from(&e))?;
+    Ok(Json(
+        cards
+            .iter()
+            .map(|(card, archived_at)| CardResponse::with_archived_at(card, *archived_at))
+            .collect(),
+    ))
 }
 
 async fn get_card(

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -5,7 +5,9 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
+use kanban_domain::{CardPriority, CardUpdate, CreateCardOptions};
 use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_service::api::CardResponse;
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -435,4 +437,264 @@ async fn test_get_card_wrong_board_returns_404() {
     );
     let json = json_of(response).await;
     assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_route_body_deserializes_as_card_response_vec() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(board_id, col_id, "Card 1".to_string(), Default::default())
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let parsed: Vec<CardResponse> =
+        serde_json::from_value(json).expect("list body should deserialize as Vec<CardResponse>");
+    assert_eq!(parsed.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_route_exposes_description_and_board_id_keys() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Card 1".to_string(),
+            CreateCardOptions {
+                description: Some("A description".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json.as_array().unwrap();
+    let item = &arr[0];
+
+    assert!(
+        item.get("description").is_some(),
+        "description key should be present"
+    );
+    assert_eq!(item["description"], "A description");
+    assert_eq!(item["board_id"], board_id.to_string());
+    assert!(item.get("prefix").is_some(), "prefix key should be present");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_route_serializes_priority_and_status_snake_case() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        let card_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Card 1".to_string(),
+                CreateCardOptions {
+                    priority: Some(CardPriority::High),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+        ctx.update_card(
+            card_id,
+            CardUpdate {
+                status: Some(kanban_domain::CardStatus::InProgress),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json.as_array().unwrap();
+    let item = &arr[0];
+
+    assert_eq!(item["priority"], "high");
+    assert_eq!(item["status"], "in_progress");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_route_stamps_archived_at_on_the_card_response() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Live Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+        let archived_card_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Archived Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.archive_card(archived_card_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?archived=include", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let parsed: Vec<CardResponse> =
+        serde_json::from_value(json).expect("list body should deserialize as Vec<CardResponse>");
+
+    let archived = parsed
+        .iter()
+        .find(|c| c.title == "Archived Card")
+        .unwrap();
+    let live = parsed.iter().find(|c| c.title == "Live Card").unwrap();
+
+    assert!(
+        archived.archived_at.is_some(),
+        "archived card should have archived_at stamped"
+    );
+    assert!(
+        live.archived_at.is_none(),
+        "live card should have no archived_at"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_and_get_card_agree_for_a_live_card() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let card_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        card_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Live Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+    }
+
+    let list_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_json = json_of(list_response).await;
+    let list: Vec<CardResponse> =
+        serde_json::from_value(list_json).expect("list body should deserialize as Vec<CardResponse>");
+
+    let get_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards/{}", board_id, card_id),
+        None,
+    )
+    .await;
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_json = json_of(get_response).await;
+    let single: CardResponse =
+        serde_json::from_value(get_json).expect("get body should deserialize as CardResponse");
+
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0], single);
 }

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -627,10 +627,7 @@ async fn test_list_cards_route_stamps_archived_at_on_the_card_response() {
     let parsed: Vec<CardResponse> =
         serde_json::from_value(json).expect("list body should deserialize as Vec<CardResponse>");
 
-    let archived = parsed
-        .iter()
-        .find(|c| c.title == "Archived Card")
-        .unwrap();
+    let archived = parsed.iter().find(|c| c.title == "Archived Card").unwrap();
     let live = parsed.iter().find(|c| c.title == "Live Card").unwrap();
 
     assert!(
@@ -680,8 +677,8 @@ async fn test_list_cards_and_get_card_agree_for_a_live_card() {
     .await;
     assert_eq!(list_response.status(), StatusCode::OK);
     let list_json = json_of(list_response).await;
-    let list: Vec<CardResponse> =
-        serde_json::from_value(list_json).expect("list body should deserialize as Vec<CardResponse>");
+    let list: Vec<CardResponse> = serde_json::from_value(list_json)
+        .expect("list body should deserialize as Vec<CardResponse>");
 
     let get_response = send(
         &state,

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -35,6 +35,26 @@ impl KanbanContext {
         self.backend.get_archived_card(id)
     }
 
+    /// Cards matching `filter` as full domain entities, each paired with its
+    /// archival marker's `archived_at` (`None` for a live card). The
+    /// [`KanbanOperations::list_cards`] projection drops `description`,
+    /// `board_id` and `prefix`; callers building a wire projection need the
+    /// whole card.
+    pub fn list_cards_detailed(
+        &self,
+        filter: CardListFilter,
+    ) -> KanbanResult<Vec<(Card, Option<chrono::DateTime<chrono::Utc>>)>> {
+        let (_ids, at_by_id) = self.archived_card_index()?;
+        Ok(self
+            .filter_cards(&filter)?
+            .into_iter()
+            .map(|c| {
+                let at = at_by_id.get(&c.id).copied();
+                (c, at)
+            })
+            .collect())
+    }
+
     /// Thin wrapper over the domain allocator: resolves the sprint override,
     /// then defers. The rule lives in `kanban_domain::allocate_card_number` so
     /// this and `CreateSubcardCommand` cannot draw from different counters.
@@ -220,16 +240,12 @@ impl KanbanContext {
     }
 
     pub(super) fn list_cards_impl(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
-        let (_ids, at_by_id) = self.archived_card_index()?;
-        let cards = self.filter_cards(&filter)?;
-        Ok(cards
+        Ok(self
+            .list_cards_detailed(filter)?
             .iter()
-            .map(|c| {
-                // Stamp `archived_at` from the marker map; `None` for a live card.
-                CardSummary {
-                    archived_at: at_by_id.get(&c.id).copied(),
-                    ..CardSummary::from(c)
-                }
+            .map(|(c, at)| CardSummary {
+                archived_at: *at,
+                ..CardSummary::from(c)
             })
             .collect())
     }

--- a/crates/kanban-service/tests/list_cards_detailed.rs
+++ b/crates/kanban-service/tests/list_cards_detailed.rs
@@ -1,0 +1,120 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_core::AppConfig;
+use kanban_domain::{ArchivedFilter, CardListFilter, CreateCardOptions, KanbanOperations};
+use kanban_service::KanbanContext;
+use std::sync::Arc;
+
+async fn make_ctx() -> KanbanContext {
+    KanbanContext::open(Arc::new(InMemoryStore::new()), AppConfig::default())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_list_cards_detailed_returns_full_cards_with_description_and_prefix() {
+    let mut ctx = make_ctx().await;
+    let board = ctx
+        .create_board("Test Board".to_string(), Some("TB".to_string()))
+        .unwrap();
+    let column = ctx
+        .create_column(board.id, "Column".to_string(), None)
+        .unwrap();
+    ctx.create_card(
+        board.id,
+        column.id,
+        "Card 1".to_string(),
+        CreateCardOptions {
+            description: Some("A description".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let pairs = ctx
+        .list_cards_detailed(CardListFilter {
+            board_id: Some(board.id),
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(pairs.len(), 1);
+    let (card, archived_at) = &pairs[0];
+    assert_eq!(card.description.as_deref(), Some("A description"));
+    assert_eq!(card.board_id, board.id);
+    assert!(!card.prefix.is_empty());
+    assert_eq!(*archived_at, None);
+}
+
+#[tokio::test]
+async fn test_list_cards_detailed_pairs_archived_card_with_its_archived_at() {
+    let mut ctx = make_ctx().await;
+    let board = ctx
+        .create_board("Test Board".to_string(), Some("TB".to_string()))
+        .unwrap();
+    let column = ctx
+        .create_column(board.id, "Column".to_string(), None)
+        .unwrap();
+    let live = ctx
+        .create_card(board.id, column.id, "Live".to_string(), Default::default())
+        .unwrap();
+    let archived = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Archived".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    ctx.archive_card(archived.id).unwrap();
+
+    let pairs = ctx
+        .list_cards_detailed(CardListFilter {
+            board_id: Some(board.id),
+            archived: ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap();
+
+    let archived_pair = pairs.iter().find(|(c, _)| c.id == archived.id).unwrap();
+    let live_pair = pairs.iter().find(|(c, _)| c.id == live.id).unwrap();
+
+    assert_eq!(archived_pair.1, ctx.card_archived_at(archived.id).unwrap());
+    assert!(archived_pair.1.is_some());
+    assert_eq!(live_pair.1, None);
+}
+
+#[tokio::test]
+async fn test_list_cards_detailed_and_list_cards_agree_on_ids_and_order() {
+    let mut ctx = make_ctx().await;
+    let board = ctx
+        .create_board("Test Board".to_string(), Some("TB".to_string()))
+        .unwrap();
+    let col1 = ctx
+        .create_column(board.id, "Column 1".to_string(), None)
+        .unwrap();
+    let col2 = ctx
+        .create_column(board.id, "Column 2".to_string(), None)
+        .unwrap();
+    ctx.create_card(board.id, col1.id, "Card A".to_string(), Default::default())
+        .unwrap();
+    ctx.create_card(board.id, col1.id, "Card B".to_string(), Default::default())
+        .unwrap();
+    ctx.create_card(board.id, col2.id, "Card C".to_string(), Default::default())
+        .unwrap();
+
+    let filter = CardListFilter {
+        board_id: Some(board.id),
+        ..Default::default()
+    };
+
+    let detailed = ctx.list_cards_detailed(filter.clone()).unwrap();
+    let summaries = ctx.list_cards(filter).unwrap();
+
+    let detailed_ids: Vec<_> = detailed.iter().map(|(c, _)| c.id).collect();
+    let summary_ids: Vec<_> = summaries.iter().map(|s| s.id).collect();
+    assert_eq!(detailed_ids, summary_ids);
+
+    let detailed_at: Vec<_> = detailed.iter().map(|(_, at)| *at).collect();
+    let summary_at: Vec<_> = summaries.iter().map(|s| s.archived_at).collect();
+    assert_eq!(detailed_at, summary_at);
+}


### PR DESCRIPTION
## Summary

- `GET /v1/boards/{board_id}/cards` now returns `Vec<CardResponse>` instead of the narrower domain `CardSummary`, matching `GET .../cards/{id}`.
- `KanbanContext` gains a public inherent `list_cards_detailed(filter)` that returns the full `Card`s the service already gathers via `filter_cards`, each paired with its archival `archived_at` stamp read from the archived-card marker index. `list_cards_impl` (the `KanbanOperations::list_cards` implementation) is re-expressed on top of it so there is exactly one gather path and one archived-index read per call.
- `KanbanOperations` is unchanged; the new method is inherent, following the `card_archived_at` precedent, so kanban-cli/kanban-mcp are unaffected.

## Wire-shape change

List items now carry `board_id`, `prefix` and `description`, which the old `CardSummary` shape omitted. `priority` and `status` values also change from PascalCase (`"High"`, `"InProgress"`) to snake_case (`"high"`, `"in_progress"`) to match every other card endpoint's DTO. There are zero known consumers of the old shape today: `kanban-backend-http`'s card `DataStore` methods are all `unsupported`, and no documentation describes the route's response body.

## Test plan

- [x] `cargo test -p kanban-service --test list_cards_detailed` (3 new tests, observed failing to compile before the implementation)
- [x] `cargo test -p kanban-server --features test-helpers --test cards_read` (5 new tests + 8 pre-existing tests, all green; new tests observed failing before the fix)
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `scripts/check-factory-compile-lock.sh`