### PR TITLE
KAN-1320 feat(service): entity cache with single-round resolve and six-dimension invalidation

### DIFF
--- a/.changeset/kan-1320.md
+++ b/.changeset/kan-1320.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 service: add EntityCache, a per-entity-kind cache that resolves a FetchPlan against a DataStore in a single round and maps each backend read to a Loaded, Missing, or Failed state without letting one failed entity starve the rest of the round. Invalidation understands all six dimensions a command batch can touch (boards, columns, cards, sprints, the dependency graph, and prefixes) and always drops the matching whole-collection view alongside the named ids, so a stale collection can never keep serving a row that was just invalidated by id. This is an internal building block; nothing outside kanban-service is wired to it yet.

--- a/.changeset/kan-1320.md
+++ b/.changeset/kan-1320.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: add EntityCache, a per-entity-kind cache that resolves a FetchPlan against a DataStore in a single round and maps each backend read to a Loaded, Missing, or Failed state without letting one failed entity starve the rest of the round. Invalidation understands all six dimensions a command batch can touch (boards, columns, cards, sprints, the dependency graph, and prefixes) and always drops the matching whole-collection view alongside the named ids, so a stale collection can never keep serving a row that was just invalidated by id. This is an internal building block; nothing outside kanban-service is wired to it yet.

--- a/crates/kanban-service/src/cache/mod.rs
+++ b/crates/kanban-service/src/cache/mod.rs
@@ -1,0 +1,68 @@
+use kanban_domain::resolved::Collection;
+use kanban_domain::{
+    Board, Card, Column, DataStore, DependencyGraph, FetchPlan, Invalidation, KanbanResult,
+    LoadState, Resolved, Sprint,
+};
+use uuid::Uuid;
+
+#[derive(Debug, Default)]
+pub struct EntityCache {
+    boards: Collection<Board>,
+    columns: Collection<Column>,
+    cards: Collection<Card>,
+    sprints: Collection<Sprint>,
+    graph: LoadState<DependencyGraph>,
+}
+
+impl EntityCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn invalidate(&mut self, _invalidation: Invalidation) {
+        todo!()
+    }
+
+    pub fn resolve(
+        &mut self,
+        _plan: &dyn FetchPlan,
+        _store: &dyn DataStore,
+    ) -> KanbanResult<Resolved> {
+        todo!()
+    }
+
+    pub fn board_list(&self) -> LoadState<&Vec<Board>> {
+        todo!()
+    }
+
+    pub fn column_list(&self) -> LoadState<&Vec<Column>> {
+        todo!()
+    }
+
+    pub fn card_list(&self) -> LoadState<&Vec<Card>> {
+        todo!()
+    }
+
+    pub fn sprint_list(&self) -> LoadState<&Vec<Sprint>> {
+        todo!()
+    }
+
+    pub fn graph(&self) -> LoadState<&DependencyGraph> {
+        todo!()
+    }
+
+    pub fn column(&self, _id: Uuid) -> LoadState<&Column> {
+        todo!()
+    }
+
+    pub fn card(&self, _id: Uuid) -> LoadState<&Card> {
+        todo!()
+    }
+
+    pub fn sprint(&self, _id: Uuid) -> LoadState<&Sprint> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/kanban-service/src/cache/mod.rs
+++ b/crates/kanban-service/src/cache/mod.rs
@@ -1,10 +1,20 @@
+use std::sync::Arc;
+
 use kanban_domain::resolved::Collection;
 use kanban_domain::{
-    Board, Card, Column, DataStore, DependencyGraph, FetchPlan, Invalidation, KanbanResult,
-    LoadState, Resolved, Sprint,
+    Board, Card, Column, DataStore, DependencyGraph, FetchPlan, FetchRound, FetchStatus,
+    Invalidation, KanbanResult, LoadState, LoadedState, Resolved, Sprint,
 };
 use uuid::Uuid;
 
