### PR TITLE
KAN-1325 feat(domain,view): Model's five fetchable collections track load state

### DIFF
--- a/.changeset/kan-1325-model-load-state-fields.md
+++ b/.changeset/kan-1325-model-load-state-fields.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+view: `Model` now records whether each of its board, column, card, sprint and dependency-graph collections has actually been loaded, instead of representing "never fetched" and "fetched and empty" the same way. New `*_state()` accessors expose that distinction; every existing accessor keeps its exact signature and behaviour, so nothing a user sees changes yet.

--- a/crates/kanban-domain/src/load_state.rs
+++ b/crates/kanban-domain/src/load_state.rs
@@ -64,6 +64,14 @@ impl<T> LoadState<T> {
     }
 }
 
+impl<T> LoadState<Vec<T>> {
+    /// The loaded contents, or an empty slice for any non-loaded state.
+    /// Callers that must distinguish those states match on the variant.
+    pub fn loaded_or_empty(&self) -> &[T] {
+        self.loaded().map(Vec::as_slice).unwrap_or(&[])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,7 +183,8 @@ mod tests {
     fn test_loaded_or_empty_returns_an_empty_slice_for_every_non_loaded_state() {
         let not_loaded: LoadState<Vec<u32>> = LoadState::NotLoaded;
         let missing: LoadState<Vec<u32>> = LoadState::Missing;
-        let failed: LoadState<Vec<u32>> = LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
+        let failed: LoadState<Vec<u32>> =
+            LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
 
         assert!(not_loaded.loaded_or_empty().is_empty());
         assert!(missing.loaded_or_empty().is_empty());

--- a/crates/kanban-domain/src/load_state.rs
+++ b/crates/kanban-domain/src/load_state.rs
@@ -166,6 +166,23 @@ mod tests {
     }
 
     #[test]
+    fn test_loaded_or_empty_returns_the_contents_when_loaded() {
+        let state: LoadState<Vec<u32>> = LoadState::Loaded(vec![1, 2, 3]);
+        assert_eq!(state.loaded_or_empty(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_loaded_or_empty_returns_an_empty_slice_for_every_non_loaded_state() {
+        let not_loaded: LoadState<Vec<u32>> = LoadState::NotLoaded;
+        let missing: LoadState<Vec<u32>> = LoadState::Missing;
+        let failed: LoadState<Vec<u32>> = LoadState::Failed(Arc::new(KanbanError::unsupported("x")));
+
+        assert!(not_loaded.loaded_or_empty().is_empty());
+        assert!(missing.loaded_or_empty().is_empty());
+        assert!(failed.loaded_or_empty().is_empty());
+    }
+
+    #[test]
     fn test_loadstate_only_not_loaded_is_non_terminal() {
         let not_loaded: LoadState<u32> = LoadState::NotLoaded;
         let loaded: LoadState<u32> = LoadState::Loaded(1);

--- a/crates/kanban-view/src/model/boards.rs
+++ b/crates/kanban-view/src/model/boards.rs
@@ -6,7 +6,11 @@ impl Model {
     /// want only one subset filter this collection by that set (the projects
     /// panel does so via `displayed_boards`). Mirrors the unified `all_cards()`.
     pub fn boards(&self) -> &[Board] {
-        self.boards.as_deref().unwrap_or(&[])
+        self.boards.loaded_or_empty()
+    }
+
+    pub fn boards_state(&self) -> &LoadState<Vec<Board>> {
+        &self.boards
     }
 
     /// The LIVE boards (unified collection minus the archived heads), in board
@@ -61,8 +65,21 @@ impl Model {
     /// deliberately archival-agnostic: a board is a board regardless of whether
     /// its head is archived.
     pub fn board_by_id(&self, id: Uuid) -> Option<&Board> {
-        let &idx = self.board_index.get(&id)?;
-        self.boards.as_ref()?.get(idx)
+        self.board_by_id_state(id).loaded().copied()
+    }
+
+    pub fn board_by_id_state(&self, id: Uuid) -> LoadState<&Board> {
+        match self.boards.as_ref() {
+            LoadState::Loaded(boards) => {
+                match self.board_index.get(&id).and_then(|&idx| boards.get(idx)) {
+                    Some(board) => LoadState::Loaded(board),
+                    None => LoadState::Missing,
+                }
+            }
+            LoadState::NotLoaded => LoadState::NotLoaded,
+            LoadState::Missing => LoadState::Missing,
+            LoadState::Failed(e) => LoadState::Failed(e),
+        }
     }
 }
 
@@ -279,7 +296,10 @@ mod tests {
         });
         let state = m.board_by_id_state(archived_id);
         assert!(state.is_loaded());
-        assert_eq!(state.loaded().map(|b| b.name.clone()), Some("Archived".to_string()));
+        assert_eq!(
+            state.loaded().map(|b| b.name.clone()),
+            Some("Archived".to_string())
+        );
         assert!(!state.is_missing());
     }
 }

--- a/crates/kanban-view/src/model/boards.rs
+++ b/crates/kanban-view/src/model/boards.rs
@@ -213,4 +213,73 @@ mod tests {
         m.load_from_snapshot(Snapshot::default());
         assert!(m.board_by_id(Uuid::new_v4()).is_none());
     }
+
+    #[test]
+    fn test_boards_state_is_not_loaded_before_load_from_snapshot() {
+        let m = Model::default();
+        assert!(m.boards_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_boards_state_is_loaded_and_empty_after_an_empty_snapshot() {
+        let mut m = Model::default();
+        m.load_from_snapshot(Snapshot::default());
+        assert!(m.boards_state().is_loaded());
+        assert!(m.boards_state().loaded().unwrap().is_empty());
+        assert!(m.boards().is_empty());
+    }
+
+    #[test]
+    fn test_board_by_id_state_is_not_loaded_before_any_snapshot() {
+        let m = Model::default();
+        let state = m.board_by_id_state(Uuid::new_v4());
+        assert!(state.is_not_loaded());
+        assert!(!state.is_missing());
+    }
+
+    #[test]
+    fn test_board_by_id_state_is_missing_for_an_absent_board_after_load() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        m.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            ..Default::default()
+        });
+        let state = m.board_by_id_state(Uuid::new_v4());
+        assert!(state.is_missing());
+        assert!(!state.is_not_loaded());
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn test_board_by_id_state_is_loaded_for_a_present_board() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let board_id = board.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            ..Default::default()
+        });
+        let state = m.board_by_id_state(board_id);
+        assert!(state.is_loaded());
+        assert_eq!(state.loaded().map(|b| b.id), Some(board_id));
+    }
+
+    #[test]
+    fn test_board_by_id_state_is_loaded_for_an_archived_board() {
+        use kanban_domain::Archived;
+        let mut m = Model::default();
+        let live = Board::new("Live", None::<String>);
+        let archived = Board::new("Archived", None::<String>);
+        let archived_id = archived.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![live, archived],
+            archived_boards: vec![Archived::now(archived_id)],
+            ..Default::default()
+        });
+        let state = m.board_by_id_state(archived_id);
+        assert!(state.is_loaded());
+        assert_eq!(state.loaded().map(|b| b.name.clone()), Some("Archived".to_string()));
+        assert!(!state.is_missing());
+    }
 }

