### PR TITLE
KAN-1317 feat(domain): Collection<T> tier on Resolved for whole-collection and per-id load state

### DIFF
--- a/.changeset/kan-1317-resolved-collection-tier.md
+++ b/.changeset/kan-1317-resolved-collection-tier.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain: Resolved gains a uniform Collection<T> tier. boards, columns, cards and sprints each carry both an all: LoadState<Vec<T>> for the whole collection and a by_id: HashMap<Uuid, LoadState<T>> for individual entities, so a resolve pass can now say that a collection loaded and is genuinely empty rather than only that a given entity was not fetched. graph stays a bare LoadState<DependencyGraph> because it is a singleton with no id to key on.

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -79,4 +79,76 @@ mod tests {
             _ => panic!("expected Failed variant"),
         }
     }
+
+    #[derive(Debug, Clone)]
+    struct NoDefault;
+
+    #[test]
+    fn test_collection_default_is_untouched() {
+        let c = Collection::<Card>::default();
+        assert!(c.all.is_not_loaded());
+        assert!(c.by_id.is_empty());
+        assert!(c.is_untouched());
+    }
+
+    #[test]
+    fn test_a_collection_with_a_loaded_empty_all_is_not_untouched() {
+        let c = Collection::<Column> {
+            all: LoadState::Loaded(vec![]),
+            ..Default::default()
+        };
+        assert!(!c.is_untouched());
+
+        let mut c = Collection::<Column>::default();
+        c.by_id.insert(Uuid::new_v4(), LoadState::Missing);
+        assert!(!c.is_untouched());
+    }
+
+    #[test]
+    fn test_resolved_columns_can_be_loaded_and_empty() {
+        let r = Resolved {
+            columns: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(r.columns.all.is_loaded());
+        assert!(r.columns.all.loaded().unwrap().is_empty());
+        assert!(!r.columns.is_untouched());
+
+        let untouched = Resolved::default();
+        assert!(untouched.columns.all.is_not_loaded());
+        assert!(untouched.columns.is_untouched());
+    }
+
+    #[test]
+    fn test_resolved_can_name_the_whole_card_list_and_one_missing_card() {
+        let card = Card::new(Uuid::new_v4(), Uuid::new_v4(), "a", 0);
+        let card_id = card.id;
+        let other = Uuid::new_v4();
+
+        let mut r = Resolved::default();
+        r.cards.all = LoadState::Loaded(vec![card]);
+        r.cards.by_id.insert(other, LoadState::Missing);
+
+        assert_eq!(r.cards.all.loaded().unwrap().len(), 1);
+        assert_eq!(r.cards.all.loaded().unwrap()[0].id, card_id);
+        assert_eq!(r.cards.by_id.len(), 1);
+        assert!(r.cards.by_id[&other].is_missing());
+    }
+
+    #[test]
+    fn test_collection_default_works_for_a_non_default_type() {
+        let c = Collection::<NoDefault>::default();
+        assert!(c.is_untouched());
+
+        let loaded = Collection {
+            all: LoadState::Loaded(vec![NoDefault]),
+            by_id: HashMap::new(),
+        };
+        assert!(!loaded.is_untouched());
+        let _ = loaded.clone();
+        let _ = format!("{loaded:?}");
+    }
 }

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -9,16 +9,51 @@ use crate::dependencies::DependencyGraph;
 use crate::load_state::LoadState;
 use crate::sprint::Sprint;
 