+/// Each entity reflects the backend as of its own individual fetch, not as
+/// of the resolve pass as a whole: two entities in the same `Resolved` may
+/// have been read moments apart. `resolve` deliberately does not wrap the
+/// round in one transaction, because that would hold a connection open
+/// across render-adjacent I/O today and, once resolve is multi-round, across
+/// an unbounded number of rounds. The consequence of a torn read is a stale
+/// entity, never a fabricated one: every value returned came from a real
+/// backend response.
 #[derive(Debug, Default)]
 pub struct EntityCache {
     boards: Collection<Board>,
@@ -14,53 +24,241 @@ pub struct EntityCache {
     graph: LoadState<DependencyGraph>,
 }
 
+/// The two tiers of a `Collection` are independent: a loaded `all` never
+/// back-fills `by_id`, and an entry in `by_id` never implies anything about
+/// `all`. This matters concretely for cards: `DataStore::list_all_cards`
+/// excludes archived cards while `DataStore::get_card` does not, so inferring
+/// `by_id` from `all` would report an archived card as `Missing`.
+///
+/// `boards.by_id` stays permanently empty: `FetchRound` carries no per-board
+/// id tier and `LoadedState` has no `board(id)` accessor, so nothing in this
+/// cache can ever populate it.
+struct LoadedView<'a>(&'a EntityCache);
+
+impl LoadedState for LoadedView<'_> {
+    fn board_list(&self) -> FetchStatus {
+        (&self.0.boards.all).into()
+    }
+    fn column_list(&self) -> FetchStatus {
+        (&self.0.columns.all).into()
+    }
+    fn card_list(&self) -> FetchStatus {
+        (&self.0.cards.all).into()
+    }
+    fn sprint_list(&self) -> FetchStatus {
+        (&self.0.sprints.all).into()
+    }
+    fn graph(&self) -> FetchStatus {
+        (&self.0.graph).into()
+    }
+    fn column(&self, id: Uuid) -> FetchStatus {
+        self.0
+            .columns
+            .by_id
+            .get(&id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn card(&self, id: Uuid) -> FetchStatus {
+        self.0
+            .cards
+            .by_id
+            .get(&id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn sprint(&self, id: Uuid) -> FetchStatus {
+        self.0
+            .sprints
+            .by_id
+            .get(&id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+}
+
 impl EntityCache {
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub fn invalidate(&mut self, _invalidation: Invalidation) {
-        todo!()
+    fn loaded_view(&self) -> LoadedView<'_> {
+        LoadedView(self)
+    }
+
+    fn fetch_round(&mut self, round: &FetchRound, store: &dyn DataStore) -> Resolved {
+        let mut resolved = Resolved::default();
+
+        if round.board_list {
+            let state = match store.list_boards() {
+                Ok(v) => LoadState::Loaded(v),
+                Err(e) => LoadState::Failed(Arc::new(e)),
+            };
+            self.boards.all = state.clone();
+            resolved.boards.all = state;
+        }
+        if round.column_list {
+            let state = match store.list_all_columns() {
+                Ok(v) => LoadState::Loaded(v),
+                Err(e) => LoadState::Failed(Arc::new(e)),
+            };
+            self.columns.all = state.clone();
+            resolved.columns.all = state;
+        }
+        if round.card_list {
+            let state = match store.list_all_cards() {
+                Ok(v) => LoadState::Loaded(v),
+                Err(e) => LoadState::Failed(Arc::new(e)),
+            };
+            self.cards.all = state.clone();
+            resolved.cards.all = state;
+        }
+        if round.sprint_list {
+            let state = match store.list_all_sprints() {
+                Ok(v) => LoadState::Loaded(v),
+                Err(e) => LoadState::Failed(Arc::new(e)),
+            };
+            self.sprints.all = state.clone();
+            resolved.sprints.all = state;
+        }
+        if round.graph {
+            let state = match store.get_graph() {
+                Ok(g) => LoadState::Loaded(g),
+                Err(e) => LoadState::Failed(Arc::new(e)),
+            };
+            self.graph = state.clone();
+            resolved.graph = state;
+        }
+
+        for &id in &round.columns {
+            let state = match store.get_column(id) {
+                Ok(Some(v)) => LoadState::Loaded(v),
+                Ok(None) => LoadState::Missing,
+                Err(e) => LoadState::Failed(Arc::new(e)),
+            };
+            self.columns.by_id.insert(id, state.clone());
+            resolved.columns.by_id.insert(id, state);
+        }
+        for &id in &round.cards {
+            let state = match store.get_card(id) {
+                Ok(Some(v)) => LoadState::Loaded(v),
+                Ok(None) => LoadState::Missing,
+                Err(e) => LoadState::Failed(Arc::new(e)),
+            };
+            self.cards.by_id.insert(id, state.clone());
+            resolved.cards.by_id.insert(id, state);
+        }
+        for &id in &round.sprints {
+            let state = match store.get_sprint(id) {
+                Ok(Some(v)) => LoadState::Loaded(v),
+                Ok(None) => LoadState::Missing,
+                Err(e) => LoadState::Failed(Arc::new(e)),
+            };
+            self.sprints.by_id.insert(id, state.clone());
+            resolved.sprints.by_id.insert(id, state);
+        }
+
+        resolved
     }
 
     pub fn resolve(
         &mut self,
-        _plan: &dyn FetchPlan,
-        _store: &dyn DataStore,
+        plan: &dyn FetchPlan,
+        store: &dyn DataStore,
     ) -> KanbanResult<Resolved> {
-        todo!()
+        let round = plan.next_round(&self.loaded_view());
+        Ok(self.fetch_round(&round, store))
+    }
+
+    /// An `Entities` value naming no ids is treated as `All`: an
+    /// invalidation that cannot say what changed must over-invalidate, never
+    /// no-op, matching the polarity `invalidation_from_inverse` already uses
+    /// for an unenumerable command batch.
+    ///
+    /// `prefixes` drops the board collection because this cache holds no
+    /// prefix rows of its own, but a prefix write bumps a counter that
+    /// board-derived display values read.
+    pub fn invalidate(&mut self, invalidation: Invalidation) {
+        let ids = match invalidation {
+            Invalidation::All => {
+                *self = Self::new();
+                return;
+            }
+            Invalidation::Entities(ids) if ids.is_empty() => {
+                *self = Self::new();
+                return;
+            }
+            Invalidation::Entities(ids) => ids,
+        };
+
+        if !ids.boards.is_empty() || ids.prefixes {
+            self.boards = Collection::default();
+        }
+        if !ids.columns.is_empty() {
+            self.columns.all = LoadState::NotLoaded;
+            for id in &ids.columns {
+                self.columns.by_id.remove(id);
+            }
+        }
+        if !ids.cards.is_empty() {
+            self.cards.all = LoadState::NotLoaded;
+            for id in &ids.cards {
+                self.cards.by_id.remove(id);
+            }
+        }
+        if !ids.sprints.is_empty() {
+            self.sprints.all = LoadState::NotLoaded;
+            for id in &ids.sprints {
+                self.sprints.by_id.remove(id);
+            }
+        }
+        if ids.graph {
+            self.graph = LoadState::NotLoaded;
+        }
     }
 
     pub fn board_list(&self) -> LoadState<&Vec<Board>> {
-        todo!()
+        self.boards.all.as_ref()
     }
 
     pub fn column_list(&self) -> LoadState<&Vec<Column>> {
-        todo!()
+        self.columns.all.as_ref()
     }
 
     pub fn card_list(&self) -> LoadState<&Vec<Card>> {
-        todo!()
+        self.cards.all.as_ref()
     }
 
     pub fn sprint_list(&self) -> LoadState<&Vec<Sprint>> {
-        todo!()
+        self.sprints.all.as_ref()
     }
 
     pub fn graph(&self) -> LoadState<&DependencyGraph> {
-        todo!()
+        self.graph.as_ref()
     }
 
-    pub fn column(&self, _id: Uuid) -> LoadState<&Column> {
-        todo!()
+    pub fn column(&self, id: Uuid) -> LoadState<&Column> {
+        self.columns
+            .by_id
+            .get(&id)
+            .map(LoadState::as_ref)
+            .unwrap_or(LoadState::NotLoaded)
     }
 
-    pub fn card(&self, _id: Uuid) -> LoadState<&Card> {
-        todo!()
+    pub fn card(&self, id: Uuid) -> LoadState<&Card> {
+        self.cards
+            .by_id
+            .get(&id)
+            .map(LoadState::as_ref)
+            .unwrap_or(LoadState::NotLoaded)
     }
 
-    pub fn sprint(&self, _id: Uuid) -> LoadState<&Sprint> {
-        todo!()
+    pub fn sprint(&self, id: Uuid) -> LoadState<&Sprint> {
+        self.sprints
+            .by_id
+            .get(&id)
+            .map(LoadState::as_ref)
+            .unwrap_or(LoadState::NotLoaded)
     }
 }
 

--- a/crates/kanban-service/src/cache/mod.rs
+++ b/crates/kanban-service/src/cache/mod.rs
@@ -7,14 +7,8 @@ use kanban_domain::{
 };
 use uuid::Uuid;
 
-/// Each entity reflects the backend as of its own individual fetch, not as
-/// of the resolve pass as a whole: two entities in the same `Resolved` may
-/// have been read moments apart. `resolve` deliberately does not wrap the
-/// round in one transaction, because that would hold a connection open
-/// across render-adjacent I/O today and, once resolve is multi-round, across
-/// an unbounded number of rounds. The consequence of a torn read is a stale
-/// entity, never a fabricated one: every value returned came from a real
-/// backend response.
+/// Entities are current as of their own individual fetch, not as of any one
+/// pass over the cache. See [`EntityCache::resolve`].
 #[derive(Debug, Default)]
 pub struct EntityCache {
     boards: Collection<Board>,
@@ -161,6 +155,14 @@ impl EntityCache {
         resolved
     }
 
+    /// Each entity reflects the backend as of its own individual fetch, not as
+    /// of the resolve pass as a whole: two entities in the same `Resolved` may
+    /// have been read moments apart. `resolve` deliberately does not wrap the
+    /// round in one transaction, because that would hold a connection open
+    /// across render-adjacent I/O today and, once resolve is multi-round,
+    /// across an unbounded number of rounds. The consequence of a torn read is
+    /// a stale entity, never a fabricated one: every value returned came from
+    /// a real backend response.
     pub fn resolve(
         &mut self,
         plan: &dyn FetchPlan,

--- a/crates/kanban-service/src/cache/tests/invalidate.rs
+++ b/crates/kanban-service/src/cache/tests/invalidate.rs
@@ -1,4 +1,5 @@
 use kanban_domain::{EntityIds, FetchRound, Invalidation};
+use uuid::Uuid;
 
 use super::{seed_board_with_column, seed_card, seed_column, seed_sprint, store, FixedPlan};
 use crate::cache::EntityCache;
@@ -11,6 +12,15 @@ fn everything(round: FetchRound) -> FixedPlan {
         sprint_list: true,
         graph: true,
         ..round
+    })
+}
+
+fn every_tier(column_id: Uuid, card_id: Uuid, sprint_id: Uuid) -> FixedPlan {
+    everything(FetchRound {
+        columns: vec![column_id],
+        cards: vec![card_id],
+        sprints: vec![sprint_id],
+        ..Default::default()
     })
 }
 
@@ -68,9 +78,11 @@ fn test_invalidate_a_sprint_id_drops_that_sprint_and_the_sprint_collection() {
 #[test]
 fn test_invalidate_a_board_id_drops_the_board_collection_and_nothing_else() {
     let store = store();
-    let (board, _column) = seed_board_with_column(&store);
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let sprint = seed_sprint(&store, &board);
     let mut cache = EntityCache::new();
-    let plan = everything(FetchRound::default());
+    let plan = every_tier(column.id, card.id, sprint.id);
     cache.resolve(&plan, &store).unwrap();
     assert!(cache.board_list().is_loaded());
 
@@ -81,6 +93,9 @@ fn test_invalidate_a_board_id_drops_the_board_collection_and_nothing_else() {
     assert!(cache.card_list().is_loaded());
     assert!(cache.sprint_list().is_loaded());
     assert!(cache.graph().is_loaded());
+    assert!(cache.column(column.id).is_loaded());
+    assert!(cache.card(card.id).is_loaded());
+    assert!(cache.sprint(sprint.id).is_loaded());
 }
 
 #[test]
@@ -166,57 +181,58 @@ fn test_invalidate_all_clears_every_one_of_the_five_kinds() {
 fn test_invalidate_prefixes_flag_drops_the_board_collection() {
     let store = store();
     let (board, column) = seed_board_with_column(&store);
-    seed_card(&store, &board, &column, "a");
+    let card = seed_card(&store, &board, &column, "a");
+    let sprint = seed_sprint(&store, &board);
     let mut cache = EntityCache::new();
-    let plan = FixedPlan(FetchRound {
-        board_list: true,
-        card_list: true,
-        graph: true,
-        ..Default::default()
-    });
+    let plan = every_tier(column.id, card.id, sprint.id);
     cache.resolve(&plan, &store).unwrap();
 
     cache.invalidate(Invalidation::Entities(EntityIds::default().with_prefixes()));
 
     assert!(cache.board_list().is_not_loaded());
+    assert!(cache.column_list().is_loaded());
     assert!(cache.card_list().is_loaded());
+    assert!(cache.sprint_list().is_loaded());
     assert!(cache.graph().is_loaded());
+    assert!(cache.column(column.id).is_loaded());
+    assert!(cache.card(card.id).is_loaded());
+    assert!(cache.sprint(sprint.id).is_loaded());
 }
 
 #[test]
 fn test_invalidate_graph_flag_drops_only_the_graph() {
     let store = store();
     let (board, column) = seed_board_with_column(&store);
-    seed_card(&store, &board, &column, "a");
+    let card = seed_card(&store, &board, &column, "a");
+    let sprint = seed_sprint(&store, &board);
     let mut cache = EntityCache::new();
-    let plan = FixedPlan(FetchRound {
-        board_list: true,
-        card_list: true,
-        graph: true,
-        ..Default::default()
-    });
+    let plan = every_tier(column.id, card.id, sprint.id);
     cache.resolve(&plan, &store).unwrap();
 
     cache.invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
 
     assert!(cache.graph().is_not_loaded());
     assert!(cache.board_list().is_loaded());
+    assert!(cache.column_list().is_loaded());
     assert!(cache.card_list().is_loaded());
+    assert!(cache.sprint_list().is_loaded());
+    assert!(cache.column(column.id).is_loaded());
+    assert!(cache.card(card.id).is_loaded());
+    assert!(cache.sprint(sprint.id).is_loaded());
 }
 
 #[test]
 fn test_invalidate_entities_with_no_ids_clears_everything() {
     let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let sprint = seed_sprint(&store, &board);
     let mut cache = EntityCache::new();
-    let plan = FixedPlan(FetchRound {
-        board_list: true,
-        column_list: true,
-        card_list: true,
-        sprint_list: true,
-        graph: true,
-        ..Default::default()
-    });
+    let plan = every_tier(column.id, card.id, sprint.id);
     cache.resolve(&plan, &store).unwrap();
+    assert!(cache.column(column.id).is_loaded());
+    assert!(cache.card(card.id).is_loaded());
+    assert!(cache.sprint(sprint.id).is_loaded());
 
     cache.invalidate(Invalidation::Entities(EntityIds::default()));
 
@@ -225,4 +241,7 @@ fn test_invalidate_entities_with_no_ids_clears_everything() {
     assert!(cache.card_list().is_not_loaded());
     assert!(cache.sprint_list().is_not_loaded());
     assert!(cache.graph().is_not_loaded());
+    assert!(cache.column(column.id).is_not_loaded());
+    assert!(cache.card(card.id).is_not_loaded());
+    assert!(cache.sprint(sprint.id).is_not_loaded());
 }

--- a/crates/kanban-service/src/cache/tests/invalidate.rs
+++ b/crates/kanban-service/src/cache/tests/invalidate.rs
@@ -66,6 +66,9 @@ fn test_invalidate_all_clears_every_one_of_the_five_kinds() {
         sprints: vec![sprint.id],
     });
     cache.resolve(&plan, &store).unwrap();
+    assert!(cache.column(column.id).is_loaded());
+    assert!(cache.card(card.id).is_loaded());
+    assert!(cache.sprint(sprint.id).is_loaded());
 
     cache.invalidate(Invalidation::All);
 

--- a/crates/kanban-service/src/cache/tests/invalidate.rs
+++ b/crates/kanban-service/src/cache/tests/invalidate.rs
@@ -1,7 +1,87 @@
 use kanban_domain::{EntityIds, FetchRound, Invalidation};
 
-use super::{seed_board_with_column, seed_card, seed_sprint, store, FixedPlan};
+use super::{seed_board_with_column, seed_card, seed_column, seed_sprint, store, FixedPlan};
 use crate::cache::EntityCache;
+
+fn everything(round: FetchRound) -> FixedPlan {
+    FixedPlan(FetchRound {
+        board_list: true,
+        column_list: true,
+        card_list: true,
+        sprint_list: true,
+        graph: true,
+        ..round
+    })
+}
+
+#[test]
+fn test_invalidate_a_column_id_drops_that_column_and_the_column_collection() {
+    let store = store();
+    let (board, a) = seed_board_with_column(&store);
+    let b = seed_column(&store, &board, "b");
+    let mut cache = EntityCache::new();
+    let plan = everything(FetchRound {
+        columns: vec![a.id, b.id],
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+    assert!(cache.column_list().is_loaded());
+    assert!(cache.column(a.id).is_loaded());
+
+    cache.invalidate(Invalidation::Entities(EntityIds::columns([a.id])));
+
+    assert!(cache.column(a.id).is_not_loaded());
+    assert!(cache.column(b.id).is_loaded());
+    assert!(cache.column_list().is_not_loaded());
+    assert!(cache.board_list().is_loaded());
+    assert!(cache.card_list().is_loaded());
+    assert!(cache.sprint_list().is_loaded());
+    assert!(cache.graph().is_loaded());
+}
+
+#[test]
+fn test_invalidate_a_sprint_id_drops_that_sprint_and_the_sprint_collection() {
+    let store = store();
+    let (board, _column) = seed_board_with_column(&store);
+    let a = seed_sprint(&store, &board);
+    let b = seed_sprint(&store, &board);
+    let mut cache = EntityCache::new();
+    let plan = everything(FetchRound {
+        sprints: vec![a.id, b.id],
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+    assert!(cache.sprint_list().is_loaded());
+    assert!(cache.sprint(a.id).is_loaded());
+
+    cache.invalidate(Invalidation::Entities(EntityIds::sprints([a.id])));
+
+    assert!(cache.sprint(a.id).is_not_loaded());
+    assert!(cache.sprint(b.id).is_loaded());
+    assert!(cache.sprint_list().is_not_loaded());
+    assert!(cache.board_list().is_loaded());
+    assert!(cache.column_list().is_loaded());
+    assert!(cache.card_list().is_loaded());
+    assert!(cache.graph().is_loaded());
+}
+
+#[test]
+fn test_invalidate_a_board_id_drops_the_board_collection_and_nothing_else() {
+    let store = store();
+    let (board, _column) = seed_board_with_column(&store);
+    let mut cache = EntityCache::new();
+    let plan = everything(FetchRound::default());
+    cache.resolve(&plan, &store).unwrap();
+    assert!(cache.board_list().is_loaded());
+
+    cache.invalidate(Invalidation::Entities(EntityIds::boards([board.id])));
+
+    assert!(cache.board_list().is_not_loaded());
+    assert!(cache.column_list().is_loaded());
+    assert!(cache.card_list().is_loaded());
+    assert!(cache.sprint_list().is_loaded());
+    assert!(cache.graph().is_loaded());
+}
 
 #[test]
 fn test_invalidate_entities_clears_only_the_named_ids() {

--- a/crates/kanban-service/src/cache/tests/invalidate.rs
+++ b/crates/kanban-service/src/cache/tests/invalidate.rs
@@ -1,0 +1,145 @@
+use kanban_domain::{EntityIds, FetchRound, Invalidation};
+
+use super::{seed_board_with_column, seed_card, seed_sprint, store, FixedPlan};
+use crate::cache::EntityCache;
+
+#[test]
+fn test_invalidate_entities_clears_only_the_named_ids() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let a = seed_card(&store, &board, &column, "a");
+    let b = seed_card(&store, &board, &column, "b");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![a.id, b.id],
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+
+    cache.invalidate(Invalidation::Entities(EntityIds::cards([a.id])));
+
+    assert!(cache.card(a.id).is_not_loaded());
+    assert!(cache.card(b.id).is_loaded());
+}
+
+#[test]
+fn test_invalidate_a_card_id_also_drops_the_whole_card_collection() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let a = seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        column_list: true,
+        card_list: true,
+        sprint_list: true,
+        graph: true,
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+    assert!(cache.card_list().is_loaded());
+
+    cache.invalidate(Invalidation::Entities(EntityIds::cards([a.id])));
+
+    assert!(cache.card_list().is_not_loaded());
+    assert!(cache.board_list().is_loaded());
+    assert!(cache.column_list().is_loaded());
+    assert!(cache.sprint_list().is_loaded());
+    assert!(cache.graph().is_loaded());
+}
+
+#[test]
+fn test_invalidate_all_clears_every_one_of_the_five_kinds() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let sprint = seed_sprint(&store, &board);
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        column_list: true,
+        card_list: true,
+        sprint_list: true,
+        graph: true,
+        columns: vec![column.id],
+        cards: vec![card.id],
+        sprints: vec![sprint.id],
+    });
+    cache.resolve(&plan, &store).unwrap();
+
+    cache.invalidate(Invalidation::All);
+
+    assert!(cache.board_list().is_not_loaded());
+    assert!(cache.column_list().is_not_loaded());
+    assert!(cache.card_list().is_not_loaded());
+    assert!(cache.sprint_list().is_not_loaded());
+    assert!(cache.graph().is_not_loaded());
+    assert!(cache.column(column.id).is_not_loaded());
+    assert!(cache.card(card.id).is_not_loaded());
+    assert!(cache.sprint(sprint.id).is_not_loaded());
+}
+
+#[test]
+fn test_invalidate_prefixes_flag_drops_the_board_collection() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        card_list: true,
+        graph: true,
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+
+    cache.invalidate(Invalidation::Entities(EntityIds::default().with_prefixes()));
+
+    assert!(cache.board_list().is_not_loaded());
+    assert!(cache.card_list().is_loaded());
+    assert!(cache.graph().is_loaded());
+}
+
+#[test]
+fn test_invalidate_graph_flag_drops_only_the_graph() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        card_list: true,
+        graph: true,
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+
+    cache.invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+
+    assert!(cache.graph().is_not_loaded());
+    assert!(cache.board_list().is_loaded());
+    assert!(cache.card_list().is_loaded());
+}
+
+#[test]
+fn test_invalidate_entities_with_no_ids_clears_everything() {
+    let store = store();
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        column_list: true,
+        card_list: true,
+        sprint_list: true,
+        graph: true,
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+
+    cache.invalidate(Invalidation::Entities(EntityIds::default()));
+
+    assert!(cache.board_list().is_not_loaded());
+    assert!(cache.column_list().is_not_loaded());
+    assert!(cache.card_list().is_not_loaded());
+    assert!(cache.sprint_list().is_not_loaded());
+    assert!(cache.graph().is_not_loaded());
+}

--- a/crates/kanban-service/src/cache/tests/loaded_view.rs
+++ b/crates/kanban-service/src/cache/tests/loaded_view.rs
@@ -1,0 +1,246 @@
+use kanban_domain::{FetchRound, FetchStatus};
+use uuid::Uuid;
+
+use super::{seed_board_with_column, seed_card, seed_sprint, store, Observed, ProbePlan};
+use crate::cache::EntityCache;
+
+fn all(status: FetchStatus) -> Observed {
+    Observed {
+        board_list: status,
+        column_list: status,
+        card_list: status,
+        sprint_list: status,
+        graph: status,
+        column: status,
+        card: status,
+        sprint: status,
+    }
+}
+
+#[test]
+fn test_an_empty_cache_projects_every_dimension_as_not_loaded() {
+    let store = store();
+    let plan = ProbePlan::new(
+        FetchRound::default(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    );
+    let mut cache = EntityCache::new();
+
+    cache.resolve(&plan, &store).unwrap();
+
+    assert_eq!(plan.last(), all(FetchStatus::NotLoaded));
+}
+
+#[test]
+fn test_each_list_dimension_projects_its_own_collection_and_no_other() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let sprint = seed_sprint(&store, &board);
+
+    for (round, expected) in [
+        (
+            FetchRound {
+                board_list: true,
+                ..Default::default()
+            },
+            Observed {
+                board_list: FetchStatus::Loaded,
+                ..all(FetchStatus::NotLoaded)
+            },
+        ),
+        (
+            FetchRound {
+                column_list: true,
+                ..Default::default()
+            },
+            Observed {
+                column_list: FetchStatus::Loaded,
+                ..all(FetchStatus::NotLoaded)
+            },
+        ),
+        (
+            FetchRound {
+                card_list: true,
+                ..Default::default()
+            },
+            Observed {
+                card_list: FetchStatus::Loaded,
+                ..all(FetchStatus::NotLoaded)
+            },
+        ),
+        (
+            FetchRound {
+                sprint_list: true,
+                ..Default::default()
+            },
+            Observed {
+                sprint_list: FetchStatus::Loaded,
+                ..all(FetchStatus::NotLoaded)
+            },
+        ),
+        (
+            FetchRound {
+                graph: true,
+                ..Default::default()
+            },
+            Observed {
+                graph: FetchStatus::Loaded,
+                ..all(FetchStatus::NotLoaded)
+            },
+        ),
+    ] {
+        let mut cache = EntityCache::new();
+        cache
+            .resolve(
+                &ProbePlan::new(round, column.id, card.id, sprint.id),
+                &store,
+            )
+            .unwrap();
+
+        let probe = ProbePlan::new(FetchRound::default(), column.id, card.id, sprint.id);
+        cache.resolve(&probe, &store).unwrap();
+
+        assert_eq!(probe.last(), expected);
+    }
+}
+
+#[test]
+fn test_each_by_id_dimension_projects_its_own_map_and_no_other() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let sprint = seed_sprint(&store, &board);
+
+    for (round, expected) in [
+        (
+            FetchRound {
+                columns: vec![column.id],
+                ..Default::default()
+            },
+            Observed {
+                column: FetchStatus::Loaded,
+                ..all(FetchStatus::NotLoaded)
+            },
+        ),
+        (
+            FetchRound {
+                cards: vec![card.id],
+                ..Default::default()
+            },
+            Observed {
+                card: FetchStatus::Loaded,
+                ..all(FetchStatus::NotLoaded)
+            },
+        ),
+        (
+            FetchRound {
+                sprints: vec![sprint.id],
+                ..Default::default()
+            },
+            Observed {
+                sprint: FetchStatus::Loaded,
+                ..all(FetchStatus::NotLoaded)
+            },
+        ),
+    ] {
+        let mut cache = EntityCache::new();
+        cache
+            .resolve(
+                &ProbePlan::new(round, column.id, card.id, sprint.id),
+                &store,
+            )
+            .unwrap();
+
+        let probe = ProbePlan::new(FetchRound::default(), column.id, card.id, sprint.id);
+        cache.resolve(&probe, &store).unwrap();
+
+        assert_eq!(probe.last(), expected);
+    }
+}
+
+#[test]
+fn test_an_id_never_fetched_projects_as_not_loaded_even_when_a_sibling_is_loaded() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let fetched = seed_card(&store, &board, &column, "a");
+    let never = seed_card(&store, &board, &column, "b");
+    let sprint = seed_sprint(&store, &board);
+    let mut cache = EntityCache::new();
+    cache
+        .resolve(
+            &ProbePlan::new(
+                FetchRound {
+                    cards: vec![fetched.id],
+                    ..Default::default()
+                },
+                column.id,
+                fetched.id,
+                sprint.id,
+            ),
+            &store,
+        )
+        .unwrap();
+
+    let probe = ProbePlan::new(FetchRound::default(), column.id, never.id, sprint.id);
+    cache.resolve(&probe, &store).unwrap();
+
+    assert_eq!(probe.last().card, FetchStatus::NotLoaded);
+}
+
+#[test]
+fn test_a_missing_entity_projects_as_missing_and_a_failed_one_as_failed() {
+    let store = store();
+    let absent = Uuid::new_v4();
+    let mut cache = EntityCache::new();
+    cache
+        .resolve(
+            &ProbePlan::new(
+                FetchRound {
+                    cards: vec![absent],
+                    ..Default::default()
+                },
+                Uuid::new_v4(),
+                absent,
+                Uuid::new_v4(),
+            ),
+            &store,
+        )
+        .unwrap();
+
+    let probe = ProbePlan::new(
+        FetchRound::default(),
+        Uuid::new_v4(),
+        absent,
+        Uuid::new_v4(),
+    );
+    cache.resolve(&probe, &store).unwrap();
+
+    assert_eq!(probe.last().card, FetchStatus::Missing);
+
+    let failing = super::store();
+    let id = Uuid::new_v4();
+    failing.fail_card(id);
+    let mut cache = EntityCache::new();
+    cache
+        .resolve(
+            &ProbePlan::new(
+                FetchRound {
+                    cards: vec![id],
+                    ..Default::default()
+                },
+                Uuid::new_v4(),
+                id,
+                Uuid::new_v4(),
+            ),
+            &failing,
+        )
+        .unwrap();
+
+    let probe = ProbePlan::new(FetchRound::default(), Uuid::new_v4(), id, Uuid::new_v4());
+    cache.resolve(&probe, &failing).unwrap();
+
+    assert_eq!(probe.last().card, FetchStatus::Failed);
+}

--- a/crates/kanban-service/src/cache/tests/loaded_view.rs
+++ b/crates/kanban-service/src/cache/tests/loaded_view.rs
@@ -184,6 +184,10 @@ fn test_an_id_never_fetched_projects_as_not_loaded_even_when_a_sibling_is_loaded
         )
         .unwrap();
 
+    let sibling = ProbePlan::new(FetchRound::default(), column.id, fetched.id, sprint.id);
+    cache.resolve(&sibling, &store).unwrap();
+    assert_eq!(sibling.last().card, FetchStatus::Loaded);
+
     let probe = ProbePlan::new(FetchRound::default(), column.id, never.id, sprint.id);
     cache.resolve(&probe, &store).unwrap();
 

--- a/crates/kanban-service/src/cache/tests/mod.rs
+++ b/crates/kanban-service/src/cache/tests/mod.rs
@@ -1,12 +1,67 @@
 use kanban_domain::{
-    requestable, Board, Card, Column, DataStore, FetchPlan, FetchRound, LoadedState, Sprint,
+    requestable, Board, Card, Column, DataStore, FetchPlan, FetchRound, FetchStatus, LoadedState,
+    Sprint,
 };
+use std::cell::RefCell;
 use uuid::Uuid;
 
 use crate::read_recorder::RecordingStore;
 
 mod invalidate;
+mod loaded_view;
 mod resolve;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Observed {
+    board_list: FetchStatus,
+    column_list: FetchStatus,
+    card_list: FetchStatus,
+    sprint_list: FetchStatus,
+    graph: FetchStatus,
+    column: FetchStatus,
+    card: FetchStatus,
+    sprint: FetchStatus,
+}
+
+struct ProbePlan {
+    round: FetchRound,
+    column_id: Uuid,
+    card_id: Uuid,
+    sprint_id: Uuid,
+    seen: RefCell<Vec<Observed>>,
+}
+
+impl ProbePlan {
+    fn new(round: FetchRound, column_id: Uuid, card_id: Uuid, sprint_id: Uuid) -> Self {
+        Self {
+            round,
+            column_id,
+            card_id,
+            sprint_id,
+            seen: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn last(&self) -> Observed {
+        *self.seen.borrow().last().expect("plan was never consulted")
+    }
+}
+
+impl FetchPlan for ProbePlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        self.seen.borrow_mut().push(Observed {
+            board_list: loaded.board_list(),
+            column_list: loaded.column_list(),
+            card_list: loaded.card_list(),
+            sprint_list: loaded.sprint_list(),
+            graph: loaded.graph(),
+            column: loaded.column(self.column_id),
+            card: loaded.card(self.card_id),
+            sprint: loaded.sprint(self.sprint_id),
+        });
+        self.round.clone()
+    }
+}
 
 fn store() -> RecordingStore {
     RecordingStore::new()

--- a/crates/kanban-service/src/cache/tests/mod.rs
+++ b/crates/kanban-service/src/cache/tests/mod.rs
@@ -13,19 +13,20 @@ mod resolve;
 mod result_mapping;
 mod retry;
 
-struct CardByIdPlan {
-    card_id: Uuid,
+struct CardsByIdPlan {
+    ids: Vec<Uuid>,
 }
 
-impl FetchPlan for CardByIdPlan {
+impl FetchPlan for CardsByIdPlan {
     fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
-        if requestable(loaded.card(self.card_id)) {
-            FetchRound {
-                cards: vec![self.card_id],
-                ..Default::default()
-            }
-        } else {
-            FetchRound::default()
+        FetchRound {
+            cards: self
+                .ids
+                .iter()
+                .copied()
+                .filter(|&id| requestable(loaded.card(id)))
+                .collect(),
+            ..Default::default()
         }
     }
 }

--- a/crates/kanban-service/src/cache/tests/mod.rs
+++ b/crates/kanban-service/src/cache/tests/mod.rs
@@ -10,6 +10,7 @@ use crate::read_recorder::RecordingStore;
 mod invalidate;
 mod loaded_view;
 mod resolve;
+mod result_mapping;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Observed {

--- a/crates/kanban-service/src/cache/tests/mod.rs
+++ b/crates/kanban-service/src/cache/tests/mod.rs
@@ -11,6 +11,24 @@ mod invalidate;
 mod loaded_view;
 mod resolve;
 mod result_mapping;
+mod retry;
+
+struct CardByIdPlan {
+    card_id: Uuid,
+}
+
+impl FetchPlan for CardByIdPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        if requestable(loaded.card(self.card_id)) {
+            FetchRound {
+                cards: vec![self.card_id],
+                ..Default::default()
+            }
+        } else {
+            FetchRound::default()
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Observed {

--- a/crates/kanban-service/src/cache/tests/mod.rs
+++ b/crates/kanban-service/src/cache/tests/mod.rs
@@ -1,0 +1,84 @@
+use kanban_domain::{
+    requestable, Board, Card, Column, DataStore, FetchPlan, FetchRound, LoadedState, Sprint,
+};
+use uuid::Uuid;
+
+use crate::read_recorder::RecordingStore;
+
+mod invalidate;
+mod resolve;
+
+fn store() -> RecordingStore {
+    RecordingStore::new()
+}
+
+fn seed_board(store: &RecordingStore, name: &str) -> Board {
+    let board = Board::new(name, None::<String>);
+    store.upsert_board(board.clone()).unwrap();
+    board
+}
+
+fn seed_column(store: &RecordingStore, board: &Board, name: &str) -> Column {
+    let column = Column::new(board.id, name, 0);
+    store.upsert_column(column.clone()).unwrap();
+    column
+}
+
+fn seed_card(store: &RecordingStore, board: &Board, column: &Column, title: &str) -> Card {
+    let card = Card::new(board.id, column.id, title, 0);
+    store.upsert_card(card.clone()).unwrap();
+    card
+}
+
+fn seed_sprint(store: &RecordingStore, board: &Board) -> Sprint {
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+    store.upsert_sprint(sprint.clone()).unwrap();
+    sprint
+}
+
+fn seed_board_with_column(store: &RecordingStore) -> (Board, Column) {
+    let board = seed_board(store, "b");
+    let column = seed_column(store, &board, "c");
+    (board, column)
+}
+
+struct FixedPlan(FetchRound);
+
+impl FetchPlan for FixedPlan {
+    fn next_round(&self, _loaded: &dyn LoadedState) -> FetchRound {
+        self.0.clone()
+    }
+}
+
+struct BoardListPlan;
+
+impl FetchPlan for BoardListPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        FetchRound {
+            board_list: requestable(loaded.board_list()),
+            ..Default::default()
+        }
+    }
+}
+
+struct GraphThenCardPlan {
+    card_id: Uuid,
+}
+
+impl FetchPlan for GraphThenCardPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        if requestable(loaded.graph()) {
+            FetchRound {
+                graph: true,
+                ..Default::default()
+            }
+        } else if requestable(loaded.card(self.card_id)) {
+            FetchRound {
+                cards: vec![self.card_id],
+                ..Default::default()
+            }
+        } else {
+            FetchRound::default()
+        }
+    }
+}

--- a/crates/kanban-service/src/cache/tests/resolve.rs
+++ b/crates/kanban-service/src/cache/tests/resolve.rs
@@ -2,7 +2,7 @@ use kanban_domain::FetchRound;
 use uuid::Uuid;
 
 use super::{
-    seed_board, seed_board_with_column, seed_card, store, BoardListPlan, FixedPlan,
+    seed_board, seed_board_with_column, seed_card, seed_sprint, store, BoardListPlan, FixedPlan,
     GraphThenCardPlan,
 };
 use crate::cache::EntityCache;
@@ -90,6 +90,53 @@ fn test_resolve_never_scans_a_collection_to_serve_a_single_id_need() {
         }],
     );
     assert!(resolved.cards.all.is_not_loaded());
+}
+
+#[test]
+fn test_resolve_of_column_and_sprint_id_needs_loads_each_into_its_own_by_id_tier() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let sprint = seed_sprint(&store, &board);
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        columns: vec![column.id],
+        sprints: vec![sprint.id],
+        ..Default::default()
+    });
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_column",
+                ids: vec![column.id],
+            },
+            ReadOp {
+                method: "get_sprint",
+                ids: vec![sprint.id],
+            },
+        ],
+    );
+    assert_eq!(
+        resolved.columns.by_id[&column.id].loaded().map(|c| c.id),
+        Some(column.id)
+    );
+    assert_eq!(
+        resolved.sprints.by_id[&sprint.id].loaded().map(|s| s.id),
+        Some(sprint.id)
+    );
+    assert_eq!(
+        cache.column(column.id).loaded().map(|c| c.id),
+        Some(column.id)
+    );
+    assert_eq!(
+        cache.sprint(sprint.id).loaded().map(|s| s.id),
+        Some(sprint.id)
+    );
+    assert!(resolved.columns.all.is_not_loaded());
+    assert!(resolved.sprints.all.is_not_loaded());
 }
 
 #[test]

