### PR TITLE
KAN-1239 feat(api,server): card dependency graph DTO and read route

### DIFF
--- a/.changeset/kan-1239-graph-dto-route.md
+++ b/.changeset/kan-1239-graph-dto-route.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: a card's dependency edges are now readable over HTTP at GET /v1/cards/{id}/graph, returning the card's parents, children, blockers, blocked cards and related cards; a request for a card that does not exist returns 404 rather than an empty result.

--- a/crates/kanban-api/README.md
+++ b/crates/kanban-api/README.md
@@ -16,10 +16,10 @@ Re-exported from `src/lib.rs` (`pub use v1::{ ... }`):
 
 ```rust
 pub use v1::{
-    ApiError, ArchivedFilterDto, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto,
-    ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
-    CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams, Patch,
-    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
+    ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
+    CardStatusDto, ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest,
+    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams,
+    Patch, ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
     ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
     TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
     UpdateSprintRequest,

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -5,9 +5,9 @@
 //! callers into an explicit version path.
 mod v1;
 pub use v1::{
-    ApiError, ArchivedFilterDto, BoardResponse, CardPriorityDto, CardResponse, CardStatusDto,
-    ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
-    CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams, Patch,
+    ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
+    CardStatusDto, ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest,
+    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams, Patch,
     ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
     ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
     TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -7,8 +7,8 @@ mod v1;
 pub use v1::{
     ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
     CardStatusDto, ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest,
-    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams, Patch,
-    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
+    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams,
+    Patch, ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
     ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
     TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
     UpdateSprintRequest,

--- a/crates/kanban-api/src/v1/graph/mod.rs
+++ b/crates/kanban-api/src/v1/graph/mod.rs
@@ -1,0 +1,3 @@
+mod response;
+
+pub use response::CardGraphResponse;

--- a/crates/kanban-api/src/v1/graph/response.rs
+++ b/crates/kanban-api/src/v1/graph/response.rs
@@ -2,6 +2,11 @@ use kanban_domain::DependencyGraph;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// A card's dependency edges, scoped to that card and split by direction.
+/// `parents`/`children` are the Spawns edges that spawned it / that it
+/// spawned; `blocked_by`/`blocks` are the Blocks edges pointing into it /
+/// out of it; `related` is its undirected Relates neighbors. Only active
+/// edges are reported; archived edges are excluded.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CardGraphResponse {
     pub card_id: Uuid,
@@ -13,8 +18,15 @@ pub struct CardGraphResponse {
 }
 
 impl CardGraphResponse {
-    pub fn from_graph(_card_id: Uuid, _graph: &DependencyGraph) -> Self {
-        unimplemented!()
+    pub fn from_graph(card_id: Uuid, graph: &DependencyGraph) -> Self {
+        Self {
+            card_id,
+            parents: graph.parents(card_id),
+            children: graph.children(card_id),
+            blocked_by: graph.blockers(card_id),
+            blocks: graph.blocked(card_id),
+            related: graph.related(card_id),
+        }
     }
 }
 
@@ -113,10 +125,22 @@ mod tests {
 
         let value = serde_json::to_value(&response).unwrap();
         let obj = value.as_object().expect("serializes to a JSON object");
-        for key in ["card_id", "parents", "children", "blocked_by", "blocks", "related"] {
+        for key in [
+            "card_id",
+            "parents",
+            "children",
+            "blocked_by",
+            "blocks",
+            "related",
+        ] {
             assert!(obj.get(key).is_some(), "missing key {key}");
         }
-        assert_eq!(obj.len(), 6, "unexpected keys: {:?}", obj.keys().collect::<Vec<_>>());
+        assert_eq!(
+            obj.len(),
+            6,
+            "unexpected keys: {:?}",
+            obj.keys().collect::<Vec<_>>()
+        );
 
         let round_tripped: CardGraphResponse = serde_json::from_value(value).unwrap();
         assert_eq!(round_tripped, response);

--- a/crates/kanban-api/src/v1/graph/response.rs
+++ b/crates/kanban-api/src/v1/graph/response.rs
@@ -1,0 +1,124 @@
+use kanban_domain::DependencyGraph;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CardGraphResponse {
+    pub card_id: Uuid,
+    pub parents: Vec<Uuid>,
+    pub children: Vec<Uuid>,
+    pub blocked_by: Vec<Uuid>,
+    pub blocks: Vec<Uuid>,
+    pub related: Vec<Uuid>,
+}
+
+impl CardGraphResponse {
+    pub fn from_graph(_card_id: Uuid, _graph: &DependencyGraph) -> Self {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::{RelatesKind, Severity};
+
+    #[test]
+    fn test_card_graph_response_from_graph_maps_all_five_edge_kinds() {
+        let subject = Uuid::new_v4();
+        let parent = Uuid::new_v4();
+        let child = Uuid::new_v4();
+        let blocker = Uuid::new_v4();
+        let blocked = Uuid::new_v4();
+        let rel = Uuid::new_v4();
+
+        let mut g = DependencyGraph::new();
+        g.set_parent(subject, parent).unwrap();
+        g.set_parent(child, subject).unwrap();
+        g.set_block(blocker, subject).unwrap();
+        g.set_block(subject, blocked).unwrap();
+        g.relate(subject, rel).unwrap();
+
+        let r = CardGraphResponse::from_graph(subject, &g);
+
+        assert_eq!(r.card_id, subject);
+        assert_eq!(r.parents, vec![parent]);
+        assert_eq!(r.children, vec![child]);
+        assert_eq!(r.blocked_by, vec![blocker]);
+        assert_eq!(r.blocks, vec![blocked]);
+        assert_eq!(r.related, vec![rel]);
+    }
+
+    #[test]
+    fn test_card_graph_response_scoped_to_the_requested_card_excludes_foreign_edges() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let subject = Uuid::new_v4();
+
+        let mut g = DependencyGraph::new();
+        g.set_parent(b, a).unwrap();
+        g.set_block(a, b).unwrap();
+        g.relate(a, b).unwrap();
+
+        let r = CardGraphResponse::from_graph(subject, &g);
+
+        assert_eq!(r.card_id, subject);
+        assert!(r.parents.is_empty());
+        assert!(r.children.is_empty());
+        assert!(r.blocked_by.is_empty());
+        assert!(r.blocks.is_empty());
+        assert!(r.related.is_empty());
+        assert!(!r.parents.contains(&a) && !r.children.contains(&b) && !r.related.contains(&a));
+    }
+
+    #[test]
+    fn test_card_graph_response_excludes_archived_edges() {
+        let subject = Uuid::new_v4();
+        let archived_parent = Uuid::new_v4();
+        let archived_child = Uuid::new_v4();
+        let archived_blocker = Uuid::new_v4();
+        let archived_rel = Uuid::new_v4();
+        let live_parent = Uuid::new_v4();
+
+        let mut g = DependencyGraph::new();
+        g.add_archived_spawns(archived_parent, subject).unwrap();
+        g.add_archived_spawns(subject, archived_child).unwrap();
+        g.add_archived_blocks(archived_blocker, subject, Severity::Medium)
+            .unwrap();
+        g.add_archived_relates(subject, archived_rel, RelatesKind::General)
+            .unwrap();
+
+        let r = CardGraphResponse::from_graph(subject, &g);
+        assert!(r.parents.is_empty());
+        assert!(r.children.is_empty());
+        assert!(r.blocked_by.is_empty());
+        assert!(r.blocks.is_empty());
+        assert!(r.related.is_empty());
+
+        g.set_parent(subject, live_parent).unwrap();
+        let r = CardGraphResponse::from_graph(subject, &g);
+        assert_eq!(r.parents, vec![live_parent]);
+    }
+
+    #[test]
+    fn test_card_graph_response_serde_round_trip() {
+        let response = CardGraphResponse {
+            card_id: Uuid::new_v4(),
+            parents: vec![Uuid::new_v4()],
+            children: vec![Uuid::new_v4()],
+            blocked_by: vec![Uuid::new_v4()],
+            blocks: vec![Uuid::new_v4()],
+            related: vec![Uuid::new_v4()],
+        };
+
+        let value = serde_json::to_value(&response).unwrap();
+        let obj = value.as_object().expect("serializes to a JSON object");
+        for key in ["card_id", "parents", "children", "blocked_by", "blocks", "related"] {
+            assert!(obj.get(key).is_some(), "missing key {key}");
+        }
+        assert_eq!(obj.len(), 6, "unexpected keys: {:?}", obj.keys().collect::<Vec<_>>());
+
+        let round_tripped: CardGraphResponse = serde_json::from_value(value).unwrap();
+        assert_eq!(round_tripped, response);
+    }
+}

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -5,6 +5,7 @@ mod enums;
 mod error;
 mod error_mapping;
 mod events;
+mod graph;
 mod pagination;
 mod patch;
 mod sprints;
@@ -20,6 +21,7 @@ pub use enums::{
 };
 pub use error::{ApiError, ErrorCode};
 pub use events::ChangeEventFrame;
+pub use graph::CardGraphResponse;
 pub use pagination::{Page, PageParams};
 pub use patch::Patch;
 pub use sprints::{

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -174,6 +174,12 @@ Column writes (create/update/delete) aren't implemented yet.
 | `PATCH` | `/v1/sprints/{id}` | Flat alias for the board-scoped `PATCH`. | `UpdateSprintRequest` |
 | `DELETE` | `/v1/sprints/{id}` | Flat alias for the board-scoped `DELETE`. | — |
 
+### Graph
+
+| Method | Path | Description | Body |
+|---|---|---|---|
+| `GET` | `/v1/cards/{id}/graph` | The card's dependency edges, scoped to that card: parents/children (spawns), blocked_by/blocks and related. Only active edges; archived edges are omitted. 404s if the card does not exist, rather than returning empty arrays. | — |
+
 Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event and, per the persistence layer's normal save path, durably writes to the configured store before responding.
 
 ## Error Handling

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -32,6 +32,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::columns::write_router())
         .merge(crate::routes::columns::flat_read_router())
         .merge(crate::routes::columns::flat_write_router())
+        .merge(crate::routes::graph::read_router())
         .merge(crate::routes::sprints::read_router())
         .merge(crate::routes::sprints::write_router())
         .merge(crate::routes::sprints::flat_read_router())

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod routes {
     pub mod cards;
     pub mod columns;
     pub mod events;
+    pub mod graph;
     pub mod sprints;
 }
 

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -69,7 +69,7 @@ fn created_status(created: bool) -> StatusCode {
     }
 }
 
-fn do_get_card(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Card, AppError> {
+pub(crate) fn do_get_card(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Card, AppError> {
     ctx.get_card(id)
         .map_err(|e| AppError::from(&e))?
         .ok_or_else(|| AppError::from(&KanbanError::not_found("Card", id)))

--- a/crates/kanban-server/src/routes/graph.rs
+++ b/crates/kanban-server/src/routes/graph.rs
@@ -1,0 +1,21 @@
+use crate::error::AppError;
+use crate::state::AppState;
+use axum::extract::{Path, State};
+use axum::routing::get;
+use axum::{Json, Router};
+use kanban_service::api::CardGraphResponse;
+use uuid::Uuid;
+
+async fn get_card_graph(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<CardGraphResponse>, AppError> {
+    let ctx = state.ctx.lock().await;
+    crate::routes::cards::do_get_card(&ctx, id)?;
+    let graph = ctx.graph().map_err(|e| AppError::from(&e))?;
+    Ok(Json(CardGraphResponse::from_graph(id, &graph)))
+}
+
+pub fn read_router() -> Router<AppState> {
+    Router::new().route("/v1/cards/{id}/graph", get(get_card_graph))
+}

--- a/crates/kanban-server/tests/graph_read.rs
+++ b/crates/kanban-server/tests/graph_read.rs
@@ -26,9 +26,16 @@ async fn test_get_card_graph_returns_only_the_requested_cards_edges() {
         let board = ctx
             .create_board("Board".to_string(), Some("KAN".to_string()))
             .unwrap();
-        let column = ctx.create_column(board.id, "Todo".to_string(), None).unwrap();
+        let column = ctx
+            .create_column(board.id, "Todo".to_string(), None)
+            .unwrap();
         subject = ctx
-            .create_card(board.id, column.id, "Subject".to_string(), Default::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Subject".to_string(),
+                Default::default(),
+            )
             .unwrap()
             .id;
         child = ctx
@@ -36,19 +43,39 @@ async fn test_get_card_graph_returns_only_the_requested_cards_edges() {
             .unwrap()
             .id;
         blocker = ctx
-            .create_card(board.id, column.id, "Blocker".to_string(), Default::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Blocker".to_string(),
+                Default::default(),
+            )
             .unwrap()
             .id;
         rel = ctx
-            .create_card(board.id, column.id, "Related".to_string(), Default::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Related".to_string(),
+                Default::default(),
+            )
             .unwrap()
             .id;
         let outsider_a = ctx
-            .create_card(board.id, column.id, "Outsider A".to_string(), Default::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Outsider A".to_string(),
+                Default::default(),
+            )
             .unwrap()
             .id;
         outsider_b = ctx
-            .create_card(board.id, column.id, "Outsider B".to_string(), Default::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Outsider B".to_string(),
+                Default::default(),
+            )
             .unwrap()
             .id;
 
@@ -84,11 +111,18 @@ async fn test_get_card_graph_unknown_card_returns_404_not_empty_arrays() {
         let board = ctx
             .create_board("Board".to_string(), Some("KAN".to_string()))
             .unwrap();
-        ctx.create_column(board.id, "Todo".to_string(), None).unwrap();
+        ctx.create_column(board.id, "Todo".to_string(), None)
+            .unwrap();
     }
 
     let unknown_id = Uuid::new_v4();
-    let response = send(&state, "GET", &format!("/v1/cards/{unknown_id}/graph"), None).await;
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/cards/{unknown_id}/graph"),
+        None,
+    )
+    .await;
 
     assert_eq!(response.status(), 404);
     let response_json = json_of(response).await;
@@ -107,9 +141,16 @@ async fn test_get_card_graph_existing_card_with_no_edges_returns_200_empty_array
         let board = ctx
             .create_board("Board".to_string(), Some("KAN".to_string()))
             .unwrap();
-        let column = ctx.create_column(board.id, "Todo".to_string(), None).unwrap();
+        let column = ctx
+            .create_column(board.id, "Todo".to_string(), None)
+            .unwrap();
         card_id = ctx
-            .create_card(board.id, column.id, "Lonely".to_string(), Default::default())
+            .create_card(
+                board.id,
+                column.id,
+                "Lonely".to_string(),
+                Default::default(),
+            )
             .unwrap()
             .id;
     }

--- a/crates/kanban-server/tests/graph_read.rs
+++ b/crates/kanban-server/tests/graph_read.rs
@@ -1,0 +1,132 @@
+#![cfg(feature = "test-helpers")]
+
+//! GET /v1/cards/{id}/graph. Read-only, no mutation, no event broadcast.
+//! Established via `tower::ServiceExt::oneshot` against the router directly,
+//! with no real TCP socket.
+
+use kanban_domain::{GraphOperations, RelatesKind, Severity};
+use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_service::KanbanOperations;
+use serde_json::json;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_graph_returns_only_the_requested_cards_edges() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let subject: Uuid;
+    let child: Uuid;
+    let blocker: Uuid;
+    let rel: Uuid;
+    let outsider_b: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        let board = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap();
+        let column = ctx.create_column(board.id, "Todo".to_string(), None).unwrap();
+        subject = ctx
+            .create_card(board.id, column.id, "Subject".to_string(), Default::default())
+            .unwrap()
+            .id;
+        child = ctx
+            .create_card(board.id, column.id, "Child".to_string(), Default::default())
+            .unwrap()
+            .id;
+        blocker = ctx
+            .create_card(board.id, column.id, "Blocker".to_string(), Default::default())
+            .unwrap()
+            .id;
+        rel = ctx
+            .create_card(board.id, column.id, "Related".to_string(), Default::default())
+            .unwrap()
+            .id;
+        let outsider_a = ctx
+            .create_card(board.id, column.id, "Outsider A".to_string(), Default::default())
+            .unwrap()
+            .id;
+        outsider_b = ctx
+            .create_card(board.id, column.id, "Outsider B".to_string(), Default::default())
+            .unwrap()
+            .id;
+
+        ctx.attach_children(subject, vec![child]).unwrap();
+        ctx.block(blocker, subject, Severity::Medium).unwrap();
+        ctx.relate(subject, rel, RelatesKind::General).unwrap();
+        ctx.attach_children(outsider_a, vec![outsider_b]).unwrap();
+    }
+
+    let response = send(&state, "GET", &format!("/v1/cards/{subject}/graph"), None).await;
+
+    assert_eq!(response.status(), 200);
+    let response_json = json_of(response).await;
+    assert_eq!(response_json["card_id"], subject.to_string());
+    assert_eq!(response_json["children"], json!([child]));
+    assert_eq!(response_json["blocked_by"], json!([blocker]));
+    assert_eq!(response_json["related"], json!([rel]));
+    assert_eq!(response_json["parents"], json!([]));
+    assert_eq!(response_json["blocks"], json!([]));
+    assert!(
+        !response_json.to_string().contains(&outsider_b.to_string()),
+        "response leaked an edge unrelated to the requested card: {response_json}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_graph_unknown_card_returns_404_not_empty_arrays() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        let board = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap();
+        ctx.create_column(board.id, "Todo".to_string(), None).unwrap();
+    }
+
+    let unknown_id = Uuid::new_v4();
+    let response = send(&state, "GET", &format!("/v1/cards/{unknown_id}/graph"), None).await;
+
+    assert_eq!(response.status(), 404);
+    let response_json = json_of(response).await;
+    assert_eq!(response_json["code"], "NOT_FOUND");
+    assert!(response_json.get("children").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_graph_existing_card_with_no_edges_returns_200_empty_arrays() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let card_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        let board = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap();
+        let column = ctx.create_column(board.id, "Todo".to_string(), None).unwrap();
+        card_id = ctx
+            .create_card(board.id, column.id, "Lonely".to_string(), Default::default())
+            .unwrap()
+            .id;
+    }
+
+    let response = send(&state, "GET", &format!("/v1/cards/{card_id}/graph"), None).await;
+
+    assert_eq!(response.status(), 200);
+    let response_json = json_of(response).await;
+    assert_eq!(
+        response_json,
+        json!({
+            "card_id": card_id.to_string(),
+            "parents": [],
+            "children": [],
+            "blocked_by": [],
+            "blocks": [],
+            "related": [],
+        })
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `CardGraphResponse` to `kanban-api` (`v1/graph/`), projecting a single card's five edge directions (`parents`, `children`, `blocked_by`, `blocks`, `related`) out of `kanban_domain::DependencyGraph`.
- Adds a read-only `GET /v1/cards/{id}/graph` route in `kanban-server`, merged into `app::router` alongside the other entity routes.
- The route 404s for a card that does not exist, rather than collapsing into an empty-arrays response; this reuses `routes/cards.rs::do_get_card` (widened to `pub(crate)`) as the existence probe.
- Only active edges are reported; archived edges are excluded, matching every other consumer of `DependencyGraph`'s accessors (`children`/`parents`/`blocked`/`blockers`/`related`).
- No mutation, no persistence, no event broadcast. `KanbanContext::graph()` remains a whole-graph read; only the response is scoped to the requested card.
- Documents the new route in `crates/kanban-server/README.md` and the new export in `crates/kanban-api/README.md`.

## Test plan
- [x] `cargo test -p kanban-api` (127 tests, including 4 new `CardGraphResponse` tests: all-five-directions mapping, foreign-edge exclusion, archived-edge exclusion, serde round-trip)
- [x] `cargo test -p kanban-server --features test-helpers` (3 new integration tests for the route: scoped edges, 404 on unknown card, 200 empty-arrays on an edgeless card)
- [x] Mutation-checked the direction mapping (swapped `blocked`/`blockers`) and the 404 guard (dropped the `do_get_card` probe): both deliberately broke the relevant test, then were reverted
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] `cargo check --package kanban-cli --no-default-features --features json,sqlite`
- [x] `bash scripts/check-factory-compile-lock.sh`
