### PR TITLE
chore(changeset): mark the board DTO removal minor so the release lands on 0.9.0

### DIFF
--- a/.changeset/kan-1159-drop-board-dto-field.md
+++ b/.changeset/kan-1159-drop-board-dto-field.md
@@ -1,5 +1,5 @@
 ---
-bump: major
+bump: minor
 ---
 
-Remove completion_column_ids from the REST board DTOs (BoardResponse, UpdateBoardRequest, ReplaceBoardRequest); clients configuring board completion via the wire must migrate to per-column default_status. Legacy request bodies that still send the key are ignored, not rejected.
+BREAKING: remove completion_column_ids from the REST board DTOs (BoardResponse, UpdateBoardRequest, ReplaceBoardRequest); clients configuring board completion via the wire must migrate to per-column default_status. Legacy request bodies that still send the key are ignored, not rejected.


### PR DESCRIPTION
`.changeset/kan-1159-drop-board-dto-field.md` carried `bump: major`. On `0.8.1` that produces `1.0.0`, not `0.9.0`.

`scripts/bump-version.sh:27-37` has no 0.x special case:

```
major)  NEW_VERSION="$((MAJOR + 1)).0.0" ;;
```

Some changeset tools map a 0.x major onto a minor automatically. This one does not, so the bump level had to change.

The project is not making a 1.0 API-stability commitment yet, and the break is confined to a REST DTO whose legacy key is ignored rather than rejected.

The breaking change itself is unchanged. Its description now opens with `BREAKING:` so it still surfaces in the changelog at its real severity, and the release notes should carry it under a breaking-changes heading since a 0.x minor is a weaker signal than a major bump.

Bump levels after this: 14 minor, 27 patch, 0 major. `aggregate-changesets.sh` takes the highest, so the release lands on 0.9.0.

Tracked on KAN-1315.