### PR TITLE
KAN-1309 feat(tui): tint the archived projects panel border

### DIFF
--- a/.changeset/kan-1309-archived-projects-border.md
+++ b/.changeset/kan-1309-archived-projects-border.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: the Projects panel now uses the same yellow border as the archived-tasks list while the archived-projects view is open and that panel is focused, so both archived surfaces signal themselves the same way. An unfocused archived Projects panel stays neutral, matching the archived-tasks panel. The tint is keyed on the stack-aware base mode, so a confirm dialog opened over the archived-projects view keeps the underlay tinted rather than flipping back to the normal border colour.

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -96,9 +96,13 @@ pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
         .unwrap_or_default();
     let title = format!("{base_title}{search_suffix}");
     let focus_title = format!("{base_title} [1]{search_suffix}");
-    let panel_config = PanelConfig::new(&title)
+    let boards_focused = app.focus.active == Focus::Boards;
+    let mut panel_config = PanelConfig::new(&title)
         .with_focus_indicator(&focus_title)
-        .focused(app.focus.active == Focus::Boards);
+        .focused(boards_focused);
+    if archived_view && boards_focused {
+        panel_config = panel_config.with_custom_border_style(deleted_view_focused_border());
+    }
 
     let content = Paragraph::new(lines);
     render_panel(frame, area, &panel_config, content);

--- a/crates/kanban-tui/tests/archived_projects_border_tests.rs
+++ b/crates/kanban-tui/tests/archived_projects_border_tests.rs
@@ -1,0 +1,125 @@
+use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+use ratatui::style::Color;
+
+fn border_fg_at(app: &mut App, x: u16, y: u16) -> Option<Color> {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let backend = TestBackend::new(120, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer().clone();
+    buffer.cell((x, y)).map(|c| c.style().fg).unwrap()
+}
+
+fn seed_archived_boards_view(name: &str) -> App {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board(name.to_string(), None).unwrap();
+    app.ctx.archive_board(board.id).unwrap();
+    app.mode = AppMode::ArchivedBoardsView;
+    app.focus.active = Focus::Boards;
+    app.reload_model();
+    app.prepare_frame();
+    app
+}
+
+#[test]
+fn test_the_archived_projects_panel_uses_the_archived_border() {
+    let mut app = seed_archived_boards_view("Archived");
+
+    let fg = border_fg_at(&mut app, 0, 0);
+
+    assert_eq!(
+        fg,
+        kanban_tui::theme::deleted_view_focused_border().fg,
+        "the archived projects panel border must use the archived-view border style"
+    );
+}
+
+#[test]
+fn test_the_archived_projects_border_survives_a_dialog_overlay() {
+    let mut app = seed_archived_boards_view("Archived");
+    app.push_mode(AppMode::Dialog(DialogMode::DeletePermanentBoardConfirm));
+
+    let fg = border_fg_at(&mut app, 0, 0);
+
+    assert_eq!(
+        fg,
+        kanban_tui::theme::deleted_view_focused_border().fg,
+        "the archived border must survive a dialog opened over the archived view"
+    );
+}
+
+#[test]
+fn test_the_live_projects_panel_border_is_unchanged() {
+    let mut app = App::test_default();
+    app.ctx.create_board("Live".to_string(), None).unwrap();
+    app.mode = AppMode::Normal;
+    app.focus.active = Focus::Boards;
+    app.reload_model();
+    app.prepare_frame();
+
+    let fg = border_fg_at(&mut app, 0, 0);
+
+    assert_eq!(
+        fg,
+        kanban_tui::theme::focused_border().fg,
+        "the live, focused projects panel border must stay the normal focused colour"
+    );
+}
+
+#[test]
+fn test_the_unfocused_archived_projects_panel_is_not_tinted() {
+    let mut app = seed_archived_boards_view("Archived");
+    app.focus.active = Focus::Cards;
+
+    let fg = border_fg_at(&mut app, 0, 0);
+
+    assert_eq!(
+        fg,
+        kanban_tui::theme::unfocused_border().fg,
+        "an unfocused archived projects panel must not be tinted"
+    );
+}
+
+#[test]
+fn test_the_archived_cards_panel_border_is_unaffected() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "ArchiveMe".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::ArchivedCardsView;
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    let fg = border_fg_at(&mut app, 36, 0);
+
+    assert_eq!(
+        fg,
+        Some(Color::Yellow),
+        "the archived cards panel border must remain tinted as before"
+    );
+}


### PR DESCRIPTION
## Summary
- The Projects panel border now uses the existing archived-view yellow (`deleted_view_focused_border()`) whenever the base mode is `ArchivedBoardsView` and focus is on the boards panel, matching how the archived-tasks panel already signals itself.
- Tint keyed on `get_base_mode()` (not `app.mode`), so a confirm dialog opened over the archived-projects view keeps the underlay tinted rather than flipping back to the normal border colour.
- An unfocused archived Projects panel stays neutral, matching the archived-cards panel's behaviour.
- No changes to `render_strategy.rs` or `theme/styles.rs`; no new colour literal.

## Test plan
- [x] New `crates/kanban-tui/tests/archived_projects_border_tests.rs`: two red tests (archived+focused tint, dialog-overlay survival) plus three regression guards (live border unchanged, unfocused archived panel not tinted, archived-cards panel border unaffected)
- [x] Confirmed the two red tests failed before the implementation commit
- [x] Mutation check: reverted the fix locally, confirmed both red tests fail again, restored
- [x] `cargo test -p kanban-tui` and `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean