### PR TITLE
KAN-1240 feat(api,server): entity identity on change events

### DIFF
--- a/.changeset/kan-1240-change-event-entity-identity.md
+++ b/.changeset/kan-1240-change-event-entity-identity.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: change events streamed from GET /v1/events now identify which entity changed and how, so a client can invalidate just that board, column, card or sprint instead of its whole cache; an event caused by another process writing the file still carries no entity, meaning everything must be refetched.

--- a/crates/kanban-api/README.md
+++ b/crates/kanban-api/README.md
@@ -17,19 +17,19 @@ Re-exported from `src/lib.rs` (`pub use v1::{ ... }`):
 ```rust
 pub use v1::{
     ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
-    CardStatusDto, ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest,
-    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams,
-    Patch, ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
-    ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
-    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
-    UpdateSprintRequest,
+    CardStatusDto, ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest,
+    CreateCardRequest, CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType,
+    ErrorCode, Page, PageParams, Patch, ReorderColumnRequest, ReplaceBoardRequest,
+    ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto,
+    SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest,
+    UpdateColumnRequest, UpdateSprintRequest,
 };
 ```
 
 - `*Response` types are the read-side DTOs returned by `kanban-server`'s REST endpoints.
 - `Create*Request` / `Replace*Request` / `Update*Request` are the write-side DTOs for `POST` / `PUT` / `PATCH` respectively — `Update*Request` follows JSON Merge Patch (RFC 7386) semantics via `Patch<T>`.
 - `ApiError` / `ErrorCode` are the shared error envelope every non-2xx response uses.
-- `ChangeEventFrame` is the payload broadcast on `kanban-server`'s internal change-event channel.
+- `ChangeEventFrame` is the payload broadcast on `kanban-server`'s internal change-event channel; `entity_type`/`entity_id`/`kind` (`EntityType`, `ChangeKind`) name the entity a mutation touched and how, all absent when the emitter cannot know (an external process wrote the file directly).
 
 The optional `schemars` feature (`dep:schemars`, `features = ["uuid1"]`) derives `schemars::JsonSchema` on these DTOs so `kanban-mcp` can use them directly as `Parameters<T>` for its tool handlers (rmcp requires a JSON Schema).
 

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -6,10 +6,10 @@
 mod v1;
 pub use v1::{
     ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
-    CardStatusDto, ChangeEventFrame, ColumnResponse, CreateBoardRequest, CreateCardRequest,
-    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, ErrorCode, Page, PageParams,
-    Patch, ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
-    ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
-    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
-    UpdateSprintRequest,
+    CardStatusDto, ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest,
+    CreateCardRequest, CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType,
+    ErrorCode, Page, PageParams, Patch, ReorderColumnRequest, ReplaceBoardRequest,
+    ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto,
+    SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest,
+    UpdateColumnRequest, UpdateSprintRequest,
 };

--- a/crates/kanban-api/src/v1/events.rs
+++ b/crates/kanban-api/src/v1/events.rs
@@ -11,8 +11,43 @@ fn default_client_id() -> ClientId {
     ClientId::nil()
 }
 
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntityType {
+    Board,
+    Column,
+    Card,
+    Sprint,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeKind {
+    Created,
+    Updated,
+    Deleted,
+}
+
+impl ChangeKind {
+    pub fn created_or_updated(created: bool) -> Self {
+        if created {
+            Self::Created
+        } else {
+            Self::Updated
+        }
+    }
+}
+
 /// SSE frame emitted by kanban-server on every successful mutation.
 /// Clients filter by `writer_instance_id` to ignore their own writes.
+///
+/// `entity_type`/`entity_id`/`kind` are `None` when the emitter cannot name
+/// what changed (an external process wrote the file). Otherwise they name the
+/// single entity that changed and how; a `Deleted` frame for a `Board` or
+/// `Column` implies everything it owned is gone too, since no per-descendant
+/// frames are emitted for a cascade.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -23,6 +58,12 @@ pub struct ChangeEventFrame {
     pub correlation_id: Uuid,
     #[serde(default = "default_client_id")]
     pub issued_by: ClientId,
+    #[serde(default)]
+    pub entity_type: Option<EntityType>,
+    #[serde(default)]
+    pub entity_id: Option<Uuid>,
+    #[serde(default)]
+    pub kind: Option<ChangeKind>,
 }
 
 impl ChangeEventFrame {
@@ -38,12 +79,37 @@ impl ChangeEventFrame {
             detected_at,
             correlation_id,
             issued_by,
+            entity_type: None,
+            entity_id: None,
+            kind: None,
         }
     }
 
     /// Construct stamped with the current time (convenience for production use).
     pub fn now(writer_instance_id: Uuid, correlation_id: Uuid, issued_by: ClientId) -> Self {
         Self::new(writer_instance_id, correlation_id, issued_by, Utc::now())
+    }
+
+    /// Construct stamped with the current time, carrying an explicit (possibly
+    /// absent) entity identity.
+    #[allow(clippy::too_many_arguments)]
+    pub fn for_entity(
+        writer_instance_id: Uuid,
+        correlation_id: Uuid,
+        issued_by: ClientId,
+        entity_type: Option<EntityType>,
+        entity_id: Option<Uuid>,
+        kind: Option<ChangeKind>,
+    ) -> Self {
+        Self {
+            writer_instance_id,
+            detected_at: Utc::now(),
+            correlation_id,
+            issued_by,
+            entity_type,
+            entity_id,
+            kind,
+        }
     }
 }
 