-/// The outcome of one resolve pass. A `NotLoaded` field or an absent map key
-/// means the pass did not touch that entity, and applying the result must
-/// leave it as it was.
+/// One entity kind's slice of a resolve pass, in two independent tiers.
+///
+/// `all` speaks about the whole collection; `by_id` speaks about individual
+/// entities. `NotLoaded` in `all` and an empty `by_id` each mean the pass did
+/// not touch that tier, so applying it leaves the target unchanged.
+///
+/// Appliers must, per entity kind: first, if `all` is `Loaded`, replace the
+/// whole target collection with it; second, apply every `by_id` entry on top.
+/// That order is what lets one pass say "here is the whole card list, and
+/// additionally card X is `Missing`". Reversed, a whole-collection result
+/// would silently overwrite a fresher per-id one.
+///
+/// `all` being `Missing` or `Failed` describes the collection read itself, not
+/// any member of it.
+#[derive(Debug, Clone)]
+pub struct Collection<T> {
+    pub all: LoadState<Vec<T>>,
+    pub by_id: HashMap<Uuid, LoadState<T>>,
+}
+
+impl<T> Default for Collection<T> {
+    fn default() -> Self {
+        Self {
+            all: LoadState::NotLoaded,
+            by_id: HashMap::new(),
+        }
+    }
+}
+
+impl<T> Collection<T> {
+    pub fn is_untouched(&self) -> bool {
+        self.all.is_not_loaded() && self.by_id.is_empty()
+    }
+}
+
+/// The outcome of one resolve pass. Each entity kind that has an id carries a
+/// `Collection`; `graph` is a singleton and has no id to key a `by_id` map on,
+/// so it stays a bare `LoadState`.
 #[derive(Debug, Clone, Default)]
 pub struct Resolved {
-    pub boards: LoadState<Vec<Board>>,
+    pub boards: Collection<Board>,
+    pub columns: Collection<Column>,
+    pub cards: Collection<Card>,
+    pub sprints: Collection<Sprint>,
     pub graph: LoadState<DependencyGraph>,
-    pub columns: HashMap<Uuid, LoadState<Column>>,
-    pub cards: HashMap<Uuid, LoadState<Card>>,
-    pub sprints: HashMap<Uuid, LoadState<Sprint>>,
 }
 
 #[cfg(test)]
