### PR TITLE
KAN-1337 fix(tui): track the active sprint by id instead of by position

### DIFF
--- a/.changeset/kan-1337.md
+++ b/.changeset/kan-1337.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: track the sprint whose detail view is open by id instead of by its position in the global sprint list. Sprints are ordered across every board, so a sprint deleted anywhere (another TUI session, the CLI, kanban-mcp) while a detail view was open could shift that position onto a different sprint, and activating or completing "the current sprint" would silently act on the wrong one. The selection now resolves by identity, so a deletion elsewhere either leaves the open sprint untouched or, if it was the one deleted, leaves the selection unresolvable rather than pointing at a neighbour.

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -501,7 +501,7 @@ mod tests {
 
     #[test]
     fn test_execute_action_carry_over_opens_dialog_for_eligible_sprint() {
-        use kanban_domain::{KanbanOperations, SprintStatus};
+        use kanban_domain::KanbanOperations;
         let mut app = App::test_default();
         let board = app.ctx.create_board("Board".into(), None).unwrap();
         // A Planning sprint must exist for carry-over to have a target.
@@ -516,13 +516,7 @@ mod tests {
         app.ctx.complete_sprint(completed.id).unwrap();
         app.reload_model();
         app.prepare_frame();
-        let sprint_idx = app
-            .model
-            .sprints()
-            .iter()
-            .position(|s| s.id == completed.id && s.status == SprintStatus::Completed)
-            .expect("completed sprint present");
-        app.selection.active_sprint_index = Some(sprint_idx);
+        app.selection.active_sprint_id = Some(completed.id);
         app.mode = AppMode::SprintDetail;
 
         app.execute_action(&KeybindingAction::CarryOver);

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -13,7 +13,12 @@ pub struct SelectionHub {
     pub active_card_id: Option<uuid::Uuid>,
     pub sprint: SelectionState,
     pub sprint_scroll: Cell<usize>,
-    pub active_sprint_index: Option<usize>,
+    /// The sprint whose detail view is open, tracked by IDENTITY: it resolves
+    /// through `Model::sprints().iter().find(...)` rather than indexing, since
+    /// a position into that collection is only meaningful against the exact
+    /// collection instance it came from — the list is ordered across every
+    /// board, so deleting any sprint ahead of this one shifts its slot.
+    pub active_sprint_id: Option<uuid::Uuid>,
     pub card_navigation_history: Vec<uuid::Uuid>,
     pub settings_config: SelectionState,
     pub settings_config_file: SelectionState,

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2224,4 +2224,44 @@ mod tests {
             "renaming while filtered must resolve the filtered list's index, not the unfiltered board order"
         );
     }
+
+    #[test]
+    fn test_sprint_detail_opens_the_sprint_the_user_selected_in_the_panel() {
+        let mut app = App::test_default();
+        let beta = app.ctx.create_board("Beta".into(), None).unwrap();
+        app.ctx
+            .create_column(beta.id, "Todo".into(), Some(0))
+            .unwrap();
+        app.ctx
+            .create_sprint(beta.id, None, Some("B1".into()))
+            .unwrap();
+        app.ctx
+            .create_sprint(beta.id, None, Some("B2".into()))
+            .unwrap();
+
+        let alpha = app.ctx.create_board("Alpha".into(), None).unwrap();
+        app.ctx
+            .create_column(alpha.id, "Todo".into(), Some(0))
+            .unwrap();
+        app.ctx
+            .create_sprint(alpha.id, None, Some("A1".into()))
+            .unwrap();
+        let a2 = app
+            .ctx
+            .create_sprint(alpha.id, None, Some("A2".into()))
+            .unwrap();
+
+        app.selection.active_board_id = Some(alpha.id);
+        app.reload_model();
+        app.prepare_frame();
+        app.push_mode(AppMode::BoardDetail);
+        app.focus.board_focus = BoardFocus::Sprints;
+        app.selection.sprint.set(Some(1));
+
+        app.handle_board_detail_navigation_key(KeyCode::Enter);
+
+        assert_eq!(app.selection.active_sprint_id, Some(a2.id));
+        assert_eq!(app.selection.active_board_id, Some(alpha.id));
+        assert_eq!(app.mode, AppMode::SprintDetail);
+    }
 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -593,20 +593,17 @@ impl App {
                     if let Some(sprint_idx) = self.selection.sprint.get() {
                         let board_ctx = self.board_in_context().map(|b| b.id);
                         if let Some(board_id) = board_ctx {
-                            let sprints = self.model.sprints();
-                            let board_sprints: Vec<_> = sprints
+                            let sprint_id = self
+                                .model
+                                .sprints()
                                 .iter()
-                                .enumerate()
-                                .filter(|(_, s)| s.board_id == board_id)
-                                .collect();
-                            if let Some((actual_idx, _)) = board_sprints.get(sprint_idx) {
-                                let actual_idx = *actual_idx;
-                                let sprint_id = sprints.get(actual_idx).map(|s| s.id);
-                                self.selection.active_sprint_index = Some(actual_idx);
+                                .filter(|s| s.board_id == board_id)
+                                .nth(sprint_idx)
+                                .map(|s| s.id);
+                            if let Some(sprint_id) = sprint_id {
+                                self.selection.active_sprint_id = Some(sprint_id);
                                 self.selection.active_board_id = Some(board_id);
-                                if let Some(sprint_id) = sprint_id {
-                                    self.populate_sprint_task_lists(sprint_id);
-                                }
+                                self.populate_sprint_task_lists(sprint_id);
                                 self.push_mode(AppMode::SprintDetail);
                             }
                         }
@@ -631,8 +628,8 @@ impl App {
     /// (Completed or Cancelled); no-op otherwise, matching the direct `M`
     /// keypress's existing guard exactly.
     pub(crate) fn carry_over_active_sprint_if_eligible(&mut self) {
-        if let Some(sprint_idx) = self.selection.active_sprint_index {
-            if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+        if let Some(sprint_id) = self.selection.active_sprint_id {
+            if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
                 use kanban_domain::SprintStatus;
                 if sprint.status == SprintStatus::Completed
                     || sprint.status == SprintStatus::Cancelled
@@ -767,7 +764,7 @@ impl App {
             KeyCode::Esc => {
                 self.pop_mode();
                 self.focus.board_focus = BoardFocus::Sprints;
-                self.selection.active_sprint_index = None;
+                self.selection.active_sprint_id = None;
             }
             KeyCode::Char('a') => {
                 self.handle_activate_sprint_key();
@@ -816,8 +813,8 @@ impl App {
                 }
             }
             KeyCode::Char('p') => {
-                if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+                if let Some(sprint_id) = self.selection.active_sprint_id {
+                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
                         let current_prefix = sprint.prefix.clone().unwrap_or_else(String::new);
                         self.input.set(current_prefix);
                         self.open_dialog(DialogMode::SetSprintPrefix);
@@ -825,8 +822,8 @@ impl App {
                 }
             }
             KeyCode::Char('C') => {
-                if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+                if let Some(sprint_id) = self.selection.active_sprint_id {
+                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
                         let current_prefix = sprint.card_prefix.clone().unwrap_or_else(String::new);
                         self.input.set(current_prefix);
                         self.open_dialog(DialogMode::SetSprintCardPrefix);
@@ -853,8 +850,8 @@ impl App {
                 self.carry_over_active_sprint_if_eligible();
             }
             KeyCode::Char('h') | KeyCode::Left => {
-                if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+                if let Some(sprint_id) = self.selection.active_sprint_id {
+                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
                         if sprint.status == kanban_domain::SprintStatus::Completed {
                             self.sprint_view.panel = SprintTaskPanel::Uncompleted;
                         }
@@ -862,8 +859,8 @@ impl App {
                 }
             }
             KeyCode::Char('l') | KeyCode::Right => {
-                if let Some(sprint_idx) = self.selection.active_sprint_index {
-                    if let Some(sprint) = self.model.sprints().get(sprint_idx) {
+                if let Some(sprint_id) = self.selection.active_sprint_id {
+                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
                         if sprint.status == kanban_domain::SprintStatus::Completed {
                             self.sprint_view.panel = SprintTaskPanel::Completed;
                         }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -272,10 +272,8 @@ impl App {
                             }
                         }
                         PrefixDialogContext::Sprint => {
-                            if let Some(sprint_idx) = self.selection.active_sprint_index {
-                                if let Some(sprint_id) =
-                                    self.model.sprints().get(sprint_idx).map(|s| s.id)
-                                {
+                            if let Some(sprint_id) = self.selection.active_sprint_id {
+                                if self.model.sprints().iter().any(|s| s.id == sprint_id) {
                                     let cmd = kanban_domain::commands::Command::Sprint(
                                         kanban_domain::commands::SprintCommand::Update(
                                             kanban_domain::commands::UpdateSprint {
@@ -301,10 +299,8 @@ impl App {
                             }
                         }
                         PrefixDialogContext::SprintCard => {
-                            if let Some(sprint_idx) = self.selection.active_sprint_index {
-                                if let Some(sprint_id) =
-                                    self.model.sprints().get(sprint_idx).map(|s| s.id)
-                                {
+                            if let Some(sprint_id) = self.selection.active_sprint_id {
+                                if self.model.sprints().iter().any(|s| s.id == sprint_id) {
                                     let cmd = kanban_domain::commands::Command::Sprint(
                                         kanban_domain::commands::SprintCommand::Update(
                                             kanban_domain::commands::UpdateSprint {
@@ -365,10 +361,8 @@ impl App {
                             }
                         }
                         PrefixDialogContext::Sprint => {
-                            if let Some(sprint_idx) = self.selection.active_sprint_index {
-                                if let Some(sprint_id) =
-                                    self.model.sprints().get(sprint_idx).map(|s| s.id)
-                                {
+                            if let Some(sprint_id) = self.selection.active_sprint_id {
+                                if self.model.sprints().iter().any(|s| s.id == sprint_id) {
                                     let cmd = kanban_domain::commands::Command::Sprint(
                                         kanban_domain::commands::SprintCommand::Update(
                                             kanban_domain::commands::UpdateSprint {
@@ -394,10 +388,8 @@ impl App {
                             }
                         }
                         PrefixDialogContext::SprintCard => {
-                            if let Some(sprint_idx) = self.selection.active_sprint_index {
-                                if let Some(sprint_id) =
-                                    self.model.sprints().get(sprint_idx).map(|s| s.id)
-                                {
+                            if let Some(sprint_id) = self.selection.active_sprint_id {
+                                if self.model.sprints().iter().any(|s| s.id == sprint_id) {
                                     let cmd = kanban_domain::commands::Command::Sprint(
                                         kanban_domain::commands::SprintCommand::Update(
                                             kanban_domain::commands::UpdateSprint {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -271,7 +271,7 @@ impl App {
                         self.reload_model();
                     }
 
-                    let is_sprint_detail = self.selection.active_sprint_index.is_some();
+                    let is_sprint_detail = self.selection.active_sprint_id.is_some();
                     self.pop_mode();
                     self.filter.sort_field_selection.clear();
 

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -14,13 +14,14 @@ impl App {
     }
 
     pub fn handle_activate_sprint_key(&mut self) {
-        if let Some(sprint_idx) = self.selection.active_sprint_index {
+        if let Some(sprint_id) = self.selection.active_sprint_id {
             // Collect sprint info before mutations
             let sprint_info = {
                 let context_board = self.board_in_context();
-                if let (Some(sprint), Some(board)) =
-                    (self.model.sprints().get(sprint_idx), context_board)
-                {
+                if let (Some(sprint), Some(board)) = (
+                    self.model.sprints().iter().find(|s| s.id == sprint_id),
+                    context_board,
+                ) {
                     if sprint.status == SprintStatus::Planning {
                         Some((sprint.id, sprint.formatted_name(board, None)))
                     } else {
@@ -67,13 +68,14 @@ impl App {
     }
 
     pub fn handle_complete_sprint_key(&mut self) {
-        if let Some(sprint_idx) = self.selection.active_sprint_index {
+        if let Some(sprint_id) = self.selection.active_sprint_id {
             // Collect sprint and board info before mutations
             let sprint_info = {
                 let context_board = self.board_in_context();
-                if let (Some(sprint), Some(board)) =
-                    (self.model.sprints().get(sprint_idx), context_board)
-                {
+                if let (Some(sprint), Some(board)) = (
+                    self.model.sprints().iter().find(|s| s.id == sprint_id),
+                    context_board,
+                ) {
                     if sprint.status == SprintStatus::Active
                         || sprint.status == SprintStatus::Planning
                     {
@@ -112,7 +114,7 @@ impl App {
 
                 self.pop_mode();
                 self.focus.board_focus = BoardFocus::Sprints;
-                self.selection.active_sprint_index = None;
+                self.selection.active_sprint_id = None;
 
                 {
                     use kanban_domain::query::sprint::get_sprint_uncompleted_cards;

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -12,11 +12,12 @@ use ratatui::{
 };
 
 pub(super) fn render_sprint_detail_view(app: &mut App, frame: &mut Frame, area: Rect) {
-    let sprint_idx = match app.selection.active_sprint_index {
-        Some(i) => i,
-        None => return,
-    };
-    let sprint = match app.model.sprints().get(sprint_idx).cloned() {
+    let sprint = match app
+        .selection
+        .active_sprint_id
+        .and_then(|id| app.model.sprints().iter().find(|s| s.id == id))
+        .cloned()
+    {
         Some(s) => s,
         None => return,
     };

--- a/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_count_leak_tests.rs
@@ -63,7 +63,7 @@ fn test_sprint_detail_card_count_excludes_archived_cards() {
     app.ctx.archive_card(archived.id).unwrap();
 
     activate_board(&mut app, board.id);
-    app.selection.active_sprint_index = Some(0);
+    app.selection.active_sprint_id = Some(sprint.id);
     app.push_mode(AppMode::SprintDetail);
     app.reload_model();
     app.prepare_frame();
@@ -278,13 +278,7 @@ fn test_carry_over_auto_open_gate_excludes_archived_cards() {
     app.ctx.archive_card(archived.id).unwrap();
 
     activate_board(&mut app, board.id);
-    app.selection.active_sprint_index = Some(
-        app.model
-            .sprints()
-            .iter()
-            .position(|s| s.id == sprint.id)
-            .unwrap(),
-    );
+    app.selection.active_sprint_id = Some(sprint.id);
 
     app.handle_complete_sprint_key();
     app.reload_model();

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -278,7 +278,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.prepare_frame();
 
     // Navigate to sprint detail and complete it
-    app.selection.active_sprint_index = Some(0);
+    app.selection.active_sprint_id = Some(sprint_id);
     app.handle_complete_sprint_key();
     app.prepare_frame();
 
@@ -324,7 +324,7 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     let sprint1_id = app.model.sprints()[0].id;
 
     // Activate sprint 1 so it can be completed
-    app.selection.active_sprint_index = Some(0);
+    app.selection.active_sprint_id = Some(sprint1_id);
     app.handle_activate_sprint_key();
     app.prepare_frame();
 
@@ -346,7 +346,7 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     app.prepare_frame();
 
     // Complete sprint 1 — sprint 2 is still Planning
-    app.selection.active_sprint_index = Some(0);
+    app.selection.active_sprint_id = Some(sprint1_id);
     app.handle_complete_sprint_key();
     app.prepare_frame();
 
@@ -727,4 +727,173 @@ fn test_move_card_right_syncs_column_list_count_to_filtered_columns_not_raw_boar
         "column_list's item count after a card move must match visible_board_columns \
          (filtered to 1 by the active column search), not the raw 3-column board count"
     );
+}
+
+fn seed_two_boards_with_sprints(
+    app: &mut App,
+    alpha_sprints: usize,
+    beta_sprints: usize,
+) -> (uuid::Uuid, Vec<uuid::Uuid>, uuid::Uuid, Vec<uuid::Uuid>) {
+    let beta = app.ctx.create_board("Beta".to_string(), None).unwrap();
+    app.ctx
+        .create_column(beta.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let beta_sprint_ids: Vec<uuid::Uuid> = (0..beta_sprints)
+        .map(|i| {
+            app.ctx
+                .create_sprint(beta.id, None, Some(format!("B{}", i + 1)))
+                .unwrap()
+                .id
+        })
+        .collect();
+
+    let alpha = app.ctx.create_board("Alpha".to_string(), None).unwrap();
+    app.ctx
+        .create_column(alpha.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let alpha_sprint_ids: Vec<uuid::Uuid> = (0..alpha_sprints)
+        .map(|i| {
+            app.ctx
+                .create_sprint(alpha.id, None, Some(format!("A{}", i + 1)))
+                .unwrap()
+                .id
+        })
+        .collect();
+
+    app.reload_model();
+    app.prepare_frame();
+    app.selection.active_board_id = Some(alpha.id);
+
+    (alpha.id, alpha_sprint_ids, beta.id, beta_sprint_ids)
+}
+
+#[test]
+fn test_active_sprint_survives_deletion_of_an_earlier_sprint() {
+    use kanban_domain::SprintStatus;
+
+    let mut app = App::test_default();
+    let (alpha_id, alpha_sprints, _beta_id, beta_sprints) =
+        seed_two_boards_with_sprints(&mut app, 4, 1);
+    let a3_id = alpha_sprints[2];
+    let a4_id = alpha_sprints[3];
+    let b1_id = beta_sprints[0];
+
+    app.selection.active_sprint_id = Some(a3_id);
+    app.push_mode(AppMode::SprintDetail);
+
+    app.ctx.delete_sprint(b1_id).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.handle_activate_sprint_key();
+
+    assert_eq!(
+        app.ctx.get_sprint(a3_id).unwrap().unwrap().status,
+        SprintStatus::Active,
+        "the sprint the user was looking at must be the one activated"
+    );
+    assert_eq!(
+        app.ctx.get_sprint(a4_id).unwrap().unwrap().status,
+        SprintStatus::Planning,
+        "the neighbour must not have been touched"
+    );
+    assert_eq!(
+        app.model
+            .board_by_id(alpha_id)
+            .unwrap()
+            .active_sprint_id,
+        Some(a3_id)
+    );
+}
+
+#[test]
+fn test_active_sprint_that_was_deleted_resolves_to_none_not_another_sprint() {
+    use kanban_domain::SprintStatus;
+    use kanban_tui::app::mode::DialogMode;
+
+    let mut app = App::test_default();
+    let (_alpha_id, alpha_sprints, _beta_id, beta_sprints) =
+        seed_two_boards_with_sprints(&mut app, 5, 1);
+    let a1_id = alpha_sprints[0];
+    let a2_id = alpha_sprints[1];
+    let a3_id = alpha_sprints[2];
+    let a4_id = alpha_sprints[3];
+    let a5_id = alpha_sprints[4];
+    let b1_id = beta_sprints[0];
+
+    app.selection.active_sprint_id = Some(a3_id);
+    app.push_mode(AppMode::SprintDetail);
+
+    app.ctx.delete_sprint(a3_id).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.handle_activate_sprint_key();
+    app.handle_sprint_detail_key(crossterm::event::KeyCode::Char('p'));
+
+    assert!(app.ctx.get_sprint(a3_id).unwrap().is_none());
+    for (label, id) in [
+        ("a1", a1_id),
+        ("a2", a2_id),
+        ("a4", a4_id),
+        ("a5", a5_id),
+        ("b1", b1_id),
+    ] {
+        assert_eq!(
+            app.ctx.get_sprint(id).unwrap().unwrap().status,
+            SprintStatus::Planning,
+            "{label} must still be Planning; it must not have absorbed the stale selection"
+        );
+    }
+    assert_eq!(
+        app.mode,
+        AppMode::SprintDetail,
+        "'p' on an unresolvable selection must not open the prefix dialog"
+    );
+    assert_ne!(
+        app.mode,
+        AppMode::Dialog(DialogMode::SetSprintPrefix),
+        "'p' on an unresolvable selection must not open the prefix dialog"
+    );
+    assert_eq!(
+        app.selection.active_sprint_id,
+        Some(a3_id),
+        "the id is retained even though it no longer resolves"
+    );
+}
+
+#[test]
+fn test_active_sprint_id_is_none_after_leaving_the_detail_view() {
+    use kanban_domain::SprintStatus;
+
+    let mut app = App::test_default();
+    let (_alpha_id, alpha_sprints, _beta_id, _beta_sprints) =
+        seed_two_boards_with_sprints(&mut app, 4, 1);
+    let a3_id = alpha_sprints[2];
+
+    app.selection.active_sprint_id = Some(a3_id);
+    app.push_mode(AppMode::SprintDetail);
+
+    app.handle_sprint_detail_key(crossterm::event::KeyCode::Esc);
+
+    assert!(app.selection.active_sprint_id.is_none());
+    assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
+
+    let mut app = App::test_default();
+    let (_alpha_id, alpha_sprints, _beta_id, _beta_sprints) =
+        seed_two_boards_with_sprints(&mut app, 4, 1);
+    let a3_id = alpha_sprints[2];
+
+    app.selection.active_sprint_id = Some(a3_id);
+    app.push_mode(AppMode::SprintDetail);
+
+    app.handle_complete_sprint_key();
+
+    assert_eq!(
+        app.ctx.get_sprint(a3_id).unwrap().unwrap().status,
+        SprintStatus::Completed,
+        "the handler must have resolved and acted on the right sprint"
+    );
+    assert!(app.selection.active_sprint_id.is_none());
+    assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
 }

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -798,10 +798,7 @@ fn test_active_sprint_survives_deletion_of_an_earlier_sprint() {
         "the neighbour must not have been touched"
     );
     assert_eq!(
-        app.model
-            .board_by_id(alpha_id)
-            .unwrap()
-            .active_sprint_id,
+        app.model.board_by_id(alpha_id).unwrap().active_sprint_id,
         Some(a3_id)
     );
 }


### PR DESCRIPTION
## Summary

`SelectionHub::active_sprint_index: Option<usize>` tracked the open sprint
detail view by position into `Model::sprints()`, a collection ordered by
per-board `sprint_number` across every board. Any sprint deletion (from this
TUI, another TUI session, the CLI, or kanban-mcp) shifted that position, so a
held index could silently resolve to a different sprint after a reload.

This replaces the field with `active_sprint_id: Option<Uuid>`, matching how
`active_board_id` and `active_card_id` already track identity, and converts
every read/write site to resolve by id instead of index.

## Reproduction

Before implementing, I confirmed the bug window is real by running the two
deletion-scenario tests in their old (index-based) form against the
untouched code:

```
REPRO a3_status=Planning a4_status=Active
REPRO2 a4_status=Active mode=Dialog(SetSprintPrefix)

thread 'test_active_sprint_survives_deletion_of_an_earlier_sprint_REPRO' panicked:
assertion `left == right` failed: a3 should be Active
  left: Planning
 right: Active

thread 'test_active_sprint_that_was_deleted_resolves_to_none_not_another_sprint_REPRO' panicked:
assertion `left == right` failed: a4 should remain Planning, not be activated
  left: Active
 right: Planning
```

With a user viewing sprint A3's detail (sprint_number 3 on board Alpha),
deleting an unrelated sprint on a different board (B1, sprint_number 1) and
reloading caused the held index to resolve to A4 instead: pressing "activate"
activated the wrong sprint (A4 went Active, A3 stayed Planning), and pressing
"set prefix" opened the prefix dialog for A4. This confirms the bug rather
than merely arguing it; the fix below removes the window.

## Changes

- `SelectionHub::active_sprint_index: Option<usize>` -> `active_sprint_id:
  Option<Uuid>`, doc comment states the identity contract.
- The writer (`detail_view_handlers.rs`, Enter/Space on the Sprints panel)
  stores the id it already computes instead of converting a panel index to a
  global index; kept the `.filter(|s| s.board_id == board_id)` board scope,
  dropped only the `.enumerate()`/global-index bookkeeping that identity no
  longer needs.
- All 13 read sites resolve via `.iter().find(|s| s.id == sprint_id)`; the 4
  prefix-dialog sites keep an explicit existence guard
  (`.iter().any(...)`) so a stale selection still no-ops exactly as before.
- Both clear-on-exit sites (Esc from sprint detail, after completing a
  sprint) updated.
- 6 test-side writers converted to set an id, including an inline test in
  `keybindings.rs` not mentioned in the original card.

## Tests

Four new tests, three in `stale_model_regression_tests.rs` and one inline in
`detail_view_handlers.rs` (the writer lives behind a private function only
reachable from that file's existing test module). Every one seeds two boards
with interleaved sprint numbers, since a single-board fixture cannot
distinguish "correct by id" from "correct by accident" (the panel index and
the global index coincide with one board).

- `test_active_sprint_survives_deletion_of_an_earlier_sprint`
- `test_active_sprint_that_was_deleted_resolves_to_none_not_another_sprint`
- `test_sprint_detail_opens_the_sprint_the_user_selected_in_the_panel`
- `test_active_sprint_id_is_none_after_leaving_the_detail_view`

Mutation-checked the central assertion by reverting the writer to an
index-based lookup: the new tests failed as expected, then the fix was
restored.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`
- `cargo check --package kanban-cli --no-default-features --features json,sqlite`

All four green. Changeset added (`patch`, since this fixes a real bug it is
described as a fix in the changeset text rather than a pure refactor note).
