### PR TITLE
KAN-1225 feat(domain): FetchPlan, FetchRound and LoadedState contract for lazy fetch rounds

### DIFF
--- a/.changeset/kan-1225-fetch-plan-contract.md
+++ b/.changeset/kan-1225-fetch-plan-contract.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: internal groundwork so a later release can ask storage for exactly the boards, columns, cards, sprints and dependency graph a screen is missing, instead of reloading everything; no behaviour changes yet.

--- a/crates/kanban-domain/src/fetch_plan.rs
+++ b/crates/kanban-domain/src/fetch_plan.rs
@@ -1,0 +1,239 @@
+use uuid::Uuid;
+
+use crate::load_state::LoadState;
+
+/// Payload-free mirror of `LoadState<T>`'s variants, usable across entity
+/// kinds behind a `dyn` trait without a generic parameter per kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchStatus {
+    NotLoaded,
+    Loaded,
+    Missing,
+    Failed,
+}
+
+impl<T> From<&LoadState<T>> for FetchStatus {
+    fn from(_state: &LoadState<T>) -> Self {
+        todo!()
+    }
+}
+
+/// `Loaded` and `Missing` are terminal and never re-requested; `Failed` may
+/// be retried.
+pub fn requestable(_status: FetchStatus) -> bool {
+    todo!()
+}
+
+/// Whole-collection accessors and per-id accessors are independent: a
+/// `card_list()` of `NotLoaded` alongside a `card(id)` of `Loaded` means one
+/// card was fetched by id and the collection as a whole has never been read.
+pub trait LoadedState {
+    fn board_list(&self) -> FetchStatus;
+    fn column_list(&self) -> FetchStatus;
+    fn card_list(&self) -> FetchStatus;
+    fn sprint_list(&self) -> FetchStatus;
+    fn graph(&self) -> FetchStatus;
+    fn column(&self, id: Uuid) -> FetchStatus;
+    fn card(&self, id: Uuid) -> FetchStatus;
+    fn sprint(&self, id: Uuid) -> FetchStatus;
+}
+
+/// The `*_list` flags request a whole collection, the id vectors request
+/// individual entities, and an empty round is `resolve`'s halt signal.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FetchRound {
+    pub board_list: bool,
+    pub column_list: bool,
+    pub card_list: bool,
+    pub sprint_list: bool,
+    pub graph: bool,
+    pub columns: Vec<Uuid>,
+    pub cards: Vec<Uuid>,
+    pub sprints: Vec<Uuid>,
+}
+
+impl FetchRound {
+    pub fn is_empty(&self) -> bool {
+        todo!()
+    }
+}
+
+pub trait FetchPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::error::KanbanError;
+
+    struct StubLoaded {
+        board_list: FetchStatus,
+        card_list: FetchStatus,
+        card: FetchStatus,
+    }
+
+    impl LoadedState for StubLoaded {
+        fn board_list(&self) -> FetchStatus {
+            self.board_list
+        }
+        fn column_list(&self) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+        fn card_list(&self) -> FetchStatus {
+            self.card_list
+        }
+        fn sprint_list(&self) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+        fn graph(&self) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+        fn column(&self, _id: Uuid) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+        fn card(&self, _id: Uuid) -> FetchStatus {
+            self.card
+        }
+        fn sprint(&self, _id: Uuid) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+    }
+
+    struct StubPlan;
+
+    impl FetchPlan for StubPlan {
+        fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+            FetchRound {
+                board_list: requestable(loaded.board_list()),
+                ..Default::default()
+            }
+        }
+    }
+
+    #[test]
+    fn test_requestable_treats_not_loaded_and_failed_as_requestable() {
+        assert!(requestable(FetchStatus::NotLoaded));
+        assert!(requestable(FetchStatus::Failed));
+    }
+
+    #[test]
+    fn test_requestable_treats_loaded_and_missing_as_terminal() {
+        assert!(!requestable(FetchStatus::Loaded));
+        assert!(!requestable(FetchStatus::Missing));
+    }
+
+    #[test]
+    fn test_fetch_status_from_load_state_preserves_every_variant() {
+        assert_eq!(
+            FetchStatus::from(&LoadState::<u32>::NotLoaded),
+            FetchStatus::NotLoaded
+        );
+        assert_eq!(
+            FetchStatus::from(&LoadState::Loaded(1u32)),
+            FetchStatus::Loaded
+        );
+        assert_eq!(
+            FetchStatus::from(&LoadState::<u32>::Missing),
+            FetchStatus::Missing
+        );
+        assert_eq!(
+            FetchStatus::from(&LoadState::<u32>::Failed(Arc::new(KanbanError::unsupported(
+                "x"
+            )))),
+            FetchStatus::Failed
+        );
+    }
+
+    #[test]
+    fn test_fetch_round_default_is_empty() {
+        assert!(FetchRound::default().is_empty());
+    }
+
+    #[test]
+    fn test_fetch_round_with_any_single_field_set_is_not_empty() {
+        let id = Uuid::new_v4();
+
+        assert!(!FetchRound {
+            board_list: true,
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            column_list: true,
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            card_list: true,
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            sprint_list: true,
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            graph: true,
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            columns: vec![id],
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            cards: vec![id],
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            sprints: vec![id],
+            ..Default::default()
+        }
+        .is_empty());
+    }
+
+    #[test]
+    fn test_loaded_state_distinguishes_whole_collection_status_from_per_id_status() {
+        let loaded = StubLoaded {
+            board_list: FetchStatus::NotLoaded,
+            card_list: FetchStatus::NotLoaded,
+            card: FetchStatus::Loaded,
+        };
+
+        assert!(requestable(loaded.card_list()));
+        assert!(!requestable(loaded.card(Uuid::new_v4())));
+    }
+
+    #[test]
+    fn test_next_round_on_stub_plan_requests_board_list_when_not_loaded() {
+        let loaded = StubLoaded {
+            board_list: FetchStatus::NotLoaded,
+            card_list: FetchStatus::NotLoaded,
+            card: FetchStatus::NotLoaded,
+        };
+        let plan = StubPlan;
+
+        let round = plan.next_round(&loaded);
+
+        assert!(round.board_list);
+        assert!(!round.is_empty());
+    }
+
+    #[test]
+    fn test_next_round_on_stub_plan_returns_empty_round_once_board_list_loaded() {
+        let loaded = StubLoaded {
+            board_list: FetchStatus::Loaded,
+            card_list: FetchStatus::NotLoaded,
+            card: FetchStatus::NotLoaded,
+        };
+        let plan = StubPlan;
+
+        assert!(plan.next_round(&loaded).is_empty());
+    }
+}

