### PR TITLE
KAN-1308 fix(tui): drop d in the archived cards view

### DIFF
--- a/.changeset/kan-1308-archived-view-drops-d.md
+++ b/.changeset/kan-1308-archived-view-drops-d.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: Pressing `d` in the archived cards view no longer fires the red archive flash on a card that is already archived. The key is now dropped in that view, matching the footer, which already omitted it; previously the stray archive also pushed an undo entry, so a following `u` would unarchive the card.

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -450,8 +450,9 @@ impl App {
     /// panel via `handle_normal_key` (LSP: an archived card is substitutable for a
     /// live one). Only the consumption-site keys differ: `r` restores and `x`
     /// permanently deletes the highlighted archived card(s), and `Esc`/`q` toggles
-    /// back to the live set. Create (`n`) is intercepted and dropped — an archived
-    /// list is not where new cards are created (would make an invisible live card).
+    /// back to the live set. Create (`n`) and archive (`d`) are intercepted and
+    /// dropped — an archived list is not where new cards are created, and the
+    /// cards it shows are already archived.
     pub fn handle_archived_cards_view_mode(&mut self, key_code: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode;
         if self.focus.active != Focus::Cards {
@@ -469,6 +470,11 @@ impl App {
             // Create makes no sense from an archived list — drop it so it never
             // creates an invisible live card (#414 finding 1).
             KeyCode::Char('n') => {
+                self.pending_key = None;
+            }
+            // Archiving an already-archived card does nothing, so drop `d`
+            // rather than let it start an archive animation for a no-op.
+            KeyCode::Char('d') => {
                 self.pending_key = None;
             }
             // `V`/`t`/`T` mutate shared board/live-filter display state, so they

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -242,8 +242,8 @@ fn test_delete_extension_in_archived_view() {
     );
 }
 
-/// #1308: pressing `d` on an already-archived card must not start a stray
-/// archive animation. The archived-view footer already omits `d`
+/// Pressing `d` on an already-archived card must not start a stray archive
+/// animation. The archived-view footer already omits `d`
 /// (`ArchivedCardsViewProvider`); the dispatch must agree.
 #[test]
 fn test_d_in_the_archived_cards_view_starts_no_animation() {
@@ -263,9 +263,8 @@ fn test_d_in_the_archived_cards_view_starts_no_animation() {
     );
 }
 
-/// #1308: before the fix, a stray `d` on an archived card completed into an
-/// idempotent `ArchiveCards` that still pushed an undo entry whose inverse
-/// (`RestoreCard`) would unarchive the card on a following `u`.
+/// A stray `d` on an already-archived card must not leave an undo entry: its
+/// inverse (`RestoreCard`) would unarchive the card on a following `u`.
 #[test]
 fn test_d_in_the_archived_cards_view_leaves_the_card_archived_after_undo() {
     let mut app = App::test_default();
@@ -298,9 +297,9 @@ fn test_d_in_the_archived_cards_view_leaves_the_card_archived_after_undo() {
     );
 }
 
-/// #1308: the drop must happen in the dispatch, before `handle_archive_card`,
-/// so it also protects the multi-select path (which otherwise starts one
-/// animation per selected id and clears the selection).
+/// The drop must happen in the dispatch, before `handle_archive_card`, so it
+/// also protects the multi-select path (which otherwise starts one animation
+/// per selected id and clears the selection).
 #[test]
 fn test_d_on_multi_selected_archived_cards_starts_no_animation_and_keeps_the_selection() {
     let mut app = App::test_default();

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -216,7 +216,10 @@ fn test_restore_extension_in_archived_view() {
 
     app.handle_archived_cards_view_mode(KeyCode::Char('r'));
     assert_eq!(
-        app.animation.animating.get(&card_id).map(|a| a.animation_type),
+        app.animation
+            .animating
+            .get(&card_id)
+            .map(|a| a.animation_type),
         Some(AnimationType::Restoring),
         "`r` starts the restore animation for the archived card"
     );
@@ -230,7 +233,10 @@ fn test_delete_extension_in_archived_view() {
 
     app.handle_archived_cards_view_mode(KeyCode::Char('x'));
     assert_eq!(
-        app.animation.animating.get(&card_id).map(|a| a.animation_type),
+        app.animation
+            .animating
+            .get(&card_id)
+            .map(|a| a.animation_type),
         Some(AnimationType::Deleting),
         "`x` starts the permanent-delete animation for the archived card"
     );
@@ -283,10 +289,7 @@ fn test_d_in_the_archived_cards_view_leaves_the_card_archived_after_undo() {
         !app.ctx.can_undo(),
         "`d` on an already-archived card must not push an undo entry"
     );
-    assert!(
-        !app.ctx.undo().unwrap(),
-        "there must be nothing to undo"
-    );
+    assert!(!app.ctx.undo().unwrap(), "there must be nothing to undo");
     app.reload_model();
     app.prepare_frame();
     assert!(
@@ -358,7 +361,10 @@ fn test_d_in_the_live_cards_view_still_archives() {
     app.handle_archive_card();
 
     assert_eq!(
-        app.animation.animating.get(&card_id).map(|a| a.animation_type),
+        app.animation
+            .animating
+            .get(&card_id)
+            .map(|a| a.animation_type),
         Some(AnimationType::Archiving),
         "`d` in the live cards view still starts an archive animation"
     );

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -11,13 +11,14 @@
 //! the stack-aware base mode (correct under a modal underlay).
 
 use crossterm::event::KeyCode;
-use kanban_domain::{CardPriority, CreateCardOptions, KanbanOperations};
+use kanban_domain::{AnimationType, CardPriority, CreateCardOptions, KanbanOperations};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::keybindings::card_list::CardListProvider;
 use kanban_tui::keybindings::normal_mode::ArchivedCardsViewProvider;
 use kanban_tui::keybindings::KeybindingProvider;
 use kanban_tui::App;
+use std::time::{Duration, Instant};
 
 /// Seed a board with two columns and a card, archive the card, then enter the
 /// archived-cards view with that card selected. Returns (board_id, col1, col2,
@@ -214,8 +215,9 @@ fn test_restore_extension_in_archived_view() {
     let (_, _, _, card_id) = seed_archived_card(&mut app);
 
     app.handle_archived_cards_view_mode(KeyCode::Char('r'));
-    assert!(
-        app.animation.animating.contains_key(&card_id),
+    assert_eq!(
+        app.animation.animating.get(&card_id).map(|a| a.animation_type),
+        Some(AnimationType::Restoring),
         "`r` starts the restore animation for the archived card"
     );
 }
@@ -227,9 +229,138 @@ fn test_delete_extension_in_archived_view() {
     let (_, _, _, card_id) = seed_archived_card(&mut app);
 
     app.handle_archived_cards_view_mode(KeyCode::Char('x'));
-    assert!(
-        app.animation.animating.contains_key(&card_id),
+    assert_eq!(
+        app.animation.animating.get(&card_id).map(|a| a.animation_type),
+        Some(AnimationType::Deleting),
         "`x` starts the permanent-delete animation for the archived card"
+    );
+}
+
+/// #1308: pressing `d` on an already-archived card must not start a stray
+/// archive animation. The archived-view footer already omits `d`
+/// (`ArchivedCardsViewProvider`); the dispatch must agree.
+#[test]
+fn test_d_in_the_archived_cards_view_starts_no_animation() {
+    let mut app = App::test_default();
+    let (_, _, _, _) = seed_archived_card(&mut app);
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('d'));
+
+    assert!(
+        app.animation.animating.is_empty(),
+        "`d` must not start any animation from the archived view"
+    );
+    assert_eq!(
+        app.mode,
+        AppMode::ArchivedCardsView,
+        "`d` must not change the mode from the archived view"
+    );
+}
+
+/// #1308: before the fix, a stray `d` on an archived card completed into an
+/// idempotent `ArchiveCards` that still pushed an undo entry whose inverse
+/// (`RestoreCard`) would unarchive the card on a following `u`.
+#[test]
+fn test_d_in_the_archived_cards_view_leaves_the_card_archived_after_undo() {
+    let mut app = App::test_default();
+    let (_, _, _, card_id) = seed_archived_card(&mut app);
+    app.ctx.clear_history().unwrap();
+    assert!(
+        !app.ctx.can_undo(),
+        "precondition: history clean after seeding"
+    );
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('d'));
+
+    if let Some(a) = app.animation.animating.get_mut(&card_id) {
+        a.start_time = Instant::now() - Duration::from_millis(200);
+    }
+    app.handle_animation_tick();
+    app.reload_model();
+    app.prepare_frame();
+
+    assert!(
+        !app.ctx.can_undo(),
+        "`d` on an already-archived card must not push an undo entry"
+    );
+    assert!(
+        !app.ctx.undo().unwrap(),
+        "there must be nothing to undo"
+    );
+    app.reload_model();
+    app.prepare_frame();
+    assert!(
+        app.model.archived_card_ids().contains(&card_id),
+        "the card must remain archived"
+    );
+}
+
+/// #1308: the drop must happen in the dispatch, before `handle_archive_card`,
+/// so it also protects the multi-select path (which otherwise starts one
+/// animation per selected id and clears the selection).
+#[test]
+fn test_d_on_multi_selected_archived_cards_starts_no_animation_and_keeps_the_selection() {
+    let mut app = App::test_default();
+    let (_, _, _, card_id) = seed_archived_card(&mut app);
+    app.multi_select.selected_cards.insert(card_id);
+    app.multi_select.selection_mode_active = true;
+
+    app.handle_archived_cards_view_mode(KeyCode::Char('d'));
+
+    assert!(
+        app.animation.animating.is_empty(),
+        "`d` must not start any animation for a multi-selected archived card"
+    );
+    assert!(
+        app.multi_select.selected_cards.contains(&card_id),
+        "`d` must not clear the multi-select"
+    );
+    assert!(
+        app.multi_select.selection_mode_active,
+        "`d` must not deactivate multi-select mode"
+    );
+}
+
+fn seed_live_card(app: &mut App) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid) {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            col.id,
+            "LiveCard".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::Normal;
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+    (board.id, col.id, card.id)
+}
+
+/// Guard: `d` in the LIVE cards view must still archive, unaffected by the
+/// archived-view-only drop.
+#[test]
+fn test_d_in_the_live_cards_view_still_archives() {
+    let mut app = App::test_default();
+    let (_, _, card_id) = seed_live_card(&mut app);
+
+    app.handle_archive_card();
+
+    assert_eq!(
+        app.animation.animating.get(&card_id).map(|a| a.animation_type),
+        Some(AnimationType::Archiving),
+        "`d` in the live cards view still starts an archive animation"
     );
 }
 


### PR DESCRIPTION
## Summary
- `handle_archived_cards_view_mode` now drops `d` (mirroring the existing `n` drop) instead of falling through to the shared normal-mode dispatch, which was starting an `AnimationType::Archiving` red flash on a card that is already archived.
- Beyond the cosmetic flash: the stray animation completed into an idempotent `ArchiveCards`, but `KanbanContext::execute_with` still pushed an undo entry unconditionally, whose inverse (`RestoreCard`) would unarchive the card on a following `u`. The fix removes that data-corrupting tail too.
- The archived-cards footer (`ArchivedCardsViewProvider`) already excluded the `d`/`ArchiveCard` binding, and README.md already omitted `d` from the Archived Cards View table, so the dispatch was the piece out of step with the advertised contract. Drop was chosen over aliasing `d` to `x` (permanent delete): aliasing would require touching the footer/README/provider as well, and would invert `x`'s deliberate extra friction as the harder-to-reach destructive key.
- Updated the doc comment on `handle_archived_cards_view_mode` to mention the new drop.

## Test plan
- [x] `cargo test -p kanban-tui --test archived_card_parity_tests`: 3 new red tests confirmed failing before the fix, all 22 tests green after
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Mutation check: reverted the new `d` arm, confirmed the 3 new tests fail again, restored