### PR TITLE
KAN-1306 fix(tui): show and control the destination column when creating a card

### DIFF
--- a/.changeset/kan-1306-columnless-board-card-column-field.md
+++ b/.changeset/kan-1306-columnless-board-card-column-field.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: The create-card dialog now shows a "Column:" field naming exactly where the new card will land. On a board that already has columns the field is disabled and greyed, filled in from the destination column and cannot be edited. On a board with no columns yet, the field is editable, prefilled with the template column name, and its value (falling back to the template name if left blank) becomes the name of the column the TUI creates alongside the card. That column create now shares the card create's undo transaction, so a single undo removes both, and the invented column carries the template's default status instead of none. The CLI's `kanban card create` still requires `--column` explicitly, since a CLI user can simply chain a second `column create` command.

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -1,6 +1,6 @@
 use crate::components::sprint_picker::{SprintFilter, SprintPicker};
 use crate::handlers::board_handlers::BoardDeleteCounts;
-use kanban_core::SelectionState;
+use kanban_core::{InputState, SelectionState};
 use kanban_view::ListComponent;
 use uuid::Uuid;
 
@@ -8,6 +8,7 @@ use uuid::Uuid;
 pub enum CreateCardFocus {
     #[default]
     Title,
+    Column,
     Sprint,
 }
 
@@ -23,6 +24,8 @@ pub struct DialogInputState {
     pub carry_over_source_sprint_id: Option<Uuid>,
     pub create_card_sprint_picker: SprintPicker,
     pub create_card_focus: CreateCardFocus,
+    pub create_card_column_input: InputState,
+    create_card_column_editable: bool,
     /// Picker for the assign-to-existing-card dialogs (single and
     /// bulk). Configured with SprintFilter::All so the user can pick
     /// from completed/ended sprints as well, which the create-card
@@ -48,6 +51,8 @@ impl Default for DialogInputState {
             carry_over_source_sprint_id: None,
             create_card_sprint_picker: SprintPicker::with_filter(SprintFilter::ActiveOnly),
             create_card_focus: CreateCardFocus::default(),
+            create_card_column_input: InputState::default(),
+            create_card_column_editable: false,
             assign_sprint_picker: SprintPicker::with_filter(SprintFilter::All),
             board_delete_counts: None,
         }
@@ -59,14 +64,38 @@ impl DialogInputState {
         self.create_card_focus == CreateCardFocus::Title
     }
 
-    pub fn toggle_create_card_focus(&mut self) {
+    pub fn create_card_focus_is_column(&self) -> bool {
+        self.create_card_focus == CreateCardFocus::Column
+    }
+
+    pub fn create_card_focus_is_sprint(&self) -> bool {
+        self.create_card_focus == CreateCardFocus::Sprint
+    }
+
+    pub fn create_card_column_is_editable(&self) -> bool {
+        self.create_card_column_editable
+    }
+
+    pub fn advance_create_card_focus(&mut self) {
         self.create_card_focus = match self.create_card_focus {
-            CreateCardFocus::Title => CreateCardFocus::Sprint,
+            CreateCardFocus::Title => {
+                if self.create_card_column_editable {
+                    CreateCardFocus::Column
+                } else {
+                    CreateCardFocus::Sprint
+                }
+            }
+            CreateCardFocus::Column => CreateCardFocus::Sprint,
             CreateCardFocus::Sprint => CreateCardFocus::Title,
         };
     }
 
     pub fn reset_create_card_focus(&mut self) {
         self.create_card_focus = CreateCardFocus::Title;
+    }
+
+    pub fn prime_create_card_column_field(&mut self, name: String, editable: bool) {
+        self.create_card_column_editable = editable;
+        self.create_card_column_input.set(name);
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1,7 +1,8 @@
 use crate::app::{App, AppMode, CardField, DialogMode, Focus};
 use crate::events::EventHandler;
 use kanban_domain::commands::{
-    BoardCommand, CardCommand, Command, CreateCard, RestoreCard, SetBoardTaskSort, UpdateCard,
+    BoardCommand, CardCommand, ColumnCommand, Command, CreateCard, CreateColumn, RestoreCard,
+    SetBoardTaskSort, UpdateCard,
 };
 use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations};
 use kanban_view::card_list::CardListId;
@@ -18,18 +19,55 @@ impl App {
                     chrono::Utc::now(),
                 );
             }
+            self.prime_create_card_column_field();
             self.open_dialog(DialogMode::CreateCard);
             self.input.clear();
         }
     }
 