--- a/crates/kanban-view/src/model/cards.rs
+++ b/crates/kanban-view/src/model/cards.rs
@@ -170,4 +170,82 @@ mod tests {
         assert_eq!(live_ids, vec![live_id]);
         assert_eq!(archived_ids, vec![archived_id]);
     }
+
+    #[test]
+    fn test_cards_state_is_not_loaded_before_load_from_snapshot() {
+        let m = Model::default();
+        assert!(m.cards_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_cards_state_is_loaded_and_empty_after_an_empty_snapshot() {
+        let mut m = Model::default();
+        m.load_from_snapshot(Snapshot::default());
+        assert!(m.cards_state().is_loaded());
+        assert!(m.cards_state().loaded().unwrap().is_empty());
+        assert!(m.all_cards().is_empty());
+    }
+
+    #[test]
+    fn test_card_by_id_state_is_not_loaded_before_any_snapshot() {
+        let m = Model::default();
+        let state = m.card_by_id_state(Uuid::new_v4());
+        assert!(state.is_not_loaded());
+        assert!(!state.is_missing());
+    }
+
+    #[test]
+    fn test_card_by_id_state_is_missing_for_an_absent_card_after_load() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let card = make_card(&board, col_id);
+        m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
+            cards: vec![card],
+            ..Default::default()
+        });
+        let state = m.card_by_id_state(Uuid::new_v4());
+        assert!(state.is_missing());
+        assert!(state.is_terminal());
+        assert!(!state.is_not_loaded());
+    }
+
+    #[test]
+    fn test_card_by_id_state_is_loaded_for_a_present_card() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let first = make_card(&board, col_id);
+        let second = make_card(&board, col_id);
+        let second_id = second.id;
+        m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
+            cards: vec![first, second],
+            ..Default::default()
+        });
+        let state = m.card_by_id_state(second_id);
+        assert!(state.is_loaded());
+        assert_eq!(state.loaded().map(|c| c.id), Some(second_id));
+    }
+
+    #[test]
+    fn test_card_by_id_state_is_loaded_for_an_archived_card() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let live = make_card(&board, col_id);
+        let archived = make_card(&board, col_id);
+        let archived_id = archived.id;
+        m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
+            cards: vec![live, archived],
+            archived_cards: vec![ArchivedCard::new(archived_id, uuid::Uuid::nil())],
+            ..Default::default()
+        });
+        let state = m.card_by_id_state(archived_id);
+        assert!(state.is_loaded());
+        assert!(!state.is_missing());
+        assert!(m.archived_card_ids().contains(&archived_id));
+    }
 }