--- a/crates/kanban-service/src/cache/tests/resolve.rs
+++ b/crates/kanban-service/src/cache/tests/resolve.rs
@@ -1,0 +1,213 @@
+use kanban_domain::FetchRound;
+use uuid::Uuid;
+
+use super::{
+    seed_board, seed_board_with_column, seed_card, store, BoardListPlan, FixedPlan,
+    GraphThenCardPlan,
+};
+use crate::cache::EntityCache;
+use crate::read_recorder::{assert_ops, ReadOp};
+
+#[test]
+fn test_resolve_for_a_board_list_need_issues_exactly_one_list_boards_read() {
+    let store = store();
+    seed_board(&store, "a");
+    seed_board(&store, "b");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        ..Default::default()
+    });
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_boards",
+            ids: vec![],
+        }],
+    );
+    assert!(resolved.boards.all.is_loaded());
+    assert_eq!(resolved.boards.all.loaded().unwrap().len(), 2);
+}
+
+#[test]
+fn test_resolve_of_a_whole_collection_need_populates_all_not_just_by_id() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        card_list: true,
+        ..Default::default()
+    });
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert!(resolved.cards.all.is_loaded());
+    assert_eq!(resolved.cards.all.loaded().unwrap().len(), 1);
+    assert!(resolved.cards.by_id.is_empty());
+}
+
+#[test]
+fn test_resolve_of_a_genuinely_empty_card_list_is_loaded_not_not_loaded() {
+    let store = store();
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        card_list: true,
+        ..Default::default()
+    });
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert!(resolved.cards.all.is_loaded());
+    assert!(resolved.cards.all.loaded().unwrap().is_empty());
+    assert!(!resolved.cards.all.is_not_loaded());
+    assert!(!resolved.cards.is_untouched());
+}
+
+#[test]
+fn test_resolve_never_scans_a_collection_to_serve_a_single_id_need() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let a = seed_card(&store, &board, &column, "a");
+    seed_card(&store, &board, &column, "b");
+    seed_card(&store, &board, &column, "c");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![a.id],
+        ..Default::default()
+    });
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![a.id],
+        }],
+    );
+    assert!(resolved.cards.all.is_not_loaded());
+}
+
+#[test]
+fn test_resolve_maps_ok_none_to_missing() {
+    let store = store();
+    let id = Uuid::new_v4();
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![id],
+        ..Default::default()
+    });
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    let state = &resolved.cards.by_id[&id];
+    assert!(state.is_missing());
+    assert!(!state.is_not_loaded());
+    assert!(!state.is_failed());
+    assert!(!state.is_loaded());
+}
+
+#[test]
+fn test_resolve_maps_a_backend_error_to_failed_without_starving_the_round() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let bad = seed_card(&store, &board, &column, "bad");
+    let good = seed_card(&store, &board, &column, "good");
+    store.fail_card(bad.id);
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![bad.id, good.id],
+        ..Default::default()
+    });
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert!(resolved.cards.by_id[&bad.id].is_failed());
+    assert!(resolved.cards.by_id[&good.id].is_loaded());
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_card",
+                ids: vec![bad.id],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![good.id],
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_resolve_does_not_refetch_an_already_loaded_entity() {
+    let store = store();
+    seed_board(&store, "a");
+    let mut cache = EntityCache::new();
+    let plan = BoardListPlan;
+
+    cache.resolve(&plan, &store).unwrap();
+    cache.resolve(&plan, &store).unwrap();
+
+    assert_eq!(store.ops().lock().unwrap().len(), 1);
+}
+
+#[test]
+fn test_a_card_never_fetched_reads_as_not_loaded_and_a_missing_one_reads_as_missing() {
+    let store = store();
+    let id = Uuid::new_v4();
+    let mut cache = EntityCache::new();
+
+    assert!(cache.card(id).is_not_loaded());
+
+    let plan = FixedPlan(FetchRound {
+        cards: vec![id],
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+
+    assert!(cache.card(id).is_missing());
+}
+
+#[test]
+fn test_a_loaded_card_collection_does_not_report_an_unfetched_card_id_as_loaded() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let a = seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        card_list: true,
+        ..Default::default()
+    });
+
+    cache.resolve(&plan, &store).unwrap();
+
+    assert!(cache.card_list().is_loaded());
+    assert!(cache.card(a.id).is_not_loaded());
+}
+
+#[test]
+fn test_a_single_round_resolve_cannot_serve_a_dependent_need() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = GraphThenCardPlan { card_id: card.id };
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert!(cache.graph().is_loaded());
+    assert!(cache.card(card.id).is_not_loaded());
+    assert!(resolved.cards.by_id.is_empty());
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_graph",
+            ids: vec![],
+        }],
+    );
+}

