### PR TITLE
KAN-1238 feat(server): page params and Page envelope on the four list routes

### DIFF
--- a/.changeset/kan-1238-list-route-pagination.md
+++ b/.changeset/kan-1238-list-route-pagination.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: the four collection endpoints (GET /v1/boards, /v1/boards/{id}/columns, /v1/boards/{id}/cards and /v1/boards/{id}/sprints) now accept ?page= and ?page_size= and return a { items, total, page, page_size, total_pages } envelope instead of a bare JSON array, so a client can page through a large board and still know how many rows exist; page_size defaults to 50 and is capped at 500, a page or page_size of 0 is a 422, and a page past the end is a 200 with an empty items list rather than an error.

--- a/crates/kanban-api/src/v1/pagination.rs
+++ b/crates/kanban-api/src/v1/pagination.rs
@@ -51,4 +51,23 @@ mod tests {
         assert_eq!(params.page, Some(2));
         assert_eq!(params.page_size, Some(25));
     }
+
+    #[test]
+    fn test_paginated_list_converts_to_page_preserving_every_field() {
+        let list = kanban_core::paginated_list::PaginatedList {
+            items: vec!["a".to_string(), "b".to_string()],
+            total: 7,
+            page: 2,
+            page_size: 3,
+            total_pages: 3,
+        };
+
+        let page = Page::from(list);
+
+        assert_eq!(page.items, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(page.total, 7);
+        assert_eq!(page.page, 2u32);
+        assert_eq!(page.page_size, 3u32);
+        assert_eq!(page.total_pages, 3u32);
+    }
 }

--- a/crates/kanban-api/src/v1/pagination.rs
+++ b/crates/kanban-api/src/v1/pagination.rs
@@ -19,6 +19,25 @@ pub struct PageParams {
     pub page_size: Option<u32>,
 }
 
