### PR TITLE
KAN-1221 feat(domain,service): derive per-entity invalidation from captured inverse batches

### DIFF
--- a/.changeset/kan-1221-invalidation-vocabulary.md
+++ b/.changeset/kan-1221-invalidation-vocabulary.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: add `EntityIds`/`Invalidation` and `invalidation_from_inverse` to derive the set of boards/columns/cards/sprints/graph a captured inverse command batch touched, plus a pure `Command::touched_entities()` across every command leaf. `KanbanContext::execute_with` computes the derived invalidation on every batch (currently unused, laying groundwork for a future cache-invalidation consumer); no observable behaviour changes.

--- a/.changeset/kan-1221-invalidation-vocabulary.md
+++ b/.changeset/kan-1221-invalidation-vocabulary.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 domain: add `EntityIds`/`Invalidation` and `invalidation_from_inverse` to derive the set of boards/columns/cards/sprints/graph/prefixes a captured inverse command batch touched, plus a pure `Command::touched_entities()` across every command leaf. `KanbanContext::execute_with` computes the derived invalidation on every batch (currently unused, laying groundwork for a future cache-invalidation consumer); no observable behaviour changes.

--- a/.changeset/kan-1221-invalidation-vocabulary.md
+++ b/.changeset/kan-1221-invalidation-vocabulary.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-domain: add `EntityIds`/`Invalidation` and `invalidation_from_inverse` to derive the set of boards/columns/cards/sprints/graph a captured inverse command batch touched, plus a pure `Command::touched_entities()` across every command leaf. `KanbanContext::execute_with` computes the derived invalidation on every batch (currently unused, laying groundwork for a future cache-invalidation consumer); no observable behaviour changes.
+domain: add `EntityIds`/`Invalidation` and `invalidation_from_inverse` to derive the set of boards/columns/cards/sprints/graph/prefixes a captured inverse command batch touched, plus a pure `Command::touched_entities()` across every command leaf. `KanbanContext::execute_with` computes the derived invalidation on every batch (currently unused, laying groundwork for a future cache-invalidation consumer); no observable behaviour changes.

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -79,6 +79,21 @@ impl BoardCommand {
             BoardCommand::Restore(c) => c.capture_inverse(store),
         }
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        match self {
+            BoardCommand::Create(c) => c.touched_entities(),
+            BoardCommand::Update(c) => c.touched_entities(),
+            BoardCommand::SetTaskSort(c) => c.touched_entities(),
+            BoardCommand::SetTaskListView(c) => c.touched_entities(),
+            BoardCommand::Delete(c) => c.touched_entities(),
+            BoardCommand::ApplySettings(c) => c.touched_entities(),
+            BoardCommand::Import(c) => c.touched_entities(),
+            BoardCommand::RestoreSprintPool(c) => c.touched_entities(),
+            BoardCommand::Archive(c) => c.touched_entities(),
+            BoardCommand::Restore(c) => c.touched_entities(),
+        }
+    }
 }
 
 /// Internal — replace a board's sprint-name pool and used-count
@@ -112,6 +127,10 @@ impl RestoreSprintPool {
             "RestoreSprintPool is a synthetic command — it must only appear inside an inverse batch (UpdateSprint undo), never as a top-level forward command. Board id: {}",
             self.board_id
         )))
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards([self.board_id]))
     }
 }
 
@@ -159,6 +178,10 @@ impl CreateBoard {
         Ok(vec![Command::Board(BoardCommand::Delete(DeleteBoard {
             board_id: self.id,
         }))])
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards([self.id]))
     }
 }
 
@@ -236,6 +259,10 @@ impl UpdateBoard {
             updates: inverse,
         }))])
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards([self.board_id]))
+    }
 }
 
 /// Update board's task sorting preference
@@ -272,6 +299,10 @@ impl SetBoardTaskSort {
             },
         ))])
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards([self.board_id]))
+    }
 }
 
 /// Update board's task list view
@@ -305,6 +336,10 @@ impl SetBoardTaskListView {
                 view: board.task_list_view,
             },
         ))])
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards([self.board_id]))
     }
 }
 
@@ -355,6 +390,10 @@ impl DeleteBoard {
             boards: vec![board],
             ..Default::default()
         }))])
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards([self.board_id]))
     }
 }
 
@@ -407,6 +446,10 @@ impl ArchiveBoards {
         }
         Ok(commands)
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards(self.ids.iter().copied()))
+    }
 }
 
 /// Restore an archived board: move it back from the archived collection into
@@ -445,6 +488,10 @@ impl RestoreBoard {
             ids: vec![self.board_id],
         }))])
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards([self.board_id]))
+    }
 }
 
 /// Apply board settings from a DTO (used by JSON editor).
@@ -482,6 +529,10 @@ impl ApplyBoardSettings {
                 dto: prior_dto,
             },
         ))])
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::boards([self.board_id]))
     }
 }
 
@@ -819,5 +870,28 @@ impl ImportEntities {
         }
 
         Ok(commands)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        if self.graph.is_some() {
+            return None;
+        }
+        Some(crate::EntityIds {
+            boards: self
+                .boards
+                .iter()
+                .map(|b| b.id)
+                .chain(self.archived_boards.iter().map(|ab| ab.entity_id))
+                .collect(),
+            columns: self.columns.iter().map(|c| c.id).collect(),
+            cards: self
+                .cards
+                .iter()
+                .map(|c| c.id)
+                .chain(self.archived_cards.iter().map(|ac| ac.entity_id))
+                .collect(),
+            sprints: self.sprints.iter().map(|s| s.id).collect(),
+            graph: false,
+        })
     }
 }

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -876,25 +876,26 @@ impl ImportEntities {
         if self.graph.is_some() {
             return None;
         }
-        Some(crate::EntityIds {
-            boards: self
-                .boards
-                .iter()
-                .map(|b| b.id)
-                .chain(self.archived_boards.iter().map(|ab| ab.entity_id))
-                .collect(),
-            columns: self.columns.iter().map(|c| c.id).collect(),
-            cards: self
-                .cards
-                .iter()
-                .map(|c| c.id)
-                .chain(self.archived_cards.iter().map(|ac| ac.entity_id))
-                .collect(),
-            sprints: self.sprints.iter().map(|s| s.id).collect(),
-            graph: false,
-            prefixes: !self.cards.is_empty()
-                || !self.sprints.is_empty()
-                || !self.prefixes.is_empty(),
-        })
+        Some(
+            crate::EntityIds {
+                boards: self
+                    .boards
+                    .iter()
+                    .map(|b| b.id)
+                    .chain(self.archived_boards.iter().map(|ab| ab.entity_id))
+                    .collect(),
+                columns: self.columns.iter().map(|c| c.id).collect(),
+                cards: self
+                    .cards
+                    .iter()
+                    .map(|c| c.id)
+                    .chain(self.archived_cards.iter().map(|ac| ac.entity_id))
+                    .collect(),
+                sprints: self.sprints.iter().map(|s| s.id).collect(),
+                graph: false,
+                prefixes: false,
+            }
+            .with_prefixes(),
+        )
     }
 }

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -892,6 +892,9 @@ impl ImportEntities {
                 .collect(),
             sprints: self.sprints.iter().map(|s| s.id).collect(),
             graph: false,
+            prefixes: !self.cards.is_empty()
+                || !self.sprints.is_empty()
+                || !self.prefixes.is_empty(),
         })
     }
 }

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -30,6 +30,10 @@ impl UpdateCard {
         "Update card".to_string()
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.card_id]))
+    }
+
     /// Inverse: read the card's current state and synthesise an
     /// `UpdateCard` whose `updates` field-by-field restore each touched
     /// field to its prior value. Fields not touched by the forward