--- a/crates/kanban-domain/src/fetch_plan.rs
+++ b/crates/kanban-domain/src/fetch_plan.rs
@@ -13,15 +13,20 @@ pub enum FetchStatus {
 }
 
 impl<T> From<&LoadState<T>> for FetchStatus {
-    fn from(_state: &LoadState<T>) -> Self {
-        todo!()
+    fn from(state: &LoadState<T>) -> Self {
+        match state {
+            LoadState::NotLoaded => FetchStatus::NotLoaded,
+            LoadState::Loaded(_) => FetchStatus::Loaded,
+            LoadState::Missing => FetchStatus::Missing,
+            LoadState::Failed(_) => FetchStatus::Failed,
+        }
     }
 }
 
 /// `Loaded` and `Missing` are terminal and never re-requested; `Failed` may
 /// be retried.
-pub fn requestable(_status: FetchStatus) -> bool {
-    todo!()
+pub fn requestable(status: FetchStatus) -> bool {
+    matches!(status, FetchStatus::NotLoaded | FetchStatus::Failed)
 }
 
 /// Whole-collection accessors and per-id accessors are independent: a
@@ -54,7 +59,14 @@ pub struct FetchRound {
 
 impl FetchRound {
     pub fn is_empty(&self) -> bool {
-        todo!()
+        !self.board_list
+            && !self.column_list
+            && !self.card_list
+            && !self.sprint_list
+            && !self.graph
+            && self.columns.is_empty()
+            && self.cards.is_empty()
+            && self.sprints.is_empty()
     }
 }
 
@@ -140,9 +152,9 @@ mod tests {
             FetchStatus::Missing
         );
         assert_eq!(
-            FetchStatus::from(&LoadState::<u32>::Failed(Arc::new(KanbanError::unsupported(
-                "x"
-            )))),
+            FetchStatus::from(&LoadState::<u32>::Failed(Arc::new(
+                KanbanError::unsupported("x")
+            ))),
             FetchStatus::Failed
         );
     }

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -19,6 +19,7 @@ pub mod data_store;
 pub mod dependencies;
 pub mod editable;
 pub mod export;
+pub mod fetch_plan;
 pub mod field_update;
 pub mod filter;
 pub mod graph_operations;

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -66,6 +66,7 @@ pub use dependencies::{
 };
 pub use editable::{BoardSettingsDto, CardMetadataDto};
 pub use export::{AllBoardsExport, BoardExport, BoardExporter, BoardImporter, ImportedEntities};
+pub use fetch_plan::{requestable, FetchPlan, FetchRound, FetchStatus, LoadedState};
 pub use field_update::FieldUpdate;
 pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;


### PR DESCRIPTION
## Summary

Adds the greenfield fetch contract to `kanban-domain`, ahead of any consumer:

- `FetchStatus`: a payload-free, `Copy` mirror of `LoadState<T>`'s four variants, usable in a `dyn` trait without a generic parameter per entity kind.
- `requestable(FetchStatus) -> bool`: true for `NotLoaded` and `Failed` (retryable), false for `Loaded` and `Missing` (terminal).
- `impl<T> From<&LoadState<T>> for FetchStatus`, exhaustively matched with no catch-all arm, so a future `LoadState` variant fails to compile here instead of silently mapping to the wrong status.
- `LoadedState`: a read-only query trait with whole-collection accessors (`board_list`, `column_list`, `card_list`, `sprint_list`, `graph`) and per-id accessors (`column`, `card`, `sprint`), independent of one another.
- `FetchRound`: a request struct with `*_list` flags for whole-collection needs and `Vec<Uuid>` fields for per-id needs, plus `is_empty()` as the halt signal for a future resolve loop.
- `FetchPlan`: a strategy trait, `next_round(&self, loaded: &dyn LoadedState) -> FetchRound`.

No consumer is added anywhere. `EntityCache::resolve` and a future `ModeFetchPlan` in `kanban-tui` both consume this contract and are separate cards.

## Deliberate deviations from the card body

1. **`column_list`/`card_list`/`sprint_list` on `FetchRound`, and their matching `LoadedState` accessors, are additions beyond the card's literal shape** (which only gave whole-collection status to boards). Every one of the four collection kinds on `Resolved` (via KAN-1317's `Collection<T> { all, by_id }`) needs a way to ask for and observe its "whole collection" tier, or `cards.all`/`columns.all`/`sprints.all` could never become populated through this contract and a later `EntityCache::resolve` could not fulfil a whole-collection request for anything but boards. This is free today (zero consumers) and expensive to retrofit later.

2. **`impl<T> From<&LoadState<T>> for FetchStatus` is an addition beyond the card's four listed items.** Every future consumer needs to convert `LoadState<T>` to `FetchStatus`; a single canonical, exhaustively-matched conversion removes the risk of a hand-rolled match silently folding `Missing` into `NotLoaded` at each call site.

## Testing

- 8 new inline unit tests in `crates/kanban-domain/src/fetch_plan.rs`, covering `requestable`'s terminal/retryable split, the `FetchStatus` conversion (all four variants, `Missing` does not collapse into `NotLoaded`), `FetchRound::is_empty` (default and all eight fields), the collection-vs-per-id independence on `LoadedState`, and object-safety of both traits via a stub `FetchPlan`.
- `cargo test -p kanban-domain`, `cargo test --all-features --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, and `cargo check -p kanban-cli --no-default-features --features json,sqlite` all pass.
- `.changeset/kan-1225-fetch-plan-contract.md` added (patch bump).

## Scope confirmation

`git grep -n 'FetchPlan\|FetchRound\|LoadedState\|FetchStatus\|requestable' -- 'crates/**/*.rs'` shows hits only inside `fetch_plan.rs`, the one `lib.rs` re-export line, and the pre-existing prose hit at `load_state.rs:49`. No consumer added in any other crate.