--- a/crates/kanban-service/src/cache/tests/resolve.rs
+++ b/crates/kanban-service/src/cache/tests/resolve.rs
@@ -51,6 +51,40 @@ fn test_resolve_of_a_whole_collection_need_populates_all_not_just_by_id() {
 }
 
 #[test]
+fn test_resolve_of_column_sprint_and_graph_list_needs_populates_the_returned_all_tier() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let sprint = seed_sprint(&store, &board);
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        column_list: true,
+        sprint_list: true,
+        graph: true,
+        ..Default::default()
+    });
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert_eq!(
+        resolved
+            .columns
+            .all
+            .loaded()
+            .map(|c| c.iter().map(|c| c.id).collect::<Vec<_>>()),
+        Some(vec![column.id])
+    );
+    assert_eq!(
+        resolved
+            .sprints
+            .all
+            .loaded()
+            .map(|s| s.iter().map(|s| s.id).collect::<Vec<_>>()),
+        Some(vec![sprint.id])
+    );
+    assert!(resolved.graph.is_loaded());
+}
+
+#[test]
 fn test_resolve_of_a_genuinely_empty_card_list_is_loaded_not_not_loaded() {
     let store = store();
     let mut cache = EntityCache::new();

--- a/crates/kanban-service/src/cache/tests/result_mapping.rs
+++ b/crates/kanban-service/src/cache/tests/result_mapping.rs
@@ -1,0 +1,127 @@
+use kanban_domain::FetchRound;
+use uuid::Uuid;
+
+use super::{seed_board_with_column, seed_sprint, store, FixedPlan};
+use crate::cache::EntityCache;
+
+#[test]
+fn test_a_failing_list_read_is_failed_not_a_loaded_empty_collection() {
+    for (method, round) in [
+        (
+            "list_boards",
+            FetchRound {
+                board_list: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "list_all_columns",
+            FetchRound {
+                column_list: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "list_all_cards",
+            FetchRound {
+                card_list: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "list_all_sprints",
+            FetchRound {
+                sprint_list: true,
+                ..Default::default()
+            },
+        ),
+    ] {
+        let store = store();
+        seed_board_with_column(&store);
+        store.fail_method(method);
+        let mut cache = EntityCache::new();
+
+        let resolved = cache.resolve(&FixedPlan(round), &store).unwrap();
+
+        let (cached, returned) = match method {
+            "list_boards" => (
+                cache.board_list().is_failed(),
+                resolved.boards.all.is_failed(),
+            ),
+            "list_all_columns" => (
+                cache.column_list().is_failed(),
+                resolved.columns.all.is_failed(),
+            ),
+            "list_all_cards" => (
+                cache.card_list().is_failed(),
+                resolved.cards.all.is_failed(),
+            ),
+            _ => (
+                cache.sprint_list().is_failed(),
+                resolved.sprints.all.is_failed(),
+            ),
+        };
+
+        assert!(
+            cached,
+            "{method}: cached tier must be Failed, not Loaded(empty)"
+        );
+        assert!(
+            returned,
+            "{method}: returned tier must be Failed, not Loaded(empty)"
+        );
+    }
+}
+
+#[test]
+fn test_a_failing_graph_read_is_failed_not_an_empty_graph() {
+    let store = store();
+    store.fail_method("get_graph");
+    let mut cache = EntityCache::new();
+
+    let resolved = cache
+        .resolve(
+            &FixedPlan(FetchRound {
+                graph: true,
+                ..Default::default()
+            }),
+            &store,
+        )
+        .unwrap();
+
+    assert!(cache.graph().is_failed());
+    assert!(resolved.graph.is_failed());
+}
+
+#[test]
+fn test_an_absent_column_or_sprint_is_missing_and_a_failing_one_is_failed() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let sprint = seed_sprint(&store, &board);
+    let absent_column = Uuid::new_v4();
+    let absent_sprint = Uuid::new_v4();
+    store.fail_column(column.id);
+    store.fail_sprint(sprint.id);
+    let mut cache = EntityCache::new();
+
+    let resolved = cache
+        .resolve(
+            &FixedPlan(FetchRound {
+                columns: vec![absent_column, column.id],
+                sprints: vec![absent_sprint, sprint.id],
+                ..Default::default()
+            }),
+            &store,
+        )
+        .unwrap();
+
+    assert!(cache.column(absent_column).is_missing());
+    assert!(cache.sprint(absent_sprint).is_missing());
+    assert!(resolved.columns.by_id[&absent_column].is_missing());
+    assert!(resolved.sprints.by_id[&absent_sprint].is_missing());
+
+    assert!(cache.column(column.id).is_failed());
+    assert!(cache.sprint(sprint.id).is_failed());
+    assert!(resolved.columns.by_id[&column.id].is_failed());
+    assert!(resolved.sprints.by_id[&sprint.id].is_failed());
+}

--- a/crates/kanban-service/src/cache/tests/retry.rs
+++ b/crates/kanban-service/src/cache/tests/retry.rs
@@ -1,0 +1,123 @@
+use kanban_domain::{EntityIds, FetchRound, Invalidation};
+
+use super::{
+    seed_board, seed_board_with_column, seed_card, store, BoardListPlan, CardByIdPlan, FixedPlan,
+};
+use crate::cache::EntityCache;
+use crate::read_recorder::{assert_ops, ReadOp};
+
+#[test]
+fn test_a_failed_card_is_refetched_and_recovers_once_the_backend_does() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    store.fail_card(card.id);
+    let mut cache = EntityCache::new();
+    let plan = CardByIdPlan { card_id: card.id };
+
+    cache.resolve(&plan, &store).unwrap();
+    assert!(cache.card(card.id).is_failed());
+
+    store.clear_failures();
+    store.clear_log();
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![card.id],
+        }],
+    );
+    assert_eq!(cache.card(card.id).loaded().map(|c| c.id), Some(card.id));
+    assert!(resolved.cards.by_id[&card.id].is_loaded());
+}
+
+#[test]
+fn test_a_failed_collection_is_refetched_and_recovers_once_the_backend_does() {
+    let store = store();
+    seed_board(&store, "a");
+    store.fail_method("list_boards");
+    let mut cache = EntityCache::new();
+
+    cache.resolve(&BoardListPlan, &store).unwrap();
+    assert!(cache.board_list().is_failed());
+
+    store.clear_failures();
+    store.clear_log();
+
+    let resolved = cache.resolve(&BoardListPlan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_boards",
+            ids: vec![],
+        }],
+    );
+    assert_eq!(cache.board_list().loaded().map(|b| b.len()), Some(1));
+    assert!(resolved.boards.all.is_loaded());
+}
+
+#[test]
+fn test_a_missing_card_is_not_refetched_while_a_failed_one_is() {
+    let store = store();
+    seed_board_with_column(&store);
+    let absent = uuid::Uuid::new_v4();
+    let mut cache = EntityCache::new();
+    let plan = CardByIdPlan { card_id: absent };
+
+    cache.resolve(&plan, &store).unwrap();
+    assert!(cache.card(absent).is_missing());
+
+    store.clear_log();
+    cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(&store.ops(), &[]);
+    assert!(cache.card(absent).is_missing());
+}
+
+#[test]
+fn test_an_invalidated_entity_is_refetched_while_an_untouched_sibling_is_not() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let a = seed_card(&store, &board, &column, "a");
+    let b = seed_card(&store, &board, &column, "b");
+    let mut cache = EntityCache::new();
+    let round = FetchRound {
+        cards: vec![a.id, b.id],
+        ..Default::default()
+    };
+    cache.resolve(&FixedPlan(round.clone()), &store).unwrap();
+    assert!(cache.card(a.id).is_loaded());
+
+    cache.invalidate(Invalidation::Entities(EntityIds::cards([a.id])));
+    assert!(cache.card(a.id).is_not_loaded());
+    assert!(cache.card(b.id).is_loaded());
+
+    store.clear_log();
+    let resolved = cache.resolve(&FixedPlan(round), &store).unwrap();
+
+    assert_eq!(cache.card(a.id).loaded().map(|c| c.id), Some(a.id));
+    assert!(resolved.cards.by_id[&a.id].is_loaded());
+}
+
+#[test]
+fn test_a_refetched_collection_replaces_the_previously_cached_contents() {
+    let store = store();
+    seed_board(&store, "a");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        ..Default::default()
+    });
+    cache.resolve(&plan, &store).unwrap();
+    assert_eq!(cache.board_list().loaded().map(|b| b.len()), Some(1));
+
+    seed_board(&store, "b");
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert_eq!(cache.board_list().loaded().map(|b| b.len()), Some(2));
+    assert_eq!(resolved.boards.all.loaded().map(|b| b.len()), Some(2));
+}