@@ -174,6 +178,14 @@ impl CreateCard {
         format!("Create card: '{}'", self.title)
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds {
+            boards: [self.board_id].into(),
+            cards: [self.id].into(),
+            ..Default::default()
+        })
+    }
+
     /// Inverse: delete the new card. `DeleteCard` is polymorphic over
     /// live / archived so it cleanly removes a freshly-created live
     /// card without leaving an archive trail. Redo via the original
@@ -254,6 +266,10 @@ impl RestoreCard {
     pub fn description(&self) -> String {
         format!("Restore card {}", self.card_id)
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
+    }
 }
 
 /// Permanently delete a card. Operates on whichever list the card is
@@ -279,6 +295,10 @@ impl DeleteCard {
 
     pub fn description(&self) -> String {
         format!("Delete card {}", self.card_id)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
     }
 
     /// Inverse: re-insert whichever state the card was in (live,
@@ -373,5 +393,9 @@ impl ArchiveCards {
 
     pub fn description(&self) -> String {
         format!("Archive {} card(s)", self.ids.len())
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards(self.ids.iter().copied()).with_graph())
     }
 }

--- a/crates/kanban-domain/src/commands/card/metadata.rs
+++ b/crates/kanban-domain/src/commands/card/metadata.rs
@@ -25,6 +25,10 @@ impl ApplyCardMetadata {
         format!("Apply card metadata for {}", self.card_id)
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.card_id]))
+    }
+
     /// Inverse: emit an `UpdateCard` (not another `ApplyCardMetadata`)
     /// because `CardMetadataDto.apply_to` is asymmetric — it can set
     /// `points` / `due_date` but `None` in the DTO means "don't change",

--- a/crates/kanban-domain/src/commands/card/mod.rs
+++ b/crates/kanban-domain/src/commands/card/mod.rs
@@ -80,4 +80,20 @@ impl CardCommand {
             CardCommand::RestoreSprintAttachment(c) => c.capture_inverse(store),
         }
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        match self {
+            CardCommand::Create(c) => c.touched_entities(),
+            CardCommand::Update(c) => c.touched_entities(),
+            CardCommand::Move(c) => c.touched_entities(),
+            CardCommand::Restore(c) => c.touched_entities(),
+            CardCommand::Delete(c) => c.touched_entities(),
+            CardCommand::Archive(c) => c.touched_entities(),
+            CardCommand::AssignToSprint(c) => c.touched_entities(),
+            CardCommand::UnassignFromSprint(c) => c.touched_entities(),
+            CardCommand::ApplyMetadata(c) => c.touched_entities(),
+            CardCommand::CompactPositions(c) => c.touched_entities(),
+            CardCommand::RestoreSprintAttachment(c) => c.touched_entities(),
+        }
+    }
 }

--- a/crates/kanban-domain/src/commands/card/positioning.rs
+++ b/crates/kanban-domain/src/commands/card/positioning.rs
@@ -35,6 +35,10 @@ impl MoveCard {
         )
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.card_id]))
+    }
+
     /// Inverse: another MoveCard pointing back to the card's current
     /// (column_id, position).
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
@@ -70,6 +74,10 @@ impl CompactColumnPositions {
 
     pub fn description(&self) -> String {
         format!("Compact positions in column {}", self.column_id)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
     }
 
     /// Inverse: for each card in the column, emit a MoveCard back to its

--- a/crates/kanban-domain/src/commands/card/sprint_binding.rs
+++ b/crates/kanban-domain/src/commands/card/sprint_binding.rs
@@ -33,6 +33,10 @@ impl RestoreCardSprintAttachment {
         format!("Restore sprint attachment for card {}", self.card_id)
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.card_id]))
+    }
+
     pub fn capture_inverse(&self, _store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         Err(KanbanError::Internal(format!(
             "RestoreCardSprintAttachment is a synthetic command — it must only appear inside an inverse batch (Assign/Unassign undo), never as a top-level forward command. Card id: {}",
@@ -112,6 +116,10 @@ impl AssignCardsToSprint {
             self.sprint_id
         )
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards(self.ids.iter().copied()))
+    }
 }
 
 /// Unassign card from current sprint
@@ -134,6 +142,10 @@ impl UnassignCardFromSprint {
 
     pub fn description(&self) -> String {
         format!("Unassign card {} from sprint", self.card_id)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.card_id]))
     }
 
     /// Inverse: if the card currently has a sprint, re-assign it to that

--- a/crates/kanban-domain/src/commands/cascade_commands.rs
+++ b/crates/kanban-domain/src/commands/cascade_commands.rs
@@ -66,6 +66,17 @@ impl CascadeCommand {
             CascadeCommand::SetArchivedCardsSprint(c) => c.capture_inverse(store),
         }
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        match self {
+            CascadeCommand::DeleteCardEdges(c) => c.touched_entities(),
+            CascadeCommand::DeleteCardsByColumns(c) => c.touched_entities(),
+            CascadeCommand::DeleteArchivedCards(c) => c.touched_entities(),
+            CascadeCommand::DeleteColumnsByBoard(c) => c.touched_entities(),
+            CascadeCommand::DeleteSprintsByBoard(c) => c.touched_entities(),
+            CascadeCommand::SetArchivedCardsSprint(c) => c.touched_entities(),
+        }
+    }
 }
 
 /// Remove all dependency-graph edges for a batch of card IDs.