--- a/crates/kanban-view/src/model/cards.rs
+++ b/crates/kanban-view/src/model/cards.rs
@@ -5,15 +5,32 @@ impl Model {
     /// genuinely need id resolution regardless of archival status — see
     /// `live_cards`/`archived_cards` for the common display case.
     pub fn all_cards(&self) -> &[Card] {
-        self.cards.as_deref().unwrap_or(&[])
+        self.cards.loaded_or_empty()
+    }
+
+    pub fn cards_state(&self) -> &LoadState<Vec<Card>> {
+        &self.cards
     }
 
     /// Resolve a card by id from the single unified collection (live AND
     /// archived rows). One index lookup — no live/archived re-join. A card is
     /// a card regardless of whether its head is archived.
     pub fn card_by_id(&self, id: Uuid) -> Option<&Card> {
-        let &idx = self.card_index.get(&id)?;
-        self.cards.as_ref()?.get(idx)
+        self.card_by_id_state(id).loaded().copied()
+    }
+
+    pub fn card_by_id_state(&self, id: Uuid) -> LoadState<&Card> {
+        match self.cards.as_ref() {
+            LoadState::Loaded(cards) => {
+                match self.card_index.get(&id).and_then(|&idx| cards.get(idx)) {
+                    Some(card) => LoadState::Loaded(card),
+                    None => LoadState::Missing,
+                }
+            }
+            LoadState::NotLoaded => LoadState::NotLoaded,
+            LoadState::Missing => LoadState::Missing,
+            LoadState::Failed(e) => LoadState::Failed(e),
+        }
     }
 
     /// The archived-card MARKER records (id + archived_at + restore context).

--- a/crates/kanban-view/src/model/collections.rs
+++ b/crates/kanban-view/src/model/collections.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::{Column, Snapshot, Sprint};
+
+    #[test]
+    fn test_columns_state_is_not_loaded_before_load_from_snapshot() {
+        let m = Model::default();
+        assert!(m.columns_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_columns_state_is_loaded_and_empty_after_an_empty_snapshot() {
+        let mut m = Model::default();
+        m.load_from_snapshot(Snapshot::default());
+        assert!(m.columns_state().is_loaded());
+        assert!(m.columns_state().loaded().unwrap().is_empty());
+        assert!(m.columns().is_empty());
+    }
+
+    #[test]
+    fn test_columns_state_is_loaded_after_load_from_snapshot() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col = Column::new(board.id, "Col", 0);
+        let col_id = col.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            columns: vec![col],
+            ..Default::default()
+        });
+        let loaded = m.columns_state().loaded().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, col_id);
+    }
+
+    #[test]
+    fn test_sprints_state_is_not_loaded_before_load_from_snapshot() {
+        let m = Model::default();
+        assert!(m.sprints_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_sprints_state_is_loaded_after_load_from_snapshot() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
+        let sprint_id = sprint.id;
+        m.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            sprints: vec![sprint],
+            ..Default::default()
+        });
+        assert!(m.sprints_state().is_loaded());
+        let loaded = m.sprints_state().loaded().unwrap();
+        assert!(loaded.iter().any(|s| s.id == sprint_id));
+    }
+}

