### PR TITLE
KAN-1235 feat(server): expose the sprint route surface, nested and flat

### DIFF
--- a/.changeset/kan-1235-server-sprint-routes.md
+++ b/.changeset/kan-1235-server-sprint-routes.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: sprints are now reachable over HTTP with list, get, create, replace, update and delete routes, both board-nested and via the flat /v1/sprints/{id} alias; listing the sprints of a board that does not exist returns 404 rather than an empty list.

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -160,6 +160,20 @@ All request/response bodies are JSON. Errors share one envelope (see [Error Hand
 
 Column writes (create/update/delete) aren't implemented yet.
 
+### Sprints
+
+| Method | Path | Description | Body |
+|---|---|---|---|
+| `GET` | `/v1/boards/{board_id}/sprints` | List a board's sprints. 404s if `board_id` doesn't exist (does not collapse into an empty list). | — |
+| `GET` | `/v1/boards/{board_id}/sprints/{id}` | Get a sprint by UUID. 404s if the sprint exists but belongs to a different board. | — |
+| `POST` | `/v1/boards/{board_id}/sprints` | Create a sprint. `201 Created`. A client-supplied `id` that already exists is a `409 Conflict`. | `CreateSprintRequest` |
+| `PUT` | `/v1/boards/{board_id}/sprints/{id}` | Full replace (RFC 9110 §9.3.4) — creates the sprint at `id` if absent (`201`), otherwise replaces it in full (`200`). 404s if `id` belongs to a different board. | `ReplaceSprintRequest` |
+| `PATCH` | `/v1/boards/{board_id}/sprints/{id}` | Partial update — JSON Merge Patch (RFC 7386). 404s if the sprint belongs to a different board. | `UpdateSprintRequest` |
+| `DELETE` | `/v1/boards/{board_id}/sprints/{id}` | Delete a sprint. `204 No Content`. 404s if the sprint belongs to a different board. | — |
+| `GET` | `/v1/sprints/{id}` | Flat alias for the board-scoped `GET`. | — |
+| `PATCH` | `/v1/sprints/{id}` | Flat alias for the board-scoped `PATCH`. | `UpdateSprintRequest` |
+| `DELETE` | `/v1/sprints/{id}` | Flat alias for the board-scoped `DELETE`. | — |
+
 Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event and, per the persistence layer's normal save path, durably writes to the configured store before responding.
 
 ## Error Handling

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -32,6 +32,10 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::columns::write_router())
         .merge(crate::routes::columns::flat_read_router())
         .merge(crate::routes::columns::flat_write_router())
+        .merge(crate::routes::sprints::read_router())
+        .merge(crate::routes::sprints::write_router())
+        .merge(crate::routes::sprints::flat_read_router())
+        .merge(crate::routes::sprints::flat_write_router())
         .merge(crate::routes::events::router())
         .with_state(state)
 }

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod routes {
     pub mod cards;
     pub mod columns;
     pub mod events;
+    pub mod sprints;
 }
 
 pub mod handlers {

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -1,0 +1,231 @@
+use crate::error::{AppError, AppJson};
+use crate::state::AppState;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, patch, post, put};
+use axum::{Json, Router};
+use kanban_domain::Sprint;
+use kanban_service::api::SprintResponse;
+use kanban_service::{
+    resolve_sprint_name, resolve_sprint_names, KanbanError, KanbanOperations, SprintUpdate,
+};
+use uuid::Uuid;
+
+async fn list_sprints(
+    State(state): State<AppState>,
+    Path(board_id): Path<Uuid>,
+) -> Result<Json<Vec<SprintResponse>>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let sprints = ctx.list_sprints(board_id).map_err(|e| AppError::from(&e))?;
+    let names = resolve_sprint_names(&*ctx, board_id, &sprints).map_err(|e| AppError::from(&e))?;
+    Ok(Json(
+        sprints
+            .iter()
+            .zip(names)
+            .map(|(s, name)| SprintResponse::new(s, name))
+            .collect(),
+    ))
+}
+
+async fn get_sprint(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<SprintResponse>, AppError> {
+    let ctx = state.ctx.lock().await;
+    require_sprint_in_board(&ctx, board_id, id)?;
+    let sprint = do_get_sprint(&ctx, id)?;
+    Ok(Json(respond(&ctx, &sprint)?))
+}
+
+pub fn read_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/boards/{board_id}/sprints", get(list_sprints))
+        .route("/v1/boards/{board_id}/sprints/{id}", get(get_sprint))
+}
+
+fn created_status(created: bool) -> StatusCode {
+    if created {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    }
+}
+
+fn do_get_sprint(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Sprint, AppError> {
+    ctx.get_sprint(id)
+        .map_err(|e| AppError::from(&e))?
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Sprint", id)))
+}
+
+fn do_update_sprint(
+    ctx: &mut kanban_service::KanbanContext,
+    id: Uuid,
+    updates: SprintUpdate,
+) -> Result<Sprint, AppError> {
+    ctx.update_sprint(id, updates)
+        .map_err(|e| AppError::from(&e))
+}
+
+fn do_delete_sprint(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
+    ctx.delete_sprint(id).map_err(|e| AppError::from(&e))
+}
+
+fn require_sprint_in_board(
+    ctx: &kanban_service::KanbanContext,
+    board_id: Uuid,
+    id: Uuid,
+) -> Result<(), AppError> {
+    ctx.get_sprint(id)
+        .map_err(|e| AppError::from(&e))?
+        .filter(|s| s.board_id == board_id)
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Sprint", id)))?;
+    Ok(())
+}
+
+fn respond(
+    ctx: &kanban_service::KanbanContext,
+    sprint: &Sprint,
+) -> Result<SprintResponse, AppError> {
+    let name = resolve_sprint_name(ctx, sprint).map_err(|e| AppError::from(&e))?;
+    Ok(SprintResponse::new(sprint, name))
+}
+
+async fn create_sprint_route(
+    State(state): State<AppState>,
+    Path(board_id): Path<Uuid>,
+    AppJson(req): AppJson<kanban_service::api::CreateSprintRequest>,
+) -> Result<(StatusCode, Json<SprintResponse>), AppError> {
+    let (resp, created) = {
+        let mut ctx = state.ctx.lock().await;
+        let result = crate::handlers::sprints::create_sprint(&mut ctx, board_id, req)
+            .map_err(AppError::from)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        result
+    };
+    Ok((created_status(created), Json(resp)))
+}
+
+async fn put_sprint_route(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+    AppJson(req): AppJson<kanban_service::api::ReplaceSprintRequest>,
+) -> Result<(StatusCode, Json<SprintResponse>), AppError> {
+    let (resp, created) = {
+        let mut ctx = state.ctx.lock().await;
+        let result =
+            crate::handlers::sprints::create_or_replace_sprint(&mut ctx, board_id, id, req)
+                .map_err(AppError::from)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        result
+    };
+    Ok((created_status(created), Json(resp)))
+}
+
+async fn update_sprint_route(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+    AppJson(req): AppJson<kanban_service::api::UpdateSprintRequest>,
+) -> Result<Json<SprintResponse>, AppError> {
+    let updates = SprintUpdate::from(req);
+    let body = {
+        let mut ctx = state.ctx.lock().await;
+        require_sprint_in_board(&ctx, board_id, id)?;
+        let sprint = do_update_sprint(&mut ctx, id, updates)?;
+        let body = respond(&ctx, &sprint)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        body
+    };
+    Ok(Json(body))
+}
+
+async fn delete_sprint_route(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        require_sprint_in_board(&ctx, board_id, id)?;
+        do_delete_sprint(&mut ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub fn write_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/boards/{board_id}/sprints", post(create_sprint_route))
+        .route(
+            "/v1/boards/{board_id}/sprints/{id}",
+            put(put_sprint_route)
+                .patch(update_sprint_route)
+                .delete(delete_sprint_route),
+        )
+}
+
+async fn get_sprint_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<SprintResponse>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let sprint = do_get_sprint(&ctx, id)?;
+    Ok(Json(respond(&ctx, &sprint)?))
+}
+
+async fn update_sprint_route_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    AppJson(req): AppJson<kanban_service::api::UpdateSprintRequest>,
+) -> Result<Json<SprintResponse>, AppError> {
+    let updates = SprintUpdate::from(req);
+    let body = {
+        let mut ctx = state.ctx.lock().await;
+        do_get_sprint(&ctx, id)?;
+        let sprint = do_update_sprint(&mut ctx, id, updates)?;
+        let body = respond(&ctx, &sprint)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        body
+    };
+    Ok(Json(body))
+}
+
+async fn delete_sprint_route_flat(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        do_get_sprint(&ctx, id)?;
+        do_delete_sprint(&mut ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub fn flat_read_router() -> Router<AppState> {
+    Router::new().route("/v1/sprints/{id}", get(get_sprint_flat))
+}
+
+pub fn flat_write_router() -> Router<AppState> {
+    Router::new().route(
+        "/v1/sprints/{id}",
+        patch(update_sprint_route_flat).delete(delete_sprint_route_flat),
+    )
+}

--- a/crates/kanban-server/tests/flat_routes.rs
+++ b/crates/kanban-server/tests/flat_routes.rs
@@ -258,7 +258,10 @@ async fn test_get_sprint_flat_returns_same_shape_as_board_scoped() {
     assert_eq!(board_scoped_json["id"], flat_json["id"]);
     assert_eq!(board_scoped_json["board_id"], flat_json["board_id"]);
     assert_eq!(board_scoped_json["name"], flat_json["name"]);
-    assert_eq!(board_scoped_json["sprint_number"], flat_json["sprint_number"]);
+    assert_eq!(
+        board_scoped_json["sprint_number"],
+        flat_json["sprint_number"]
+    );
     assert_eq!(board_scoped_json["prefix"], flat_json["prefix"]);
 }
 
@@ -316,7 +319,13 @@ async fn test_get_sprint_flat_missing_returns_404() {
     let state = make_state(&dir.path().join("s.json"));
     let unknown_sprint = Uuid::new_v4();
 
-    let response = send(&state, "GET", &format!("/v1/sprints/{unknown_sprint}"), None).await;
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/sprints/{unknown_sprint}"),
+        None,
+    )
+    .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let json = json_of(response).await;
     assert_eq!(json["code"], "NOT_FOUND");

--- a/crates/kanban-server/tests/flat_routes.rs
+++ b/crates/kanban-server/tests/flat_routes.rs
@@ -54,6 +54,18 @@ async fn seed_board_and_card(state: &AppState) -> (Uuid, Uuid) {
     (board_id, card.id)
 }
 
+async fn seed_board_and_sprint(state: &AppState, name: &str) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let sprint = ctx
+        .create_sprint(board_id, Some("SPR".to_string()), Some(name.to_string()))
+        .unwrap();
+    (board_id, sprint.id)
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_column_flat_returns_same_shape_as_board_scoped() {
     let dir = tempdir().unwrap();
@@ -220,4 +232,110 @@ async fn test_get_card_flat_missing_returns_404() {
 
     let response = send(&state, "GET", &format!("/v1/cards/{unknown_card}"), None).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_flat_returns_same_shape_as_board_scoped() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let board_scoped_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    let flat_response = send(&state, "GET", &format!("/v1/sprints/{sprint_id}"), None).await;
+
+    assert_eq!(board_scoped_response.status(), StatusCode::OK);
+    assert_eq!(flat_response.status(), StatusCode::OK);
+
+    let board_scoped_json = json_of(board_scoped_response).await;
+    let flat_json = json_of(flat_response).await;
+
+    assert_eq!(board_scoped_json["id"], flat_json["id"]);
+    assert_eq!(board_scoped_json["board_id"], flat_json["board_id"]);
+    assert_eq!(board_scoped_json["name"], flat_json["name"]);
+    assert_eq!(board_scoped_json["sprint_number"], flat_json["sprint_number"]);
+    assert_eq!(board_scoped_json["prefix"], flat_json["prefix"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_sprint_flat_updates_and_matches_board_scoped_route() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let flat_response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/sprints/{sprint_id}"),
+        Some(&json!({"name": "Updated via flat"})),
+    )
+    .await;
+
+    assert_eq!(flat_response.status(), StatusCode::OK);
+    let flat_json = json_of(flat_response).await;
+    assert_eq!(flat_json["name"], "Updated via flat");
+
+    let verify_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    let verify_json = json_of(verify_response).await;
+    assert_eq!(verify_json["name"], "Updated via flat");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_sprint_flat_deletes() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let delete_response = send(&state, "DELETE", &format!("/v1/sprints/{sprint_id}"), None).await;
+    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+
+    let verify_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(verify_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_flat_missing_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let unknown_sprint = Uuid::new_v4();
+
+    let response = send(&state, "GET", &format!("/v1/sprints/{unknown_sprint}"), None).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_sprint_flat_unknown_id_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let unknown_sprint = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/sprints/{unknown_sprint}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
 }

--- a/crates/kanban-server/tests/sprints_read.rs
+++ b/crates/kanban-server/tests/sprints_read.rs
@@ -46,7 +46,11 @@ async fn test_list_sprints_returns_only_the_boards_sprints() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
     let arr = json.as_array().expect("response should be an array");
-    assert_eq!(arr.len(), 2, "should have exactly the board's own 2 sprints");
+    assert_eq!(
+        arr.len(),
+        2,
+        "should have exactly the board's own 2 sprints"
+    );
 
     let names: std::collections::HashSet<_> = arr
         .iter()
@@ -56,7 +60,10 @@ async fn test_list_sprints_returns_only_the_boards_sprints() {
         names,
         std::collections::HashSet::from(["Alpha".to_string(), "Beta".to_string()])
     );
-    assert!(!names.contains("Gamma"), "sprint from another board leaked in");
+    assert!(
+        !names.contains("Gamma"),
+        "sprint from another board leaked in"
+    );
 
     for sprint in arr {
         assert_eq!(sprint["board_id"], board_a.to_string());

--- a/crates/kanban-server/tests/sprints_read.rs
+++ b/crates/kanban-server/tests/sprints_read.rs
@@ -1,0 +1,242 @@
+#![cfg(feature = "test-helpers")]
+
+//! Sprint read routes (GET /v1/boards/{board_id}/sprints, GET /v1/boards/{board_id}/sprints/{id}).
+//! Read-only, no mutation, no event broadcast. Established via `tower::ServiceExt::oneshot`
+//! against the router directly, with no real TCP socket.
+
+use axum::http::StatusCode;
+use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_service::KanbanOperations;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_returns_only_the_boards_sprints() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_a: Uuid;
+    let board_b: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_a = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        board_b = ctx
+            .create_board("Board B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_sprint(board_a, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap();
+        ctx.create_sprint(board_a, Some("SPR".to_string()), Some("Beta".to_string()))
+            .unwrap();
+        ctx.create_sprint(board_b, Some("SPR".to_string()), Some("Gamma".to_string()))
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints", board_a),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json.as_array().expect("response should be an array");
+    assert_eq!(arr.len(), 2, "should have exactly the board's own 2 sprints");
+
+    let names: std::collections::HashSet<_> = arr
+        .iter()
+        .map(|s| s["name"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        names,
+        std::collections::HashSet::from(["Alpha".to_string(), "Beta".to_string()])
+    );
+    assert!(!names.contains("Gamma"), "sprint from another board leaked in");
+
+    for sprint in arr {
+        assert_eq!(sprint["board_id"], board_a.to_string());
+        assert!(!sprint["sprint_number"].is_null());
+        assert!(
+            sprint.get("name_index").is_none(),
+            "name_index must not be on the wire"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_empty_board_returns_200_empty_array() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Empty Board".to_string(), Some("EB".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json, serde_json::json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_unknown_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_board_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints", random_board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "unknown board_id must 404, not collapse into an empty list"
+    );
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_returns_the_sprint_for_its_own_board() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let sprint_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        sprint_id = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints/{}", board_id, sprint_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["id"], sprint_id.to_string());
+    assert_eq!(json["board_id"], board_id.to_string());
+    assert_eq!(json["sprint_number"], 1);
+    assert_eq!(json["name"], "Alpha");
+    assert!(
+        json.get("name_index").is_none(),
+        "name_index must not be on the wire"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_unknown_id_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let random_sprint_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints/{}", board_id, random_sprint_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_from_another_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_a: Uuid;
+    let board_b: Uuid;
+    let sprint_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_a = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        board_b = ctx
+            .create_board("Board B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        sprint_id = ctx
+            .create_sprint(board_a, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints/{}", board_b, sprint_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "sprint from a different board should 404"
+    );
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+
+    let follow_up = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints/{}", board_a, sprint_id),
+        None,
+    )
+    .await;
+    assert_eq!(
+        follow_up.status(),
+        StatusCode::OK,
+        "the guard must reject, not delete, the sprint"
+    );
+}

--- a/crates/kanban-server/tests/sprints_write.rs
+++ b/crates/kanban-server/tests/sprints_write.rs
@@ -191,7 +191,10 @@ async fn test_put_sprint_from_another_board_returns_404() {
     )
     .await;
     let check_json = json_of(check).await;
-    assert_eq!(check_json["name"], "Alpha", "original name must be unchanged");
+    assert_eq!(
+        check_json["name"], "Alpha",
+        "original name must be unchanged"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/sprints_write.rs
+++ b/crates/kanban-server/tests/sprints_write.rs
@@ -1,0 +1,360 @@
+#![cfg(feature = "test-helpers")]
+
+//! Sprint write routes (POST, PUT, PATCH, DELETE /v1/boards/{id}/sprints*).
+//! Each handler acquires the context lock, calls the seam layer, broadcasts
+//! a change event on success, then returns the appropriate status.
+
+use axum::http::StatusCode;
+use kanban_domain::KanbanOperations;
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_state, send};
+use serde_json::json;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn seed_board(state: &AppState) -> Uuid {
+    let mut ctx = state.ctx.lock().await;
+    ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id
+}
+
+async fn seed_board_and_sprint(state: &AppState, name: &str) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let sprint = ctx
+        .create_sprint(board_id, Some("SPR".to_string()), Some(name.to_string()))
+        .unwrap();
+    (board_id, sprint.id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_sprint_creates_and_returns_201() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints"),
+        Some(&json!({"name": "Alpha", "prefix": "SPR"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "Alpha");
+    assert_eq!(json["board_id"], board_id.to_string());
+    assert_eq!(json["sprint_number"], 1);
+    assert_eq!(json["prefix"], "SPR");
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints"),
+        Some(&json!({"name": "Beta", "prefix": "SPR"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = json_of(response).await;
+    assert_eq!(json["sprint_number"], 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_sprint_unknown_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_board_id = Uuid::new_v4();
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{random_board_id}/sprints"),
+        Some(&json!({"name": "Alpha"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_sprint_with_existing_id_returns_409() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = seed_board(&state).await;
+    let explicit_id = Uuid::new_v4();
+
+    let first = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints"),
+        Some(&json!({"id": explicit_id, "name": "Alpha"})),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    let second = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints"),
+        Some(&json!({"id": explicit_id, "name": "Alpha Again"})),
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+    let json = json_of(second).await;
+    assert_eq!(json["code"], "ALREADY_EXISTS");
+
+    let list = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints"),
+        None,
+    )
+    .await;
+    let arr = json_of(list).await;
+    assert_eq!(arr.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_sprint_creates_when_absent_then_replaces_with_200() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = seed_board(&state).await;
+    let fresh_id = Uuid::new_v4();
+
+    let create_response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/sprints/{fresh_id}"),
+        Some(&json!({"name": "Alpha", "prefix": "SPR"})),
+    )
+    .await;
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let created_json = json_of(create_response).await;
+    assert_eq!(created_json["id"], fresh_id.to_string());
+    let sprint_number = created_json["sprint_number"].clone();
+
+    let replace_response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/sprints/{fresh_id}"),
+        Some(&json!({"name": "Alpha", "prefix": "SPR"})),
+    )
+    .await;
+    assert_eq!(replace_response.status(), StatusCode::OK);
+    let replaced_json = json_of(replace_response).await;
+    assert_eq!(replaced_json["id"], fresh_id.to_string());
+    assert_eq!(replaced_json["sprint_number"], sprint_number);
+
+    let list = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints"),
+        None,
+    )
+    .await;
+    let arr = json_of(list).await;
+    assert_eq!(arr.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_sprint_from_another_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_a, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+    let board_b = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_b}/sprints/{sprint_id}"),
+        Some(&json!({"name": "Hijacked"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+
+    let check = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_a}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    let check_json = json_of(check).await;
+    assert_eq!(check_json["name"], "Alpha", "original name must be unchanged");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_sprint_updates_name_and_returns_200() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        Some(&json!({"name": "Renamed"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "Renamed");
+    assert_eq!(json["sprint_number"], 1);
+
+    let follow_up = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    let follow_up_json = json_of(follow_up).await;
+    assert_eq!(follow_up_json["name"], "Renamed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_sprint_from_another_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_a, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+    let board_b = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_b}/sprints/{sprint_id}"),
+        Some(&json!({"name": "Hijacked"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+
+    let check = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_a}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    let check_json = json_of(check).await;
+    assert_eq!(check_json["name"], "Alpha");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_sprint_returns_204_and_removes_it() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let follow_up = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(follow_up.status(), StatusCode::NOT_FOUND);
+
+    let list = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints"),
+        None,
+    )
+    .await;
+    assert_eq!(list.status(), StatusCode::OK);
+    let arr = json_of(list).await;
+    assert_eq!(arr, serde_json::json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_sprint_from_another_board_returns_404_and_keeps_it() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_a, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+    let board_b = seed_board(&state).await;
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_b}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+
+    let check = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_a}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(check.status(), StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_sprint_persists_to_disk() {
+    use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+    use kanban_service::{resolve_sprint_name, AppConfig, KanbanBackend, KanbanContext};
+    use std::sync::Arc;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("s.json");
+
+    let state = make_state(&path);
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Original Name").await;
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        Some(&json!({"name": "Renamed"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "Renamed");
+
+    let independent_backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let independent_ctx = KanbanContext::open(independent_backend, AppConfig::default())
+        .await
+        .unwrap();
+
+    let sprint_from_disk = independent_ctx
+        .get_sprint(sprint_id)
+        .unwrap()
+        .expect("sprint should exist on disk");
+    let name = resolve_sprint_name(&independent_ctx, &sprint_from_disk).unwrap();
+    assert_eq!(
+        name,
+        Some("Renamed".to_string()),
+        "PATCH update must be persisted to disk, not just in-memory state"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `crates/kanban-server/src/routes/sprints.rs`, the fourth entity route module, wiring the previously unreachable `handlers::sprints::create_sprint`/`create_or_replace_sprint` plus new list/get/patch/delete handlers into the router.
- Exposes nine routes: `GET`/`POST` `/v1/boards/{board_id}/sprints`, `GET`/`PUT`/`PATCH`/`DELETE` `/v1/boards/{board_id}/sprints/{id}`, and the flat `GET`/`PATCH`/`DELETE` `/v1/sprints/{id}` aliases.
- `GET /v1/boards/{unknown}/sprints` returns 404, not `200 []`. Listing sprints resolves names via `resolve_sprint_names`, which reads the owning board once; that read is also the board-existence check, so an unknown board never collapses into an empty list. This is a deliberate divergence from the columns/cards list routes.
- Cross-board access on any nested sprint route (`GET`/`PUT`/`PATCH`/`DELETE`) 404s and leaves the sprint untouched under its real board.
- Every mutating handler persists and broadcasts inside the context lock; a disk round-trip test proves the PATCH write reaches the store.
- Adds a `### Sprints` route table to the server README and a changeset.

## Test plan

- [x] 21 new integration tests (`sprints_read.rs`, `sprints_write.rs`, 5 cases in `flat_routes.rs`), all RED before the route wiring, all GREEN after.
- [x] Mutation check: reintroduced the empty-list short-circuit in `list_sprints`, confirmed `test_list_sprints_unknown_board_returns_404` fails, reverted.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace` (212 test-result blocks, all ok)
- [x] `cargo check --package kanban-cli --no-default-features --features json,sqlite`
- [x] `sprint_create_seam.rs` and `columns_read.rs`'s `test_list_columns_unknown_board_id_returns_200_empty_array` unchanged and still passing