@@ -87,6 +98,10 @@ impl DeleteCardEdges {
 
     pub fn description(&self) -> String {
         format!("Remove {} card(s) from dependency graph", self.ids.len())
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
     }
 
     /// Inverse: capture every active edge involving any id in self.ids and
@@ -116,6 +131,10 @@ impl DeleteCardsByColumns {
 
     pub fn description(&self) -> String {
         format!("Delete all cards in {} column(s)", self.column_ids.len())
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
     }
 
     /// Inverse: capture every live card in the target columns and emit an
@@ -154,6 +173,10 @@ impl DeleteArchivedCards {
 
     pub fn description(&self) -> String {
         format!("Delete {} archived card(s)", self.card_ids.len())
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
     }
 
     /// Inverse: reference-marker model. `delete_archived_card` removes BOTH the
@@ -201,6 +224,10 @@ impl DeleteColumnsByBoard {
         format!("Delete all columns in board {}", self.board_id)
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
+    }
+
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let columns = store.list_columns_by_board(self.board_id)?;
         if columns.is_empty() {
@@ -226,6 +253,10 @@ impl DeleteSprintsByBoard {
 
     pub fn description(&self) -> String {
         format!("Delete all sprints in board {}", self.board_id)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
     }
 
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
@@ -272,6 +303,12 @@ impl SetArchivedCardsSprint {
             self.sprint_id,
             self.archived_card_ids.len()
         )
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards(
+            self.archived_card_ids.iter().copied(),
+        ))
     }
 
     /// Synthetic-only. Rejects top-level execute so misuse fails

--- a/crates/kanban-domain/src/commands/column_commands.rs
+++ b/crates/kanban-domain/src/commands/column_commands.rs
@@ -39,6 +39,14 @@ impl ColumnCommand {
             ColumnCommand::Delete(c) => c.capture_inverse(store),
         }
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        match self {
+            ColumnCommand::Create(c) => c.touched_entities(),
+            ColumnCommand::Update(c) => c.touched_entities(),
+            ColumnCommand::Delete(c) => c.touched_entities(),
+        }
+    }
 }
 
 /// Update column properties (name, position, wip_limit)
@@ -97,6 +105,10 @@ impl UpdateColumn {
             updates: inverse_updates,
         }))])
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::columns([self.column_id]))
+    }
 }
 
 /// Create a new column
@@ -139,6 +151,10 @@ impl CreateColumn {
         Ok(vec![Command::Column(ColumnCommand::Delete(DeleteColumn {
             column_id: self.id,
         }))])
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::columns([self.id]))
     }
 }
 
@@ -194,5 +210,9 @@ impl DeleteColumn {
 
     pub fn description(&self) -> String {
         format!("Delete column {}", self.column_id)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::columns([self.column_id]))
     }
 }

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -536,13 +536,15 @@ impl CreateSubcardCommand {
     }
 
     pub fn touched_entities(&self) -> Option<crate::EntityIds> {
-        Some(crate::EntityIds {
-            boards: [self.board_id].into(),
-            cards: [self.id, self.parent_id].into(),
-            graph: true,
-            prefixes: true,
-            ..Default::default()
-        })
+        Some(
+            crate::EntityIds {
+                boards: [self.board_id].into(),
+                cards: [self.id, self.parent_id].into(),
+                graph: true,
+                ..Default::default()
+            }
+            .with_prefixes(),
+        )
     }
 
     /// Inverse: delete the new card. `DeleteCard` is polymorphic over

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -67,6 +67,18 @@ impl DependencyCommand {
             DependencyCommand::CreateSubcard(c) => c.capture_inverse(store),
         }
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        match self {
+            DependencyCommand::AddSpawns(c) => c.touched_entities(),
+            DependencyCommand::AddBlocks(c) => c.touched_entities(),
+            DependencyCommand::AddRelates(c) => c.touched_entities(),
+            DependencyCommand::RemoveSpawns(c) => c.touched_entities(),
+            DependencyCommand::RemoveBlocks(c) => c.touched_entities(),
+            DependencyCommand::RemoveRelates(c) => c.touched_entities(),
+            DependencyCommand::CreateSubcard(c) => c.touched_entities(),
+        }
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -105,6 +117,10 @@ impl AddSpawns {
 
     pub fn description(&self) -> String {
         format!("Set parent: {} is parent of {}", self.source, self.target)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
     }
 
     /// Inverse: per-kind [`RemoveSpawns`] with `tolerate_missing =
@@ -156,6 +172,10 @@ impl AddBlocks {
         )
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
+    }
+
     /// Inverse: per-kind [`RemoveBlocks`] with `tolerate_missing =
     /// true`. See [`AddSpawns::capture_inverse`] for the rationale.
     pub fn capture_inverse(&self, _store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
@@ -199,6 +219,10 @@ impl AddRelates {
             "Add relates-to dependency ({:?}): {} <-> {}",
             self.kind, self.source, self.target
         )
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
     }
 
     /// Inverse: per-kind [`RemoveRelates`] with `tolerate_missing =
@@ -262,6 +286,10 @@ impl RemoveSpawns {
         )
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
+    }
+
     /// Inverse: re-add the parent edge (as active — user-initiated
     /// removes only fire against active edges, so the original state
     /// was active).
@@ -303,6 +331,10 @@ impl RemoveBlocks {
             "Remove blocks dependency: {} no longer blocks {}",
             self.source, self.target
         )
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
     }
 
     /// Inverse: re-add the blocks edge. We don't know the original
@@ -354,6 +386,10 @@ impl RemoveRelates {
             "Remove relates-to dependency: {} <-> {}",
             self.source, self.target
         )
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
     }
 
     /// Inverse: re-add the relates edge. Same as RemoveBlocks: we
@@ -497,6 +533,15 @@ impl CreateSubcardCommand {
             "Create subcard '{}' under parent {}",
             self.title, self.parent_id
         )
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds {
+            boards: [self.board_id].into(),
+            cards: [self.id, self.parent_id].into(),
+            graph: true,
+            ..Default::default()
+        })
     }
 
     /// Inverse: delete the new card. `DeleteCard` is polymorphic over

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -540,6 +540,7 @@ impl CreateSubcardCommand {
             boards: [self.board_id].into(),
             cards: [self.id, self.parent_id].into(),
             graph: true,
+            prefixes: true,
             ..Default::default()
         })
     }

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -72,6 +72,13 @@ impl Command {
             Command::Cascade(cmd) => cmd.capture_inverse(store),
         }
     }
+
+    /// The exact set of entities this command's `execute` writes, or `None`
+    /// if the write's full scope cannot be enumerated from this command's
+    /// own fields alone.
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        todo!()
+    }
 }
 
 /// Context passed to commands for mutation.

--- a/crates/kanban-domain/src/commands/mod.rs
+++ b/crates/kanban-domain/src/commands/mod.rs
@@ -77,7 +77,14 @@ impl Command {
     /// if the write's full scope cannot be enumerated from this command's
     /// own fields alone.
     pub fn touched_entities(&self) -> Option<crate::EntityIds> {
-        todo!()
+        match self {
+            Command::Board(cmd) => cmd.touched_entities(),
+            Command::Column(cmd) => cmd.touched_entities(),
+            Command::Card(cmd) => cmd.touched_entities(),
+            Command::Sprint(cmd) => cmd.touched_entities(),
+            Command::Dependency(cmd) => cmd.touched_entities(),
+            Command::Cascade(cmd) => cmd.touched_entities(),
+        }
     }
 }
 

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -326,6 +326,7 @@ impl CreateSprint {
         Some(crate::EntityIds {
             boards: [self.board_id].into(),
             sprints: [self.id].into(),
+            prefixes: true,
             ..Default::default()
         })
     }

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -323,12 +323,14 @@ impl CreateSprint {
     }
 
     pub fn touched_entities(&self) -> Option<crate::EntityIds> {
-        Some(crate::EntityIds {
-            boards: [self.board_id].into(),
-            sprints: [self.id].into(),
-            prefixes: true,
-            ..Default::default()
-        })
+        Some(
+            crate::EntityIds {
+                boards: [self.board_id].into(),
+                sprints: [self.id].into(),
+                ..Default::default()
+            }
+            .with_prefixes(),
+        )
     }
 
     /// Inverse: delete the newly-created sprint. The board's