--- a/crates/kanban-service/src/cache/tests/retry.rs
+++ b/crates/kanban-service/src/cache/tests/retry.rs
@@ -1,7 +1,7 @@
 use kanban_domain::{EntityIds, FetchRound, Invalidation};
 
 use super::{
-    seed_board, seed_board_with_column, seed_card, store, BoardListPlan, CardByIdPlan, FixedPlan,
+    seed_board, seed_board_with_column, seed_card, store, BoardListPlan, CardsByIdPlan, FixedPlan,
 };
 use crate::cache::EntityCache;
 use crate::read_recorder::{assert_ops, ReadOp};
@@ -13,7 +13,7 @@ fn test_a_failed_card_is_refetched_and_recovers_once_the_backend_does() {
     let card = seed_card(&store, &board, &column, "a");
     store.fail_card(card.id);
     let mut cache = EntityCache::new();
-    let plan = CardByIdPlan { card_id: card.id };
+    let plan = CardsByIdPlan { ids: vec![card.id] };
 
     cache.resolve(&plan, &store).unwrap();
     assert!(cache.card(card.id).is_failed());
@@ -63,18 +63,29 @@ fn test_a_failed_collection_is_refetched_and_recovers_once_the_backend_does() {
 #[test]
 fn test_a_missing_card_is_not_refetched_while_a_failed_one_is() {
     let store = store();
-    seed_board_with_column(&store);
+    let (board, column) = seed_board_with_column(&store);
+    let failing = seed_card(&store, &board, &column, "a");
     let absent = uuid::Uuid::new_v4();
+    store.fail_card(failing.id);
     let mut cache = EntityCache::new();
-    let plan = CardByIdPlan { card_id: absent };
+    let plan = CardsByIdPlan {
+        ids: vec![absent, failing.id],
+    };
 
     cache.resolve(&plan, &store).unwrap();
     assert!(cache.card(absent).is_missing());
+    assert!(cache.card(failing.id).is_failed());
 
     store.clear_log();
     cache.resolve(&plan, &store).unwrap();
 
-    assert_ops(&store.ops(), &[]);
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![failing.id],
+        }],
+    );
     assert!(cache.card(absent).is_missing());
 }
 
