### PR TITLE
KAN-1318 feat(service): record and expose invalidation across execute, undo and redo

### DIFF
--- a/.changeset/kan-1318-undo-redo-invalidation.md
+++ b/.changeset/kan-1318-undo-redo-invalidation.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: undo and redo now derive and record which entities they invalidated, the same way a forward execution does, so a cache attached to the context cannot serve stale entities after an undo; the value is readable via ctx.last_invalidation() and is None until a batch has committed.

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -85,11 +85,18 @@ pub enum Invalidation {
     All,
 }
 
-/// Derive the [`Invalidation`] a captured inverse batch implies.
+/// Derive the [`Invalidation`] a batch of commands implies, whether the batch
+/// is a captured inverse or a forward batch about to be committed.
+/// [`crate::commands::Command::touched_entities`] reads only the command's
+/// own fields, so it applies to either direction.
 ///
-/// Folds [`crate::commands::Command::touched_entities`] over `inverse`,
-/// falling back to `All` the moment any command in the batch returns `None`,
-/// or when the batch (or its accumulated ids) is empty.
+/// Folds `touched_entities` over `inverse`, falling back to `All` the moment
+/// any command in the batch returns `None`, or when the batch (or its
+/// accumulated ids) is empty.
+///
+/// A forward batch and its own inverse are different commands and can imply
+/// different results: `CreateCard` names its card and board, while its
+/// inverse `DeleteCard` is unenumerable and yields `All`.
 pub fn invalidation_from_inverse(inverse: &[crate::commands::Command]) -> Invalidation {
     if inverse.is_empty() {
         return Invalidation::All;

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -37,6 +37,7 @@ pub struct KanbanContext {
     pub(super) conflict_pending: bool,
     pub(super) session_id: Uuid,
     pub(super) app_type: AppType,
+    pub(super) last_invalidation: Option<Invalidation>,
 }
 ```
 
@@ -111,6 +112,7 @@ ctx.can_redo() -> bool
 ctx.undo_depth() -> usize
 ctx.redo_depth() -> usize
 ctx.clear_history() -> KanbanResult<()>
+ctx.last_invalidation() -> Option<&Invalidation>
 ```
 
 Every undoable command captures an inverse at `execute` time; the
@@ -122,6 +124,10 @@ advances once the batch commits, so a failed undo/redo leaves the stack
 ready to retry the same entry. `execute` also appends the forward batch to
 the `CommandStore` audit log via `backend.append_batch` — informational
 only, it records what happened but does not drive undo.
+
+Every path that commits a batch (`execute`, `undo`, `redo`) records the
+`Invalidation` that batch implies; `last_invalidation()` returns `None`
+until a batch has committed on this context.
 
 ### Board Operations
 

--- a/crates/kanban-service/src/context/core.rs
+++ b/crates/kanban-service/src/context/core.rs
@@ -20,6 +20,7 @@ impl KanbanContext {
             conflict_pending: false,
             session_id: Uuid::new_v4(),
             app_type: AppType::Unknown,
+            last_invalidation: None,
         }
     }
 

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -2,8 +2,8 @@ use crate::backend::KanbanBackend;
 use kanban_core::{AppConfig, AppType};
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter,
-    CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, KanbanOperations,
-    KanbanResult, Sprint, SprintUpdate,
+    CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, Invalidation,
+    KanbanOperations, KanbanResult, Sprint, SprintUpdate,
 };
 use serde::Serialize;
 use std::sync::Arc;
@@ -67,6 +67,9 @@ pub struct KanbanContext {
     pub(super) session_id: Uuid,
     /// Which application surface owns this context. Default: Unknown.
     pub(super) app_type: AppType,
+    /// The invalidation implied by the most recent command batch that
+    /// committed, forward or inverse. `None` until one has.
+    pub(super) last_invalidation: Option<Invalidation>,
 }
 
 // The `KanbanOperations` trait impl must live in a single block (Rust forbids

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -1,7 +1,9 @@
 use super::KanbanContext;
 use kanban_core::{ClientId, KANBAN_VERSION};
 use kanban_domain::commands::{Command, CommandContext};