--- a/crates/kanban-domain/src/commands/sprint_commands.rs
+++ b/crates/kanban-domain/src/commands/sprint_commands.rs
@@ -50,6 +50,17 @@ impl SprintCommand {
             SprintCommand::Delete(c) => c.capture_inverse(store),
         }
     }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        match self {
+            SprintCommand::Create(c) => c.touched_entities(),
+            SprintCommand::Update(c) => c.touched_entities(),
+            SprintCommand::Activate(c) => c.touched_entities(),
+            SprintCommand::Complete(c) => c.touched_entities(),
+            SprintCommand::Cancel(c) => c.touched_entities(),
+            SprintCommand::Delete(c) => c.touched_entities(),
+        }
+    }
 }
 
 /// Update sprint properties (name_index, prefix, card_prefix, status, dates)
@@ -82,6 +93,13 @@ impl UpdateSprint {
 
     pub fn description(&self) -> String {
         "Update sprint".to_string()
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        if self.updates.name.is_some() {
+            return None;
+        }
+        Some(crate::EntityIds::sprints([self.sprint_id]))
     }
 
     /// Inverse: read the current Sprint (and Board if the forward
@@ -304,6 +322,14 @@ impl CreateSprint {
         format!("Create sprint for board {}", self.board_id)
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds {
+            boards: [self.board_id].into(),
+            sprints: [self.id].into(),
+            ..Default::default()
+        })
+    }
+
     /// Inverse: delete the newly-created sprint. The board's
     /// sprint_name_used_count stays bumped — display numbering drifts
     /// for *future* sprints only, redo of this one reproduces the same
@@ -335,6 +361,10 @@ impl ActivateSprint {
         format!("Activate sprint {}", self.sprint_id)
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::sprints([self.sprint_id]))
+    }
+
     /// Inverse: restore the sprint's prior status, start_date, end_date.
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         capture_status_revert(store, self.sprint_id)
@@ -359,6 +389,10 @@ impl CompleteSprint {
         format!("Complete sprint {}", self.sprint_id)
     }
 
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::sprints([self.sprint_id]))
+    }
+
     /// Inverse: restore the sprint's prior status.
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         capture_status_revert(store, self.sprint_id)
@@ -381,6 +415,10 @@ impl CancelSprint {
 
     pub fn description(&self) -> String {
         format!("Cancel sprint {}", self.sprint_id)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        Some(crate::EntityIds::sprints([self.sprint_id]))
     }
 
     /// Inverse: restore the sprint's prior status.
@@ -437,6 +475,10 @@ impl DeleteSprint {
 
     pub fn description(&self) -> String {
         format!("Delete sprint {}", self.sprint_id)
+    }
+
+    pub fn touched_entities(&self) -> Option<crate::EntityIds> {
+        None
     }
 
     /// Inverse: capture the Sprint, every live card assigned to it, and

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -49,6 +49,11 @@ impl EntityIds {
         self
     }
 
+    pub fn with_prefixes(mut self) -> Self {
+        self.prefixes = true;
+        self
+    }
+
     pub fn is_empty(&self) -> bool {
         self.boards.is_empty()
             && self.columns.is_empty()
@@ -421,14 +426,5 @@ mod tests {
             })),
         ];
         assert_eq!(invalidation_from_inverse(&batch), Invalidation::All);
-    }
-
-    #[test]
-    fn test_invalidation_from_a_batch_whose_accumulated_ids_are_empty_is_all() {
-        let cmd = Command::Board(BoardCommand::Import(ImportEntities::default()));
-        assert_eq!(
-            invalidation_from_inverse(std::slice::from_ref(&cmd)),
-            Invalidation::All
-        );
     }
 }

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -3,8 +3,8 @@ use uuid::Uuid;
 
 /// The set of entities a command touched, scoped per collection.
 ///
-/// `graph` is a separate boolean rather than folded into `cards` because the
-/// dependency graph is cached independently of card rows.
+/// `graph` is set when the command mutated the dependency graph. `prefixes`
+/// is set when the command upserted a prefix row.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EntityIds {
     pub boards: HashSet<Uuid>,