@@ -85,21 +96,29 @@ fn test_an_invalidated_entity_is_refetched_while_an_untouched_sibling_is_not() {
     let a = seed_card(&store, &board, &column, "a");
     let b = seed_card(&store, &board, &column, "b");
     let mut cache = EntityCache::new();
-    let round = FetchRound {
-        cards: vec![a.id, b.id],
-        ..Default::default()
+    let plan = CardsByIdPlan {
+        ids: vec![a.id, b.id],
     };
-    cache.resolve(&FixedPlan(round.clone()), &store).unwrap();
+    cache.resolve(&plan, &store).unwrap();
     assert!(cache.card(a.id).is_loaded());
+    assert!(cache.card(b.id).is_loaded());
 
     cache.invalidate(Invalidation::Entities(EntityIds::cards([a.id])));
     assert!(cache.card(a.id).is_not_loaded());
     assert!(cache.card(b.id).is_loaded());
 
     store.clear_log();
-    let resolved = cache.resolve(&FixedPlan(round), &store).unwrap();
+    let resolved = cache.resolve(&plan, &store).unwrap();
 
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![a.id],
+        }],
+    );
     assert_eq!(cache.card(a.id).loaded().map(|c| c.id), Some(a.id));
+    assert_eq!(resolved.cards.by_id.len(), 1);
     assert!(resolved.cards.by_id[&a.id].is_loaded());
 }
 

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -18,6 +18,8 @@ mod cascade;
 pub mod config;
 mod context;
 mod path;