+impl<T> From<kanban_core::paginated_list::PaginatedList<T>> for Page<T> {
+    fn from(list: kanban_core::paginated_list::PaginatedList<T>) -> Self {
+        let kanban_core::paginated_list::PaginatedList {
+            items,
+            total,
+            page,
+            page_size,
+            total_pages,
+        } = list;
+        Self {
+            items,
+            total,
+            page: page as u32,
+            page_size: page_size as u32,
+            total_pages: total_pages as u32,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -74,27 +74,33 @@ curl -s http://127.0.0.1:58548/health | jq
 curl -s http://127.0.0.1:58548/v1/boards | jq
 ```
 ```json
-[
-  {
-    "id": "e119c091-e1fa-4596-9bc7-038ceab6adec",
-    "name": "Kanban",
-    "description": "Management of the **Kanban** project\n",
-    "sprint_prefix": "KAN",
-    "card_prefix": "KAN",
-    "task_sort_field": "updated_at",
-    "task_sort_order": "descending",
-    "sprint_duration_days": 7,
-    "task_list_view": "grouped_by_column",
-    "active_sprint_id": "2ab2a4d3-80d0-4bd6-881c-88bed5fd7670",
-    "position": 0,
-    "created_at": "2025-10-10T08:47:44.779097Z",
-    "updated_at": "2026-07-04T10:55:00.488151029Z"
-  }
-]
+{
+  "items": [
+    {
+      "id": "e119c091-e1fa-4596-9bc7-038ceab6adec",
+      "name": "Kanban",
+      "description": "Management of the **Kanban** project\n",
+      "sprint_prefix": "KAN",
+      "card_prefix": "KAN",
+      "task_sort_field": "updated_at",
+      "task_sort_order": "descending",
+      "sprint_duration_days": 7,
+      "task_list_view": "grouped_by_column",
+      "active_sprint_id": "2ab2a4d3-80d0-4bd6-881c-88bed5fd7670",
+      "position": 0,
+      "created_at": "2025-10-10T08:47:44.779097Z",
+      "updated_at": "2026-07-04T10:55:00.488151029Z"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "page_size": 50,
+  "total_pages": 1
+}
 ```
 
 ```bash
-curl -s http://127.0.0.1:58548/v1/boards/e119c091-e1fa-4596-9bc7-038ceab6adec/columns | jq '.[].name'
+curl -s http://127.0.0.1:58548/v1/boards/e119c091-e1fa-4596-9bc7-038ceab6adec/columns | jq '.items[].name'
 ```
 ```json
 "Backlog"
@@ -132,7 +138,7 @@ curl -s http://127.0.0.1:58548/v1/boards/00000000-0000-0000-0000-000000000000 | 
 
 ## Endpoints
 
-All request/response bodies are JSON. Errors share one envelope (see [Error Handling](#error-handling)).
+All request/response bodies are JSON. Errors share one envelope (see [Error Handling](#error-handling)). The four collection `GET`s (`/v1/boards`, `/v1/boards/{board_id}/columns`, `/v1/boards/{board_id}/cards`, `/v1/boards/{board_id}/sprints`) accept `?page=&page_size=` and return a `Page<T>` envelope; see [Pagination](#pagination).
 
 ### Health
 
@@ -144,7 +150,7 @@ All request/response bodies are JSON. Errors share one envelope (see [Error Hand
 
 | Method | Path | Description | Body |
 |---|---|---|---|
-| `GET` | `/v1/boards` | List all boards | — |
+| `GET` | `/v1/boards` | List all boards. Returns `Page<BoardResponse>`; accepts `?page=&page_size=`. | — |
 | `GET` | `/v1/boards/{id}` | Get a board by UUID. Returns `archived_at` (present only if the board is archived). | — |
 | `POST` | `/v1/boards` | Create a board. `201 Created`. A board created this way always has zero columns. | `CreateBoardRequest` |
 | `PUT` | `/v1/boards/{id}` | Full replace (RFC 9110 §9.3.4) — creates the board at `id` if absent (`201`), otherwise replaces it in full (`200`). All non-nullable fields are required; a partial body is a 400. | `ReplaceBoardRequest` |
@@ -155,7 +161,7 @@ All request/response bodies are JSON. Errors share one envelope (see [Error Hand
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/v1/boards/{board_id}/columns` | List a board's columns |
+| `GET` | `/v1/boards/{board_id}/columns` | List a board's columns. Returns `Page<ColumnResponse>`; accepts `?page=&page_size=`. |
 | `GET` | `/v1/boards/{board_id}/columns/{id}` | Get a column by UUID. 404s if the column exists but belongs to a different board. |
 
 Column writes (create/update/delete) aren't implemented yet.
@@ -164,7 +170,7 @@ Column writes (create/update/delete) aren't implemented yet.
 
 | Method | Path | Description | Body |
 |---|---|---|---|
-| `GET` | `/v1/boards/{board_id}/sprints` | List a board's sprints. 404s if `board_id` doesn't exist (does not collapse into an empty list). | — |
+| `GET` | `/v1/boards/{board_id}/sprints` | List a board's sprints. 404s if `board_id` doesn't exist (does not collapse into an empty list). Returns `Page<SprintResponse>`; accepts `?page=&page_size=`. | — |
 | `GET` | `/v1/boards/{board_id}/sprints/{id}` | Get a sprint by UUID. 404s if the sprint exists but belongs to a different board. | — |
 | `POST` | `/v1/boards/{board_id}/sprints` | Create a sprint. `201 Created`. A client-supplied `id` that already exists is a `409 Conflict`. | `CreateSprintRequest` |
 | `PUT` | `/v1/boards/{board_id}/sprints/{id}` | Full replace (RFC 9110 §9.3.4) — creates the sprint at `id` if absent (`201`), otherwise replaces it in full (`200`). 404s if `id` belongs to a different board. | `ReplaceSprintRequest` |
@@ -173,6 +179,14 @@ Column writes (create/update/delete) aren't implemented yet.
 | `GET` | `/v1/sprints/{id}` | Flat alias for the board-scoped `GET`. | — |
 | `PATCH` | `/v1/sprints/{id}` | Flat alias for the board-scoped `PATCH`. | `UpdateSprintRequest` |
 | `DELETE` | `/v1/sprints/{id}` | Flat alias for the board-scoped `DELETE`. | — |
+
+### Cards
+
+| Method | Path | Description | Body |
+|---|---|---|---|
+| `GET` | `/v1/boards/{board_id}/cards` | List a board's cards. Supports `?column_id=`, `?sprint_id=` and `?archived=` filters alongside pagination. Returns `Page<CardResponse>`; accepts `?page=&page_size=`. | — |
+
+The remaining card routes (get/create/replace/update/delete, and the flat `/v1/cards/{id}` aliases) exist but aren't documented in this table yet.
 
 ### Graph
 
@@ -187,6 +201,21 @@ Column writes (create/update/delete) aren't implemented yet.
 | `GET` | `/v1/events` | Server-Sent Events stream of `ChangeEventFrame`s, one per successful mutation (or per detected external write). Each frame carries `entity_type`/`entity_id`/`kind`, all absent when the emitter cannot name what changed. |
 
 Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event naming the entity it touched and, per the persistence layer's normal save path, durably writes to the configured store before responding.
+
+## Pagination
+
+`GET /v1/boards`, `GET /v1/boards/{board_id}/columns`, `GET /v1/boards/{board_id}/cards` and `GET /v1/boards/{board_id}/sprints` accept `?page=` (1-based) and `?page_size=`, both optional, and return a `Page<T>` envelope:
+
+```json
+{ "items": [...], "total": 42, "page": 1, "page_size": 50, "total_pages": 1 }
+```
+
+- `page` defaults to `1`, `page_size` defaults to `50`.
+- `page_size` is capped at `500`; `page=0`, `page_size=0` or `page_size` over the cap is a `422 VALIDATION_FAILED`.
+- A `page` past the last page is a normal `200` with `items: []`; `total` still reports the true, unfiltered count.
+- `total_pages` is `0` for an empty collection.
+- Slicing is in-memory: the full collection is read from storage first, then windowed. There is no store-level `LIMIT`/`OFFSET`.
+- Other query params on `GET /v1/boards/{board_id}/cards` (`column_id`, `sprint_id`, `archived`) apply before pagination, so `total` reflects the filtered count, not the whole board.
 
 ## Error Handling
 

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod app;
 pub mod error;
+pub mod pagination;
 pub mod state;
 pub mod watch;
 

--- a/crates/kanban-server/src/pagination.rs
+++ b/crates/kanban-server/src/pagination.rs
@@ -1,0 +1,17 @@
+use crate::error::AppError;
+use axum::Json;
+use kanban_core::paginated_list::{resolve_page_params, PaginatedList};
+use kanban_service::api::{Page, PageParams};
+use kanban_service::KanbanError;
+
+/// # Errors
+///
+/// A zero or over-`MAX_PAGE_SIZE` parameter becomes a `VALIDATION_FAILED`
+/// [`AppError`] (HTTP 422).
+pub fn paginate_response<T>(items: Vec<T>, params: &PageParams) -> Result<Json<Page<T>>, AppError> {
+    let (page, page_size) = resolve_page_params(params.page, params.page_size)
+        .map_err(|e| AppError::from(&KanbanError::from(e)))?;
+    let paginated = PaginatedList::paginate(items, page, page_size)
+        .map_err(|e| AppError::from(&KanbanError::from(e)))?;
+    Ok(Json(paginated.into()))
+}

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -1,21 +1,25 @@
 use crate::error::{AppError, AppJson};
 use crate::handlers::boards::{create_board, create_or_replace_board};
+use crate::pagination::paginate_response;
 use crate::state::AppState;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use kanban_service::api::{
-    BoardResponse, ChangeKind, CreateBoardRequest, EntityType, ReplaceBoardRequest,
-    UpdateBoardRequest,
+    BoardResponse, ChangeKind, CreateBoardRequest, EntityType, Page, PageParams,
+    ReplaceBoardRequest, UpdateBoardRequest,
 };
 use kanban_service::{KanbanError, KanbanOperations};
 use uuid::Uuid;
 
-async fn list_boards(State(state): State<AppState>) -> Result<Json<Vec<BoardResponse>>, AppError> {
+async fn list_boards(
+    State(state): State<AppState>,
+    Query(params): Query<PageParams>,
+) -> Result<Json<Page<BoardResponse>>, AppError> {
     let ctx = state.ctx.lock().await;
     let boards = ctx.list_boards().map_err(|e| AppError::from(&e))?;
-    Ok(Json(boards.iter().map(BoardResponse::from).collect()))
+    paginate_response(boards.iter().map(BoardResponse::from).collect(), &params)
 }
 
 async fn get_board(

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -1,4 +1,5 @@
 use crate::error::{AppError, AppJson};
+use crate::pagination::paginate_response;
 use crate::state::AppState;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
@@ -7,7 +8,9 @@ use axum::{Json, Router};
 use kanban_domain::{Card, CardListFilter};
 use kanban_service::api::ArchivedFilterDto;
 use kanban_service::api::CardResponse;
-use kanban_service::api::{ChangeKind, CreateCardRequest, EntityType, UpdateCardRequest};
+use kanban_service::api::{
+    ChangeKind, CreateCardRequest, EntityType, Page, PageParams, UpdateCardRequest,
+};
 use kanban_service::{CardUpdate, KanbanError, KanbanOperations};
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -25,7 +28,8 @@ async fn list_cards(
     State(state): State<AppState>,
     Path(board_id): Path<Uuid>,
     Query(q): Query<CardQuery>,
-) -> Result<Json<Vec<CardResponse>>, AppError> {
+    Query(params): Query<PageParams>,
+) -> Result<Json<Page<CardResponse>>, AppError> {
     let filter = CardListFilter {
         board_id: Some(board_id),
         column_id: q.column_id,
@@ -37,12 +41,11 @@ async fn list_cards(
     let cards = ctx
         .list_cards_detailed(filter)
         .map_err(|e| AppError::from(&e))?;
-    Ok(Json(
-        cards
-            .iter()
-            .map(|(card, archived_at)| CardResponse::with_archived_at(card, *archived_at))
-            .collect(),
-    ))
+    let responses: Vec<CardResponse> = cards
+        .iter()
+        .map(|(card, archived_at)| CardResponse::with_archived_at(card, *archived_at))
+        .collect();
+    paginate_response(responses, &params)
 }
 
 async fn get_card(

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -1,21 +1,23 @@
 use crate::error::{AppError, AppJson};
+use crate::pagination::paginate_response;
 use crate::state::AppState;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use kanban_domain::Column;
-use kanban_service::api::{ChangeKind, ColumnResponse, EntityType};
+use kanban_service::api::{ChangeKind, ColumnResponse, EntityType, Page, PageParams};
 use kanban_service::{ColumnUpdate, KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 async fn list_columns(
     State(state): State<AppState>,
     Path(board_id): Path<Uuid>,
-) -> Result<Json<Vec<ColumnResponse>>, AppError> {
+    Query(params): Query<PageParams>,
+) -> Result<Json<Page<ColumnResponse>>, AppError> {
     let ctx = state.ctx.lock().await;
     let cols = ctx.list_columns(board_id).map_err(|e| AppError::from(&e))?;
-    Ok(Json(cols.iter().map(ColumnResponse::from).collect()))
+    paginate_response(cols.iter().map(ColumnResponse::from).collect(), &params)
 }
 
 async fn get_column(

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -1,11 +1,12 @@
 use crate::error::{AppError, AppJson};
+use crate::pagination::paginate_response;
 use crate::state::AppState;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use kanban_domain::Sprint;
-use kanban_service::api::{ChangeKind, EntityType, SprintResponse};
+use kanban_service::api::{ChangeKind, EntityType, Page, PageParams, SprintResponse};
 use kanban_service::{
     resolve_sprint_name, resolve_sprint_names, KanbanError, KanbanOperations, SprintUpdate,
 };
@@ -14,17 +15,17 @@ use uuid::Uuid;
 async fn list_sprints(
     State(state): State<AppState>,
     Path(board_id): Path<Uuid>,
-) -> Result<Json<Vec<SprintResponse>>, AppError> {
+    Query(params): Query<PageParams>,
+) -> Result<Json<Page<SprintResponse>>, AppError> {
     let ctx = state.ctx.lock().await;
     let sprints = ctx.list_sprints(board_id).map_err(|e| AppError::from(&e))?;
     let names = resolve_sprint_names(&*ctx, board_id, &sprints).map_err(|e| AppError::from(&e))?;
-    Ok(Json(
-        sprints
-            .iter()
-            .zip(names)
-            .map(|(s, name)| SprintResponse::new(s, name))
-            .collect(),
-    ))
+    let responses: Vec<SprintResponse> = sprints
+        .iter()
+        .zip(names)
+        .map(|(s, name)| SprintResponse::new(s, name))
+        .collect();
+    paginate_response(responses, &params)
 }
 
 async fn get_sprint(

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -11,7 +11,7 @@ use tempfile::tempdir;
 use uuid::Uuid;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_boards_empty_returns_200_empty_array() {
+async fn test_list_boards_empty_returns_200_empty_page() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -19,7 +19,11 @@ async fn test_list_boards_empty_returns_200_empty_array() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    assert_eq!(json, serde_json::json!([]));
+    assert_eq!(json["items"], serde_json::json!([]));
+    assert_eq!(json["total"], 0);
+    assert_eq!(json["total_pages"], 0);
+    assert_eq!(json["page"], 1);
+    assert_eq!(json["page_size"], 50);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -46,8 +50,7 @@ async fn test_list_boards_returns_all_seeded_boards() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
 
-    assert!(json.is_array(), "response should be an array");
-    let arr = json.as_array().unwrap();
+    let arr = json["items"].as_array().expect("items should be an array");
     assert_eq!(arr.len(), 2, "should have 2 boards");
 
     let returned_ids: std::collections::HashSet<_> = arr

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -65,8 +65,7 @@ async fn test_list_cards_returns_all_board_cards_by_default() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
 
-    assert!(json.is_array(), "response should be an array");
-    let arr = json.as_array().unwrap();
+    let arr = json["items"].as_array().expect("items should be an array");
     assert_eq!(
         arr.len(),
         2,
@@ -138,8 +137,7 @@ async fn test_list_cards_column_filter_returns_only_that_column() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
 
-    assert!(json.is_array(), "response should be an array");
-    let arr = json.as_array().unwrap();
+    let arr = json["items"].as_array().expect("items should be an array");
     assert_eq!(arr.len(), 2, "should have 2 cards in column 1");
 
     for card in arr {
@@ -209,8 +207,7 @@ async fn test_list_cards_sprint_filter_returns_only_that_sprint() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
 
-    assert!(json.is_array(), "response should be an array");
-    let arr = json.as_array().unwrap();
+    let arr = json["items"].as_array().expect("items should be an array");
     assert_eq!(arr.len(), 1, "should have 1 card in the sprint");
     assert_eq!(arr[0]["sprint_id"], sprint_id.to_string());
 }
@@ -266,8 +263,7 @@ async fn test_list_cards_archived_include_returns_live_and_archived_with_archive
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
 
-    assert!(json.is_array(), "response should be an array");
-    let arr = json.as_array().unwrap();
+    let arr = json["items"].as_array().expect("items should be an array");
     assert_eq!(arr.len(), 2, "should have 2 cards (1 live, 1 archived)");
 
     let mut archived_found = false;
@@ -289,7 +285,7 @@ async fn test_list_cards_archived_include_returns_live_and_archived_with_archive
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_cards_unknown_board_id_returns_200_empty_array() {
+async fn test_list_cards_unknown_board_id_returns_200_empty_page() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -309,7 +305,8 @@ async fn test_list_cards_unknown_board_id_returns_200_empty_array() {
         "unknown board_id should return 200, not 404"
     );
     let json = json_of(response).await;
-    assert_eq!(json, serde_json::json!([]));
+    assert_eq!(json["items"], serde_json::json!([]));
+    assert_eq!(json["total"], 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -440,7 +437,7 @@ async fn test_get_card_wrong_board_returns_404() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_cards_route_body_deserializes_as_card_response_vec() {
+async fn test_list_cards_route_body_deserializes_as_page_of_card_response() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -469,9 +466,9 @@ async fn test_list_cards_route_body_deserializes_as_card_response_vec() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    let parsed: Vec<CardResponse> =
-        serde_json::from_value(json).expect("list body should deserialize as Vec<CardResponse>");
-    assert_eq!(parsed.len(), 1);
+    let parsed: kanban_service::api::Page<CardResponse> = serde_json::from_value(json)
+        .expect("list body should deserialize as Page<CardResponse>");
+    assert_eq!(parsed.items.len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -512,7 +509,7 @@ async fn test_list_cards_route_exposes_description_and_board_id_keys() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    let arr = json.as_array().unwrap();
+    let arr = json["items"].as_array().unwrap();
     let item = &arr[0];
 
     assert!(
@@ -572,7 +569,7 @@ async fn test_list_cards_route_serializes_priority_and_status_snake_case() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    let arr = json.as_array().unwrap();
+    let arr = json["items"].as_array().unwrap();
     let item = &arr[0];
 
     assert_eq!(item["priority"], "high");
@@ -624,11 +621,15 @@ async fn test_list_cards_route_stamps_archived_at_on_the_card_response() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    let parsed: Vec<CardResponse> =
-        serde_json::from_value(json).expect("list body should deserialize as Vec<CardResponse>");
+    let parsed: kanban_service::api::Page<CardResponse> = serde_json::from_value(json)
+        .expect("list body should deserialize as Page<CardResponse>");
 
-    let archived = parsed.iter().find(|c| c.title == "Archived Card").unwrap();
-    let live = parsed.iter().find(|c| c.title == "Live Card").unwrap();
+    let archived = parsed
+        .items
+        .iter()
+        .find(|c| c.title == "Archived Card")
+        .unwrap();
+    let live = parsed.items.iter().find(|c| c.title == "Live Card").unwrap();
 
     assert!(
         archived.archived_at.is_some(),
@@ -677,8 +678,8 @@ async fn test_list_cards_and_get_card_agree_for_a_live_card() {
     .await;
     assert_eq!(list_response.status(), StatusCode::OK);
     let list_json = json_of(list_response).await;
-    let list: Vec<CardResponse> = serde_json::from_value(list_json)
-        .expect("list body should deserialize as Vec<CardResponse>");
+    let list: kanban_service::api::Page<CardResponse> = serde_json::from_value(list_json)
+        .expect("list body should deserialize as Page<CardResponse>");
 
     let get_response = send(
         &state,
@@ -692,6 +693,6 @@ async fn test_list_cards_and_get_card_agree_for_a_live_card() {
     let single: CardResponse =
         serde_json::from_value(get_json).expect("get body should deserialize as CardResponse");
 
-    assert_eq!(list.len(), 1);
-    assert_eq!(list[0], single);
+    assert_eq!(list.items.len(), 1);
+    assert_eq!(list.items[0], single);
 }

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -466,8 +466,8 @@ async fn test_list_cards_route_body_deserializes_as_page_of_card_response() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    let parsed: kanban_service::api::Page<CardResponse> = serde_json::from_value(json)
-        .expect("list body should deserialize as Page<CardResponse>");
+    let parsed: kanban_service::api::Page<CardResponse> =
+        serde_json::from_value(json).expect("list body should deserialize as Page<CardResponse>");
     assert_eq!(parsed.items.len(), 1);
 }
 
@@ -621,15 +621,19 @@ async fn test_list_cards_route_stamps_archived_at_on_the_card_response() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    let parsed: kanban_service::api::Page<CardResponse> = serde_json::from_value(json)
-        .expect("list body should deserialize as Page<CardResponse>");
+    let parsed: kanban_service::api::Page<CardResponse> =
+        serde_json::from_value(json).expect("list body should deserialize as Page<CardResponse>");
 
     let archived = parsed
         .items
         .iter()
         .find(|c| c.title == "Archived Card")
         .unwrap();
-    let live = parsed.items.iter().find(|c| c.title == "Live Card").unwrap();
+    let live = parsed
+        .items
+        .iter()
+        .find(|c| c.title == "Live Card")
+        .unwrap();
 
     assert!(
         archived.archived_at.is_some(),

--- a/crates/kanban-server/tests/columns_read.rs
+++ b/crates/kanban-server/tests/columns_read.rs
@@ -47,8 +47,7 @@ async fn test_list_columns_returns_board_columns_in_position_order() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
 
-    assert!(json.is_array(), "response should be an array");
-    let arr = json.as_array().unwrap();
+    let arr = json["items"].as_array().expect("items should be an array");
     assert_eq!(arr.len(), 3, "should have 3 columns");
 
     assert_eq!(arr[0]["position"], 0, "first should be position 0");
@@ -65,7 +64,7 @@ async fn test_list_columns_returns_board_columns_in_position_order() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_columns_empty_board_returns_200_empty_array() {
+async fn test_list_columns_empty_board_returns_200_empty_page() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -88,11 +87,13 @@ async fn test_list_columns_empty_board_returns_200_empty_array() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    assert_eq!(json, serde_json::json!([]));
+    assert_eq!(json["items"], serde_json::json!([]));
+    assert_eq!(json["total"], 0);
+    assert_eq!(json["total_pages"], 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_columns_unknown_board_id_returns_200_empty_array() {
+async fn test_list_columns_unknown_board_id_returns_200_empty_page() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -112,7 +113,8 @@ async fn test_list_columns_unknown_board_id_returns_200_empty_array() {
         "unknown board_id should return 200, not 404"
     );
     let json = json_of(response).await;
-    assert_eq!(json, serde_json::json!([]));
+    assert_eq!(json["items"], serde_json::json!([]));
+    assert_eq!(json["total"], 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/pagination.rs
+++ b/crates/kanban-server/tests/pagination.rs
@@ -31,7 +31,10 @@ async fn test_list_boards_paginates_with_explicit_params() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
 
-    assert!(json.get("items").is_some(), "body should be a page envelope: {json}");
+    assert!(
+        json.get("items").is_some(),
+        "body should be a page envelope: {json}"
+    );
     let items = json["items"].as_array().unwrap();
     assert_eq!(items.len(), 2);
     assert_eq!(json["total"], 3);
@@ -198,7 +201,10 @@ async fn test_list_sprints_paginates() {
     assert_eq!(json["total"], 3);
     assert_eq!(json["total_pages"], 2);
     for item in items {
-        assert!(!item["name"].is_null(), "sprint name must survive pagination");
+        assert!(
+            !item["name"].is_null(),
+            "sprint name must survive pagination"
+        );
     }
 }
 
@@ -265,31 +271,56 @@ async fn test_list_cards_column_filter_and_archived_still_apply_alongside_paging
             .unwrap()
             .id;
 
-        ctx.create_card(board_id, col1_id, "Col1 Live 1".to_string(), Default::default())
-            .unwrap();
-        ctx.create_card(board_id, col1_id, "Col1 Live 2".to_string(), Default::default())
-            .unwrap();
+        ctx.create_card(
+            board_id,
+            col1_id,
+            "Col1 Live 1".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+        ctx.create_card(
+            board_id,
+            col1_id,
+            "Col1 Live 2".to_string(),
+            Default::default(),
+        )
+        .unwrap();
         let archived_id = ctx
-            .create_card(board_id, col1_id, "Col1 Archived".to_string(), Default::default())
+            .create_card(
+                board_id,
+                col1_id,
+                "Col1 Archived".to_string(),
+                Default::default(),
+            )
             .unwrap()
             .id;
         ctx.archive_card(archived_id).unwrap();
 
-        ctx.create_card(board_id, col2_id, "Col2 Live".to_string(), Default::default())
-            .unwrap();
+        ctx.create_card(
+            board_id,
+            col2_id,
+            "Col2 Live".to_string(),
+            Default::default(),
+        )
+        .unwrap();
     }
 
     let response = send(
         &state,
         "GET",
-        &format!("/v1/boards/{board_id}/cards?column_id={col1_id}&archived=include&page=2&page_size=2"),
+        &format!(
+            "/v1/boards/{board_id}/cards?column_id={col1_id}&archived=include&page=2&page_size=2"
+        ),
         None,
     )
     .await;
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    assert_eq!(json["total"], 3, "total should count only col1's live+archived cards");
+    assert_eq!(
+        json["total"], 3,
+        "total should count only col1's live+archived cards"
+    );
     let items = json["items"].as_array().unwrap();
     assert_eq!(items.len(), 1);
     for item in items {
@@ -315,7 +346,10 @@ async fn test_pagination_rejects_page_zero_with_422() {
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     let json = json_of(response).await;
     assert_eq!(json["code"], "VALIDATION_FAILED");
-    assert!(json.get("items").is_none(), "invalid page must not render as a page envelope");
+    assert!(
+        json.get("items").is_none(),
+        "invalid page must not render as a page envelope"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -371,7 +405,10 @@ async fn test_list_sprints_unknown_board_with_paging_still_returns_404() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let json = json_of(response).await;
     assert_eq!(json["code"], "NOT_FOUND");
-    assert!(json.get("items").is_none(), "a missing board must not render as an empty page");
+    assert!(
+        json.get("items").is_none(),
+        "a missing board must not render as an empty page"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -393,5 +430,8 @@ async fn test_list_boards_page_envelope_is_absent_on_the_single_entity_get() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
     assert_eq!(json["id"], board_id.to_string());
-    assert!(json.get("items").is_none(), "single-entity GET must stay a bare object");
+    assert!(
+        json.get("items").is_none(),
+        "single-entity GET must stay a bare object"
+    );
 }

--- a/crates/kanban-server/tests/pagination.rs
+++ b/crates/kanban-server/tests/pagination.rs
@@ -1,0 +1,397 @@
+#![cfg(feature = "test-helpers")]
+
+//! Pagination (`?page=&page_size=`) across the four collection list routes:
+//! `GET /v1/boards`, `GET /v1/boards/{b}/columns`, `GET /v1/boards/{b}/cards`,
+//! `GET /v1/boards/{b}/sprints`. Established via `tower::ServiceExt::oneshot`
+//! against the router directly, with no real TCP socket.
+
+use axum::http::StatusCode;
+use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_service::KanbanOperations;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_paginates_with_explicit_params() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board 1".to_string(), Some("B1".to_string()))
+            .unwrap();
+        ctx.create_board("Board 2".to_string(), Some("B2".to_string()))
+            .unwrap();
+        ctx.create_board("Board 3".to_string(), Some("B3".to_string()))
+            .unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/boards?page=1&page_size=2", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+
+    assert!(json.get("items").is_some(), "body should be a page envelope: {json}");
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(json["total"], 3);
+    assert_eq!(json["page"], 1);
+    assert_eq!(json["page_size"], 2);
+    assert_eq!(json["total_pages"], 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_second_page_returns_the_remainder() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board 1".to_string(), Some("B1".to_string()))
+            .unwrap();
+        ctx.create_board("Board 2".to_string(), Some("B2".to_string()))
+            .unwrap();
+        ctx.create_board("Board 3".to_string(), Some("B3".to_string()))
+            .unwrap();
+    }
+
+    let first_page = send(&state, "GET", "/v1/boards?page=1&page_size=2", None).await;
+    let first_json = json_of(first_page).await;
+    let first_ids: std::collections::HashSet<String> = first_json["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["id"].as_str().unwrap().to_string())
+        .collect();
+
+    let response = send(&state, "GET", "/v1/boards?page=2&page_size=2", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(json["total"], 3);
+    assert_eq!(json["page"], 2);
+    assert_eq!(json["total_pages"], 2);
+
+    let second_id = items[0]["id"].as_str().unwrap().to_string();
+    assert!(
+        !first_ids.contains(&second_id),
+        "second page must not repeat an id from the first page"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_defaults_to_page_1_size_50_when_params_omitted() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board 1".to_string(), Some("B1".to_string()))
+            .unwrap();
+        ctx.create_board("Board 2".to_string(), Some("B2".to_string()))
+            .unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/boards", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["items"].as_array().unwrap().len(), 2);
+    assert_eq!(json["total"], 2);
+    assert_eq!(json["page"], 1);
+    assert_eq!(json["page_size"], 50);
+    assert_eq!(json["total_pages"], 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_body_deserializes_as_page_of_board_response() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board 1".to_string(), Some("B1".to_string()))
+            .unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/boards", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let parsed: kanban_service::api::Page<kanban_service::api::BoardResponse> =
+        serde_json::from_value(json).expect("body should deserialize as Page<BoardResponse>");
+    assert_eq!(parsed.items.len(), 1);
+    assert_eq!(parsed.total, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_columns_paginates() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("B".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_column(board_id, "Column 1".to_string(), Some(0))
+            .unwrap();
+        ctx.create_column(board_id, "Column 2".to_string(), Some(1))
+            .unwrap();
+        ctx.create_column(board_id, "Column 3".to_string(), Some(2))
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/columns?page=2&page_size=2"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(json["total"], 3);
+    assert_eq!(json["total_pages"], 2);
+    assert_eq!(items[0]["position"], 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_paginates() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("B".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap();
+        ctx.create_sprint(board_id, Some("SPR".to_string()), Some("Beta".to_string()))
+            .unwrap();
+        ctx.create_sprint(board_id, Some("SPR".to_string()), Some("Gamma".to_string()))
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints?page=1&page_size=2"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(json["total"], 3);
+    assert_eq!(json["total_pages"], 2);
+    for item in items {
+        assert!(!item["name"].is_null(), "sprint name must survive pagination");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_paginates_and_reports_correct_total() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("B".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(board_id, col_id, "Card 1".to_string(), Default::default())
+            .unwrap();
+        ctx.create_card(board_id, col_id, "Card 2".to_string(), Default::default())
+            .unwrap();
+        ctx.create_card(board_id, col_id, "Card 3".to_string(), Default::default())
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/cards?page=1&page_size=2"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(json["total"], 3);
+    assert_eq!(json["page_size"], 2);
+    assert_eq!(json["total_pages"], 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_column_filter_and_archived_still_apply_alongside_paging() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let col1_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("B".to_string()))
+            .unwrap()
+            .id;
+        col1_id = ctx
+            .create_column(board_id, "Column 1".to_string(), None)
+            .unwrap()
+            .id;
+        let col2_id = ctx
+            .create_column(board_id, "Column 2".to_string(), None)
+            .unwrap()
+            .id;
+
+        ctx.create_card(board_id, col1_id, "Col1 Live 1".to_string(), Default::default())
+            .unwrap();
+        ctx.create_card(board_id, col1_id, "Col1 Live 2".to_string(), Default::default())
+            .unwrap();
+        let archived_id = ctx
+            .create_card(board_id, col1_id, "Col1 Archived".to_string(), Default::default())
+            .unwrap()
+            .id;
+        ctx.archive_card(archived_id).unwrap();
+
+        ctx.create_card(board_id, col2_id, "Col2 Live".to_string(), Default::default())
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/cards?column_id={col1_id}&archived=include&page=2&page_size=2"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["total"], 3, "total should count only col1's live+archived cards");
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    for item in items {
+        assert_eq!(item["column_id"], col1_id.to_string());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pagination_rejects_page_zero_with_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board 1".to_string(), Some("B1".to_string()))
+            .unwrap();
+        ctx.create_board("Board 2".to_string(), Some("B2".to_string()))
+            .unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/boards?page=0", None).await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "VALIDATION_FAILED");
+    assert!(json.get("items").is_none(), "invalid page must not render as a page envelope");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pagination_rejects_page_size_over_max_with_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = send(&state, "GET", "/v1/boards?page_size=501", None).await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pagination_out_of_range_page_returns_empty_items_not_error() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board 1".to_string(), Some("B1".to_string()))
+            .unwrap();
+        ctx.create_board("Board 2".to_string(), Some("B2".to_string()))
+            .unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/boards?page=5&page_size=2", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["items"], serde_json::json!([]));
+    assert_eq!(json["total"], 2);
+    assert_eq!(json["page"], 5);
+    assert_eq!(json["total_pages"], 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_unknown_board_with_paging_still_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_board_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{random_board_id}/sprints?page=1&page_size=2"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+    assert!(json.get("items").is_none(), "a missing board must not render as an empty page");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_page_envelope_is_absent_on_the_single_entity_get() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("B".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(&state, "GET", &format!("/v1/boards/{board_id}"), None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["id"], board_id.to_string());
+    assert!(json.get("items").is_none(), "single-entity GET must stay a bare object");
+}

--- a/crates/kanban-server/tests/sprints_read.rs
+++ b/crates/kanban-server/tests/sprints_read.rs
@@ -45,7 +45,7 @@ async fn test_list_sprints_returns_only_the_boards_sprints() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    let arr = json.as_array().expect("response should be an array");
+    let arr = json["items"].as_array().expect("items should be an array");
     assert_eq!(
         arr.len(),
         2,
@@ -76,7 +76,7 @@ async fn test_list_sprints_returns_only_the_boards_sprints() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_sprints_empty_board_returns_200_empty_array() {
+async fn test_list_sprints_empty_board_returns_200_empty_page() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -99,7 +99,9 @@ async fn test_list_sprints_empty_board_returns_200_empty_array() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
-    assert_eq!(json, serde_json::json!([]));
+    assert_eq!(json["items"], serde_json::json!([]));
+    assert_eq!(json["total"], 0);
+    assert_eq!(json["total_pages"], 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/sprints_write.rs
+++ b/crates/kanban-server/tests/sprints_write.rs
@@ -118,8 +118,8 @@ async fn test_post_sprint_with_existing_id_returns_409() {
         None,
     )
     .await;
-    let arr = json_of(list).await;
-    assert_eq!(arr.as_array().unwrap().len(), 1);
+    let page = json_of(list).await;
+    assert_eq!(page["items"].as_array().unwrap().len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -160,8 +160,8 @@ async fn test_put_sprint_creates_when_absent_then_replaces_with_200() {
         None,
     )
     .await;
-    let arr = json_of(list).await;
-    assert_eq!(arr.as_array().unwrap().len(), 1);
+    let page = json_of(list).await;
+    assert_eq!(page["items"].as_array().unwrap().len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -289,8 +289,9 @@ async fn test_delete_sprint_returns_204_and_removes_it() {
     )
     .await;
     assert_eq!(list.status(), StatusCode::OK);
-    let arr = json_of(list).await;
-    assert_eq!(arr, serde_json::json!([]));
+    let page = json_of(list).await;
+    assert_eq!(page["items"], serde_json::json!([]));
+    assert_eq!(page["total"], 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Wires `PageParams` (query) and the `Page<T>` envelope (response) into all four `kanban-server` collection GET routes: `GET /v1/boards`, `GET /v1/boards/{b}/cards`, `GET /v1/boards/{b}/columns`, `GET /v1/boards/{b}/sprints`.

- `impl From<PaginatedList<T>> for Page<T>` in `kanban-api` (destructures every field, no `..`, so a future `PaginatedList` field is a compile error).
- One shared `paginate_response` helper in `kanban-server/src/pagination.rs`; each of the four handlers grows exactly one `Query<PageParams>` extractor and one call site.
- In-memory slicing only; no store-level `LIMIT`/`OFFSET`.
- `page` defaults to 1, `page_size` defaults to 50, capped at 500; `page=0`/`page_size=0`/over-cap is `422 VALIDATION_FAILED`; a page past the end is `200` with `items: []` and the true `total`; `total_pages` is `0` for an empty collection.
- `list_sprints` keeps `resolve_sprint_names` running over the full sprint list before pagination, so the name/sprint zip cannot desync across a page boundary.
- Rewrote the 17 existing tests that asserted a bare-array body shape (boards_read, columns_read, sprints_read, cards_read, sprints_write) to the new envelope, keeping every original semantic assertion (counts, ids, ordering, cross-board isolation, archived_at, snake_case enums).
- Updated `crates/kanban-server/README.md`: both curl examples, the Boards/Columns/Sprints endpoint tables, a new minimal Cards table row, and a Pagination section.
- Changeset: `minor` (the top-level JSON type of four GET endpoints changes from array to object).

## Deviation from the card

The card's acceptance criterion mandates `#[serde(flatten)] pub page: PageParams` inside `CardQuery`, and explicitly forbids a second `Query<T>` extractor on `list_cards`. That design does not work: axum's `Query` extractor deserializes through `serde_urlencoded`, and `#[serde(flatten)]` routes every field through serde's internal `Content` buffer, which `serde_urlencoded` populates with strings regardless of the target type. Verified directly against this workspace's pinned `axum 0.8.9` / `serde_urlencoded 0.7.1` in a scratch crate: `?page=2&page_size=25` against a `#[serde(flatten)] page: PageParams` field fails with `invalid type: string "2", expected u32`.

`list_cards` instead composes two independent extractors, `Query<CardQuery>` and `Query<PageParams>`. This is legal in axum 0.8.9 (each `Query<T>` parses the full query string independently and ignores keys it does not own, verified empirically) and is covered by `test_list_cards_column_filter_and_archived_still_apply_alongside_paging`, which exercises `column_id`, `archived`, `page` and `page_size` together in one request.

`CardQuery` and `PageParams` both stay free of `#[serde(deny_unknown_fields)]`, which is what makes the two-extractor composition safe; adding it to either would silently break this.

## Test plan

- [x] `nix develop --command cargo fmt --all -- --check`
- [x] `nix develop --command cargo clippy --all-targets --all-features -- -D warnings`
- [x] `nix develop --command cargo test --all-features --workspace` (217 test-result blocks, 0 failures)
- [x] `nix develop --command cargo check --package kanban-cli --no-default-features --features json,sqlite`
- [x] `bash scripts/check-factory-compile-lock.sh`
- [x] Mutation check: reverted `paginate_response` to ignore query params, confirmed 9 tests in `tests/pagination.rs` fail, restored the fix, confirmed green again.