--- a/crates/kanban-api/src/v1/events.rs
+++ b/crates/kanban-api/src/v1/events.rs
@@ -91,4 +91,80 @@ mod tests {
         assert_eq!(parsed.correlation_id, Uuid::nil());
         assert_eq!(parsed.issued_by, ClientId::nil());
     }
+
+    #[test]
+    fn test_change_event_frame_carries_entity_identity() {
+        let card_id = Uuid::new_v4();
+        let frame = ChangeEventFrame::for_entity(
+            Uuid::nil(),
+            Uuid::nil(),
+            ClientId::nil(),
+            Some(EntityType::Card),
+            Some(card_id),
+            Some(ChangeKind::Created),
+        );
+        let json = serde_json::to_string(&frame).unwrap();
+        let parsed: ChangeEventFrame = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.entity_type, Some(EntityType::Card));
+        assert_eq!(parsed.entity_id, Some(card_id));
+        assert_eq!(parsed.kind, Some(ChangeKind::Created));
+    }
+
+    #[test]
+    fn test_change_event_frame_deserializes_without_entity_fields() {
+        let json = r#"{"writer_instance_id":"00000000-0000-0000-0000-000000000000","detected_at":"1970-01-01T00:00:00Z"}"#;
+        let parsed: ChangeEventFrame = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.correlation_id, Uuid::nil());
+        assert_eq!(parsed.issued_by, ClientId::nil());
+        assert!(parsed.entity_type.is_none());
+        assert!(parsed.entity_id.is_none());
+        assert!(parsed.kind.is_none());
+    }
+
+    #[test]
+    fn test_change_event_frame_entity_fields_serialize_as_snake_case() {
+        let card_id = Uuid::new_v4();
+        let card_frame = ChangeEventFrame::for_entity(
+            Uuid::nil(),
+            Uuid::nil(),
+            ClientId::nil(),
+            Some(EntityType::Card),
+            Some(card_id),
+            Some(ChangeKind::Created),
+        );
+        let v = serde_json::to_value(&card_frame).unwrap();
+        assert_eq!(v["entity_type"], "card");
+        assert_eq!(v["kind"], "created");
+        assert_eq!(v["entity_id"], card_id.to_string());
+
+        let board_id = Uuid::new_v4();
+        let board_frame = ChangeEventFrame::for_entity(
+            Uuid::nil(),
+            Uuid::nil(),
+            ClientId::nil(),
+            Some(EntityType::Board),
+            Some(board_id),
+            Some(ChangeKind::Deleted),
+        );
+        let v = serde_json::to_value(&board_frame).unwrap();
+        assert_eq!(v["entity_type"], "board");
+        assert_eq!(v["kind"], "deleted");
+        assert_eq!(v["entity_id"], board_id.to_string());
+    }
+
+    #[test]
+    fn test_change_event_frame_unscoped_serializes_entity_fields_as_null() {
+        let frame = ChangeEventFrame::for_entity(
+            Uuid::nil(),
+            Uuid::nil(),
+            ClientId::nil(),
+            None,
+            None,
+            None,
+        );
+        let v = serde_json::to_value(&frame).unwrap();
+        assert_eq!(v.get("entity_type"), Some(&serde_json::Value::Null));
+        assert_eq!(v.get("entity_id"), Some(&serde_json::Value::Null));
+        assert_eq!(v.get("kind"), Some(&serde_json::Value::Null));
+    }
 }

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -20,7 +20,7 @@ pub use enums::{
     TaskListViewDto,
 };
 pub use error::{ApiError, ErrorCode};
-pub use events::ChangeEventFrame;
+pub use events::{ChangeEventFrame, ChangeKind, EntityType};
 pub use graph::CardGraphResponse;
 pub use pagination::{Page, PageParams};
 pub use patch::Patch;

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -19,7 +19,7 @@ graph TD
 
 A `tokio::sync::Mutex` is used rather than a sync `RwLock`: `KanbanContext`'s write path (`save`/`reload`) is async, and holding a sync write guard across an `.await` would be a `Send`/deadlock hazard.
 
