### PR TITLE
KAN-1304 fix(tui,view): escape clears whichever search is active

### DIFF
--- a/.changeset/kan-1304-escape-clears-active-search.md
+++ b/.changeset/kan-1304-escape-clears-active-search.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: Escape now clears whichever search is active - the projects panel search and the board detail column search, not only the cards search. Committing a search with Enter and then pressing Escape previously left the panel filtered with no way out but reopening the search.

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -425,20 +425,7 @@ impl App {
 
     pub fn handle_search_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
-        // Exactly one of `search` (cards) / `board_search` (boards) /
-        // `column_search` (board detail's column list) is active at a time —
-        // whichever `/` activated in `handle_normal_key` or
-        // `handle_board_detail_navigation_key` — so route input to that one.
-        // Keeping them as three independent `SearchState`s (rather than one
-        // shared field) means a query typed for one panel can never leak
-        // into another panel's search.
-        let active = if self.filter.board_search.is_active {
-            &mut self.filter.board_search
-        } else if self.filter.column_search.is_active {
-            &mut self.filter.column_search
-        } else {
-            &mut self.filter.search
-        };
+        let active = self.filter.search_input_target_mut();
         match key_code {
             KeyCode::Char(c) => {
                 active.input.insert_char(c);

--- a/crates/kanban-tui/src/components/footer.rs
+++ b/crates/kanban-tui/src/components/footer.rs
@@ -9,7 +9,11 @@ use ratatui::{
 };
 
 pub fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
-    if let Some(search) = app.filter.active_search().filter(|_| app.mode != AppMode::Search) {
+    if let Some(search) = app
+        .filter
+        .active_search()
+        .filter(|_| app.mode != AppMode::Search)
+    {
         let search_text = format!("/{}", search.query());
         let help_text = "j/k: navigate | ESC: clear";
 

--- a/crates/kanban-tui/src/components/footer.rs
+++ b/crates/kanban-tui/src/components/footer.rs
@@ -1,6 +1,5 @@
 use crate::app::{App, AppMode};
 use crate::theme::*;
-use kanban_view::search::SearchState;
 use ratatui::{
     layout::Rect,
     style::{Color, Style},
@@ -9,25 +8,8 @@ use ratatui::{
     Frame,
 };
 
-/// Whichever `SearchState` is actually active — `board_search` (the projects
-/// panel), `column_search` (the board detail column list), or `search` (the
-/// tasks panel) — mirroring the routing `handle_search_mode`
-/// (`app/input_router.rs`) already uses to decide which field typed
-/// keystrokes go to. At most one of the three is active at a time.
-fn active_search(app: &App) -> Option<&SearchState> {
-    if app.filter.board_search.is_active {
-        Some(&app.filter.board_search)
-    } else if app.filter.column_search.is_active {
-        Some(&app.filter.column_search)
-    } else if app.filter.search.is_active {
-        Some(&app.filter.search)
-    } else {
-        None
-    }
-}
-
 pub fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
-    if let Some(search) = active_search(app).filter(|_| app.mode != AppMode::Search) {
+    if let Some(search) = app.filter.active_search().filter(|_| app.mode != AppMode::Search) {
         let search_text = format!("/{}", search.query());
         let help_text = "j/k: navigate | ESC: clear";
 
@@ -58,7 +40,7 @@ pub fn render_footer(app: &App, frame: &mut Frame, area: Rect) {
     }
 
     if app.mode == AppMode::Search {
-        let query = active_search(app).map(SearchState::query).unwrap_or("");
+        let query = app.filter.active_search().map(|s| s.query()).unwrap_or("");
         let search_text = format!("/{query}");
         let help_text = "ESC: clear | Enter: apply";
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -416,6 +416,10 @@ impl App {
         let should_restart = false;
         match key_code {
             KeyCode::Esc => {
+                if self.filter.column_search.is_active {
+                    self.filter.column_search.deactivate();
+                    return should_restart;
+                }
                 self.pop_mode();
                 self.focus.board_focus = BoardFocus::Name;
             }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2165,6 +2165,34 @@ mod tests {
     }
 
     #[test]
+    fn test_escape_in_board_detail_clears_the_column_search_before_leaving_the_view() {
+        let mut app = App::test_default();
+        seed_board_with_named_columns(&mut app, &[("Todo", 0), ("Doing", 1)]);
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('/'));
+        app.handle_search_mode(KeyCode::Char('t'));
+        app.handle_search_mode(KeyCode::Enter);
+
+        app.handle_board_detail_navigation_key(KeyCode::Esc);
+
+        assert!(!app.filter.column_search.is_active);
+        assert!(app.filter.column_search.query().is_empty());
+        assert_eq!(app.mode, AppMode::BoardDetail);
+        assert_eq!(app.focus.board_focus, BoardFocus::Columns);
+    }
+
+    #[test]
+    fn test_escape_in_board_detail_without_a_column_search_still_leaves_the_view() {
+        let mut app = App::test_default();
+        seed_board_with_named_columns(&mut app, &[("Todo", 0)]);
+
+        app.handle_board_detail_navigation_key(KeyCode::Esc);
+
+        assert_ne!(app.mode, AppMode::BoardDetail);
+        assert_eq!(app.focus.board_focus, BoardFocus::Name);
+    }
+
+    #[test]
     fn test_rename_column_key_resolves_correct_column_when_search_filters_list() {
         let mut app = App::test_default();
         seed_board_with_named_columns(

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -499,8 +499,8 @@ impl App {
     }
 
     pub fn handle_escape_key(&mut self) {
-        if self.filter.search.is_active {
-            self.filter.search.deactivate();
+        if let Some(search) = self.filter.active_search_mut() {
+            search.deactivate();
             return;
         }
 

--- a/crates/kanban-tui/tests/escape_search_tests.rs
+++ b/crates/kanban-tui/tests/escape_search_tests.rs
@@ -6,8 +6,13 @@ use kanban_tui::App;
 #[test]
 fn test_escape_clears_a_committed_board_search_without_leaving_the_active_board() {
     let mut app = App::test_default();
-    let alpha = app.ctx.create_board("Alpha Project".to_string(), None).unwrap();
-    app.ctx.create_board("Beta Project".to_string(), None).unwrap();
+    let alpha = app
+        .ctx
+        .create_board("Alpha Project".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_board("Beta Project".to_string(), None)
+        .unwrap();
     app.reload_model();
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/escape_search_tests.rs
+++ b/crates/kanban-tui/tests/escape_search_tests.rs
@@ -1,0 +1,99 @@
+use kanban_domain::KanbanOperations;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::App;
+
+#[test]
+fn test_escape_clears_a_committed_board_search_without_leaving_the_active_board() {
+    let mut app = App::test_default();
+    let alpha = app.ctx.create_board("Alpha Project".to_string(), None).unwrap();
+    app.ctx.create_board("Beta Project".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.focus.active = Focus::Boards;
+    app.selection.active_board_id = Some(alpha.id);
+    app.filter.board_search.activate();
+    for c in "alpha".chars() {
+        app.filter.board_search.input.insert_char(c);
+    }
+    app.push_mode(AppMode::Search);
+    app.handle_search_mode(crossterm::event::KeyCode::Enter);
+
+    app.handle_escape_key();
+
+    assert!(!app.filter.board_search.is_active);
+    assert!(app.filter.board_search.query().is_empty());
+    assert_eq!(app.displayed_boards().len(), 2);
+    assert_eq!(app.selection.active_board_id, Some(alpha.id));
+}
+
+#[test]
+fn test_escape_clears_a_column_search_left_active_in_normal_mode() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.selection.active_board_id = Some(board.id);
+    app.filter.column_search.activate();
+    for c in "todo".chars() {
+        app.filter.column_search.input.insert_char(c);
+    }
+
+    app.handle_escape_key();
+
+    assert!(!app.filter.column_search.is_active);
+    assert!(app.filter.column_search.query().is_empty());
+    assert_eq!(app.selection.active_board_id, Some(board.id));
+}
+
+#[test]
+fn test_escape_still_clears_a_committed_card_search() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.selection.active_board_id = Some(board.id);
+    app.filter.search.activate();
+    app.filter.search.input.insert_char('x');
+
+    app.handle_escape_key();
+
+    assert!(!app.filter.search.is_active);
+    assert_eq!(app.selection.active_board_id, Some(board.id));
+}
+
+#[test]
+fn test_escape_without_an_active_search_still_exits_selection_mode() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.selection.active_board_id = Some(board.id);
+    app.multi_select.selection_mode_active = true;
+    app.multi_select.selected_cards.insert(uuid::Uuid::new_v4());
+
+    app.handle_escape_key();
+
+    assert!(!app.multi_select.selection_mode_active);
+    assert!(app.multi_select.selected_cards.is_empty());
+    assert_eq!(app.selection.active_board_id, Some(board.id));
+}
+
+#[test]
+fn test_escape_with_no_search_or_selection_still_leaves_the_active_board() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.selection.active_board_id = Some(board.id);
+
+    app.handle_escape_key();
+
+    assert_eq!(app.selection.active_board_id, None);
+    assert_eq!(app.focus.active, Focus::Boards);
+}

--- a/crates/kanban-view/src/filter_state.rs
+++ b/crates/kanban-view/src/filter_state.rs
@@ -27,6 +27,61 @@ pub struct FilterState {
     pub dialog_state: Option<FilterDialogState>,
 }
 
+#[derive(Clone, Copy)]
+enum SearchSlot {
+    Board,
+    Column,
+    Card,
+}
+
+impl FilterState {
+    fn active_slot(&self) -> Option<SearchSlot> {
+        if self.board_search.is_active {
+            Some(SearchSlot::Board)
+        } else if self.column_search.is_active {
+            Some(SearchSlot::Column)
+        } else if self.search.is_active {
+            Some(SearchSlot::Card)
+        } else {
+            None
+        }
+    }
+
+    fn slot(&self, slot: SearchSlot) -> &SearchState {
+        match slot {
+            SearchSlot::Board => &self.board_search,
+            SearchSlot::Column => &self.column_search,
+            SearchSlot::Card => &self.search,
+        }
+    }
+
+    fn slot_mut(&mut self, slot: SearchSlot) -> &mut SearchState {
+        match slot {
+            SearchSlot::Board => &mut self.board_search,
+            SearchSlot::Column => &mut self.column_search,
+            SearchSlot::Card => &mut self.search,
+        }
+    }
+
+    /// The one search state currently active, or `None`; at most one of the
+    /// three is active at a time.
+    pub fn active_search(&self) -> Option<&SearchState> {
+        Some(self.slot(self.active_slot()?))
+    }
+
+    pub fn active_search_mut(&mut self) -> Option<&mut SearchState> {
+        let slot = self.active_slot()?;
+        Some(self.slot_mut(slot))
+    }
+
+    /// Where typed search keystrokes go; falls back to the cards search when
+    /// none is active.
+    pub fn search_input_target_mut(&mut self) -> &mut SearchState {
+        let slot = self.active_slot().unwrap_or(SearchSlot::Card);
+        self.slot_mut(slot)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-view/src/filter_state.rs
+++ b/crates/kanban-view/src/filter_state.rs
@@ -44,4 +44,60 @@ mod tests {
         assert!(!state.board_search.is_active);
         assert!(!state.column_search.is_active);
     }
+
+    #[test]
+    fn test_active_search_returns_none_when_no_search_is_active() {
+        let mut state = FilterState::default();
+
+        assert!(state.active_search().is_none());
+        assert!(state.active_search_mut().is_none());
+    }
+
+    #[test]
+    fn test_active_search_prefers_board_then_column_then_card() {
+        let mut state = FilterState::default();
+        state.search.activate();
+        state.search.input.insert_char('c');
+        state.board_search.activate();
+        state.board_search.input.insert_char('b');
+        state.column_search.activate();
+        state.column_search.input.insert_char('l');
+
+        assert_eq!(state.active_search().unwrap().query(), "b");
+
+        state.board_search.deactivate();
+        assert_eq!(state.active_search().unwrap().query(), "l");
+
+        state.column_search.deactivate();
+        assert_eq!(state.active_search().unwrap().query(), "c");
+    }
+
+    #[test]
+    fn test_active_search_mut_deactivates_the_board_search_through_the_accessor() {
+        let mut state = FilterState::default();
+        state.board_search.activate();
+        state.board_search.input.insert_char('b');
+
+        state.active_search_mut().unwrap().deactivate();
+
+        assert!(!state.board_search.is_active);
+        assert!(state.board_search.query().is_empty());
+        assert!(!state.search.is_active);
+        assert!(!state.column_search.is_active);
+    }
+
+    #[test]
+    fn test_search_input_target_mut_falls_back_to_the_card_search_when_none_is_active() {
+        let mut state = FilterState::default();
+
+        state.search_input_target_mut().input.insert_char('x');
+        assert_eq!(state.search.query(), "x");
+
+        let mut state = FilterState::default();
+        state.column_search.activate();
+
+        state.search_input_target_mut().input.insert_char('y');
+        assert_eq!(state.column_search.query(), "y");
+        assert!(state.search.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Escape previously cleared only the cards search (`filter.search`), leaving a committed projects-panel search (`board_search`) or board-detail column search (`column_search`) active with no way out but reopening it.
- Adds `FilterState::active_search` / `active_search_mut` / `search_input_target_mut` (kanban-view) as the single definition of which of the three searches is currently active, replacing three separate copies of the same predicate that had drifted out of sync with `handle_escape_key`.
- `App::handle_escape_key` now deactivates whichever search is active via `active_search_mut`.
- The board-detail Esc arm (which never routed through `handle_escape_key` at all) now checks `column_search` first and clears it before leaving the view, instead of unconditionally popping the mode.
- Refactors the footer and `handle_search_mode`'s search-input routing to use the new shared accessors, removing the footer's private `active_search` duplicate.

## Test plan

- [x] `cargo test -p kanban-view`: new accessor tests, all green
- [x] `cargo test -p kanban-tui`: new escape/search regression and integration tests, all green
- [x] `cargo clippy -p kanban-view -p kanban-tui --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] Mutation check: reverted the fix commit, confirmed the board-detail Esc test failed, restored