-    fn get_focused_column_id(&mut self) -> Option<uuid::Uuid> {
+    fn get_focused_column_id(&self) -> Option<uuid::Uuid> {
         if let Some(task_list) = self.view.strategy.get_active_task_list() {
             if let CardListId::Column(column_id) = task_list.id {
                 return Some(column_id);
             }
         }
         None
+    }
+
+    pub fn create_card_target_column(&self, board_id: uuid::Uuid) -> Option<kanban_domain::Column> {
+        let target_column_id = if let Some(focused_col_id) = self.get_focused_column_id() {
+            Some(focused_col_id)
+        } else {
+            self.model
+                .columns()
+                .iter()
+                .find(|col| col.board_id == board_id)
+                .map(|col| col.id)
+        };
+
+        target_column_id.and_then(|col_id| {
+            self.model
+                .columns()
+                .iter()
+                .find(|col| col.id == col_id)
+                .cloned()
+        })
+    }
+
+    pub(crate) fn prime_create_card_column_field(&mut self) {
+        let target = self
+            .selection
+            .active_board_id
+            .and_then(|bid| self.create_card_target_column(bid));
+        match target {
+            Some(col) => self
+                .dialog_input
+                .prime_create_card_column_field(col.name, false),
+            None => self.dialog_input.prime_create_card_column_field(
+                kanban_domain::DEFAULT_TEMPLATE_COLUMNS[0].0.to_string(),
+                true,
+            ),
+        }
     }
 
     pub fn handle_toggle_card_completion(&mut self) {
@@ -334,56 +372,54 @@ impl App {
 
     pub fn create_card(&mut self) {
         if let Some(board_id) = self.selection.active_board_id {
-            let focused_col_id = self.get_focused_column_id();
             let board_info = self.model.board_by_id(board_id).map(|b| b.id);
 
             if let Some(bid) = board_info {
-                let target_column_id = if let Some(focused_col_id) = focused_col_id {
-                    Some(focused_col_id)
-                } else {
-                    self.model
-                        .columns()
-                        .iter()
-                        .find(|col| col.board_id == bid)
-                        .map(|col| col.id)
+                let existing_column = self.create_card_target_column(bid);
+
+                let (column_id, position, mark_as_complete, new_column_cmd) = match existing_column
+                {
+                    Some(col) => {
+                        let cards = self.model.all_cards();
+                        let position =
+                            kanban_domain::card_lifecycle::next_position_in_column(cards, col.id);
+                        let columns = self.model.columns();
+                        let mark_as_complete = self
+                            .model
+                            .board_by_id(board_id)
+                            .map(|board| {
+                                kanban_domain::card_lifecycle::should_auto_complete_new_card(
+                                    col.id, board, columns,
+                                )
+                            })
+                            .unwrap_or(false);
+                        (col.id, position, mark_as_complete, None)
+                    }
+                    None => {
+                        let (template_name, default_status) =
+                            kanban_domain::DEFAULT_TEMPLATE_COLUMNS[0];
+                        let entered = self
+                            .dialog_input
+                            .create_card_column_input
+                            .as_str()
+                            .trim()
+                            .to_string();
+                        let name = if entered.is_empty() {
+                            template_name.to_string()
+                        } else {
+                            entered
+                        };
+                        let new_column_id = uuid::Uuid::new_v4();
+                        let cmd = Command::Column(ColumnCommand::Create(CreateColumn {
+                            id: new_column_id,
+                            board_id: bid,
+                            name,
+                            position: 0,
+                            default_status,
+                        }));
+                        (new_column_id, 0, false, Some(cmd))
+                    }
                 };
-
-                let column = if let Some(col_id) = target_column_id {
-                    self.model
-                        .columns()
-                        .iter()
-                        .find(|col| col.id == col_id)
-                        .cloned()
-                } else {
-                    None
-                };
-
-                let column = match column {
-                    Some(col) => col,
-                    None => match self.ctx.create_column(bid, "Todo".to_string(), Some(0)) {
-                        Ok(col) => col,
-                        Err(e) => {
-                            tracing::error!("Failed to create column: {}", e);
-                            self.set_error(format!("Failed to create column: {}", e));
-                            return;
-                        }
-                    },
-                };
-
-                let cards = self.model.all_cards();
-                let position =
-                    kanban_domain::card_lifecycle::next_position_in_column(cards, column.id);
-
-                let columns = self.model.columns();
-                let mark_as_complete = self
-                    .model
-                    .board_by_id(board_id)
-                    .map(|board| {
-                        kanban_domain::card_lifecycle::should_auto_complete_new_card(
-                            column.id, board, columns,
-                        )
-                    })
-                    .unwrap_or(false);
 
                 let now = chrono::Utc::now();
                 let sprint_id = self
@@ -391,7 +427,6 @@ impl App {
                     .create_card_sprint_picker
                     .selected_sprint_id_for(bid);
                 let card_id = uuid::Uuid::new_v4();
-                let column_id = column.id;
                 let title = self.input.as_str().to_string();
 
                 // The number is allocated from the prefix row INSIDE the
@@ -416,21 +451,21 @@ impl App {
                         Some(&default_card_prefix),
                     )?;
 
-                    let mut commands: Vec<Command> =
-                        vec![Command::Card(CardCommand::Create(CreateCard {
-                            id: card_id,
-                            card_number,
-                            board_id: bid,
-                            column_id,
-                            title,
-                            position,
-                            options: kanban_domain::CreateCardOptions {
-                                sprint_id,
-                                ..Default::default()
-                            },
-                            timestamp: now,
-                            default_card_prefix: default_card_prefix.clone(),
-                        }))];
+                    let mut commands: Vec<Command> = new_column_cmd.into_iter().collect();
+                    commands.push(Command::Card(CardCommand::Create(CreateCard {
+                        id: card_id,
+                        card_number,
+                        board_id: bid,
+                        column_id,
+                        title,
+                        position,
+                        options: kanban_domain::CreateCardOptions {
+                            sprint_id,
+                            ..Default::default()
+                        },
+                        timestamp: now,
+                        default_card_prefix: default_card_prefix.clone(),
+                    })));
 
                     if mark_as_complete {
                         commands.push(Command::Card(CardCommand::Update(UpdateCard {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1014,6 +1014,7 @@ impl App {
                             }
                         }
                         CardListAction::Create => {
+                            self.prime_create_card_column_field();
                             self.open_dialog(DialogMode::CreateCard);
                             self.input.clear();
                         }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -37,27 +37,44 @@ impl App {
                 self.create_card();
                 self.pop_mode();
                 self.input.clear();
+                self.dialog_input.create_card_column_input.clear();
                 self.dialog_input.create_card_sprint_picker.clear();
                 self.dialog_input.reset_create_card_focus();
                 return;
             }
             KeyCode::Tab => {
-                self.dialog_input.toggle_create_card_focus();
+                self.dialog_input.advance_create_card_focus();
                 return;
             }
             _ => {}
         }
 
         if self.dialog_input.create_card_focus_is_title() {
-            // Title focus: Down/Esc drop focus into the sprint picker so the
+            // Title focus: Down/Esc drop focus into the next field so the
             // visual cursor moves out of the text input; all other keys edit
             // the title.
             match key_code {
                 KeyCode::Down | KeyCode::Esc => {
-                    self.dialog_input.toggle_create_card_focus();
+                    self.dialog_input.advance_create_card_focus();
                 }
                 _ => {
                     handle_dialog_input(&mut self.input, key_code, false);
+                }
+            }
+            return;
+        }
+
+        if self.dialog_input.create_card_focus_is_column() {
+            match key_code {
+                KeyCode::Down | KeyCode::Esc => {
+                    self.dialog_input.advance_create_card_focus();
+                }
+                _ => {
+                    handle_dialog_input(
+                        &mut self.dialog_input.create_card_column_input,
+                        key_code,
+                        true,
+                    );
                 }
             }
             return;
@@ -69,6 +86,7 @@ impl App {
         if matches!(key_code, KeyCode::Esc) {
             self.pop_mode();
             self.input.clear();
+            self.dialog_input.create_card_column_input.clear();
             self.dialog_input.create_card_sprint_picker.clear();
             self.dialog_input.reset_create_card_focus();
             return;

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -19,7 +19,11 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         return;
     };
 
-    let area = crate::components::centered_rect_abs(60, 18, frame.area());
+    let area = crate::components::centered_rect_abs(
+        60,
+        (frame.area().height * 60 / 100).max(18),
+        frame.area(),
+    );
     frame.render_widget(Clear, area);
 
     let block = Block::default()

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -8,8 +8,6 @@ use ratatui::{
 };
 
 pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
-    use crate::components::centered_rect;
-
     let Some(board) = app.active_board() else {
         render_input_popup(
             frame,
@@ -21,7 +19,7 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         return;
     };
 
-    let area = centered_rect(60, 60, frame.area());
+    let area = crate::components::centered_rect_abs(60, 18, frame.area());
     frame.render_widget(Clear, area);
 
     let block = Block::default()
@@ -39,11 +37,15 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
             Constraint::Length(1),
             Constraint::Length(3),
             Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
             Constraint::Min(0),
         ])
         .split(inner);
 
     let title_focused = app.dialog_input.create_card_focus_is_title();
+    let column_focused = app.dialog_input.create_card_focus_is_column();
+    let sprint_focused = app.dialog_input.create_card_focus_is_sprint();
     let unfocused_border = Style::default().fg(Color::DarkGray);
 
     frame.render_widget(
@@ -70,19 +72,52 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
     }
 
     frame.render_widget(
-        Paragraph::new("Sprint:").style(Style::default().fg(Color::Yellow)),
+        Paragraph::new("Column:").style(Style::default().fg(Color::Yellow)),
         chunks[2],
+    );
+
+    let column_text_style = if app.dialog_input.create_card_column_is_editable() {
+        crate::theme::normal_text()
+    } else {
+        crate::theme::label_text()
+    };
+    let column_input = Paragraph::new(app.dialog_input.create_card_column_input.as_str())
+        .style(column_text_style)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(if column_focused {
+                    crate::theme::focused_border()
+                } else {
+                    unfocused_border
+                }),
+        );
+    frame.render_widget(column_input, chunks[3]);
+    if column_focused {
+        let cursor_x = chunks[3].x
+            + app
+                .dialog_input
+                .create_card_column_input
+                .cursor_byte_offset() as u16
+            + 1;
+        let cursor_y = chunks[3].y + 1;
+        frame.set_cursor_position((cursor_x, cursor_y));
+    }
+
+    frame.render_widget(
+        Paragraph::new("Sprint:").style(Style::default().fg(Color::Yellow)),
+        chunks[4],
     );
 
     let picker_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(if title_focused {
-            unfocused_border
-        } else {
+        .border_style(if sprint_focused {
             crate::theme::focused_border()
+        } else {
+            unfocused_border
         });
-    let picker_inner = picker_block.inner(chunks[3]);
-    frame.render_widget(picker_block, chunks[3]);
+    let picker_inner = picker_block.inner(chunks[5]);
+    frame.render_widget(picker_block, chunks[5]);
     app.dialog_input.create_card_sprint_picker.render(
         frame,
         picker_inner,

--- a/crates/kanban-tui/tests/columnless_board_card_tests.rs
+++ b/crates/kanban-tui/tests/columnless_board_card_tests.rs
@@ -477,6 +477,34 @@ fn test_the_dialog_fits_within_an_80x24_terminal_without_collapsing() {
 }
 
 #[test]
+fn test_the_sprint_picker_shows_real_sprints_not_just_none_on_a_taller_terminal() {
+    let width = 120u16;
+    let height = 40u16;
+
+    let mut app = setup_app_with_two_columns();
+    let board_id = app.selection.active_board_id.unwrap();
+    let board = app.ctx.get_board(board_id).unwrap().unwrap();
+    let mut sprint_names = Vec::new();
+    for i in 0..3 {
+        let sprint = app
+            .ctx
+            .create_sprint(board_id, None, Some(format!("Probe Sprint {i}")))
+            .unwrap();
+        sprint_names.push(sprint.formatted_name(&board, None));
+    }
+    app.reload_model();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    let grid = render_to_string(&mut app, width, height);
+
+    assert!(grid.contains("(None)"));
+    assert!(
+        sprint_names.iter().any(|name| grid.contains(name)),
+        "no seeded sprint name is visible in the rendered picker at {width}x{height}:\n{grid}"
+    );
+}
+
+#[test]
 fn test_a_board_with_existing_columns_gains_no_new_column() {
     let mut app = setup_app_with_two_columns();
     app.focus.active = Focus::Cards;

--- a/crates/kanban-tui/tests/columnless_board_card_tests.rs
+++ b/crates/kanban-tui/tests/columnless_board_card_tests.rs
@@ -1,0 +1,499 @@
+use crossterm::event::KeyCode;
+use kanban_domain::{CardStatus, KanbanOperations};
+use kanban_tui::app::dialog_input::CreateCardFocus;
+use kanban_tui::app::focus::Focus;
+use kanban_tui::view_strategy::UnifiedViewStrategy;
+use kanban_tui::App;
+use kanban_view::card_list::CardListId;
+use ratatui::backend::TestBackend;
+use ratatui::style::Color;
+use ratatui::Terminal;
+
+fn setup_app_without_columns() -> App {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.selection.active_board_id = Some(board.id);
+    app
+}
+
+fn setup_app_with_two_columns() -> App {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let _c1 = app
+        .ctx
+        .create_column(board.id, "Backlog".to_string(), Some(0))
+        .unwrap();
+    let _c2 = app
+        .ctx
+        .create_column(board.id, "Doing".to_string(), Some(1))
+        .unwrap();
+    app.reload_model();
+    app.prepare_frame();
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.selection.active_board_id = Some(board.id);
+    app
+}
+
+fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
+}
+
+fn render_with_colors(app: &mut App, width: u16, height: u16) -> Vec<(String, Option<Color>)> {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = Vec::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            let cell = buffer.cell((x, y)).unwrap();
+            result.push((cell.symbol().to_string(), cell.style().fg));
+        }
+    }
+    result
+}
+
+fn row_containing(grid: &str, substring: &str) -> Option<usize> {
+    grid.lines()
+        .enumerate()
+        .find(|(_, line)| line.contains(substring))
+        .map(|(i, _)| i)
+}
+
+fn color_of_row(
+    grid: &[(String, Option<Color>)],
+    width: usize,
+    _height: usize,
+    row: usize,
+    substring: &str,
+) -> Option<Color> {
+    let line: String = (0..width)
+        .map(|x| grid[row * width + x].0.clone())
+        .collect();
+    let start = line.find(substring)?;
+    let char_start = line[..start].chars().count();
+    grid[row * width + char_start].1
+}
+
+#[test]
+fn test_the_column_field_is_editable_and_prefilled_with_the_template_name_on_a_columnless_board() {
+    let mut app = setup_app_without_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    assert_eq!(
+        app.dialog_input.create_card_column_input.as_str(),
+        kanban_domain::DEFAULT_TEMPLATE_COLUMNS[0].0
+    );
+    assert!(app.dialog_input.create_card_column_is_editable());
+}
+
+#[test]
+fn test_the_column_field_is_disabled_and_names_the_destination_column_when_the_board_has_columns() {
+    let mut app = setup_app_with_two_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    assert!(!app.dialog_input.create_card_column_is_editable());
+    assert_eq!(
+        app.dialog_input.create_card_column_input.as_str(),
+        "Backlog"
+    );
+}
+
+#[test]
+fn test_the_column_field_names_the_column_the_card_actually_lands_in() {
+    // (a) board with columns, focused on the SECOND column's card list
+    let mut app = setup_app_with_two_columns();
+    app.focus.active = Focus::Cards;
+    app.view.strategy = Box::new(UnifiedViewStrategy::kanban());
+    app.prepare_frame();
+    assert!(app.view.strategy.navigate_right(false));
+    assert_eq!(
+        app.view
+            .strategy
+            .get_active_task_list()
+            .map(|l| l.id.clone()),
+        Some(CardListId::Column(
+            app.model
+                .columns()
+                .iter()
+                .find(|c| c.name == "Doing")
+                .unwrap()
+                .id
+        ))
+    );
+    app.handle_create_card_key();
+    let snapshot = app
+        .dialog_input
+        .create_card_column_input
+        .as_str()
+        .to_string();
+    assert_eq!(
+        snapshot, "Doing",
+        "the field must name the focused (second) column, not fall back to the first"
+    );
+    for ch in "Task".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
+    let card = app
+        .model
+        .all_cards()
+        .iter()
+        .find(|c| c.title == "Task")
+        .expect("card created")
+        .clone();
+    let col = app
+        .model
+        .columns()
+        .iter()
+        .find(|c| c.id == card.column_id)
+        .expect("column exists");
+    assert_eq!(col.name, snapshot);
+
+    // (b) columnless board
+    let mut app2 = setup_app_without_columns();
+    app2.focus.active = Focus::Cards;
+    app2.handle_create_card_key();
+    let snapshot2 = app2
+        .dialog_input
+        .create_card_column_input
+        .as_str()
+        .to_string();
+    for ch in "Task2".chars() {
+        app2.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app2.handle_create_card_dialog(KeyCode::Enter);
+    app2.reload_model();
+    let cols2 = app2.model.columns();
+    assert_eq!(cols2.len(), 1);
+    assert_eq!(cols2[0].name, snapshot2);
+}
+
+#[test]
+fn test_focus_never_lands_on_the_column_field_when_the_board_has_columns() {
+    let mut app = setup_app_with_two_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    for _ in 0..6 {
+        app.handle_create_card_dialog(KeyCode::Tab);
+        assert_ne!(app.dialog_input.create_card_focus, CreateCardFocus::Column);
+    }
+}
+
+#[test]
+fn test_focus_cycles_title_then_column_then_sprint_on_a_columnless_board() {
+    let mut app = setup_app_without_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    assert_eq!(app.dialog_input.create_card_focus, CreateCardFocus::Title);
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert_eq!(app.dialog_input.create_card_focus, CreateCardFocus::Column);
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert_eq!(app.dialog_input.create_card_focus, CreateCardFocus::Sprint);
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert_eq!(app.dialog_input.create_card_focus, CreateCardFocus::Title);
+}
+
+#[test]
+fn test_typing_in_the_column_field_edits_it_and_leaves_the_title_alone() {
+    let mut app = setup_app_without_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    for ch in "Task".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Tab);
+    for _ in 0..4 {
+        app.handle_create_card_dialog(KeyCode::Backspace);
+    }
+    for ch in "Inbox".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+
+    assert_eq!(app.dialog_input.create_card_column_input.as_str(), "Inbox");
+    assert_eq!(app.input.as_str(), "Task");
+}
+
+#[test]
+fn test_typing_cannot_change_the_column_field_while_it_is_disabled() {
+    let mut app = setup_app_with_two_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    app.handle_create_card_dialog(KeyCode::Tab);
+    app.handle_create_card_dialog(KeyCode::Char('x'));
+    app.handle_create_card_dialog(KeyCode::Char('y'));
+    app.handle_create_card_dialog(KeyCode::Char('z'));
+    app.handle_create_card_dialog(KeyCode::Tab);
+    app.handle_create_card_dialog(KeyCode::Backspace);
+    app.handle_create_card_dialog(KeyCode::Tab);
+    app.handle_create_card_dialog(KeyCode::Char('q'));
+
+    assert_eq!(
+        app.dialog_input.create_card_column_input.as_str(),
+        "Backlog"
+    );
+}
+
+#[test]
+fn test_creating_a_card_on_a_columnless_board_creates_the_template_named_column_with_its_default_status(
+) {
+    let mut app = setup_app_without_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    for ch in "Probe".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
+
+    let cols = app.model.columns();
+    assert_eq!(cols.len(), 1);
+    assert_eq!(cols[0].name, "TODO");
+    assert_eq!(cols[0].default_status, Some(CardStatus::Todo));
+}
+
+#[test]
+fn test_an_edited_column_name_is_used_for_the_created_column() {
+    let mut app = setup_app_without_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    for ch in "Probe".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Tab);
+    for _ in 0..app
+        .dialog_input
+        .create_card_column_input
+        .as_str()
+        .chars()
+        .count()
+    {
+        app.handle_create_card_dialog(KeyCode::Backspace);
+    }
+    for ch in "Inbox".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
+
+    let cols = app.model.columns();
+    assert_eq!(cols.len(), 1);
+    assert_eq!(cols[0].name, "Inbox");
+    assert_eq!(cols[0].default_status, Some(CardStatus::Todo));
+    let card = app
+        .model
+        .all_cards()
+        .iter()
+        .find(|c| c.title == "Probe")
+        .unwrap();
+    assert_eq!(card.column_id, cols[0].id);
+}
+
+#[test]
+fn test_an_emptied_column_name_falls_back_to_the_template_name() {
+    let mut app = setup_app_without_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    for ch in "Probe".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Tab);
+    for _ in 0..app
+        .dialog_input
+        .create_card_column_input
+        .as_str()
+        .chars()
+        .count()
+    {
+        app.handle_create_card_dialog(KeyCode::Backspace);
+    }
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
+
+    let cols = app.model.columns();
+    assert_eq!(cols.len(), 1);
+    assert_eq!(cols[0].name, "TODO");
+    let card = app
+        .model
+        .all_cards()
+        .iter()
+        .find(|c| c.title == "Probe")
+        .unwrap();
+    assert_eq!(card.column_id, cols[0].id);
+    assert!(app.ui_state.banner.is_none());
+}
+
+#[test]
+fn test_undoing_the_card_create_also_removes_the_invented_column() {
+    let mut app = setup_app_without_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    for ch in "Probe".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
+    assert_eq!(app.model.all_cards().len(), 1);
+    assert_eq!(app.model.columns().len(), 1);
+
+    app.ctx.undo().unwrap();
+    app.reload_model();
+
+    assert!(app.model.all_cards().is_empty());
+    assert!(app.model.columns().is_empty());
+}
+
+#[test]
+fn test_the_create_card_dialog_has_the_same_shape_with_and_without_columns() {
+    let mut app_no_cols = setup_app_without_columns();
+    app_no_cols.focus.active = Focus::Cards;
+    app_no_cols.handle_create_card_key();
+    let grid_no_cols = render_to_string(&mut app_no_cols, 120, 40);
+
+    let mut app_cols = setup_app_with_two_columns();
+    app_cols.focus.active = Focus::Cards;
+    app_cols.handle_create_card_key();
+    let grid_cols = render_to_string(&mut app_cols, 120, 40);
+
+    assert!(grid_no_cols.contains("Column:"));
+    assert!(grid_cols.contains("Column:"));
+    assert!(grid_no_cols.contains("Sprint:"));
+    assert!(grid_cols.contains("Sprint:"));
+
+    let sprint_row_no_cols = row_containing(&grid_no_cols, "Sprint:").unwrap();
+    let sprint_row_cols = row_containing(&grid_cols, "Sprint:").unwrap();
+    assert_eq!(sprint_row_no_cols, sprint_row_cols);
+}
+
+#[test]
+fn test_the_disabled_column_field_is_greyed_and_the_editable_one_is_not() {
+    let width = 120u16;
+    let height = 40u16;
+
+    let mut app_no_cols = setup_app_without_columns();
+    app_no_cols.focus.active = Focus::Cards;
+    app_no_cols.handle_create_card_key();
+    let grid_no_cols = render_to_string(&mut app_no_cols, width, height);
+    let colors_no_cols = render_with_colors(&mut app_no_cols, width, height);
+    let row = row_containing(&grid_no_cols, kanban_domain::DEFAULT_TEMPLATE_COLUMNS[0].0).unwrap();
+    let color = color_of_row(
+        &colors_no_cols,
+        width as usize,
+        height as usize,
+        row,
+        kanban_domain::DEFAULT_TEMPLATE_COLUMNS[0].0,
+    );
+    assert_eq!(color, Some(Color::White));
+
+    let mut app_cols = setup_app_with_two_columns();
+    app_cols.focus.active = Focus::Cards;
+    app_cols.handle_create_card_key();
+    let grid_cols = render_to_string(&mut app_cols, width, height);
+    let colors_cols = render_with_colors(&mut app_cols, width, height);
+    let row2 = row_containing(&grid_cols, "Backlog").unwrap();
+    let color2 = color_of_row(
+        &colors_cols,
+        width as usize,
+        height as usize,
+        row2,
+        "Backlog",
+    );
+    assert_eq!(color2, Some(Color::DarkGray));
+}
+
+#[test]
+fn test_the_dialog_fits_within_an_80x24_terminal_without_collapsing() {
+    let width = 80u16;
+    let height = 24u16;
+
+    fn assert_title_input_has_content_row(grid: &str) {
+        let title_row = row_containing(grid, "Task Title:").unwrap();
+        let lines: Vec<&str> = grid.lines().collect();
+        let top_border = lines[title_row + 1];
+        let content = lines[title_row + 2];
+        let bottom_border = lines[title_row + 3];
+        assert!(
+            top_border.contains('┌') && top_border.contains('┐'),
+            "no top border for the title input box at 80x24:\n{grid}"
+        );
+        assert!(
+            bottom_border.contains('└') && bottom_border.contains('┘'),
+            "no bottom border for the title input box at 80x24:\n{grid}"
+        );
+        assert!(
+            !content.contains('┌') && !content.contains('└'),
+            "title input box has no distinct content row at 80x24 (top and bottom border collapsed together):\n{grid}"
+        );
+    }
+
+    let mut app_no_cols = setup_app_without_columns();
+    app_no_cols.focus.active = Focus::Cards;
+    app_no_cols.handle_create_card_key();
+    let grid_no_cols = render_to_string(&mut app_no_cols, width, height);
+    assert_title_input_has_content_row(&grid_no_cols);
+    assert!(
+        grid_no_cols.contains("(None)"),
+        "sprint picker did not render its first entry at 80x24:\n{grid_no_cols}"
+    );
+
+    let mut app_cols = setup_app_with_two_columns();
+    app_cols.focus.active = Focus::Cards;
+    app_cols.handle_create_card_key();
+    let grid_cols = render_to_string(&mut app_cols, width, height);
+    assert_title_input_has_content_row(&grid_cols);
+    assert!(
+        grid_cols.contains("(None)"),
+        "sprint picker did not render its first entry at 80x24:\n{grid_cols}"
+    );
+}
+
+#[test]
+fn test_a_board_with_existing_columns_gains_no_new_column() {
+    let mut app = setup_app_with_two_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    for ch in "Task".chars() {
+        app.handle_create_card_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_card_dialog(KeyCode::Enter);
+    app.reload_model();
+
+    let cols = app.model.columns();
+    assert_eq!(cols.len(), 2);
+    let card = app
+        .model
+        .all_cards()
+        .iter()
+        .find(|c| c.title == "Task")
+        .unwrap();
+    assert_eq!(card.column_id, cols[0].id);
+}


### PR DESCRIPTION
Replaces the TUI's silent invention of a column named "Todo" on a column-less board with an always-present "Column:" field in the create-card dialog.

## Changes

- Adds a `Column:` field to the create-card dialog, always visible:
  - Column-less board: editable, prefilled with the template column name (`DEFAULT_TEMPLATE_COLUMNS[0].0`, i.e. "TODO"), falls back to the template name if left blank.
  - Board with columns: disabled/greyed, prefilled with the actual destination column's name, cannot be edited.
- `App::create_card_target_column` is the single resolver feeding both the field and the create path, so the field can never disagree with where the card actually lands. It reproduces the existing focused-column-then-first-column fallback byte for byte.
- The invented column create now shares the card create's undo transaction (pushed first in the command batch), so a single undo removes both the card and the column. Previously the column create was a separate, unbatched call, so undo left an orphaned column behind.
- The invented column now carries `default_status: Some(CardStatus::Todo)` (from the template), instead of `None`.
- `CreateCardFocus` gains a `Column` variant; the Tab cycle is Title → Column → Sprint on a column-less board, and skips straight to Sprint when the board already has columns (`advance_create_card_focus`, renamed from `toggle_create_card_focus`).
- Both dialog entry points (`handle_create_card_key` and the sprint-detail `CardListAction::Create`) now prime the field on open, since either can leave a stale/wrong destination showing otherwise.
- Disabled state is signalled by text colour (`theme::label_text()` vs `theme::normal_text()`), not the border, since the existing unfocused border colour is already indistinguishable from a "disabled" one.
- The dialog's popup area now uses `centered_rect_abs(60, (frame height * 60 / 100).max(18), ..)` instead of a percentage-based `centered_rect(60, 60, ..)`, so the extra Column row doesn't collapse the title input or sprint picker to zero height on a small (80x24) terminal, while a taller terminal gets proportionally more room instead of being capped at a fixed 18 rows (which starved the sprint picker to a single visible row). `centered_rect_abs` still clamps the result to the frame, so it can't overflow.
- CLI (`kanban card create`) is deliberately left requiring `--column`, since a CLI user can chain a second `column create` command.

## Test plan

- [x] `cargo test -p kanban-tui` green, including 16 new tests in `crates/kanban-tui/tests/columnless_board_card_tests.rs` and the pre-existing `create_card_dialog_tests.rs` unmodified
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] New 80x24 regression test renders the dialog at that size (both column-less and with-columns) and asserts the title input keeps a distinct content row and the sprint picker renders its first entry
- [x] New test asserts the field names the *focused* (not just first) column on a multi-column board, driven through `UnifiedViewStrategy::kanban()` + `navigate_right`
- [x] Mutation-checked both fixes: reverting the popup sizing and reverting the focused-column resolution to a stub each make their respective new test fail, confirming they are load-bearing