-Each successful mutation broadcasts a `ChangeEventFrame` on an in-process `tokio::sync::broadcast` channel (`AppState::broadcast_change`), for future streaming (e.g. SSE) consumers — nothing currently subscribes to it.
+Each successful mutation broadcasts a `ChangeEventFrame` on an in-process `tokio::sync::broadcast` channel (`AppState::broadcast_change`), naming the entity type, id and change kind (created/updated/deleted) it touched. `GET /v1/events` streams these frames to clients over SSE, so a client can invalidate just the affected board, column, card or sprint instead of its whole cache. A frame caused by an external process writing the file directly (`AppState::broadcast_unscoped_change`) carries no entity identity, meaning subscribers must invalidate everything.
 
 ## Installation
 
@@ -180,7 +180,13 @@ Column writes (create/update/delete) aren't implemented yet.
 |---|---|---|---|
 | `GET` | `/v1/cards/{id}/graph` | The card's dependency edges, scoped to that card: parents/children (spawns), blocked_by/blocks and related. Only active edges; archived edges are omitted. 404s if the card does not exist, rather than returning empty arrays. | — |
 
-Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event and, per the persistence layer's normal save path, durably writes to the configured store before responding.
+### Events
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/events` | Server-Sent Events stream of `ChangeEventFrame`s, one per successful mutation (or per detected external write). Each frame carries `entity_type`/`entity_id`/`kind`, all absent when the emitter cannot name what changed. |
+
+Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event naming the entity it touched and, per the persistence layer's normal save path, durably writes to the configured store before responding.
 
 ## Error Handling
 

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -6,7 +6,8 @@ use axum::http::StatusCode;
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use kanban_service::api::{
-    BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest,
+    BoardResponse, ChangeKind, CreateBoardRequest, EntityType, ReplaceBoardRequest,
+    UpdateBoardRequest,
 };
 use kanban_service::{KanbanError, KanbanOperations};
 use uuid::Uuid;
@@ -46,7 +47,7 @@ async fn post_board(
         let mut ctx = state.ctx.lock().await;
         let resp = create_board(&mut ctx, req).map_err(AppError::from)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Board, resp.id, ChangeKind::Created)
             .await
             .map_err(|e| AppError::from(&e))?;
         resp
@@ -63,7 +64,12 @@ async fn put_board(
         let mut ctx = state.ctx.lock().await;
         let (resp, created) = create_or_replace_board(&mut ctx, id, req).map_err(AppError::from)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(
+                &ctx,
+                EntityType::Board,
+                id,
+                ChangeKind::created_or_updated(created),
+            )
             .await
             .map_err(|e| AppError::from(&e))?;
         (resp, created)
@@ -87,7 +93,7 @@ async fn patch_board(
             .update_board(id, req.into())
             .map_err(|e| AppError::from(&e))?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Board, id, ChangeKind::Updated)
             .await
             .map_err(|e| AppError::from(&e))?;
         board
@@ -103,7 +109,7 @@ async fn delete_board(
         let mut ctx = state.ctx.lock().await;
         ctx.delete_board(id).map_err(|e| AppError::from(&e))?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Board, id, ChangeKind::Deleted)
             .await
             .map_err(|e| AppError::from(&e))?;
     }

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -7,7 +7,7 @@ use axum::{Json, Router};
 use kanban_domain::{Card, CardListFilter};
 use kanban_service::api::ArchivedFilterDto;
 use kanban_service::api::CardResponse;
-use kanban_service::api::{CreateCardRequest, UpdateCardRequest};
+use kanban_service::api::{ChangeKind, CreateCardRequest, EntityType, UpdateCardRequest};
 use kanban_service::{CardUpdate, KanbanError, KanbanOperations};
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -113,7 +113,12 @@ async fn create_card_route(
         let result = crate::handlers::cards::create_card(&mut ctx, column_id, req)
             .map_err(AppError::from)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(
+                &ctx,
+                EntityType::Card,
+                result.0.id,
+                ChangeKind::created_or_updated(result.1),
+            )
             .await
             .map_err(|e| AppError::from(&e))?;
         result
@@ -131,7 +136,12 @@ async fn put_card_route(
         let result = crate::handlers::cards::create_or_replace_card(&mut ctx, column_id, id, req)
             .map_err(AppError::from)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(
+                &ctx,
+                EntityType::Card,
+                id,
+                ChangeKind::created_or_updated(result.1),
+            )
             .await
             .map_err(|e| AppError::from(&e))?;
         result
@@ -150,7 +160,7 @@ async fn update_card_route(
         require_card_in_board(&ctx, board_id, id)?;
         let card = do_update_card(&mut ctx, id, updates)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
             .await
             .map_err(|e| AppError::from(&e))?;
         card
@@ -167,7 +177,7 @@ async fn delete_card_route(
         require_card_in_board(&ctx, board_id, id)?;
         do_delete_card(&mut ctx, id)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Deleted)
             .await
             .map_err(|e| AppError::from(&e))?;
     }
@@ -203,7 +213,7 @@ async fn update_card_route_flat(
         let mut ctx = state.ctx.lock().await;
         let card = do_update_card(&mut ctx, id, updates)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
             .await
             .map_err(|e| AppError::from(&e))?;
         card
@@ -219,7 +229,7 @@ async fn delete_card_route_flat(
         let mut ctx = state.ctx.lock().await;
         do_delete_card(&mut ctx, id)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Deleted)
             .await
             .map_err(|e| AppError::from(&e))?;
     }

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use kanban_domain::Column;
-use kanban_service::api::ColumnResponse;
+use kanban_service::api::{ChangeKind, ColumnResponse, EntityType};
 use kanban_service::{ColumnUpdate, KanbanError, KanbanOperations};
 use uuid::Uuid;
 
@@ -87,7 +87,12 @@ async fn create_column_route(
         let result = crate::handlers::columns::create_column(&mut ctx, board_id, req)
             .map_err(AppError::from)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(
+                &ctx,
+                EntityType::Column,
+                result.0.id,
+                ChangeKind::created_or_updated(result.1),
+            )
             .await
             .map_err(|e| AppError::from(&e))?;
         result
@@ -106,7 +111,12 @@ async fn put_column_route(
             crate::handlers::columns::create_or_replace_column(&mut ctx, board_id, id, req)
                 .map_err(AppError::from)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(
+                &ctx,
+                EntityType::Column,
+                id,
+                ChangeKind::created_or_updated(result.1),
+            )
             .await
             .map_err(|e| AppError::from(&e))?;
         result
@@ -125,7 +135,7 @@ async fn update_column_route(
         require_column_in_board(&ctx, board_id, id)?;
         let col = do_update_column(&mut ctx, id, updates)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Column, id, ChangeKind::Updated)
             .await
             .map_err(|e| AppError::from(&e))?;
         col
@@ -142,7 +152,7 @@ async fn delete_column_route(
         require_column_in_board(&ctx, board_id, id)?;
         do_delete_column(&mut ctx, id)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Column, id, ChangeKind::Deleted)
             .await
             .map_err(|e| AppError::from(&e))?;
     }
@@ -162,7 +172,7 @@ async fn reorder_column_route(
             .reorder_column(id, position)
             .map_err(|e| AppError::from(&e))?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Column, id, ChangeKind::Updated)
             .await
             .map_err(|e| AppError::from(&e))?;
         col
@@ -204,7 +214,7 @@ async fn update_column_route_flat(
         let mut ctx = state.ctx.lock().await;
         let col = do_update_column(&mut ctx, id, updates)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Column, id, ChangeKind::Updated)
             .await
             .map_err(|e| AppError::from(&e))?;
         col
@@ -220,7 +230,7 @@ async fn delete_column_route_flat(
         let mut ctx = state.ctx.lock().await;
         do_delete_column(&mut ctx, id)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Column, id, ChangeKind::Deleted)
             .await
             .map_err(|e| AppError::from(&e))?;
     }

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use kanban_domain::Sprint;
-use kanban_service::api::SprintResponse;
+use kanban_service::api::{ChangeKind, EntityType, SprintResponse};
 use kanban_service::{
     resolve_sprint_name, resolve_sprint_names, KanbanError, KanbanOperations, SprintUpdate,
 };
@@ -100,7 +100,12 @@ async fn create_sprint_route(
         let result = crate::handlers::sprints::create_sprint(&mut ctx, board_id, req)
             .map_err(AppError::from)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(
+                &ctx,
+                EntityType::Sprint,
+                result.0.id,
+                ChangeKind::created_or_updated(result.1),
+            )
             .await
             .map_err(|e| AppError::from(&e))?;
         result
@@ -119,7 +124,12 @@ async fn put_sprint_route(
             crate::handlers::sprints::create_or_replace_sprint(&mut ctx, board_id, id, req)
                 .map_err(AppError::from)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(
+                &ctx,
+                EntityType::Sprint,
+                id,
+                ChangeKind::created_or_updated(result.1),
+            )
             .await
             .map_err(|e| AppError::from(&e))?;
         result
@@ -139,7 +149,7 @@ async fn update_sprint_route(
         let sprint = do_update_sprint(&mut ctx, id, updates)?;
         let body = respond(&ctx, &sprint)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Updated)
             .await
             .map_err(|e| AppError::from(&e))?;
         body
@@ -156,7 +166,7 @@ async fn delete_sprint_route(
         require_sprint_in_board(&ctx, board_id, id)?;
         do_delete_sprint(&mut ctx, id)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Deleted)
             .await
             .map_err(|e| AppError::from(&e))?;
     }
@@ -195,7 +205,7 @@ async fn update_sprint_route_flat(
         let sprint = do_update_sprint(&mut ctx, id, updates)?;
         let body = respond(&ctx, &sprint)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Updated)
             .await
             .map_err(|e| AppError::from(&e))?;
         body
@@ -212,7 +222,7 @@ async fn delete_sprint_route_flat(
         do_get_sprint(&ctx, id)?;
         do_delete_sprint(&mut ctx, id)?;
         state
-            .persist_and_broadcast(&ctx)
+            .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Deleted)
             .await
             .map_err(|e| AppError::from(&e))?;
     }

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -1,5 +1,5 @@
 use kanban_core::ClientId;
-use kanban_service::api::ChangeEventFrame;
+use kanban_service::api::{ChangeEventFrame, ChangeKind, EntityType};
 use kanban_service::{KanbanContext, KanbanResult};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -27,30 +27,57 @@ impl AppState {
         }
     }
 
-    /// Broadcast a change event after a successful mutation. Shared across
-    /// every entity's write routes so each doesn't reimplement it; call after
-    /// the context lock guard has been dropped. A missing subscriber (no SSE
-    /// consumer connected yet) is not an error, hence the discarded result.
-    pub fn broadcast_change(&self) {
-        let _ = self.event_tx.send(ChangeEventFrame::now(
+    fn emit(
+        &self,
+        entity_type: Option<EntityType>,
+        entity_id: Option<Uuid>,
+        kind: Option<ChangeKind>,
+    ) {
+        let _ = self.event_tx.send(ChangeEventFrame::for_entity(
             self.instance_id,
             Uuid::new_v4(),
             ClientId::nil(),
+            entity_type,
+            entity_id,
+            kind,
         ));
     }
 
-    /// Durably persist any pending changes, then broadcast. Call this from
-    /// *inside* the context lock (needs `&KanbanContext` — `save()` takes
-    /// `&self`, so no reacquire is needed), immediately after a successful
-    /// mutation and before the lock guard drops. A write whose `save()` fails
-    /// must not report success to the client — callers propagate the error via
-    /// `AppError::from(&e)` exactly like every other `KanbanResult` in this
-    /// crate, so a 201/200 response is only ever returned once the data is
-    /// actually on disk (or in SQLite's case, harmlessly redundant — `flush()`
-    /// is a no-op cost there since each statement already committed).
-    pub async fn persist_and_broadcast(&self, ctx: &KanbanContext) -> KanbanResult<()> {
+    /// Broadcast a change event naming the entity a mutation touched. Shared
+    /// across every entity's write routes so each doesn't reimplement it;
+    /// call after the context lock guard has been dropped. A missing
+    /// subscriber (no SSE consumer connected yet) is not an error, hence the
+    /// discarded result.
+    pub fn broadcast_change(&self, entity_type: EntityType, entity_id: Uuid, kind: ChangeKind) {
+        self.emit(Some(entity_type), Some(entity_id), Some(kind));
+    }
+
+    /// Broadcast a change event whose origin is outside this process (an
+    /// external writer changed the file), so the specific entity touched is
+    /// unknowable.
+    pub fn broadcast_unscoped_change(&self) {
+        self.emit(None, None, None);
+    }
+
+    /// Durably persist any pending changes, then broadcast that `entity_id`
+    /// changed. Call this from *inside* the context lock (needs
+    /// `&KanbanContext` — `save()` takes `&self`, so no reacquire is needed),
+    /// immediately after a successful mutation and before the lock guard
+    /// drops. A write whose `save()` fails must not report success to the
+    /// client — callers propagate the error via `AppError::from(&e)` exactly
+    /// like every other `KanbanResult` in this crate, so a 201/200 response
+    /// is only ever returned once the data is actually on disk (or in
+    /// SQLite's case, harmlessly redundant — `flush()` is a no-op cost there
+    /// since each statement already committed).
+    pub async fn persist_and_broadcast(
+        &self,
+        ctx: &KanbanContext,
+        entity_type: EntityType,
+        entity_id: Uuid,
+        kind: ChangeKind,
+    ) -> KanbanResult<()> {
         ctx.save().await?;
-        self.broadcast_change();
+        self.broadcast_change(entity_type, entity_id, kind);
         Ok(())
     }
 }

--- a/crates/kanban-server/src/watch.rs
+++ b/crates/kanban-server/src/watch.rs
@@ -38,7 +38,7 @@ pub async fn watch_for_external_changes(
             match ctx.reload().await {
                 Ok(()) => {
                     drop(ctx);
-                    state.broadcast_change();
+                    state.broadcast_unscoped_change();
                     tracing::info!("Reloaded state from external file change");
                 }
                 Err(e) => tracing::error!("Failed to reload from disk: {e}"),

--- a/crates/kanban-server/tests/events_entity_identity.rs
+++ b/crates/kanban-server/tests/events_entity_identity.rs
@@ -358,18 +358,18 @@ async fn test_flat_routes_broadcast_their_own_entity_identity() {
     assert_eq!(frame.entity_id, Some(sprint_id));
     assert_eq!(frame.kind, Some(ChangeKind::Deleted));
 
-    let response = send(&state, "DELETE", &format!("/v1/columns/{column_id}"), None).await;
-    assert_eq!(response.status(), StatusCode::NO_CONTENT);
-    let frame = next_frame(&mut rx).await;
-    assert_eq!(frame.entity_type, Some(EntityType::Column));
-    assert_eq!(frame.entity_id, Some(column_id));
-    assert_eq!(frame.kind, Some(ChangeKind::Deleted));
-
     let response = send(&state, "DELETE", &format!("/v1/cards/{card_id}"), None).await;
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
     let frame = next_frame(&mut rx).await;
     assert_eq!(frame.entity_type, Some(EntityType::Card));
     assert_eq!(frame.entity_id, Some(card_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Deleted));
+
+    let response = send(&state, "DELETE", &format!("/v1/columns/{column_id}"), None).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Column));
+    assert_eq!(frame.entity_id, Some(column_id));
     assert_eq!(frame.kind, Some(ChangeKind::Deleted));
 }
 

--- a/crates/kanban-server/tests/events_entity_identity.rs
+++ b/crates/kanban-server/tests/events_entity_identity.rs
@@ -372,4 +372,3 @@ async fn test_flat_routes_broadcast_their_own_entity_identity() {
     assert_eq!(frame.entity_id, Some(column_id));
     assert_eq!(frame.kind, Some(ChangeKind::Deleted));
 }
-

--- a/crates/kanban-server/tests/events_entity_identity.rs
+++ b/crates/kanban-server/tests/events_entity_identity.rs
@@ -1,0 +1,375 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::http::StatusCode;
+use kanban_domain::KanbanOperations;
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_service::api::{ChangeEventFrame, ChangeKind, EntityType};
+use serde_json::json;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+async fn next_frame(rx: &mut broadcast::Receiver<ChangeEventFrame>) -> ChangeEventFrame {
+    tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for a change event frame")
+        .expect("broadcast channel closed unexpectedly")
+}
+
+async fn seed_board_and_column(state: &AppState) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col = ctx
+        .create_column(board_id, "To Do".to_string(), None)
+        .unwrap();
+    (board_id, col.id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_broadcast_change_includes_entity_identity() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let mut rx = state.event_tx.subscribe();
+
+    let id = Uuid::new_v4();
+    state.broadcast_change(EntityType::Board, id, ChangeKind::Updated);
+
+    let frame = rx.try_recv().unwrap();
+    assert_eq!(frame.entity_type, Some(EntityType::Board));
+    assert_eq!(frame.entity_id, Some(id));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+    assert_eq!(frame.writer_instance_id, state.instance_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unscoped_broadcast_leaves_entity_fields_none() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let mut rx = state.event_tx.subscribe();
+
+    state.broadcast_unscoped_change();
+
+    let frame = rx.try_recv().unwrap();
+    assert!(frame.entity_type.is_none());
+    assert!(frame.entity_id.is_none());
+    assert!(frame.kind.is_none());
+    assert_eq!(frame.writer_instance_id, state.instance_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_card_broadcasts_created_kind() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, column_id) = seed_board_and_column(&state).await;
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/columns/{column_id}/cards"),
+        Some(&json!({"title": "Task 1"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_of(response).await;
+    let card_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Card));
+    assert_eq!(frame.entity_id, Some(card_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Created));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_card_broadcasts_deleted_kind() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, column_id) = seed_board_and_column(&state).await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/columns/{column_id}/cards"),
+        Some(&json!({"title": "Task 1"})),
+    )
+    .await;
+    let body = json_of(response).await;
+    let card_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+
+    let mut rx = state.event_tx.subscribe();
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/cards/{card_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Card));
+    assert_eq!(frame.entity_id, Some(card_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Deleted));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_card_create_or_replace_reports_created_or_updated_correctly() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, column_id) = seed_board_and_column(&state).await;
+    let id = Uuid::new_v4();
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/columns/{column_id}/cards/{id}"),
+        Some(&json!({"title": "Task 1"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Card));
+    assert_eq!(frame.entity_id, Some(id));
+    assert_eq!(frame.kind, Some(ChangeKind::Created));
+
+    let response = send(
+        &state,
+        "PUT",
+        &format!("/v1/columns/{column_id}/cards/{id}"),
+        Some(&json!({"title": "Task 1 renamed"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Card));
+    assert_eq!(frame.entity_id, Some(id));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_card_with_existing_body_id_broadcasts_updated_kind() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, column_id) = seed_board_and_column(&state).await;
+    let id = Uuid::new_v4();
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/columns/{column_id}/cards"),
+        Some(&json!({"id": id, "title": "Task 1"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_id, Some(id));
+    assert_eq!(frame.kind, Some(ChangeKind::Created));
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/columns/{column_id}/cards"),
+        Some(&json!({"id": id, "title": "Task 1 again"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_id, Some(id));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_routes_broadcast_their_own_entity_type() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/boards",
+        Some(&json!({"name": "Board", "card_prefix": "KAN"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_of(response).await;
+    let board_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Board));
+    assert_eq!(frame.entity_id, Some(board_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Created));
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns"),
+        Some(&json!({"name": "To Do"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_of(response).await;
+    let column_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Column));
+    assert_eq!(frame.entity_id, Some(column_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Created));
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints"),
+        Some(&json!({"name": "Sprint 1"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_of(response).await;
+    let sprint_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Sprint));
+    assert_eq!(frame.entity_id, Some(sprint_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Created));
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        Some(&json!({"name": "Sprint 1 renamed"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Sprint));
+    assert_eq!(frame.entity_id, Some(sprint_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns/{column_id}/reorder"),
+        Some(&json!({"position": 0})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Column));
+    assert_eq!(frame.entity_id, Some(column_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/columns/{column_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Column));
+    assert_eq!(frame.entity_id, Some(column_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Deleted));
+
+    let response = send(&state, "DELETE", &format!("/v1/boards/{board_id}"), None).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Board));
+    assert_eq!(frame.entity_id, Some(board_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Deleted));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_flat_routes_broadcast_their_own_entity_identity() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, column_id) = seed_board_and_column(&state).await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/columns/{column_id}/cards"),
+        Some(&json!({"title": "Task 1"})),
+    )
+    .await;
+    let body = json_of(response).await;
+    let card_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board2".to_string(), Some("KAN2".to_string()))
+            .unwrap()
+            .id
+    };
+    let sprint_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_sprint(board_id, None, None).unwrap().id
+    };
+
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/cards/{card_id}"),
+        Some(&json!({"title": "Renamed"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Card));
+    assert_eq!(frame.entity_id, Some(card_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/columns/{column_id}"),
+        Some(&json!({"name": "Renamed"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Column));
+    assert_eq!(frame.entity_id, Some(column_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/sprints/{sprint_id}"),
+        Some(&json!({"name": "Renamed"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Sprint));
+    assert_eq!(frame.entity_id, Some(sprint_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+
+    let response = send(&state, "DELETE", &format!("/v1/sprints/{sprint_id}"), None).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Sprint));
+    assert_eq!(frame.entity_id, Some(sprint_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Deleted));
+
+    let response = send(&state, "DELETE", &format!("/v1/columns/{column_id}"), None).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Column));
+    assert_eq!(frame.entity_id, Some(column_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Deleted));
+
+    let response = send(&state, "DELETE", &format!("/v1/cards/{card_id}"), None).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Card));
+    assert_eq!(frame.entity_id, Some(card_id));
+    assert_eq!(frame.kind, Some(ChangeKind::Deleted));
+}
+

--- a/crates/kanban-server/tests/events_sse.rs
+++ b/crates/kanban-server/tests/events_sse.rs
@@ -60,6 +60,37 @@ async fn test_sse_stream_emits_frame_on_mutation() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_sse_frame_carries_entity_identity_for_board_create() {
+    let server = TestServer::start().await;
+
+    let mut events_response = server
+        .client()
+        .get(format!("{}/v1/events", server.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    let board_response = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .json(&serde_json::json!({"name": "Test Board", "card_prefix": "TB"}))
+        .send()
+        .await
+        .unwrap();
+    let board_json: serde_json::Value = board_response.json().await.unwrap();
+    let board_id = board_json["id"].as_str().unwrap();
+
+    let frame = read_one_sse_frame(&mut events_response).await;
+
+    assert_eq!(frame["entity_type"], "board");
+    assert_eq!(frame["kind"], "created");
+    assert_eq!(frame["entity_id"].as_str().unwrap(), board_id);
+
+    drop(events_response);
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_sse_frame_carries_writer_instance_id() {
     let server = TestServer::start().await;
 

--- a/crates/kanban-server/tests/external_reload.rs
+++ b/crates/kanban-server/tests/external_reload.rs
@@ -57,6 +57,45 @@ async fn test_get_boards_reflects_board_created_by_external_writer() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_external_file_change_broadcasts_unscoped_frame() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("s.json");
+
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let state = AppState::new(ctx);
+    watch_for_external_changes(state.clone(), path.to_str().unwrap())
+        .await
+        .unwrap();
+
+    let mut rx = state.event_tx.subscribe();
+
+    {
+        let backend: Arc<dyn KanbanBackend> =
+            Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+        let mut external_ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        external_ctx
+            .create_board("External Board".to_string(), Some("EXT".to_string()))
+            .unwrap();
+        external_ctx.save().await.unwrap();
+    }
+
+    let frame = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        .await
+        .expect("timed out waiting for the external-change broadcast")
+        .unwrap();
+
+    assert!(frame.entity_type.is_none());
+    assert!(frame.entity_id.is_none());
+    assert!(frame.kind.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_watch_for_external_changes_is_noop_for_sqlite_locator() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("s.sqlite");


### PR DESCRIPTION
## Summary

`ChangeEventFrame` gains an optional entity identity: `entity_type` (`EntityType`), `entity_id` (`Uuid`), and `kind` (`ChangeKind`), each `#[serde(default)]` so pre-1240 JSON still deserializes. `AppState::broadcast_change`/`persist_and_broadcast` now require that identity, so every write route stamps the entity it touched with the correct `Created`/`Updated`/`Deleted` kind. The one caller that cannot know what changed, `watch.rs`'s external-file-change reload, gets a separate `broadcast_unscoped_change()` that emits all three fields as `None` rather than fabricating an identity.