-use kanban_domain::{invalidation_from_inverse, DataStore, Invalidation, KanbanError, KanbanResult};
+use kanban_domain::{
+    invalidation_from_inverse, DataStore, Invalidation, KanbanError, KanbanResult,
+};
 use std::sync::Arc;
 use uuid::Uuid;
 

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -1,7 +1,7 @@
 use super::KanbanContext;
 use kanban_core::{ClientId, KANBAN_VERSION};
 use kanban_domain::commands::{Command, CommandContext};
-use kanban_domain::{DataStore, KanbanError, KanbanResult};
+use kanban_domain::{invalidation_from_inverse, DataStore, Invalidation, KanbanError, KanbanResult};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -70,7 +70,7 @@ impl KanbanContext {
             Ok(())
         }))?;
         let inverses: Vec<Command> = per_cmd_inverses.into_iter().rev().flatten().collect();
-        let _invalidation = kanban_domain::invalidation_from_inverse(&inverses);
+        self.record_invalidation(invalidation_from_inverse(&inverses));
 
         self.undo_stack.push(crate::undo_stack::UndoEntry {
             forward: commands,
@@ -89,6 +89,7 @@ impl KanbanContext {
             Some(entry) => entry.inverse.clone(),
             None => return Ok(false),
         };
+        let invalidation = invalidation_from_inverse(&inverse);
         let backend = Arc::clone(&self.backend);
         self.backend.with_transaction(Box::new(move || {
             let store: &dyn DataStore = backend.as_data_store();
@@ -96,6 +97,7 @@ impl KanbanContext {
             inverse.iter().try_for_each(|cmd| cmd.execute(&ctx))
         }))?;
         self.undo_stack.commit_undo();
+        self.record_invalidation(invalidation);
         self.dirty = true;
         Ok(true)
     }
@@ -108,6 +110,7 @@ impl KanbanContext {
             Some(entry) => entry.forward.clone(),
             None => return Ok(false),
         };
+        let invalidation = invalidation_from_inverse(&forward);
         let backend = Arc::clone(&self.backend);
         self.backend.with_transaction(Box::new(move || {
             let store: &dyn DataStore = backend.as_data_store();
@@ -115,6 +118,7 @@ impl KanbanContext {
             forward.iter().try_for_each(|cmd| cmd.execute(&ctx))
         }))?;
         self.undo_stack.commit_redo();
+        self.record_invalidation(invalidation);
         self.dirty = true;
         Ok(true)
     }
@@ -140,6 +144,18 @@ impl KanbanContext {
 
     pub fn redo_depth(&self) -> usize {
         self.undo_stack.redo_depth()
+    }
+
+    fn record_invalidation(&mut self, invalidation: Invalidation) {
+        self.last_invalidation = Some(invalidation);
+    }
+
+    /// The invalidation implied by the most recently committed command
+    /// batch, forward or inverse. `None` means nothing has committed on
+    /// this context yet; `Some(Invalidation::All)` means something
+    /// committed whose blast radius could not be enumerated.
+    pub fn last_invalidation(&self) -> Option<&Invalidation> {
+        self.last_invalidation.as_ref()
     }
 }
 

--- a/crates/kanban-service/tests/undo_invalidation.rs
+++ b/crates/kanban-service/tests/undo_invalidation.rs
@@ -1,0 +1,185 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::{CardUpdate, EntityIds, Invalidation, KanbanOperations, KanbanResult};
+use kanban_service::KanbanContext;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+async fn make_ctx() -> KanbanContext {
+    KanbanContext::open(
+        Arc::new(InMemoryStore::new()),
+        kanban_core::AppConfig::default(),
+    )
+    .await
+    .unwrap()
+}
+
+fn entities(ctx: &KanbanContext) -> &EntityIds {
+    match ctx
+        .last_invalidation()
+        .expect("expected a recorded invalidation, found None")
+    {
+        Invalidation::Entities(ids) => ids,
+        Invalidation::All => panic!("expected Entities, got All"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_fresh_context_has_no_recorded_invalidation() {
+    let ctx = make_ctx().await;
+    assert!(ctx.last_invalidation().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_forward_execution_records_the_derived_invalidation() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+
+    ctx.update_card(
+        card.id,
+        CardUpdate {
+            title: Some("Renamed".into()),
+            ..Default::default()
+        },
+    )?;
+
+    assert_eq!(entities(&ctx).cards, HashSet::from([card.id]));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undo_records_the_invalidation_of_the_entry_it_reverses() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+    let card_b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
+
+    ctx.update_card(
+        card_a.id,
+        CardUpdate {
+            title: Some("A2".into()),
+            ..Default::default()
+        },
+    )?;
+    ctx.update_card(
+        card_b.id,
+        CardUpdate {
+            title: Some("B2".into()),
+            ..Default::default()
+        },
+    )?;
+
+    assert!(ctx.undo()?);
+    assert_eq!(entities(&ctx).cards, HashSet::from([card_b.id]));
+
+    assert!(ctx.undo()?);
+    let ids = entities(&ctx);
+    assert_eq!(ids.cards, HashSet::from([card_a.id]));
+    assert!(!ids.cards.contains(&card_b.id));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_redo_records_the_invalidation_of_the_forward_batch() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+
+    assert_eq!(
+        ctx.last_invalidation(),
+        Some(&Invalidation::All),
+        "create's inverse is DeleteCard, which is unenumerable"
+    );
+
+    assert!(ctx.undo()?);
+    assert!(ctx.redo()?);
+
+    let ids = entities(&ctx);
+    assert_eq!(ids.cards, HashSet::from([card.id]));
+    assert_eq!(ids.boards, HashSet::from([board.id]));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undo_of_a_batch_whose_inverse_is_unenumerable_records_all() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+    let _card_c = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
+
+    ctx.update_card(
+        card_a.id,
+        CardUpdate {
+            title: Some("A2".into()),
+            ..Default::default()
+        },
+    )?;
+    assert_eq!(entities(&ctx).cards, HashSet::from([card_a.id]));
+
+    assert!(ctx.undo()?);
+    assert_eq!(entities(&ctx).cards, HashSet::from([card_a.id]));
+
+    assert!(ctx.undo()?);
+    assert_eq!(ctx.last_invalidation(), Some(&Invalidation::All));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_failed_undo_leaves_the_previously_recorded_invalidation_intact() -> KanbanResult<()>
+{
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+    let card_b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
+
+    ctx.update_card(
+        card_a.id,
+        CardUpdate {
+            title: Some("A2".into()),
+            ..Default::default()
+        },
+    )?;
+    ctx.update_card(
+        card_b.id,
+        CardUpdate {
+            title: Some("B2".into()),
+            ..Default::default()
+        },
+    )?;
+
+    assert!(ctx.undo()?);
+    assert_eq!(entities(&ctx).cards, HashSet::from([card_b.id]));
+
+    ctx.data_store().delete_card(card_a.id)?;
+
+    assert!(ctx.undo().is_err());
+    let ids = entities(&ctx);
+    assert_eq!(ids.cards, HashSet::from([card_b.id]));
+    assert!(!ids.cards.contains(&card_a.id));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undo_with_an_empty_stack_records_nothing() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    assert!(!ctx.undo()?);
+    assert!(ctx.last_invalidation().is_none());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_redo_with_an_empty_stack_records_nothing() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    assert!(!ctx.redo()?);
+    assert!(ctx.last_invalidation().is_none());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Give `KanbanContext` a single private sink, `last_invalidation: Option<Invalidation>`, that records the `Invalidation` derived from every command batch that actually commits.
- Wire all three commit paths through it: `execute_with` (previously discarded the derived value into `let _invalidation = ...`), `undo()` and `redo()` (previously bypassed derivation entirely).
- Expose the recorded value read-only via `ctx.last_invalidation() -> Option<&Invalidation>`. `None` means nothing has committed on this context yet; `Some(Invalidation::All)` means something committed whose blast radius could not be enumerated. The two states stay distinguishable so a cache attached to the context (KAN-1302) has exactly one seam to hook.

## Changes

- `crates/kanban-service/src/context/mod.rs`: add the `last_invalidation` field to `KanbanContext`.
- `crates/kanban-service/src/context/core.rs`: initialize it to `None` in `open_deferred` (the only constructor).
- `crates/kanban-service/src/context/undo.rs`: replace the discarded `_invalidation` binding in `execute_with`; derive and record in `undo()` and `redo()` before/after the transaction respectively; add `record_invalidation` (private) and `last_invalidation` (public accessor).
- `crates/kanban-domain/src/invalidation.rs`: doc-comment only. Clarifies that `invalidation_from_inverse` applies to a forward batch as well as a captured inverse (it reads only each command's own fields, no store, no direction parameter), and explicitly notes forward and inverse of the same mutation can imply different results.
- `crates/kanban-service/README.md`: mirror the new field and accessor.
- `.changeset/kan-1318-undo-redo-invalidation.md`: new, `bump: minor`.
- `crates/kanban-service/tests/undo_invalidation.rs`: new integration test file (8 tests) over `InMemoryStore`.

## Why the tests live in a new integration test file, not inline in `undo.rs`

The existing inline `#[cfg(test)] mod tests` in `undo.rs` runs against `MockBackend`, whose `remote_writes()` returns `Some`. `execute_with` bails with `unsupported` before opening a transaction whenever that's the case, so no command can ever commit and no invalidation can ever be observed there. `kanban-backend-memory` is a `[dev-dependencies]` entry of `kanban-service`, so it's reachable from an integration test in `tests/` (matching the precedent set by `tests/invalidation_from_inverse.rs`) without adding a production dependency purely for testing.

## Why `undo`/`redo` are not routed through `execute_with`

`execute_with` does three things beyond running commands: it captures fresh inverses via `capture_inverse`, pushes a new `UndoEntry` onto the undo stack, and appends a new `CommandBatch` to the append-only audit log. Routing undo/redo through it would corrupt the undo stack (pushing an entry for what is itself an undo/redo) and double-log the audit trail. Undo/redo already execute a *previously captured* batch and must do none of those three things; they only need to derive the `Invalidation` from the batch they are about to run and record it once the transaction commits.

## No extra store read

`invalidation_from_inverse(&[Command]) -> Invalidation` takes no store; it folds `Command::touched_entities()`, which is direction-agnostic and reads only each command's own fields. In `undo()`/`redo()` the derivation happens against the batch already held in a local variable (`inverse`/`forward`), before that batch is moved into the `with_transaction` closure, so no clone and no additional store access is introduced.

## Red proof

The tests-only commit does not compile, by design:

```
error[E0599]: no method named `last_invalidation` found for reference `&KanbanContext` in the current scope
error[E0599]: no method named `last_invalidation` found for struct `KanbanContext` in the current scope
   (x6, one per call site in crates/kanban-service/tests/undo_invalidation.rs)
error: could not compile `kanban-service` (test "undo_invalidation") due to 7 previous errors
```

## Mutation check

Temporarily removed the `record_invalidation` call from `undo()` (kept the derived value in a `let _ = invalidation;` binding to isolate the change): `test_undo_records_the_invalidation_of_the_entry_it_reverses` and `test_undo_of_a_batch_whose_inverse_is_unenumerable_records_all` failed, both on the second undo in their sequence (the first undo passes vacuously because the forward pass already recorded the same value for the entry being reversed). Reverted before committing.

## Out of scope

`replace_backend()` and `reload()` swap or re-read the entire dataset and clear the undo stack, but do not touch `last_invalidation`. A cache attached at this seam by KAN-1302 would see a stale value across either call. That belongs to KAN-1302 / the KAN-1223 split; not addressed here.

## Verification

All run from the worktree with `CARGO_TARGET_DIR=/home/max/wt/kanban/.shared-target`:

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features --workspace`: 215 test suites, 0 failed
- `cargo check --package kanban-cli --no-default-features --features json,sqlite`: clean

No crate added or removed; no backend/store-factory change, so `check-crate-list-sync.sh` / `check-factory-compile-lock.sh` are not applicable.
