### PR TITLE
KAN-1233 perf(tui): resolve card-detail relationship rows by id

### DIFF
--- a/.changeset/perf-kan-1233-card-detail-relation-lookup.md
+++ b/.changeset/perf-kan-1233-card-detail-relation-lookup.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: the card-detail view now resolves the Parents/Children relationship rows by looking each related card up by id instead of cloning the entire workspace card collection on every render.

--- a/crates/kanban-tui/src/components/relationship_section.rs
+++ b/crates/kanban-tui/src/components/relationship_section.rs
@@ -1,13 +1,25 @@
 use crate::components::ListItemConfig;
 use crate::theme::*;
 use kanban_domain::Card;
+use kanban_view::model::Model;
 use kanban_view::ListComponent;
 use ratatui::text::{Line, Span};
 use uuid::Uuid;
 
+/// Clone the cards named by `card_ids`, in order. An id with no matching card
+/// in `model` is omitted, exactly as [`render_relationship_section`] treats an
+/// id it cannot resolve. Resolution is by id over the unified live+archived
+/// collection and is not scoped to any board.
+pub fn resolve_relationship_cards(model: &Model, card_ids: &[Uuid]) -> Vec<Card> {
+    card_ids
+        .iter()
+        .filter_map(|id| model.card_by_id(*id).cloned())
+        .collect()
+}
+
 pub fn render_relationship_section(
     card_ids: &[Uuid],
-    all_cards: &[Card],
+    cards: &[Card],
     title: &str,
     is_focused: bool,
     list_component: &ListComponent,
@@ -37,7 +49,7 @@ pub fn render_relationship_section(
         // Render visible items
         for &idx in &page_info.visible_indices {
             if let Some(&card_id) = card_ids.get(idx) {
-                if let Some(card) = all_cards.iter().find(|c| c.id == card_id) {
+                if let Some(card) = cards.iter().find(|c| c.id == card_id) {
                     let is_selected = list_component.selection.get() == Some(idx);
 
                     let config = ListItemConfig::new()

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -32,10 +32,11 @@ pub(super) fn render_relationship_boxes(
     let parents_config = FieldSectionConfig::new("Parents")
         .with_focus_indicator("Parents [4]")
         .focused(app.focus.card_focus == CardFocus::Parents);
-    let all_cards: Vec<kanban_domain::Card> = app.model.all_cards().to_vec();
+    let related_ids = [parents, children].concat();
+    let related_cards = resolve_relationship_cards(&app.model, &related_ids);
     let parents_lines = render_relationship_section(
         parents,
-        &all_cards,
+        &related_cards,
         "Parents",
         app.focus.card_focus == CardFocus::Parents,
         &app.relationship.parents_list,
@@ -52,7 +53,7 @@ pub(super) fn render_relationship_boxes(
         .focused(app.focus.card_focus == CardFocus::Children);
     let children_lines = render_relationship_section(
         children,
-        &all_cards,
+        &related_cards,
         "Children",
         app.focus.card_focus == CardFocus::Children,
         &app.relationship.children_list,

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -1,0 +1,209 @@
+mod helpers;
+
+use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations};
+use kanban_tui::components::resolve_relationship_cards;
+use kanban_tui::App;
+use uuid::Uuid;
+
+fn create_board_and_column(app: &mut App, board_title: &str) -> (Uuid, Uuid) {
+    let board = app.ctx.create_board(board_title.into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "TODO".into(), None)
+        .unwrap();
+    (board.id, column.id)
+}
+
+fn create_card(app: &mut App, board_id: Uuid, column_id: Uuid, title: &str) -> Uuid {
+    app.ctx
+        .create_card(
+            board_id,
+            column_id,
+            title.into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap()
+        .id
+}
+
+#[test]
+fn test_resolve_relationship_cards_returns_only_the_related_cards() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+
+    let mut card_ids = Vec::new();
+    for i in 0..50 {
+        card_ids.push(create_card(
+            &mut app,
+            board_id,
+            column_id,
+            &format!("Card {i}"),
+        ));
+    }
+    let subject = card_ids[0];
+    let parent = card_ids[1];
+    let child = card_ids[2];
+
+    app.ctx.attach_child(parent, subject).unwrap();
+    app.ctx.attach_child(subject, child).unwrap();
+    app.reload_model();
+
+    assert_eq!(app.model.all_cards().len(), 50);
+
+    let ids = [
+        app.model.graph().parents(subject),
+        app.model.graph().children(subject),
+    ]
+    .concat();
+
+    let resolved = resolve_relationship_cards(&app.model, &ids);
+    let resolved_ids: std::collections::HashSet<Uuid> = resolved.iter().map(|c| c.id).collect();
+
+    assert_eq!(resolved.len(), 2);
+    assert_eq!(
+        resolved_ids,
+        std::collections::HashSet::from([parent, child])
+    );
+}
+
+#[test]
+fn test_resolve_relationship_cards_resolves_archived_related_card() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+
+    let subject = create_card(&mut app, board_id, column_id, "Subject");
+    let parent = create_card(&mut app, board_id, column_id, "ArchivedParentXYZ");
+
+    app.ctx.attach_child(parent, subject).unwrap();
+    app.ctx.archive_card(parent).unwrap();
+    app.reload_model();
+
+    assert!(app.model.archived_card_ids().contains(&parent));
+    assert!(!app.model.live_cards().iter().any(|c| c.id == parent));
+
+    let resolved = resolve_relationship_cards(&app.model, &[parent]);
+
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].id, parent);
+    assert_eq!(resolved[0].title, "ArchivedParentXYZ");
+}
+
+#[test]
+fn test_resolve_relationship_cards_resolves_cross_board_related_card() {
+    let mut app = App::test_default();
+    let (board_b_id, column_b_id) = create_board_and_column(&mut app, "Board B");
+    let (board_c_id, column_c_id) = create_board_and_column(&mut app, "Board C");
+
+    let subject = create_card(&mut app, board_b_id, column_b_id, "Subject");
+    let cross = create_card(&mut app, board_c_id, column_c_id, "CrossBoardChildXYZ");
+
+    app.ctx.attach_child(subject, cross).unwrap();
+    app.reload_model();
+    app.selection.active_board_id = Some(board_b_id);
+
+    let children = app.model.graph().children(subject);
+    let resolved = resolve_relationship_cards(&app.model, &children);
+
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].id, cross);
+    assert_eq!(resolved[0].title, "CrossBoardChildXYZ");
+}
+
+#[test]
+fn test_resolve_relationship_cards_omits_id_with_no_card() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+
+    let known = create_card(&mut app, board_id, column_id, "Known");
+    create_card(&mut app, board_id, column_id, "Other1");
+    create_card(&mut app, board_id, column_id, "Other2");
+    app.reload_model();
+
+    let unknown = Uuid::new_v4();
+    let resolved = resolve_relationship_cards(&app.model, &[known, unknown]);
+
+    let resolved_ids: Vec<Uuid> = resolved.iter().map(|c| c.id).collect();
+    assert_eq!(resolved_ids, vec![known]);
+}
+
+#[test]
+fn test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan() {
+    let mut app = App::test_default();
+    let (board_b_id, column_b_id) = create_board_and_column(&mut app, "Board B");
+    let (board_c_id, column_c_id) = create_board_and_column(&mut app, "Board C");
+
+    let subject = create_card(&mut app, board_b_id, column_b_id, "Subject");
+    let live_parent = create_card(&mut app, board_b_id, column_b_id, "LiveParent");
+    let archived_parent = create_card(&mut app, board_b_id, column_b_id, "ArchivedParent");
+    let cross_child = create_card(&mut app, board_c_id, column_c_id, "CrossBoardChild");
+
+    app.ctx.attach_child(live_parent, subject).unwrap();
+    app.ctx.attach_child(archived_parent, subject).unwrap();
+    app.ctx.attach_child(subject, cross_child).unwrap();
+    app.ctx.archive_card(archived_parent).unwrap();
+    app.reload_model();
+
+    let mut ids = [
+        app.model.graph().parents(subject),
+        app.model.graph().children(subject),
+    ]
+    .concat();
+    ids.push(archived_parent);
+    ids.push(Uuid::new_v4());
+
+    let expected: Vec<Uuid> = ids
+        .iter()
+        .filter_map(|id| app.model.all_cards().iter().find(|c| c.id == *id).cloned())
+        .map(|c| c.id)
+        .collect();
+    assert_eq!(expected.len(), 3);
+
+    let actual: Vec<Uuid> = resolve_relationship_cards(&app.model, &ids)
+        .iter()
+        .map(|c| c.id)
+        .collect();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn test_resolve_relationship_cards_with_no_ids_returns_empty() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+    for i in 0..50 {
+        create_card(&mut app, board_id, column_id, &format!("Card {i}"));
+    }
+    app.reload_model();
+
+    assert_eq!(app.model.all_cards().len(), 50);
+
+    let resolved = resolve_relationship_cards(&app.model, &[]);
+    assert!(resolved.is_empty());
+}
+
+#[test]
+fn test_card_detail_children_box_shows_cross_board_child_title() {
+    use kanban_tui::app::mode::AppMode;
+
+    let mut app = App::test_default();
+    let (board_b_id, column_b_id) = create_board_and_column(&mut app, "Board B");
+    let (board_c_id, column_c_id) = create_board_and_column(&mut app, "Board C");
+
+    let subject = create_card(&mut app, board_b_id, column_b_id, "Subject");
+    let cross = create_card(&mut app, board_c_id, column_c_id, "CrossBoardChildXYZ");
+    let decoy = create_card(&mut app, board_b_id, column_b_id, "UnrelatedDecoyABC");
+    let _ = decoy;
+
+    app.ctx.attach_child(subject, cross).unwrap();
+    app.reload_model();
+    app.selection.active_board_id = Some(board_b_id);
+    app.selection.active_card_id = Some(subject);
+    app.push_mode(AppMode::CardDetail);
+    app.relationship.children_list.update_item_count(1);
+
+    let output =
+        helpers::render_widget_to_string(120, 40, |frame| kanban_tui::ui::render(&mut app, frame));
+
+    assert!(output.contains("CrossBoardChildXYZ"));
+    assert!(!output.contains("UnrelatedDecoyABC"));
+}


### PR DESCRIPTION
## Summary

- `render_relationship_boxes` no longer clones the entire workspace card collection (`app.model.all_cards().to_vec()`) on every card-detail render.
- New `pub fn resolve_relationship_cards(model: &Model, card_ids: &[Uuid]) -> Vec<Card>` in `components/relationship_section.rs` resolves only the parent/child ids the two relationship boxes actually name, via `Model::card_by_id`'s existing index lookup.
- `card_detail.rs` computes `related_ids = [parents, children].concat()` once and passes the narrowed `related_cards` to both `render_relationship_section` calls.
- `render_relationship_section`'s second parameter is renamed from `all_cards` to `cards`; arity, order and types are unchanged.

## Why it's safe

`Model::card_by_id` indexes the same unified `self.cards` vec that `all_cards()` returns (`card_index` is rebuilt from that vec in the same `load_from_snapshot` call that assigns `self.cards`), so the id-to-card resolution is set-identical to the old whole-collection scan: it resolves live and archived cards, and cards on any board. This equivalence is pinned by `test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan`.

## Tests

Added `crates/kanban-tui/tests/relationship_resolution_tests.rs`:
- `test_resolve_relationship_cards_returns_only_the_related_cards` - narrows 50 cards down to the 2 actually related
- `test_resolve_relationship_cards_resolves_archived_related_card` - an archived card is still resolved by id
- `test_resolve_relationship_cards_resolves_cross_board_related_card` - resolution is not scoped to the active board
- `test_resolve_relationship_cards_omits_id_with_no_card` - an id with no matching card is silently omitted, no panic
- `test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan` - direct equivalence proof against the old `all_cards()` scan
- `test_resolve_relationship_cards_with_no_ids_returns_empty`
- `test_card_detail_children_box_shows_cross_board_child_title` - end-to-end render guard through `ui::render`, with a negative control on an unrelated card's title

One correction made against the original card spec: two of the tests originally sourced the archived/related id via `graph().parents()`/`graph().children()`. `ArchiveCards::execute` calls `graph.archive_node(id)`, which archives every edge incident to that card (`kanban-core/src/graph/core.rs`), and `DagGraph::outgoing`/`incoming` (backing `parents`/`children`) only return active edges. So after a card is archived, `graph().parents()` no longer returns it - the edge itself goes inactive, not just the card. Those two tests now construct the id list directly instead of relying on the graph traversal to surface an archived-card id, since that's the actual contract `resolve_relationship_cards` needs to hold regardless of how a caller sourced the id list.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features --workspace
cargo check --package kanban-cli --no-default-features --features json,sqlite
```

All four green.