- Added `EntityType { Board, Column, Card, Sprint }` and `ChangeKind { Created, Updated, Deleted }` to `crates/kanban-api/src/v1/events.rs`, both `#[non_exhaustive]`, `snake_case` on the wire, neither deriving `Default` (a missing identity is `None`, never a sentinel).
- `ChangeEventFrame::for_entity(...)` builds a frame with an explicit (possibly absent) identity; `new`/`now` still exist unchanged.
- The three new fields always serialize, including as `null` when absent, so an unscoped frame stays distinguishable on the wire from a legacy frame that predates the concept.
- Re-exported through `v1/mod.rs` and `lib.rs` so `kanban_service::api::{EntityType, ChangeKind}` resolves with no manifest change (`kanban-server` reaches `kanban-api` only through `kanban_service::api`).
- All 23 `persist_and_broadcast` call sites now pass an entity type, id and kind: boards 4, cards 6, columns 7, sprints 6 (recounted directly against `origin/develop`; the card that seeded this PR said 17 because it predates the sprint write routes landing). POST/PUT create-or-replace sites use `ChangeKind::created_or_updated(created)` rather than a hardcoded kind, since `handlers::{cards,columns,sprints}::create_*` can legitimately report `created=false` for an idempotent create with a client-supplied id.
- `watch.rs` now calls `broadcast_unscoped_change()` instead of the old argument-less `broadcast_change()`.
- Updated `crates/kanban-server/README.md` and `crates/kanban-api/README.md` to describe the identity fields and to correct a stale claim that nothing subscribes to the change-event channel (the SSE route has since landed).

## Test plan

- [x] `cargo test -p kanban-api`: new frame-identity unit tests (round trip, backward-compat deserialization, snake_case wire naming, null-not-omitted for unscoped frames) plus all existing tests, green.
- [x] `cargo test -p kanban-server --features test-helpers`: new `events_entity_identity.rs` integration suite (all 23 write routes, POST/PUT created-vs-updated including the idempotent-POST case, per-route entity-type walk for both nested and flat routers), plus extended `events_sse.rs` (identity survives onto the SSE wire) and `external_reload.rs` (external file change stays unscoped), plus all existing tests, green.
- [x] Mutation check: hardcoded `create_card_route` to always broadcast `ChangeKind::Created`; confirmed `test_post_card_with_existing_body_id_broadcasts_updated_kind` fails; reverted.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (workspace)
- [x] `cargo test --all-features --workspace`: 215 test-result blocks, 0 failures
- [x] `cargo check --package kanban-cli --no-default-features --features json,sqlite`
- [x] `./scripts/check-factory-compile-lock.sh`
- [x] Changeset added: `.changeset/kan-1240-change-event-entity-identity.md` (`bump: minor`, since the public `broadcast_change`/`persist_and_broadcast` signatures change, which is breaking pre-1.0)