+#[cfg(test)]
+mod read_recorder;
 mod sprint_name;
 mod store_adapter;
 mod store_manager;

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -14,6 +14,7 @@ pub use kanban_api as api;
 pub use kanban_backend as backend;
 #[cfg(test)]
 mod backend_test_support;
+pub mod cache;
 mod cascade;
 pub mod config;
 mod context;
@@ -24,6 +25,7 @@ mod sprint_name;
 mod store_adapter;
 mod store_manager;
 pub mod undo_stack;
+pub use cache::EntityCache;
 pub use config::AppConfigDto;
 pub use context::{
     BatchOperationFailure, BatchOperationResult, BoardCreateOutcome, BoardRelations,

--- a/crates/kanban-service/src/read_recorder.rs
+++ b/crates/kanban-service/src/read_recorder.rs
@@ -1,0 +1,252 @@
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::{
+    ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
+    KanbanResult, Prefix, Snapshot, Sprint,
+};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadOp {
+    pub method: &'static str,
+    pub ids: Vec<Uuid>,
+}
+
+pub type ReadOpLog = Arc<Mutex<Vec<ReadOp>>>;
+
+pub fn assert_ops(log: &Mutex<Vec<ReadOp>>, expected: &[ReadOp]) {
+    let actual = log.lock().unwrap().clone();
+    assert_eq!(
+        actual.as_slice(),
+        expected,
+        "read op log mismatch\n  expected: {expected:?}\n  actual:   {actual:?}"
+    );
+}
+
+pub struct RecordingStore {
+    inner: InMemoryStore,
+    ops: ReadOpLog,
+    fail_cards: Mutex<HashSet<Uuid>>,
+}
+
+impl RecordingStore {
+    pub fn new() -> Self {
+        Self {
+            inner: InMemoryStore::new(),
+            ops: Arc::new(Mutex::new(Vec::new())),
+            fail_cards: Mutex::new(HashSet::new()),
+        }
+    }
+
+    pub fn ops(&self) -> ReadOpLog {
+        self.ops.clone()
+    }
+
+    pub fn clear_log(&self) {
+        self.ops.lock().unwrap().clear();
+    }
+
+    pub fn fail_card(&self, id: Uuid) {
+        self.fail_cards.lock().unwrap().insert(id);
+    }
+
+    fn record(&self, method: &'static str, ids: Vec<Uuid>) {
+        self.ops.lock().unwrap().push(ReadOp { method, ids });
+    }
+}
+
+impl Default for RecordingStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DataStore for RecordingStore {
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<Prefix>> {
+        self.record("get_prefix", vec![]);
+        self.inner.get_prefix(name)
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<Prefix>> {
+        self.record("list_prefixes", vec![]);
+        self.inner.list_prefixes()
+    }
+    fn upsert_prefix(&self, prefix: Prefix) -> KanbanResult<()> {
+        self.inner.upsert_prefix(prefix)
+    }
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        self.record("get_board", vec![id]);
+        self.inner.get_board(id)
+    }
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        self.record("list_boards", vec![]);
+        self.inner.list_boards()
+    }
+    fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+        self.inner.upsert_board(board)
+    }
+    fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_board(id)
+    }
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        self.record("get_column", vec![id]);
+        self.inner.get_column(id)
+    }
+    fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        self.record("list_columns_by_board", vec![board_id]);
+        self.inner.list_columns_by_board(board_id)
+    }
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.record("list_all_columns", vec![]);
+        self.inner.list_all_columns()
+    }
+    fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+        self.inner.upsert_column(column)
+    }
+    fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_column(id)
+    }
+    fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_columns_by_board(board_id)
+    }
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        self.record("get_card", vec![id]);
+        if self.fail_cards.lock().unwrap().contains(&id) {
+            return Err(KanbanError::unsupported("injected read failure"));
+        }
+        self.inner.get_card(id)
+    }
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.record("list_all_cards", vec![]);
+        self.inner.list_all_cards()
+    }
+    fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.record("list_cards_by_column", vec![column_id]);
+        self.inner.list_cards_by_column(column_id)
+    }
+    fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.record("list_cards_by_sprint", vec![sprint_id]);
+        self.inner.list_cards_by_sprint(sprint_id)
+    }
+    fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+        self.record("count_cards_in_column", vec![column_id]);
+        self.inner.count_cards_in_column(column_id)
+    }
+    fn count_cards_in_column_excluding(
+        &self,
+        column_id: Uuid,
+        exclude_ids: &[Uuid],
+    ) -> KanbanResult<usize> {
+        self.record("count_cards_in_column_excluding", vec![column_id]);
+        self.inner
+            .count_cards_in_column_excluding(column_id, exclude_ids)
+    }
+    fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+        self.inner.upsert_card(card)
+    }
+    fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_card(id)
+    }
+    fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+        self.inner.delete_cards_by_columns(column_ids)
+    }
+    fn clear_sprint_from_cards(
+        &self,
+        sprint_id: Uuid,
+        cleared_at: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner.clear_sprint_from_cards(sprint_id, cleared_at)
+    }
+    fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        self.record("get_archived_card", vec![card_id]);
+        self.inner.get_archived_card(card_id)
+    }
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        self.record("list_archived_cards", vec![]);
+        self.inner.list_archived_cards()
+    }
+    fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+        self.inner.insert_archived_card(ac)
+    }
+    fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_card(card_id)
+    }
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        self.inner.get_archived_board(board_id)
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.inner.list_archived_boards()
+    }
+    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        self.inner.insert_archived_board(ab)
+    }
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_board(board_id)
+    }
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.unarchive_board(board_id)
+    }
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        self.record("get_sprint", vec![id]);
+        self.inner.get_sprint(id)
+    }
+    fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        self.record("list_sprints_by_board", vec![board_id]);
+        self.inner.list_sprints_by_board(board_id)
+    }
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.record("list_all_sprints", vec![]);
+        self.inner.list_all_sprints()
+    }
+    fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+        self.inner.upsert_sprint(sprint)
+    }
+    fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprint(id)
+    }
+    fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprints_by_board(board_id)
+    }
+    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+        self.record("get_graph", vec![]);
+        self.inner.get_graph()
+    }
+    fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+        self.inner.set_graph(graph)
+    }
+    fn snapshot(&self) -> KanbanResult<Snapshot> {
+        self.record("snapshot", vec![]);
+        self.inner.snapshot()
+    }
+    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+        self.inner.apply_snapshot(snapshot)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_recorder_logs_one_get_card_for_one_get_card_call() {
+        let store = RecordingStore::new();
+        let card = Card::new(Uuid::new_v4(), Uuid::new_v4(), "t", 0);
+        let id = card.id;
+        store.upsert_card(card).unwrap();
+        store.clear_log();
+
+        let fetched = store.get_card(id).unwrap();
+
+        assert!(fetched.is_some());
+        assert_ops(
+            &store.ops(),
+            &[ReadOp {
+                method: "get_card",
+                ids: vec![id],
+            }],
+        );
+    }
+}

--- a/crates/kanban-service/src/read_recorder.rs
+++ b/crates/kanban-service/src/read_recorder.rs
@@ -72,6 +72,13 @@ impl RecordingStore {
         self.fail_methods.lock().unwrap().insert(method);
     }
 