@@ -34,47 +69,50 @@ mod tests {
     #[test]
     fn test_resolved_default_mentions_no_entity_kind() {
         let resolved = Resolved::default();
-        assert!(resolved.boards.is_not_loaded());
+        assert!(resolved.boards.is_untouched());
         assert!(resolved.graph.is_not_loaded());
-        assert!(resolved.columns.is_empty());
-        assert!(resolved.cards.is_empty());
-        assert!(resolved.sprints.is_empty());
+        assert!(resolved.columns.is_untouched());
+        assert!(resolved.cards.is_untouched());
+        assert!(resolved.sprints.is_untouched());
     }
 
     #[test]
     fn test_resolved_distinguishes_a_loaded_empty_board_list_from_an_unmentioned_one() {
         let loaded_empty = Resolved {
-            boards: LoadState::Loaded(vec![]),
+            boards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
             ..Default::default()
         };
-        assert!(loaded_empty.boards.is_loaded());
-        assert!(loaded_empty.boards.loaded().unwrap().is_empty());
+        assert!(loaded_empty.boards.all.is_loaded());
+        assert!(loaded_empty.boards.all.loaded().unwrap().is_empty());
 
         let unmentioned = Resolved::default();
-        assert!(unmentioned.boards.is_not_loaded());
+        assert!(unmentioned.boards.all.is_not_loaded());
     }
 
     #[test]
     fn test_resolved_carries_per_entity_missing_for_a_card_the_backend_did_not_have() {
         let id = Uuid::new_v4();
         let mut resolved = Resolved::default();
-        resolved.cards.insert(id, LoadState::Missing);
+        resolved.cards.by_id.insert(id, LoadState::Missing);
 
-        assert!(resolved.cards[&id].is_missing());
-        assert!(resolved.cards[&id].is_terminal());
+        assert!(resolved.cards.by_id[&id].is_missing());
+        assert!(resolved.cards.by_id[&id].is_terminal());
     }
 
     #[test]
     fn test_resolved_clone_shares_the_same_failed_error() {
         let id = Uuid::new_v4();
         let mut resolved = Resolved::default();
-        resolved.cards.insert(
+        resolved.cards.by_id.insert(
             id,
             LoadState::Failed(Arc::new(KanbanError::unsupported("x"))),
         );
 
         let cloned = resolved.clone();
-        match (&resolved.cards[&id], &cloned.cards[&id]) {
+        match (&resolved.cards.by_id[&id], &cloned.cards.by_id[&id]) {
             (LoadState::Failed(a), LoadState::Failed(b)) => assert!(Arc::ptr_eq(a, b)),
             _ => panic!("expected Failed variant"),
         }


### PR DESCRIPTION
## Summary

- Adds `Collection<T> { all: LoadState<Vec<T>>, by_id: HashMap<Uuid, LoadState<T>> }` to `crates/kanban-domain/src/resolved.rs`.
- Reshapes `Resolved` so `boards`, `columns`, `cards` and `sprints` each become `Collection<T>`. `graph` stays a bare `LoadState<DependencyGraph>` deliberately: it is a singleton with no id, so a `by_id` map on it could never hold a meaningful key.
- This closes the asymmetry where three of four collection kinds could only speak per-id and therefore could never say "this collection loaded and is genuinely empty" versus "the pass never touched it" (the `None` vs `Some(empty)` collapse from epic KAN-1218, one layer down).
- `Collection::is_untouched()` is the only method added: `self.all.is_not_loaded() && self.by_id.is_empty()`. `Default` on `Collection<T>` is hand-written rather than derived, so it carries no `T: Default` bound; `#[derive(Default)]` would silently require every future `T` to implement `Default`.
- The four pre-existing tests are repathed to the new field access (`resolved.cards.by_id[...]` instead of `resolved.cards[...]`, `.boards.all` instead of `.boards`), with assertions unchanged in meaning. Five new tests pin the `Collection` type itself, including a mutation-style guard against the exact failure mode this card exists to prevent (`is_untouched` collapsing a loaded-empty collection into "untouched").

## Verification

Re-ran the consumer grep at pickup time, against `origin/develop` (6184251f):

```
$ git grep -n "Resolved" origin/develop -- crates | grep -v kanban-domain/src/resolved.rs
crates/kanban-domain/src/lib.rs:94:pub use resolved::Resolved;
crates/kanban-server/README.md:49: (English prose, unrelated "Resolved with ...")
crates/kanban-tui/src/app/view_management.rs:89: (comment, unrelated)
crates/kanban-tui/src/handlers/column_handlers.rs:343: (comment, unrelated)
```

Zero real consumers of `Resolved`'s field shape outside `resolved.rs` itself, so this change is purely additive. This is why the diff touches only `crates/kanban-domain/src/resolved.rs` and the changeset:

```
$ git diff --name-only origin/develop...HEAD
.changeset/kan-1317-resolved-collection-tier.md
crates/kanban-domain/src/resolved.rs
```

`Collection` is intentionally not re-exported from `crates/kanban-domain/src/lib.rs`. `pub mod resolved;` already makes it reachable as `kanban_domain::resolved::Collection`; the first cross-crate consumer adds the top-level re-export in the same PR that needs it.

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --all-features --workspace` clean
- `cargo check --package kanban-cli --no-default-features --features json,sqlite` clean

## Test plan

- [x] Red: 5 new tests fail to compile against the old shape (`E0422`/`E0433`/`E0609`/`E0599`), committed alone
- [x] Green: `Collection<T>` added, `Resolved` reshaped, 4 pre-existing tests repathed, all 9 tests in `resolved.rs` pass
- [x] Mutation check: broke `is_untouched` to `self.all.loaded().map_or(true, |v| v.is_empty()) && self.by_id.is_empty()`, confirmed 2 tests fail, reverted
- [x] Full workspace test/clippy/fmt/cli-feature-check green