@@ -12,6 +12,7 @@ pub struct EntityIds {
     pub cards: HashSet<Uuid>,
     pub sprints: HashSet<Uuid>,
     pub graph: bool,
+    pub prefixes: bool,
 }
 
 impl EntityIds {
@@ -54,6 +55,7 @@ impl EntityIds {
             && self.cards.is_empty()
             && self.sprints.is_empty()
             && !self.graph
+            && !self.prefixes
     }
 
     pub fn merge(&mut self, other: EntityIds) {
@@ -62,6 +64,7 @@ impl EntityIds {
         self.cards.extend(other.cards);
         self.sprints.extend(other.sprints);
         self.graph |= other.graph;
+        self.prefixes |= other.prefixes;
     }
 }
 
@@ -163,6 +166,20 @@ mod tests {
     }
 
     #[test]
+    fn test_create_sprint_touched_entities_marks_prefixes_dirty() {
+        let cmd = Command::Sprint(SprintCommand::Create(CreateSprint {
+            id: Uuid::new_v4(),
+            board_id: Uuid::new_v4(),
+            name: None,
+            default_sprint_prefix: "kan".into(),
+            explicit_prefix: None,
+            auto_consume_name: false,
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert!(ids.prefixes);
+    }
+
+    #[test]
     fn test_update_sprint_without_a_name_change_names_only_that_sprint() {
         let sprint_id = Uuid::new_v4();
         let cmd = Command::Sprint(SprintCommand::Update(UpdateSprint {
@@ -203,6 +220,22 @@ mod tests {
         let ids = cmd.touched_entities().expect("enumerable");
         assert_eq!(ids.cards, HashSet::from([source, target]));
         assert!(ids.graph);
+    }
+
+    #[test]
+    fn test_create_subcard_touched_entities_marks_prefixes_dirty() {
+        let cmd = Command::Dependency(DependencyCommand::CreateSubcard(CreateSubcardCommand {
+            id: Uuid::new_v4(),
+            parent_id: Uuid::new_v4(),
+            board_id: Uuid::new_v4(),
+            column_id: Uuid::new_v4(),
+            title: "t".into(),
+            description: None,
+            position: 0,
+            default_card_prefix: "kan".into(),
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert!(ids.prefixes);
     }
 
     #[test]
@@ -307,6 +340,14 @@ mod tests {
         assert_eq!(ids.cards, HashSet::from([card_id, archived_card_id]));
         assert_eq!(ids.sprints, HashSet::from([sprint_id]));
         assert!(!ids.graph);
+        assert!(ids.prefixes);
+    }
+
+    #[test]
+    fn test_import_entities_with_no_cards_sprints_or_prefixes_does_not_mark_prefixes_dirty() {
+        let cmd = Command::Board(BoardCommand::Import(ImportEntities::default()));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert!(!ids.prefixes);
     }
 
     #[test]
@@ -380,5 +421,14 @@ mod tests {
             })),
         ];
         assert_eq!(invalidation_from_inverse(&batch), Invalidation::All);
+    }
+
+    #[test]
+    fn test_invalidation_from_a_batch_whose_accumulated_ids_are_empty_is_all() {
+        let cmd = Command::Board(BoardCommand::Import(ImportEntities::default()));
+        assert_eq!(
+            invalidation_from_inverse(std::slice::from_ref(&cmd)),
+            Invalidation::All
+        );
     }
 }

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -344,10 +344,10 @@ mod tests {
     }
 
     #[test]
-    fn test_import_entities_with_no_cards_sprints_or_prefixes_does_not_mark_prefixes_dirty() {
+    fn test_import_entities_with_only_boards_still_marks_prefixes_dirty() {
         let cmd = Command::Board(BoardCommand::Import(ImportEntities::default()));
         let ids = cmd.touched_entities().expect("enumerable");
-        assert!(!ids.prefixes);
+        assert!(ids.prefixes);
     }
 
     #[test]

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -1,0 +1,384 @@
+use std::collections::HashSet;
+use uuid::Uuid;
+
+/// The set of entities a command touched, scoped per collection.
+///
+/// `graph` is a separate boolean rather than folded into `cards` because the
+/// dependency graph is cached independently of card rows.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EntityIds {
+    pub boards: HashSet<Uuid>,
+    pub columns: HashSet<Uuid>,
+    pub cards: HashSet<Uuid>,
+    pub sprints: HashSet<Uuid>,
+    pub graph: bool,
+}
+
+impl EntityIds {
+    pub fn boards(ids: impl IntoIterator<Item = Uuid>) -> Self {
+        Self {
+            boards: ids.into_iter().collect(),
+            ..Default::default()
+        }
+    }
+
+    pub fn columns(ids: impl IntoIterator<Item = Uuid>) -> Self {
+        Self {
+            columns: ids.into_iter().collect(),
+            ..Default::default()
+        }
+    }
+
+    pub fn cards(ids: impl IntoIterator<Item = Uuid>) -> Self {
+        Self {
+            cards: ids.into_iter().collect(),
+            ..Default::default()
+        }
+    }
+
+    pub fn sprints(ids: impl IntoIterator<Item = Uuid>) -> Self {
+        Self {
+            sprints: ids.into_iter().collect(),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_graph(mut self) -> Self {
+        self.graph = true;
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.boards.is_empty()
+            && self.columns.is_empty()
+            && self.cards.is_empty()
+            && self.sprints.is_empty()
+            && !self.graph
+    }
+
+    pub fn merge(&mut self, other: EntityIds) {
+        self.boards.extend(other.boards);
+        self.columns.extend(other.columns);
+        self.cards.extend(other.cards);
+        self.sprints.extend(other.sprints);
+        self.graph |= other.graph;
+    }
+}
+
+/// What a batch of commands invalidated in a cache keyed on entity id.
+///
+/// `Entities` names exactly what changed. `All` is the safe fallback for any
+/// batch containing a command whose full blast radius cannot be enumerated
+/// from its own fields (an empty batch counts as unenumerable, never as "no
+/// invalidation").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Invalidation {
+    Entities(EntityIds),
+    All,
+}
+
+/// Derive the [`Invalidation`] a captured inverse batch implies.
+///
+/// Folds [`crate::commands::Command::touched_entities`] over `inverse`,
+/// falling back to `All` the moment any command in the batch returns `None`,
+/// or when the batch (or its accumulated ids) is empty.
+pub fn invalidation_from_inverse(inverse: &[crate::commands::Command]) -> Invalidation {
+    if inverse.is_empty() {
+        return Invalidation::All;
+    }
+    let mut acc = EntityIds::default();
+    for cmd in inverse {
+        match cmd.touched_entities() {
+            Some(ids) => acc.merge(ids),
+            None => return Invalidation::All,
+        }
+    }
+    if acc.is_empty() {
+        return Invalidation::All;
+    }
+    Invalidation::Entities(acc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::cascade_commands::{
+        CascadeCommand, DeleteArchivedCards, DeleteCardsByColumns,
+    };
+    use crate::commands::*;
+    use crate::{ArchivedBoard, ArchivedCard, Board, CardUpdate, ColumnUpdate, SprintUpdate};
+    use crate::{BoardUpdate, CreateCardOptions, DependencyGraph};
+    use chrono::Utc;
+
+    #[test]
+    fn test_update_card_touched_entities_names_only_that_card() {
+        let card_id = Uuid::new_v4();
+        let cmd = Command::Card(CardCommand::Update(UpdateCard {
+            card_id,
+            updates: CardUpdate::default(),
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.cards, HashSet::from([card_id]));
+        assert!(ids.boards.is_empty());
+        assert!(ids.columns.is_empty());
+        assert!(ids.sprints.is_empty());
+        assert!(!ids.graph);
+    }
+
+    #[test]
+    fn test_create_card_touched_entities_includes_the_counter_bumping_board() {
+        let id = Uuid::new_v4();
+        let board_id = Uuid::new_v4();
+        let cmd = Command::Card(CardCommand::Create(CreateCard {
+            id,
+            card_number: 1,
+            board_id,
+            column_id: Uuid::new_v4(),
+            title: "t".into(),
+            position: 0,
+            options: CreateCardOptions::default(),
+            timestamp: Utc::now(),
+            default_card_prefix: "kan".into(),
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.cards, HashSet::from([id]));
+        assert_eq!(ids.boards, HashSet::from([board_id]));
+    }
+
+    #[test]
+    fn test_create_sprint_touched_entities_includes_the_owning_board() {
+        let id = Uuid::new_v4();
+        let board_id = Uuid::new_v4();
+        let cmd = Command::Sprint(SprintCommand::Create(CreateSprint {
+            id,
+            board_id,
+            name: None,
+            default_sprint_prefix: "kan".into(),
+            explicit_prefix: None,
+            auto_consume_name: false,
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.sprints, HashSet::from([id]));
+        assert_eq!(ids.boards, HashSet::from([board_id]));
+    }
+
+    #[test]
+    fn test_update_sprint_without_a_name_change_names_only_that_sprint() {
+        let sprint_id = Uuid::new_v4();
+        let cmd = Command::Sprint(SprintCommand::Update(UpdateSprint {
+            sprint_id,
+            updates: SprintUpdate {
+                name: None,
+                status: Some(crate::SprintStatus::Active),
+                ..Default::default()
+            },
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.sprints, HashSet::from([sprint_id]));
+        assert!(ids.boards.is_empty());
+    }
+
+    #[test]
+    fn test_update_sprint_with_a_name_change_is_unenumerable() {
+        let sprint_id = Uuid::new_v4();
+        let cmd = Command::Sprint(SprintCommand::Update(UpdateSprint {
+            sprint_id,
+            updates: SprintUpdate {
+                name: Some("Alpha".into()),
+                ..Default::default()
+            },
+        }));
+        assert!(cmd.touched_entities().is_none());
+    }
+
+    #[test]
+    fn test_add_spawns_touched_entities_marks_the_graph_dirty() {
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let cmd = Command::Dependency(DependencyCommand::AddSpawns(AddSpawns {
+            source,
+            target,
+            as_archived: false,
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.cards, HashSet::from([source, target]));
+        assert!(ids.graph);
+    }
+
+    #[test]
+    fn test_archive_cards_touched_entities_marks_the_graph_dirty() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let cmd = Command::Card(CardCommand::Archive(ArchiveCards { ids: vec![a, b] }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.cards, HashSet::from([a, b]));
+        assert!(ids.graph);
+    }
+
+    #[test]
+    fn test_delete_card_touched_entities_is_unenumerable() {
+        let cmd = Command::Card(CardCommand::Delete(DeleteCard {
+            card_id: Uuid::new_v4(),
+        }));
+        assert!(cmd.touched_entities().is_none());
+    }
+
+    #[test]
+    fn test_delete_archived_cards_touched_entities_is_unenumerable() {
+        let cmd = Command::Cascade(CascadeCommand::DeleteArchivedCards(DeleteArchivedCards {
+            card_ids: vec![Uuid::new_v4()],
+        }));
+        assert!(cmd.touched_entities().is_none());
+    }
+
+    #[test]
+    fn test_delete_cards_by_columns_touched_entities_is_unenumerable() {
+        let cmd = Command::Cascade(CascadeCommand::DeleteCardsByColumns(DeleteCardsByColumns {
+            column_ids: vec![Uuid::new_v4()],
+        }));
+        assert!(cmd.touched_entities().is_none());
+    }
+
+    #[test]
+    fn test_import_entities_without_a_graph_enumerates_every_collection() {
+        let board = Board::create(
+            crate::NewBoard {
+                name: "B".into(),
+                description: None,
+                sprint_prefix: None,
+                card_prefix: None,
+                task_sort_field: None,
+                task_sort_order: None,
+                sprint_duration_days: None,
+                task_list_view: None,
+            },
+            Uuid::new_v4(),
+            Utc::now(),
+        )
+        .unwrap();
+        let board_id = board.id;
+        let column = crate::Column::create(
+            crate::NewColumn {
+                board_id,
+                name: "TODO".into(),
+                wip_limit: None,
+                default_status: None,
+            },
+            Uuid::new_v4(),
+            0,
+            Utc::now(),
+        )
+        .unwrap();
+        let column_id = column.id;
+        let card = crate::Card::new(board_id, column_id, "c1", 0);
+        let card_id = card.id;
+        let archived_card_id = Uuid::new_v4();
+        let archived_card = ArchivedCard::new(archived_card_id, board_id);
+        let archived_board_id = Uuid::new_v4();
+        let archived_board: ArchivedBoard = crate::Archived::now(archived_board_id);
+        let sprint = crate::Sprint::create(
+            crate::NewSprint {
+                board_id,
+                sprint_number: 1,
+                name_index: None,
+                prefix: None,
+                card_prefix: None,
+            },
+            Uuid::new_v4(),
+            Utc::now(),
+        )
+        .unwrap();
+        let sprint_id = sprint.id;
+
+        let cmd = Command::Board(BoardCommand::Import(ImportEntities {
+            boards: vec![board],
+            columns: vec![column],
+            cards: vec![card],
+            archived_cards: vec![archived_card],
+            archived_boards: vec![archived_board],
+            sprints: vec![sprint],
+            graph: None,
+            ..Default::default()
+        }));
+
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.boards, HashSet::from([board_id, archived_board_id]));
+        assert_eq!(ids.columns, HashSet::from([column_id]));
+        assert_eq!(ids.cards, HashSet::from([card_id, archived_card_id]));
+        assert_eq!(ids.sprints, HashSet::from([sprint_id]));
+        assert!(!ids.graph);
+    }
+
+    #[test]
+    fn test_import_entities_with_a_graph_is_unenumerable() {
+        let cmd = Command::Board(BoardCommand::Import(ImportEntities {
+            graph: Some(DependencyGraph::default()),
+            ..Default::default()
+        }));
+        assert!(cmd.touched_entities().is_none());
+    }
+
+    #[test]
+    fn test_update_column_touched_entities_names_only_that_column() {
+        let column_id = Uuid::new_v4();
+        let cmd = Command::Column(ColumnCommand::Update(UpdateColumn {
+            column_id,
+            updates: ColumnUpdate::default(),
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.columns, HashSet::from([column_id]));
+    }
+
+    #[test]
+    fn test_update_board_touched_entities_names_only_that_board() {
+        let board_id = Uuid::new_v4();
+        let cmd = Command::Board(BoardCommand::Update(UpdateBoard {
+            board_id,
+            updates: BoardUpdate::default(),
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.boards, HashSet::from([board_id]));
+    }
+
+    #[test]
+    fn test_invalidation_from_empty_inverse_batch_is_all() {
+        assert_eq!(invalidation_from_inverse(&[]), Invalidation::All);
+    }
+
+    #[test]
+    fn test_invalidation_merges_ids_across_a_multi_command_batch() {
+        let card_a = Uuid::new_v4();
+        let board_b = Uuid::new_v4();
+        let batch = vec![
+            Command::Card(CardCommand::Update(UpdateCard {
+                card_id: card_a,
+                updates: CardUpdate::default(),
+            })),
+            Command::Board(BoardCommand::Update(UpdateBoard {
+                board_id: board_b,
+                updates: BoardUpdate::default(),
+            })),
+        ];
+        match invalidation_from_inverse(&batch) {
+            Invalidation::Entities(ids) => {
+                assert_eq!(ids.cards, HashSet::from([card_a]));
+                assert_eq!(ids.boards, HashSet::from([board_b]));
+            }
+            Invalidation::All => panic!("expected Entities, got All"),
+        }
+    }
+
+    #[test]
+    fn test_invalidation_from_a_mixed_batch_with_one_unenumerable_command_is_all() {
+        let batch = vec![
+            Command::Card(CardCommand::Update(UpdateCard {
+                card_id: Uuid::new_v4(),
+                updates: CardUpdate::default(),
+            })),
+            Command::Card(CardCommand::Delete(DeleteCard {
+                card_id: Uuid::new_v4(),
+            })),
+        ];
+        assert_eq!(invalidation_from_inverse(&batch), Invalidation::All);
+    }
+}

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -415,6 +415,18 @@ mod tests {
     }
 
     #[test]
+    fn test_a_command_touching_no_entities_invalidates_everything() {
+        let cmd = Command::Card(CardCommand::AssignToSprint(AssignCardsToSprint {
+            ids: vec![],
+            sprint_id: Uuid::new_v4(),
+        }));
+        assert_eq!(
+            invalidation_from_inverse(std::slice::from_ref(&cmd)),
+            Invalidation::All
+        );
+    }
+
+    #[test]
     fn test_invalidation_from_a_mixed_batch_with_one_unenumerable_command_is_all() {
         let batch = vec![
             Command::Card(CardCommand::Update(UpdateCard {

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -22,6 +22,7 @@ pub mod export;
 pub mod field_update;
 pub mod filter;
 pub mod graph_operations;
+pub mod invalidation;
 pub mod load_state;
 pub mod operations;
 pub mod prefix;
@@ -67,6 +68,7 @@ pub use export::{AllBoardsExport, BoardExport, BoardExporter, BoardImporter, Imp
 pub use field_update::FieldUpdate;
 pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
+pub use invalidation::{invalidation_from_inverse, EntityIds, Invalidation};
 pub use load_state::LoadState;
 pub use operations::KanbanOperations;
 pub use prefix::{

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -70,6 +70,7 @@ impl KanbanContext {
             Ok(())
         }))?;
         let inverses: Vec<Command> = per_cmd_inverses.into_iter().rev().flatten().collect();
+        let _invalidation = kanban_domain::invalidation_from_inverse(&inverses);
 
         self.undo_stack.push(crate::undo_stack::UndoEntry {
             forward: commands,

--- a/crates/kanban-service/tests/invalidation_from_inverse.rs
+++ b/crates/kanban-service/tests/invalidation_from_inverse.rs
@@ -81,3 +81,35 @@ async fn test_invalidation_from_a_real_empty_capture_inverse_is_all() {
 
     assert_eq!(invalidation_from_inverse(&inverse), Invalidation::All);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalidation_from_a_columns_only_import_inverse_declares_prefixes() {
+    use kanban_domain::commands::cascade_commands::DeleteColumnsByBoard;
+
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    ctx.create_column(board.id, "A".into(), None).unwrap();
+    ctx.create_sprint(board.id, Some("ops".into()), None)
+        .unwrap();
+
+    let backend = ctx.backend();
+    let store: &dyn DataStore = backend.as_data_store();
+
+    let cmd = Command::Cascade(CascadeCommand::DeleteColumnsByBoard(DeleteColumnsByBoard {
+        board_id: board.id,
+    }));
+    let inverse = cmd.capture_inverse(store).unwrap();
+    assert!(!inverse.is_empty(), "board has a column to restore");
+
+    let invalidation = invalidation_from_inverse(&inverse);
+    match invalidation {
+        Invalidation::Entities(ids) => {
+            assert!(
+                ids.prefixes,
+                "restoring columns can still resolve a prefix namespace for the \
+                 board's sprint and mint a prefix row on undo"
+            );
+        }
+        Invalidation::All => panic!("expected Entities, got All"),
+    }
+}

--- a/crates/kanban-service/tests/invalidation_from_inverse.rs
+++ b/crates/kanban-service/tests/invalidation_from_inverse.rs
@@ -1,0 +1,83 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::commands::cascade_commands::{CascadeCommand, DeleteArchivedCards};
+use kanban_domain::commands::{CardCommand, Command, CommandContext, MoveCard, UpdateCard};
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{invalidation_from_inverse, CardUpdate, Invalidation, KanbanOperations};
+use kanban_service::KanbanContext;
+use std::collections::HashSet;
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn make_ctx() -> KanbanContext {
+    KanbanContext::open(
+        Arc::new(InMemoryStore::new()),
+        kanban_core::AppConfig::default(),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalidation_from_a_real_capture_inverse_batch_names_exactly_the_touched_cards() {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None).unwrap();
+    let col_a = ctx.create_column(board.id, "A".into(), None).unwrap();
+    let col_b = ctx.create_column(board.id, "B".into(), None).unwrap();
+    let card1 = ctx
+        .create_card(board.id, col_a.id, "Card 1".into(), Default::default())
+        .unwrap();
+    let card2 = ctx
+        .create_card(board.id, col_a.id, "Card 2".into(), Default::default())
+        .unwrap();
+    let _card3 = ctx
+        .create_card(board.id, col_a.id, "Card 3".into(), Default::default())
+        .unwrap();
+
+    let backend = ctx.backend();
+    let store: &dyn DataStore = backend.as_data_store();
+    let cmd_ctx = CommandContext { store };
+
+    let update_cmd = Command::Card(CardCommand::Update(UpdateCard {
+        card_id: card1.id,
+        updates: CardUpdate {
+            title: Some("Renamed".into()),
+            ..Default::default()
+        },
+    }));
+    let mut inverse = update_cmd.capture_inverse(store).unwrap();
+    update_cmd.execute(&cmd_ctx).unwrap();
+
+    let move_cmd = Command::Card(CardCommand::Move(MoveCard {
+        card_id: card2.id,
+        new_column_id: col_b.id,
+        new_position: 0,
+    }));
+    inverse.extend(move_cmd.capture_inverse(store).unwrap());
+    move_cmd.execute(&cmd_ctx).unwrap();
+
+    let invalidation = invalidation_from_inverse(&inverse);
+    match invalidation {
+        Invalidation::Entities(ids) => {
+            assert_eq!(ids.cards, HashSet::from([card1.id, card2.id]));
+        }
+        Invalidation::All => panic!("expected Entities, got All"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalidation_from_a_real_empty_capture_inverse_is_all() {
+    let ctx = make_ctx().await;
+    let backend = ctx.backend();
+    let store: &dyn DataStore = backend.as_data_store();
+
+    let cmd = Command::Cascade(CascadeCommand::DeleteArchivedCards(DeleteArchivedCards {
+        card_ids: vec![Uuid::new_v4()],
+    }));
+    let inverse = cmd.capture_inverse(store).unwrap();
+    assert!(
+        inverse.is_empty(),
+        "no such archived card, inverse must be empty"
+    );
+
+    assert_eq!(invalidation_from_inverse(&inverse), Invalidation::All);
+}


### PR DESCRIPTION
## Summary

Adds the two-level cache-invalidation vocabulary and wires it as a discarded computation on every command batch, so the cost is real from day one while behaviour stays bit-identical.

- `EntityIds { boards, columns, cards, sprints, graph: bool, prefixes: bool }` and `Invalidation { Entities(EntityIds), All }` in `kanban-domain/src/invalidation.rs`.
- `Command::touched_entities()`, a pure, field-only method dispatched exhaustively across all ~40 command leaves (no wildcard arm at any level), returning the exact entity ids a command touches, or `None` when the blast radius cannot be enumerated from the command's own fields.
- `invalidation_from_inverse(&[Command]) -> Invalidation`, which folds `touched_entities()` over a captured inverse batch; an empty batch, an accumulated-empty result, or any single `None` in the batch all fall back to `Invalidation::All`.
- `KanbanContext::execute_with` computes `invalidation_from_inverse(&inverses)` into a discarded local immediately after building the inverse batch. No new field, no new public surface; the context cache and its `invalidate`/`resolve` API are out of scope for this card (KAN-1302).

## Location deviation from the card

The card's acceptance criterion places `EntityIds`/`Invalidation`/`invalidation_from_inverse` in `kanban-service`. That is overridden by KAN-1218's later "BLOCKING CROSS-CUTTING GAP" section, which lists these exact types as crossing the EntityCache/Model boundary and requires they live in `kanban-domain`, since `kanban-service` and `kanban-view` are siblings that cannot name each other's types. All three land in `kanban-domain/src/invalidation.rs` per that clause.

## The `graph: bool` decision

`EntityIds` carries a `graph: bool` channel that neither the card nor the reference spike has. The cache holds the dependency graph independently of card rows (`Resolved` has separate `graph`/`cards` fields), and several commands mutate the graph without their id set alone implying it:
- All six `DependencyCommand` add/remove leaves and `CreateSubcardCommand`, for edge writes.
- `ArchiveCards`, whose `execute` calls `modify_graph`/`archive_node`, easy to miss since the type's own name reads as card-only.

Every graph-mutating leaf sets `graph: true`; every other leaf leaves it `false`. No leaf returns `Some` with `graph: false` while its `execute` touches the graph.

## The `prefixes: bool` channel (review fix)

A first review pass found that `ImportEntities` and `CreateSprint` return `Some(..)` while their `execute` also upserts a prefix row, which the original `EntityIds` could not express. I audited every call site of `upsert_prefix`, `allocate_card_number`, and `allocate_sprint_number` outside `prefix.rs` itself (`grep -rn` across `crates/kanban-domain/src/commands/`) and found three, not two: `ImportEntities` (`board_commands.rs`, via `merge_prefix_counters`), `CreateSprint` (`sprint_commands.rs`, via `allocate_sprint_number`), and `CreateSubcardCommand` (`dependency_commands.rs`, via `allocate_card_number`). The third one was missed by the first review too.

Added a `prefixes: bool` channel to `EntityIds`, in the same shape as `graph`, and set `true` on all three sites via a new `EntityIds::with_prefixes()` builder.

A second review pass found `ImportEntities`'s condition was still wrong: it declared `prefixes` only when the payload itself carried cards, sprints, or explicit prefix rows. `merge_prefix_counters` derives the namespace set from `entity_universe`, which unions the payload with everything already in the store, so a boards-or-columns-only import can still resolve a namespace from a stored sprint and mint a prefix row that no payload-derived condition can see. `touched_entities` has no access to store contents at declaration time, so any condition based on the payload alone is guessing. Fixed by declaring `prefixes: true` unconditionally on `ImportEntities`; over-invalidation is safe, under-invalidation is the bug this card exists to close. This matters because `ImportEntities` is the standard inverse for deletions (`cascade_commands.rs`, `sprint_commands.rs`, `card/lifecycle.rs`), so it is exactly what `invalidation_from_inverse` folds over on the undo path.

I looked for a cheap way to guard against a future command writing a prefix row without declaring it, and could not find one that stays proportionate: the write happens inside `prefix.rs` helper functions called from arbitrary command bodies, so a static check would need to walk call graphs, and a runtime check would mean instrumenting every `DataStore` implementation. I did not build either. This is a real gap; the mitigation is that `prefix.rs` has exactly three external callers today, and any new one is easy to catch in review by grepping for `allocate_card_number`/`allocate_sprint_number`/`upsert_prefix`.

## `None`-by-design (not oversights)

`DeleteCard`, `DeleteCardEdges`, `DeleteArchivedCards`, `RestoreCard`, `CompactColumnPositions`, `DeleteSprint`, `DeleteCardsByColumns`, `DeleteColumnsByBoard`, `DeleteSprintsByBoard`, `ImportEntities` with a graph payload, and `UpdateSprint` when it sets `name` (which also mutates the owning board's name pool) all return `None`; their full blast radius cannot be enumerated from the command's own fields.

## `undo_stack.clear()` sites, disposition

None of the five `undo_stack.clear()` call sites (`context/undo.rs:132` inside `clear_history`; `context/core.rs`; `context/persistence.rs` x2; `context/sprints.rs`) runs through `execute_with`, so none of them produces an inverse batch and none is touched by this card's empty-to-`All` path. All five are deferred to KAN-1223 (B5), which owns the wholesale-invalidation story for bulk reload/replace paths.

## Report-only findings for the epic (not fixed here, in scope elsewhere)

- `undo()` (`context/undo.rs:82-101`) and `redo()` (`:106-120`) call `with_transaction` directly and never reach `execute_with`, so they derive no invalidation at all today. This is real and belongs to KAN-1302's territory, not this card.
- Parent-collection membership is not modelled: `MoveCard` reports only the card though it leaves one column and joins another, `AssignCardsToSprint` likewise, and `CreateColumn` does not report the board's column list growing. This is consistent with the contract as worded, but a cache memoising "cards in column X" would go stale on any of these. Flagging it for the epic to resolve before that cache is designed.
- Prefix writes happen inside `execute_with` but outside any command: `kanban-service/src/context/cards.rs:160` and `kanban-tui/src/handlers/card_handlers.rs:412` both call `allocate_card_number` directly, so an ordinary card create writes a prefix row that no command's `touched_entities` can ever declare. It is masked today only because `CreateCard`'s inverse is `DeleteCard`, which returns `None` and therefore invalidates everything. That means the derivation's correctness for prefixes currently rests on an inverse-command accident rather than on the declared contract. Flagging for KAN-1302 / the epic to resolve before the invalidation vocabulary is relied on for a real cache.

## Testing

- 20 `#[cfg(test)]` unit tests in `kanban-domain/src/invalidation.rs` covering every command family's `touched_entities()` (including the graph-dirty, prefixes-dirty, and unenumerable cases) plus the derivation's merge/fallback semantics.
- 3 integration tests in `kanban-service/tests/invalidation_from_inverse.rs` running real `capture_inverse` + `execute` against an `InMemoryStore`: proving the derivation names exactly the touched cards (not a superset); that a genuinely-empty real inverse batch (`DeleteArchivedCards` against a non-existent id) derives `All`; and the second review-fix's reproduction, `test_invalidation_from_a_columns_only_import_inverse_declares_prefixes`, which seeds a board, a column, and a sprint carrying a prefix, captures the inverse of `DeleteColumnsByBoard` (a columns-only `ImportEntities`), and asserts the derived invalidation declares `prefixes`. Written RED first against the over-narrow condition, confirmed failing, then made GREEN by the unconditional fix.
- Mutation-checked the central assertion: flipped `DeleteCard::touched_entities` to `Some(...)`, confirmed the unenumerable and mixed-batch tests fail, reverted.
- `cargo test -p kanban-domain -p kanban-service`, `cargo clippy -p kanban-domain -p kanban-service --all-targets -- -D warnings`, and `cargo fmt --check` are all green.