--- a/crates/kanban-view/src/model/collections.rs
+++ b/crates/kanban-view/src/model/collections.rs
@@ -1,5 +1,23 @@
 use super::*;
 
+impl Model {
+    pub fn columns(&self) -> &[Column] {
+        self.columns.loaded_or_empty()
+    }
+
+    pub fn columns_state(&self) -> &LoadState<Vec<Column>> {
+        &self.columns
+    }
+
+    pub fn sprints(&self) -> &[Sprint] {
+        self.sprints.loaded_or_empty()
+    }
+
+    pub fn sprints_state(&self) -> &LoadState<Vec<Sprint>> {
+        &self.sprints
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-view/src/model/graph.rs
+++ b/crates/kanban-view/src/model/graph.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::Snapshot;
+
+    #[test]
+    fn test_graph_state_is_not_loaded_on_a_default_model() {
+        let m = Model::default();
+        assert!(m.graph_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_graph_state_is_loaded_after_load_from_snapshot() {
+        let mut m = Model::default();
+        m.load_from_snapshot(Snapshot::default());
+        assert!(m.graph_state().is_loaded());
+    }
+
+    #[test]
+    fn test_graph_accessor_returns_one_shared_empty_graph_when_not_loaded() {
+        let a = Model::default();
+        let b = Model::default();
+        assert!(std::ptr::eq(a.graph(), b.graph()));
+        assert_eq!(a.graph(), &DependencyGraph::default());
+        assert_eq!(b.graph(), &DependencyGraph::default());
+    }
+}

--- a/crates/kanban-view/src/model/graph.rs
+++ b/crates/kanban-view/src/model/graph.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+impl Model {
+    pub fn empty_graph() -> &'static DependencyGraph {
+        static EMPTY: std::sync::OnceLock<DependencyGraph> = std::sync::OnceLock::new();
+        EMPTY.get_or_init(DependencyGraph::default)
+    }
+
+    pub fn graph(&self) -> &DependencyGraph {
+        self.graph.loaded().unwrap_or_else(|| Self::empty_graph())
+    }
+
+    pub fn graph_state(&self) -> &LoadState<DependencyGraph> {
+        &self.graph
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -201,6 +201,8 @@ impl Model {
 mod board_sort;
 mod boards;
 mod cards;
+mod collections;
+mod graph;
 
 #[cfg(test)]
 mod tests {

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -2,19 +2,19 @@ use chrono::{DateTime, Utc};
 use kanban_core::AppConfig;
 use kanban_domain::{
     filter_and_sort_boards, ArchivedBoard, ArchivedCard, Board, BoardListFilter, BoardSortField,
-    Card, Column, DependencyGraph, Snapshot, SortOrder, Sprint, DEFAULT_ARCHIVED_BOARD_SORT,
-    DEFAULT_BOARD_SORT_LIVE,
+    Card, Column, DependencyGraph, LoadState, Snapshot, SortOrder, Sprint,
+    DEFAULT_ARCHIVED_BOARD_SORT, DEFAULT_BOARD_SORT_LIVE,
 };
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use uuid::Uuid;
 pub struct Model {
-    boards: Option<Vec<Board>>,
-    columns: Option<Vec<Column>>,
-    cards: Option<Vec<Card>>,
+    boards: LoadState<Vec<Board>>,
+    columns: LoadState<Vec<Column>>,
+    cards: LoadState<Vec<Card>>,
     card_index: HashMap<Uuid, usize>,
     board_index: HashMap<Uuid, usize>,
-    sprints: Option<Vec<Sprint>>,
+    sprints: LoadState<Vec<Sprint>>,
     archived_cards: Option<Vec<ArchivedCard>>,
     archived_card_ids: HashSet<Uuid>,
     archived_boards: Option<Vec<ArchivedBoard>>,
@@ -46,18 +46,18 @@ pub struct Model {
     live_board_sort_order: SortOrder,
     archived_board_sort_field: BoardSortField,
     archived_board_sort_order: SortOrder,
-    graph: DependencyGraph,
+    graph: LoadState<DependencyGraph>,
 }
 
 impl Default for Model {
     fn default() -> Self {
         Self {
-            boards: None,
-            columns: None,
-            cards: None,
+            boards: LoadState::NotLoaded,
+            columns: LoadState::NotLoaded,
+            cards: LoadState::NotLoaded,
             card_index: HashMap::new(),
             board_index: HashMap::new(),
-            sprints: None,
+            sprints: LoadState::NotLoaded,
             archived_cards: None,
             archived_card_ids: HashSet::new(),
             archived_boards: None,
@@ -71,24 +71,12 @@ impl Default for Model {
             live_board_sort_order: DEFAULT_BOARD_SORT_LIVE.1,
             archived_board_sort_field: DEFAULT_ARCHIVED_BOARD_SORT.0,
             archived_board_sort_order: DEFAULT_ARCHIVED_BOARD_SORT.1,
-            graph: DependencyGraph::default(),
+            graph: LoadState::NotLoaded,
         }
     }
 }
 
 impl Model {
-    pub fn columns(&self) -> &[Column] {
-        self.columns.as_deref().unwrap_or(&[])
-    }
-
-    pub fn sprints(&self) -> &[Sprint] {
-        self.sprints.as_deref().unwrap_or(&[])
-    }
-
-    pub fn graph(&self) -> &DependencyGraph {
-        &self.graph
-    }
-
     pub fn load_from_snapshot(&mut self, snapshot: Snapshot) {
         // Reference-marker model: `snapshot.cards` carries EVERY card — live AND
         // archived — with archival recorded by markers in `snapshot.archived_cards`
@@ -134,13 +122,13 @@ impl Model {
         }
         self.archived_board_ids = archived_board_ids;
 
-        self.boards = Some(boards);
-        self.columns = Some(snapshot.columns);
-        self.sprints = Some(snapshot.sprints);
-        self.cards = Some(cards);
+        self.boards = LoadState::Loaded(boards);
+        self.columns = LoadState::Loaded(snapshot.columns);
+        self.sprints = LoadState::Loaded(snapshot.sprints);
+        self.cards = LoadState::Loaded(cards);
         self.archived_cards = Some(snapshot.archived_cards);
         self.archived_boards = Some(snapshot.archived_boards);
-        self.graph = snapshot.graph;
+        self.graph = LoadState::Loaded(snapshot.graph);
 
         // Partition the unified collections into live/archived subsets ONCE, here
         // on load (snapshot-on-open), so `displayed_cards`/`displayed_boards` can


### PR DESCRIPTION
This is B8a of KAN-1226 only. Remaining work: KAN-1326 (b8b-1, boards and graph), KAN-1327 (b8b-2, cards), KAN-1328 (b8b-3, columns and sprints). Not marking KAN-1226 done.

## Changes

- `kanban-domain`: `LoadState::<Vec<T>>::loaded_or_empty` returns the loaded contents, or an empty slice for `NotLoaded`, `Missing`, or `Failed` alike.
- `kanban-view`: `Model`'s five fetchable collections (`boards`, `columns`, `cards`, `sprints`, `graph`) are now `LoadState`-backed instead of `Option<Vec<T>>` / a bare `DependencyGraph`.
- Seven new `*_state()` accessors (`boards_state`, `columns_state`, `cards_state`, `sprints_state`, `graph_state`, `board_by_id_state`, `card_by_id_state`) distinguish `NotLoaded` from `Missing` from `Loaded`. The two by-id variants return `Missing` (not `NotLoaded`) for an absent id after a load, since `NotLoaded` is the only non-terminal state and a fetch plan would otherwise re-request a nonexistent entity forever.
- `Model::empty_graph() -> &'static DependencyGraph` is a new `pub`, `OnceLock`-backed fallback. `graph()` now falls back to this shared instance instead of holding a real `DependencyGraph` field, resolving D8: a default `Model` can now be told apart from one that loaded an empty graph.
- Strictly additive. Every existing accessor (`boards()`, `columns()`, `all_cards()`, `sprints()`, `graph()`, `board_by_id()`, `card_by_id()`) keeps its exact signature and observed behaviour; the receiver-qualified grep counts for all seven across `crates/kanban-tui` and `crates/kanban-view` are identical before and after:

| accessor | before | after |
|---|---|---|
| `boards()` | 72 | 72 |
| `sprints()` | 85 | 85 |
| `card_by_id(` | 53 | 53 |
| `all_cards()` | 49 | 49 |
| `columns()` | 38 | 38 |
| `graph()` | 16 | 16 |
| `board_by_id(` | 16 | 16 |

- `archived_cards` and `archived_boards` stay `Option`-backed. `Resolved` (post KAN-1317, `crates/kanban-domain/src/resolved.rs`) has exactly `boards`/`columns`/`cards`/`sprints: Collection<T>` plus `graph: LoadState<DependencyGraph>` and no archived field, which is the live evidence for this ruling. It is provisional: KAN-1225's `FetchRound` has not landed yet, so this cannot be checked against its actual fields.
- `Model::graph`, `Model::columns`, `Model::sprints` moved into new private submodules `model/collections.rs` and `model/graph.rs`, mirroring the existing `model/boards.rs` / `model/cards.rs` split (`mod.rs` was already at the repo's 300-line guideline).

## Testing

- 22 new red tests across `crates/kanban-domain/src/load_state.rs` and `crates/kanban-view/src/model/{collections,graph,boards,cards}.rs`, committed separately from the implementation.
- Mutation-checked the two central invariants by hand: initializing `graph` to `Loaded(DependencyGraph::default())` in `Default` fails `test_graph_state_is_not_loaded_on_a_default_model` and `test_graph_accessor_returns_one_shared_empty_graph_when_not_loaded`; returning `NotLoaded` instead of `Missing` for an absent id after a load fails `test_board_by_id_state_is_missing_for_an_absent_board_after_load`. Both mutations reverted before committing.
- `crates/kanban-tui/tests/model_tests.rs` passes unedited, including the out-of-crate `assert_eq!(model.graph(), &DependencyGraph::default())` check that `graph()`'s observed behaviour is unchanged.
- `cargo test --all-features --workspace`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, and `cargo check --package kanban-cli --no-default-features --features json,sqlite` all pass.
- `git diff --stat origin/develop...HEAD` touches only `crates/kanban-domain/src/load_state.rs`, `crates/kanban-view/src/model/**`, and `.changeset/`.