+    pub fn clear_failures(&self) {
+        self.fail_cards.lock().unwrap().clear();
+        self.fail_columns.lock().unwrap().clear();
+        self.fail_sprints.lock().unwrap().clear();
+        self.fail_methods.lock().unwrap().clear();
+    }
+
     fn check(&self, method: &'static str) -> KanbanResult<()> {
         if self.fail_methods.lock().unwrap().contains(method) {
             return Err(KanbanError::unsupported("injected read failure"));

--- a/crates/kanban-service/src/read_recorder.rs
+++ b/crates/kanban-service/src/read_recorder.rs
@@ -31,6 +31,9 @@ pub struct RecordingStore {
     inner: InMemoryStore,
     ops: ReadOpLog,
     fail_cards: Mutex<HashSet<Uuid>>,
+    fail_columns: Mutex<HashSet<Uuid>>,
+    fail_sprints: Mutex<HashSet<Uuid>>,
+    fail_methods: Mutex<HashSet<&'static str>>,
 }
 
 impl RecordingStore {
@@ -39,6 +42,9 @@ impl RecordingStore {
             inner: InMemoryStore::new(),
             ops: Arc::new(Mutex::new(Vec::new())),
             fail_cards: Mutex::new(HashSet::new()),
+            fail_columns: Mutex::new(HashSet::new()),
+            fail_sprints: Mutex::new(HashSet::new()),
+            fail_methods: Mutex::new(HashSet::new()),
         }
     }
 
@@ -52,6 +58,25 @@ impl RecordingStore {
 
     pub fn fail_card(&self, id: Uuid) {
         self.fail_cards.lock().unwrap().insert(id);
+    }
+
+    pub fn fail_column(&self, id: Uuid) {
+        self.fail_columns.lock().unwrap().insert(id);
+    }
+
+    pub fn fail_sprint(&self, id: Uuid) {
+        self.fail_sprints.lock().unwrap().insert(id);
+    }
+
+    pub fn fail_method(&self, method: &'static str) {
+        self.fail_methods.lock().unwrap().insert(method);
+    }
+
+    fn check(&self, method: &'static str) -> KanbanResult<()> {
+        if self.fail_methods.lock().unwrap().contains(method) {
+            return Err(KanbanError::unsupported("injected read failure"));
+        }
+        Ok(())
     }
 
     fn record(&self, method: &'static str, ids: Vec<Uuid>) {
@@ -83,6 +108,7 @@ impl DataStore for RecordingStore {
     }
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
         self.record("list_boards", vec![]);
+        self.check("list_boards")?;
         self.inner.list_boards()
     }
     fn upsert_board(&self, board: Board) -> KanbanResult<()> {
@@ -93,6 +119,9 @@ impl DataStore for RecordingStore {
     }
     fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
         self.record("get_column", vec![id]);
+        if self.fail_columns.lock().unwrap().contains(&id) {
+            return Err(KanbanError::unsupported("injected read failure"));
+        }
         self.inner.get_column(id)
     }
     fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
@@ -101,6 +130,7 @@ impl DataStore for RecordingStore {
     }
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
         self.record("list_all_columns", vec![]);
+        self.check("list_all_columns")?;
         self.inner.list_all_columns()
     }
     fn upsert_column(&self, column: Column) -> KanbanResult<()> {
@@ -121,6 +151,7 @@ impl DataStore for RecordingStore {
     }
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
         self.record("list_all_cards", vec![]);
+        self.check("list_all_cards")?;
         self.inner.list_all_cards()
     }
     fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
@@ -191,6 +222,9 @@ impl DataStore for RecordingStore {
     }
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
         self.record("get_sprint", vec![id]);
+        if self.fail_sprints.lock().unwrap().contains(&id) {
+            return Err(KanbanError::unsupported("injected read failure"));
+        }
         self.inner.get_sprint(id)
     }
     fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
@@ -199,6 +233,7 @@ impl DataStore for RecordingStore {
     }
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
         self.record("list_all_sprints", vec![]);
+        self.check("list_all_sprints")?;
         self.inner.list_all_sprints()
     }
     fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
@@ -212,6 +247,7 @@ impl DataStore for RecordingStore {
     }
     fn get_graph(&self) -> KanbanResult<DependencyGraph> {
         self.record("get_graph", vec![]);
+        self.check("get_graph")?;
         self.inner.get_graph()
     }
     fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {


### PR DESCRIPTION
Implements KAN-1320: `EntityCache` with `invalidate` and a single-round `resolve`.

## Changes

- `crates/kanban-service/src/cache/mod.rs`: `EntityCache` holding a `Collection<T>` per entity kind plus a `LoadState<DependencyGraph>` singleton. `resolve(&mut self, plan: &dyn FetchPlan, store: &dyn DataStore) -> KanbanResult<Resolved>` fetches one round via the narrowest `DataStore` method per item and maps `Ok(Some)` to `Loaded`, `Ok(None)` to `Missing`, `Err` to `Failed`, continuing the round rather than letting one failure starve the rest.
- `invalidate` covers all six dimensions a command batch can touch (boards, columns, cards, sprints, graph, prefixes) and always clears the whole-collection tier alongside the named ids.
- `crates/kanban-service/src/read_recorder.rs`: a recording `DataStore` so tests can assert exactly which reads a resolve performed, with per-method and per-id failure injection that can be cleared again.
- Tests in `crates/kanban-service/src/cache/tests/`.

Nothing outside `kanban-service` is wired to this yet; `KanbanContext` integration is KAN-1302.

## Design note

`EntityCache` mirrors `Resolved`'s two-tier shape, one `Collection<T>` per kind rather than per-id maps only. Without the `all` tier the cache could not represent "the whole card list loaded and is genuinely empty", which is the distinction KAN-1317 added `Collection<T>` to provide, and every list-all read would be uncacheable.

## Test plan

- [x] `cargo test -p kanban-service`: 124 lib tests plus every integration binary, 0 failed
- [x] `cargo clippy -p kanban-service --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] Changeset added: `.changeset/kan-1320.md` (`bump: minor`, new public module and re-export)

## Note on provenance

The implementer agent was interrupted by a process exit after committing and before pushing. Verification above was re-run from scratch on the final commit; no implementation logic was changed after the interruption.

**Six review rounds followed. Every rejection was about the tests, never the behaviour, so the implementation is unchanged from the original four commits.**

Round 1 rejected a coverage hole on the column and sprint by-id tiers, whose only assertions were taken after `Invalidation::All` and so held whether or not `resolve` ever populated those maps, and the currency doc comment sitting on the `EntityCache` struct rather than on `resolve`. Fixed in `2f288ea8` (tests) and `033e334d` (doc comment relocation, no logic change).

Round 2 ran a sabotage matrix over every write in `fetch_round` and found three more unguarded: `resolved.columns.all`, `resolved.sprints.all` and `resolved.graph` could each be replaced with `NotLoaded` with the suite still green. These sit on the returned value rather than the cache, so a regression would strand a consumer with a permanently empty view that no later round repairs, because the cache side reads `Loaded` and `requestable` is therefore false. Fixed in `934701f6`.

Round 3 sent two independent reviewers. One passed the design, contract and hygiene axes. The other confirmed the sixteen-write matrix held but found the same class still open outside `fetch_round`: three of `invalidate`'s six `EntityIds` dimensions had no test at all, and seven of `LoadedView`'s eight accessors were indistinguishable from constants. Because every accessor returns the payload-free `FetchStatus`, a wrong-tier copy-paste there is invisible to the type checker and would strand a consumer exactly as the round-2 defect would. Fixed in `d627fa81`.

Round 4 found that every round so far had pinned which field each branch writes and never what value it writes. Nine of the eleven result-mapping arms survived mutation: every list read could map `Err` to `Loaded(vec![])`, `get_graph` could map `Err` to `NotLoaded`, and `get_column`/`get_sprint` could collapse `Ok(None)` into `NotLoaded` or report `Err` as `Missing`. An error surfacing as a loaded empty collection is the exact failure this cache exists to prevent. The root cause was the fixture: `RecordingStore` could only inject failure for `get_card`, so the suite's reach had been silently bounded by what the test double could express. Fixed in `5cd6e5b4`, which added per-method and per-id injection.

Round 5 found that no test fetched the same tier or id twice, so every write in `fetch_round` was indistinguishable from write-once and a `Failed` entity could never recover. `requestable` is `NotLoaded | Failed`, so retry is the one thing `Failed` exists for. The root cause was the fixture again: failures could be added but never cleared, so "the backend healed" was inexpressible. Fixed in `938d752f`, which added `clear_failures` and a refetch suite that also pins the cross-crate `requestable` polarity.

Round 6 was aimed at correctness rather than coverage, since five rounds of coverage pressure had never moved the implementation. Two reviewers cleared the behaviour: one rebuilt the production invalidation pipeline in a probe and drove twelve real command batches through it against a fully populated cache, diffing every surviving cached claim against a fresh store read, and found no stale claim; the other verified every cross-crate premise the module's doc comments assert. The third found four tests whose contrastive names promised more than their bodies proved. The worst was `test_an_invalidated_entity_is_refetched_while_an_untouched_sibling_is_not`, which drove both resolves with a plan that ignores `LoadedState`: the sibling was refetched on every run, nothing asserted otherwise, and deleting the `invalidate` call left the test green, so neither clause of the name was caused by the code under test. Fixed in `a10afb18`.

Coverage is established by mutation rather than by assertion count. Every write in `fetch_round`, every dimension of `invalidate`, every accessor on `LoadedView`, every result-mapping arm, and the refetch-after-failure and refetch-after-invalidation paths each fail at least one test when individually broken.
