### PR TITLE
KAN-1326 refactor(view,tui): migrate off Model's collapsing boards, board_by_id and graph accessors

### DIFF
--- a/.changeset/kan-1326-b8b-boards-graph-migration.md
+++ b/.changeset/kan-1326-b8b-boards-graph-migration.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+view: every call site that read a `Model`'s boards, resolved a board by id, or read the dependency graph now goes through the load-state accessors, so "never loaded" is named instead of silently collapsing into "empty". The collapsing `Model::boards`, `Model::board_by_id` and `Model::graph` accessors are removed. Behaviour is unchanged everywhere.

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -4,7 +4,12 @@ use kanban_domain::{partition_sprint_cards, sort_card_ids, Card, SortField, Sort
 impl App {
     pub fn get_board_card_count(&self, board_id: uuid::Uuid) -> usize {
         let filter = self.board_card_filter(board_id);
-        let board = self.model.boards().iter().find(|b| b.id == board_id);
+        let board = self
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .find(|b| b.id == board_id);
         kanban_domain::count_filtered_cards(
             self.model.live_cards(),
             self.model.columns(),
@@ -16,7 +21,12 @@ impl App {
 
     pub fn get_sorted_board_cards(&self, board_id: uuid::Uuid) -> Vec<Card> {
         let filter = self.board_card_filter(board_id);
-        let board = self.model.boards().iter().find(|b| b.id == board_id);
+        let board = self
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .find(|b| b.id == board_id);
         kanban_domain::filter_and_sort_cards(
             self.model.live_cards(),
             self.model.columns(),
@@ -113,7 +123,7 @@ impl App {
         let board_opt = self
             .selection
             .active_board_id
-            .and_then(|id| self.model.board_by_id(id));
+            .and_then(|id| self.model.board_by_id_state(id).loaded().copied());
 
         let (uncompleted_ids, completed_ids) = if let Some(board) = board_opt {
             let columns = self.model.columns();

--- a/crates/kanban-tui/src/app/file_io.rs
+++ b/crates/kanban-tui/src/app/file_io.rs
@@ -13,7 +13,12 @@ impl App {
         field: BoardField,
     ) -> io::Result<()> {
         if let Some(board_id) = self.board_list.get_selected_board_id() {
-            let board = self.model.board_by_id(board_id).cloned();
+            let board = self
+                .model
+                .board_by_id_state(board_id)
+                .loaded()
+                .copied()
+                .cloned();
             if let Some(board) = board {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -15,7 +15,13 @@ impl App {
                 ended_sprints.len()
             );
             for sprint in &ended_sprints {
-                if let Some(board) = self.model.boards().iter().find(|b| b.id == sprint.board_id) {
+                if let Some(board) = self
+                    .model
+                    .boards_state()
+                    .loaded_or_empty()
+                    .iter()
+                    .find(|b| b.id == sprint.board_id)
+                {
                     tracing::warn!(
                         "  - {} (ended: {})",
                         sprint.formatted_name(board, None),

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -19,7 +19,7 @@ impl App {
     pub fn active_board(&self) -> Option<&Board> {
         self.selection
             .active_board_id
-            .and_then(|id| self.model.board_by_id(id))
+            .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
     }
 
     /// The board a board-scoped operation acts on: the active board (by id) if
@@ -31,7 +31,7 @@ impl App {
             .selection
             .active_board_id
             .or_else(|| self.board_list.get_selected_board_id())?;
-        self.model.board_by_id(id)
+        self.model.board_by_id_state(id).loaded().copied()
     }
 
     /// The card subset the tasks panel currently displays: the archived cards
@@ -105,7 +105,8 @@ impl App {
         self.board_list.update_boards(board_ids);
         let highlighted_id: Option<Uuid> = self.board_list.get_selected_board_id();
         let board_id: Option<Uuid> = self.selection.active_board_id.or(highlighted_id);
-        let board: Option<&Board> = board_id.and_then(|id| self.model.board_by_id(id));
+        let board: Option<&Board> =
+            board_id.and_then(|id| self.model.board_by_id_state(id).loaded().copied());
 
         if let Some(board) = board {
             let search_query = if self.filter.search.is_active {

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -65,7 +65,7 @@ impl App {
             if let Some(name) = self
                 .board_list
                 .get_selected_board_id()
-                .and_then(|id| self.model.board_by_id(id))
+                .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                 .map(|b| b.name.clone())
             {
                 self.input.set(name);
@@ -92,7 +92,7 @@ impl App {
             if let Some(board_name) = self
                 .board_list
                 .get_selected_board_id()
-                .and_then(|id| self.model.board_by_id(id))
+                .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                 .map(|b| b.name.clone())
             {
                 let filename = format!(
@@ -989,7 +989,7 @@ mod tests {
         create_named_board(&mut app, "B");
         create_named_board(&mut app, "C");
         create_named_board(&mut app, "D");
-        let a_id = app.model.boards()[0].id;
+        let a_id = app.model.boards_state().loaded_or_empty()[0].id;
         // Viewing A; highlight is on D (index 3).
         app.selection.active_board_id = Some(a_id);
         app.focus.active = Focus::Boards;
@@ -1013,7 +1013,7 @@ mod tests {
         create_named_board(&mut app, "A");
         create_named_board(&mut app, "B");
         create_named_board(&mut app, "C");
-        let c_id = app.model.boards()[2].id;
+        let c_id = app.model.boards_state().loaded_or_empty()[2].id;
         app.selection.active_board_id = Some(c_id); // viewing C
         app.focus.active = Focus::Boards;
         app.board_list.inner_mut().set_selected_index(Some(0)); // highlight A
@@ -1033,7 +1033,7 @@ mod tests {
         let mut app = App::test_default();
         create_named_board(&mut app, "A");
         create_named_board(&mut app, "B");
-        let b_id = app.model.boards()[1].id;
+        let b_id = app.model.boards_state().loaded_or_empty()[1].id;
         app.selection.active_board_id = Some(b_id); // viewing B
         app.focus.active = Focus::Boards;
         app.board_list.inner_mut().set_selected_index(Some(1)); // highlight B (the active board)
@@ -1051,7 +1051,7 @@ mod tests {
         let mut app = App::test_default();
         create_named_board(&mut app, "A");
         create_named_board(&mut app, "B");
-        let a_id = app.model.boards()[0].id;
+        let a_id = app.model.boards_state().loaded_or_empty()[0].id;
         // A uses the kanban (ColumnView) layout, not the Flat default.
         app.ctx
             .update_board(
@@ -1083,7 +1083,7 @@ mod tests {
         create_named_board(&mut app, "A");
         create_named_board(&mut app, "B");
         create_named_board(&mut app, "C");
-        let c_id = app.model.boards()[2].id;
+        let c_id = app.model.boards_state().loaded_or_empty()[2].id;
         // C uses the kanban (ColumnView) layout; A and B keep the Flat default.
         app.ctx
             .update_board(
@@ -1112,7 +1112,12 @@ mod tests {
     fn test_delete_last_board_leaves_no_cards() {
         let mut app = App::test_default();
         create_named_board(&mut app, "Solo");
-        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
+        app.selection.active_board_id = app
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .first()
+            .map(|b| b.id);
         app.focus.active = Focus::Boards;
         app.board_list.inner_mut().set_selected_index(Some(0));
         // Simulate a populated cards panel.
@@ -1134,7 +1139,7 @@ mod tests {
     fn test_q_in_delete_board_confirm_cancels_not_quits() {
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
-        let board_id = app.model.boards()[0].id;
+        let board_id = app.model.boards_state().loaded_or_empty()[0].id;
         app.focus.active = Focus::Boards;
         app.board_list.inner_mut().set_selected_index(Some(0));
         app.handle_delete_board_key();
@@ -1158,7 +1163,7 @@ mod tests {
     fn test_delete_board_counts_snapshotted_on_open() {
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
-        let board_id = app.model.boards()[0].id;
+        let board_id = app.model.boards_state().loaded_or_empty()[0].id;
         let column_id = first_column_id(&app, board_id);
         app.ctx
             .create_card(

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -6,6 +6,7 @@ use kanban_domain::commands::{
 };
 use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations};
 use kanban_view::card_list::CardListId;
+use kanban_view::model::Model;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -372,7 +373,12 @@ impl App {
 
     pub fn create_card(&mut self) {
         if let Some(board_id) = self.selection.active_board_id {
-            let board_info = self.model.board_by_id(board_id).map(|b| b.id);
+            let board_info = self
+                .model
+                .board_by_id_state(board_id)
+                .loaded()
+                .copied()
+                .map(|b| b.id);
 
             if let Some(bid) = board_info {
                 let existing_column = self.create_card_target_column(bid);
@@ -386,7 +392,9 @@ impl App {
                         let columns = self.model.columns();
                         let mark_as_complete = self
                             .model
-                            .board_by_id(board_id)
+                            .board_by_id_state(board_id)
+                            .loaded()
+                            .copied()
                             .map(|board| {
                                 kanban_domain::card_lifecycle::should_auto_complete_new_card(
                                     col.id, board, columns,
@@ -917,7 +925,11 @@ impl App {
         };
 
         // Get ancestors to exclude (would create cycle)
-        let graph = self.model.graph();
+        let graph = self
+            .model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph());
         let ancestors = graph.ancestors(card_id);
 
         // Get cards from current board, excluding self and ancestors
@@ -941,7 +953,11 @@ impl App {
             .collect();
 
         // Get current children (for checkbox display)
-        let graph = self.model.graph();
+        let graph = self
+            .model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph());
         let current_children: std::collections::HashSet<_> =
             graph.children(card_id).into_iter().collect();
 
@@ -982,7 +998,12 @@ mod create_card_factory_tests {
             .create_column(board.id, "TODO".into(), Some(0))
             .unwrap();
         refresh(app);
-        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
+        app.selection.active_board_id = app
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .first()
+            .map(|b| b.id);
     }
 
     /// KAN-796: the TUI card-create entry point funnels through the Card factory

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -585,7 +585,12 @@ mod tests {
         app.create_board();
         app.input.clear();
         // Column operations act on the active board (as when editing its detail).
-        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
+        app.selection.active_board_id = app
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .first()
+            .map(|b| b.id);
     }
 
     fn create_named_column(app: &mut App, name: &str) {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -7,6 +7,7 @@ use crossterm::event::KeyCode;
 use kanban_core::Editable;
 use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::{BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, Searcher};
+use kanban_view::model::Model;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -1083,7 +1084,12 @@ impl App {
 
                 if let Some(board_id) = board_id {
                     // Get all descendants to exclude (to prevent cycles)
-                    let descendants = self.model.graph().descendants(card_id);
+                    let descendants = self
+                        .model
+                        .graph_state()
+                        .loaded()
+                        .unwrap_or_else(|| Model::empty_graph())
+                        .descendants(card_id);
 
                     // Get cards from current board, excluding self and descendants
                     let column_ids: std::collections::HashSet<_> = self
@@ -1110,8 +1116,14 @@ impl App {
                         .collect();
 
                     // Get current parents (for checkbox display)
-                    let current_parents: std::collections::HashSet<_> =
-                        self.model.graph().parents(card_id).into_iter().collect();
+                    let current_parents: std::collections::HashSet<_> = self
+                        .model
+                        .graph_state()
+                        .loaded()
+                        .unwrap_or_else(|| Model::empty_graph())
+                        .parents(card_id)
+                        .into_iter()
+                        .collect();
 
                     // Set up dialog state
                     self.relationship.card_ids = eligible_cards;
@@ -1141,7 +1153,12 @@ impl App {
 
                 if let Some(board_id) = board_id {
                     // Get all ancestors to exclude (to prevent cycles)
-                    let ancestors = self.model.graph().ancestors(card_id);
+                    let ancestors = self
+                        .model
+                        .graph_state()
+                        .loaded()
+                        .unwrap_or_else(|| Model::empty_graph())
+                        .ancestors(card_id);
 
                     // Get cards from current board, excluding self and ancestors
                     let column_ids: std::collections::HashSet<_> = self
@@ -1168,8 +1185,14 @@ impl App {
                         .collect();
 
                     // Get current children (for checkbox display)
-                    let current_children: std::collections::HashSet<_> =
-                        self.model.graph().children(card_id).into_iter().collect();
+                    let current_children: std::collections::HashSet<_> = self
+                        .model
+                        .graph_state()
+                        .loaded()
+                        .unwrap_or_else(|| Model::empty_graph())
+                        .children(card_id)
+                        .into_iter()
+                        .collect();
 
                     // Set up dialog state
                     self.relationship.card_ids = eligible_cards;
@@ -1186,7 +1209,12 @@ impl App {
     pub fn get_current_card_parents(&self) -> Vec<uuid::Uuid> {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id(active_id) {
-                return self.model.graph().parents(card.id);
+                return self
+                    .model
+                    .graph_state()
+                    .loaded()
+                    .unwrap_or_else(|| Model::empty_graph())
+                    .parents(card.id);
             }
         }
         Vec::new()
@@ -1195,7 +1223,12 @@ impl App {
     pub fn get_current_card_children(&self) -> Vec<uuid::Uuid> {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id(active_id) {
-                return self.model.graph().children(card.id);
+                return self
+                    .model
+                    .graph_state()
+                    .loaded()
+                    .unwrap_or_else(|| Model::empty_graph())
+                    .children(card.id);
             }
         }
         Vec::new()
@@ -1551,7 +1584,7 @@ mod tests {
         let card_id = seed_sprint_with_card(&mut app, "task");
         // Real navigation into SprintDetail always sets active_board_id first
         // (detail_view_handlers.rs's activate-sprint flow); mirror that here.
-        let board_id = app.model.boards()[0].id;
+        let board_id = app.model.boards_state().loaded_or_empty()[0].id;
         app.selection.active_board_id = Some(board_id);
         // A second sprint on the same board so the picker has something to
         // assign to (the dialog only opens when sprint_count > 0).
@@ -1584,7 +1617,7 @@ mod tests {
         use crate::app::{AppMode, DialogMode};
         let mut app = App::test_default();
         let uncompleted_id = seed_sprint_with_card(&mut app, "task");
-        let board_id = app.model.boards()[0].id;
+        let board_id = app.model.boards_state().loaded_or_empty()[0].id;
         app.selection.active_board_id = Some(board_id);
         app.ctx.create_sprint(board_id, None, None).unwrap();
 
@@ -1635,7 +1668,7 @@ mod tests {
     fn test_sprint_detail_y_on_card_reaches_copy_branch_name() {
         let mut app = App::test_default();
         let card_id = seed_sprint_with_card(&mut app, "task");
-        app.selection.active_board_id = Some(app.model.boards()[0].id);
+        app.selection.active_board_id = Some(app.model.boards_state().loaded_or_empty()[0].id);
 
         app.handle_sprint_detail_key(KeyCode::Char('y'));
 
@@ -1654,7 +1687,7 @@ mod tests {
     fn test_sprint_detail_shift_y_on_card_reaches_copy_git_checkout_command() {
         let mut app = App::test_default();
         let card_id = seed_sprint_with_card(&mut app, "task");
-        app.selection.active_board_id = Some(app.model.boards()[0].id);
+        app.selection.active_board_id = Some(app.model.boards_state().loaded_or_empty()[0].id);
 
         app.handle_sprint_detail_key(KeyCode::Char('Y'));
 
@@ -1792,7 +1825,12 @@ mod tests {
 
         load_with_card_order(&mut app, &[a.id, p.id, b.id, c.id, d.id]);
         app.selection.active_card_id = Some(a.id);
-        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
+        app.selection.active_board_id = app
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .first()
+            .map(|b| b.id);
 
         app.focus.card_focus = CardFocus::Children;
         app.relationship.children_list.update_item_count(1);

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -94,7 +94,7 @@ impl App {
         if let Some(board) = self
             .selection
             .active_board_id
-            .and_then(|id| self.model.board_by_id(id))
+            .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
         {
             let now = chrono::Utc::now();
             self.dialog_input.create_card_sprint_picker.handle_key(

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -32,11 +32,13 @@ impl App {
                 }
                 KeyCode::Char('j') | KeyCode::Down => match dialog_state.current_section {
                     FilterDialogSection::Sprints => {
-                        if let Some(board_id) = self
-                            .selection
-                            .active_board_id
-                            .and_then(|id| self.model.board_by_id(id).map(|b| b.id))
-                        {
+                        if let Some(board_id) = self.selection.active_board_id.and_then(|id| {
+                            self.model
+                                .board_by_id_state(id)
+                                .loaded()
+                                .copied()
+                                .map(|b| b.id)
+                        }) {
                             {
                                 let sprint_count = self
                                     .model
@@ -78,7 +80,7 @@ impl App {
                         } else if let Some(board) = self
                             .selection
                             .active_board_id
-                            .and_then(|id| self.model.board_by_id(id))
+                            .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                         {
                             {
                                 let sprints = self.model.sprints();

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -454,7 +454,9 @@ impl App {
                 // every view/operation resolves it archival-agnostically.
                 let activated = self.board_list.get_selected_board_id().and_then(|id| {
                     self.model
-                        .board_by_id(id)
+                        .board_by_id_state(id)
+                        .loaded()
+                        .copied()
                         .map(|b| (b.id, b.task_list_view, b.task_sort_field, b.task_sort_order))
                 });
 
@@ -1323,7 +1325,12 @@ mod tests {
             .unwrap();
         let snap = app.ctx.snapshot().unwrap();
         app.model.load_from_snapshot(snap);
-        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
+        app.selection.active_board_id = app
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .first()
+            .map(|b| b.id);
         app
     }
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -362,7 +362,7 @@ impl App {
                 let active_board_id = self
                     .selection
                     .active_board_id
-                    .and_then(|id| self.model.board_by_id(id))
+                    .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                     .map(|b| b.id);
                 let picker = &self.dialog_input.assign_sprint_picker;
                 let board_matches = active_board_id
@@ -405,7 +405,7 @@ impl App {
                 if let Some(board) = self
                     .selection
                     .active_board_id
-                    .and_then(|id| self.model.board_by_id(id))
+                    .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                 {
                     let now = chrono::Utc::now();
                     self.dialog_input.assign_sprint_picker.handle_key(
@@ -433,7 +433,7 @@ impl App {
                 let active_board_id = self
                     .selection
                     .active_board_id
-                    .and_then(|id| self.model.board_by_id(id))
+                    .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                     .map(|b| b.id);
                 let picker = &self.dialog_input.assign_sprint_picker;
                 let board_matches = active_board_id
@@ -483,7 +483,7 @@ impl App {
                 if let Some(board) = self
                     .selection
                     .active_board_id
-                    .and_then(|id| self.model.board_by_id(id))
+                    .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                 {
                     let now = chrono::Utc::now();
                     self.dialog_input.assign_sprint_picker.handle_key(
@@ -558,7 +558,8 @@ impl App {
                                     .find(|s| s.id == to_sprint_id)
                                     .map(|s| {
                                         self.model
-                                            .boards()
+                                            .boards_state()
+                                            .loaded_or_empty()
                                             .iter()
                                             .find(|b| b.id == board_id)
                                             .and_then(|b| s.get_name(b))
@@ -782,7 +783,8 @@ mod tests {
         let sprints = app.model.sprints().to_vec();
         let board = app
             .model
-            .boards()
+            .boards_state()
+            .loaded_or_empty()
             .iter()
             .find(|b| b.id == fx.board_id)
             .cloned()

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -230,7 +230,12 @@ mod create_sprint_factory_tests {
             .create_board("Board".into(), Some("KAN".into()))
             .unwrap();
         refresh(app);
-        app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
+        app.selection.active_board_id = app
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .first()
+            .map(|b| b.id);
     }
 
     /// KAN-798: the TUI sprint-create entry point funnels through the Sprint

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -109,7 +109,12 @@ pub fn setup_reload_resort_fixture(app: &mut App) -> ReloadResortFixture {
 
     load_with_card_order(app, &[p.id, a.id, b.id, c.id, d.id]);
     app.selection.active_card_id = Some(a.id);
-    app.selection.active_board_id = app.model.boards().first().map(|b| b.id);
+    app.selection.active_board_id = app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .first()
+        .map(|b| b.id);
 
     load_with_card_order(app, &[a.id, p.id, b.id, c.id, d.id]);
 

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -1,6 +1,7 @@
 use crate::app::{App, CardFocus};
 use crate::components::*;
 use crate::theme::*;
+use kanban_view::model::Model;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     widgets::Paragraph,
@@ -72,8 +73,18 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                 let card_id = card.id;
 
                 // Get parent and child information
-                let parents = app.model.graph().parents(card_id);
-                let children = app.model.graph().children(card_id);
+                let parents = app
+                    .model
+                    .graph_state()
+                    .loaded()
+                    .unwrap_or_else(|| Model::empty_graph())
+                    .parents(card_id);
+                let children = app
+                    .model
+                    .graph_state()
+                    .loaded()
+                    .unwrap_or_else(|| Model::empty_graph())
+                    .children(card_id);
                 let child_count = children.len();
 
                 let constraints = vec![

--- a/crates/kanban-tui/src/ui/dialogs/boards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/boards.rs
@@ -33,7 +33,9 @@ pub(crate) fn render_export_boards_popup(app: &App, frame: &mut Frame) {
                 .map(|(i, &id)| {
                     let name = app
                         .model
-                        .board_by_id(id)
+                        .board_by_id_state(id)
+                        .loaded()
+                        .copied()
                         .map(|b| b.name.as_str())
                         .unwrap_or("?");
                     let checkbox = if dialog.board_selections.get(i).copied().unwrap_or(false) {

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -30,7 +30,12 @@ fn test_toggle_into_archived_boards_view_and_back() {
     app.prepare_frame();
     // The live boards view (unified collection filtered by the archived-id set)
     // excludes the archived head, even though `boards()` now carries it.
-    assert!(app.model.boards().iter().any(|b| b.id == archived_id));
+    assert!(app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .iter()
+        .any(|b| b.id == archived_id));
     assert!(app.displayed_boards().iter().all(|b| b.id != archived_id));
 
     app.handle_toggle_archived_boards_view();

--- a/crates/kanban-tui/tests/cold_start_reload_tests.rs
+++ b/crates/kanban-tui/tests/cold_start_reload_tests.rs
@@ -21,7 +21,12 @@ async fn test_cold_start_reads_the_whole_workspace_once() {
         1,
         "cold start must read the whole workspace exactly once"
     );
-    let board_present = app.model.boards().iter().any(|b| b.name == "Board");
+    let board_present = app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .iter()
+        .any(|b| b.name == "Board");
     assert!(board_present, "the model must reflect the seeded board");
 }
 

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -25,7 +25,7 @@ fn setup_app_with_board() -> App {
 }
 
 fn board_id(app: &App) -> uuid::Uuid {
-    app.model.boards()[0].id
+    app.model.boards_state().loaded_or_empty()[0].id
 }
 
 fn confirm_create_card_dialog(app: &mut App, title: &str) {
@@ -342,7 +342,8 @@ fn test_create_card_does_not_carry_sprint_id_from_a_different_board() {
     let sprints = app.model.sprints().to_vec();
     let board_a_ref = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_a)
         .cloned()

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -5,7 +5,7 @@
 //! live list).
 //!
 //! Before the fix, `export_all_boards_with_filename` / `auto_save` read the
-//! live-scoped `model.boards()` / `model.all_cards()`, so an archived board's head
+//! live-scoped `model.boards_state().loaded_or_empty()` / `model.all_cards()`, so an archived board's head
 //! and subtree were omitted and the exported `archived_boards` marker referenced
 //! a board absent from the file → orphan / silent data loss on re-import. These
 //! tests drive the ACTUAL TUI export entry point (not the snapshot path
@@ -92,7 +92,11 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
 
     // Live board still live.
     assert!(
-        app2.model.boards().iter().any(|b| b.id == live_board.id),
+        app2.model
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .any(|b| b.id == live_board.id),
         "live board must be present after re-import"
     );
 
@@ -103,7 +107,11 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
         "archived board must remain hidden from live list after re-import"
     );
     assert!(
-        app2.model.boards().iter().any(|b| b.id == arch_board.id)
+        app2.model
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .any(|b| b.id == arch_board.id)
             && app2.model.archived_board_ids().contains(&arch_board.id),
         "archived board head must round-trip and remain archived"
     );

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -176,8 +176,11 @@ fn test_import_valid_format() {
 
     app.reload_model();
     app.prepare_frame();
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "Imported Board");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "Imported Board"
+    );
     assert_eq!(app.model.columns().len(), 1);
     assert_eq!(app.model.all_cards().len(), 1);
     assert_eq!(app.model.all_cards()[0].title, "Imported Task");
@@ -279,8 +282,11 @@ async fn test_async_load_initial_state_sqlite() {
     app.load_initial_state().await;
     app.reload_model();
     app.prepare_frame();
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "SQLite Board");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "SQLite Board"
+    );
     assert_eq!(app.model.columns().len(), 1);
     assert_eq!(app.model.columns()[0].name, "Backlog");
 }
@@ -356,12 +362,15 @@ fn test_export_import_sprint_and_card_prefixes() {
     // Verify prefixes preserved after import
     app2.reload_model();
     app2.prepare_frame();
-    assert_eq!(app2.model.boards().len(), 1);
+    assert_eq!(app2.model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(
-        app2.model.boards()[0].sprint_prefix,
+        app2.model.boards_state().loaded_or_empty()[0].sprint_prefix,
         Some("sprint".to_string())
     );
-    assert_eq!(app2.model.boards()[0].card_prefix, Some("task".to_string()));
+    assert_eq!(
+        app2.model.boards_state().loaded_or_empty()[0].card_prefix,
+        Some("task".to_string())
+    );
     assert_eq!(app2.model.sprints().len(), 1);
     assert_eq!(
         app2.model.sprints()[0].card_prefix,
@@ -438,14 +447,20 @@ fn test_backward_compat_old_export_format() {
     // Verify board imported and old branch_prefix is mapped to sprint_prefix
     app.reload_model();
     app.prepare_frame();
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "Old Board");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(
-        app.model.boards()[0].sprint_prefix,
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "Old Board"
+    );
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].sprint_prefix,
         Some("FEAT".to_string())
     );
     // card_prefix should be None since old format didn't have it
-    assert_eq!(app.model.boards()[0].card_prefix, None);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].card_prefix,
+        None
+    );
 
     // Verify cards still work
     assert_eq!(app.model.all_cards().len(), 1);
@@ -492,7 +507,7 @@ fn test_import_column_missing_default_status_key_defaults_to_none() {
 
     app.reload_model();
     app.prepare_frame();
-    assert_eq!(app.model.boards().len(), 1);
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.columns().len(), 1);
     assert_eq!(app.model.columns()[0].default_status, None);
 }

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -253,7 +253,11 @@ fn test_sprint_assignment_is_visible_in_model_without_a_further_redraw() {
         .reset_for_card_assignment(
             Some(sprint.id),
             app.model.sprints(),
-            app.model.board_by_id(board.id).unwrap(),
+            app.model
+                .board_by_id_state(board.id)
+                .loaded()
+                .copied()
+                .unwrap(),
             chrono::Utc::now(),
         );
     app.handle_assign_card_to_sprint_popup(crossterm::event::KeyCode::Enter);

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -51,11 +51,14 @@ async fn test_import_failure_prevents_empty_state_save() {
     app.reload_model();
     app.prepare_frame();
     assert_eq!(
-        app.model.boards().len(),
+        app.model.boards_state().loaded_or_empty().len(),
         1,
         "V2 format should be imported successfully"
     );
-    assert_eq!(app.model.boards()[0].name, "Test Board");
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "Test Board"
+    );
     assert!(
         app.persistence.save_file.is_some(),
         "save_file should still be enabled after successful V2 import"
@@ -128,8 +131,11 @@ async fn test_v2_format_is_imported_correctly() {
     // Should successfully import the board with its column and card
     app.reload_model();
     app.prepare_frame();
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "My Project");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "My Project"
+    );
     assert_eq!(app.model.columns().len(), 1);
     assert_eq!(app.model.all_cards().len(), 1);
     assert_eq!(app.model.all_cards()[0].title, "Important Task");

--- a/crates/kanban-tui/tests/initial_board_selection_tests.rs
+++ b/crates/kanban-tui/tests/initial_board_selection_tests.rs
@@ -95,7 +95,7 @@ async fn test_load_initial_state_does_not_clobber_existing_board_selection() -> 
     // than a speculative raw index into not-yet-loaded data: `board_list` only
     // accepts an index within its current, already-synced item count.
     app.load_initial_state().await;
-    let beta_id = app.model.boards()[1].id;
+    let beta_id = app.model.boards_state().loaded_or_empty()[1].id;
     app.board_list.select_board(beta_id);
 
     app.load_initial_state().await;

--- a/crates/kanban-tui/tests/lifecycle_reload_tests.rs
+++ b/crates/kanban-tui/tests/lifecycle_reload_tests.rs
@@ -51,8 +51,11 @@ fn test_import_board_from_file_refreshes_the_whole_model_without_a_further_reloa
     app.import_board_from_file(file_path.to_str().unwrap())
         .unwrap();
 
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "Imported Board");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "Imported Board"
+    );
     assert_eq!(app.model.columns().len(), 1);
     assert_eq!(app.model.all_cards().len(), 1);
     assert_eq!(app.model.all_cards()[0].title, "Imported Task");
@@ -62,7 +65,10 @@ fn test_import_board_from_file_refreshes_the_whole_model_without_a_further_reloa
 async fn test_storage_location_change_refreshes_the_model_without_a_further_reload() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    assert_eq!(app.model.boards()[0].name, "OriginalBoard");
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "OriginalBoard"
+    );
 
     let sqlite_path =
         helpers::create_test_sqlite_file(dir.path(), "other.db", &["SqliteBoard"]).await;
@@ -74,8 +80,11 @@ async fn test_storage_location_change_refreshes_the_model_without_a_further_relo
     app.apply_storage_location_change(old_config, &old_storage_location);
     app.await_migration().await;
 
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "SqliteBoard");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "SqliteBoard"
+    );
     assert_eq!(
         app.persistence.save_file.as_deref(),
         Some(sqlite_path.as_str())

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -30,8 +30,8 @@ fn test_prepare_frame_populates_model_from_snapshot() {
     app.reload_model();
     app.prepare_frame();
 
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "Board");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(app.model.boards_state().loaded_or_empty()[0].name, "Board");
     assert_eq!(app.model.columns().len(), 1);
     assert_eq!(app.model.all_cards().len(), 1);
     assert_eq!(app.model.card_by_id(card.id).unwrap().title, "Task");

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -9,12 +9,18 @@ fn make_card(board: &Board, column_id: Uuid, title: &str, pos: i32) -> Card {
 #[test]
 fn test_empty_model_returns_empty_slices() {
     let model = Model::default();
-    assert!(model.boards().is_empty());
+    assert!(model.boards_state().loaded_or_empty().is_empty());
     assert!(model.columns().is_empty());
     assert!(model.all_cards().is_empty());
     assert!(model.sprints().is_empty());
     assert!(model.archived_card_markers().is_empty());
-    assert_eq!(model.graph(), &DependencyGraph::default());
+    assert_eq!(
+        model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph()),
+        &DependencyGraph::default()
+    );
 }
 
 #[test]
@@ -39,8 +45,8 @@ fn test_load_from_snapshot_populates_all_fields() {
 
     model.load_from_snapshot(snapshot);
 
-    assert_eq!(model.boards().len(), 1);
-    assert_eq!(model.boards()[0].name, "Board1");
+    assert_eq!(model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(model.boards_state().loaded_or_empty()[0].name, "Board1");
     assert_eq!(model.columns().len(), 1);
     assert_eq!(model.columns()[0].name, "Col1");
     assert_eq!(model.all_cards().len(), 1);

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -3,6 +3,7 @@ mod helpers;
 use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations};
 use kanban_tui::components::resolve_relationship_cards;
 use kanban_tui::App;
+use kanban_view::model::Model;
 use uuid::Uuid;
 
 fn create_board_and_column(app: &mut App, board_title: &str) -> (Uuid, Uuid) {
@@ -51,8 +52,16 @@ fn test_resolve_relationship_cards_returns_only_the_related_cards() {
     assert_eq!(app.model.all_cards().len(), 50);
 
     let ids = [
-        app.model.graph().parents(subject),
-        app.model.graph().children(subject),
+        app.model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .parents(subject),
+        app.model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .children(subject),
     ]
     .concat();
 
@@ -101,7 +110,12 @@ fn test_resolve_relationship_cards_resolves_cross_board_related_card() {
     app.reload_model();
     app.selection.active_board_id = Some(board_b_id);
 
-    let children = app.model.graph().children(subject);
+    let children = app
+        .model
+        .graph_state()
+        .loaded()
+        .unwrap_or_else(|| Model::empty_graph())
+        .children(subject);
     let resolved = resolve_relationship_cards(&app.model, &children);
 
     assert_eq!(resolved.len(), 1);
@@ -144,8 +158,16 @@ fn test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan() {
     app.reload_model();
 
     let mut ids = [
-        app.model.graph().parents(subject),
-        app.model.graph().children(subject),
+        app.model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .parents(subject),
+        app.model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .children(subject),
     ]
     .concat();
     ids.push(archived_parent);

--- a/crates/kanban-tui/tests/settings_storage_tests.rs
+++ b/crates/kanban-tui/tests/settings_storage_tests.rs
@@ -39,8 +39,11 @@ async fn test_file_arg_new_file_defaults_to_json() {
 async fn test_migrate_json_to_sqlite_creates_file() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "OriginalBoard");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "OriginalBoard"
+    );
 
     let old_config = app.app_config.clone();
     let old_storage_location = app.app_config.effective_storage_location();
@@ -52,8 +55,11 @@ async fn test_migrate_json_to_sqlite_creates_file() {
     app.reload_model();
     app.prepare_frame();
     assert!(sqlite_path.exists(), "SQLite file should be created");
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "OriginalBoard");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "OriginalBoard"
+    );
     assert_eq!(
         app.persistence.save_file.as_deref(),
         Some(sqlite_path.to_str().unwrap())
@@ -64,7 +70,10 @@ async fn test_migrate_json_to_sqlite_creates_file() {
 async fn test_switch_to_existing_sqlite_reloads_data() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    assert_eq!(app.model.boards()[0].name, "OriginalBoard");
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "OriginalBoard"
+    );
 
     let sqlite_path =
         helpers::create_test_sqlite_file(dir.path(), "other.db", &["SqliteBoard"]).await;
@@ -77,8 +86,11 @@ async fn test_switch_to_existing_sqlite_reloads_data() {
     app.await_migration().await;
     app.reload_model();
     app.prepare_frame();
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "SqliteBoard");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "SqliteBoard"
+    );
     assert_eq!(
         app.persistence.save_file.as_deref(),
         Some(sqlite_path.as_str())
@@ -89,7 +101,10 @@ async fn test_switch_to_existing_sqlite_reloads_data() {
 async fn test_switch_to_existing_json_reloads_data() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    assert_eq!(app.model.boards()[0].name, "OriginalBoard");
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "OriginalBoard"
+    );
 
     let second_json =
         helpers::create_test_json_file(dir.path(), "other.json", &["SecondBoard"]).await;
@@ -102,8 +117,11 @@ async fn test_switch_to_existing_json_reloads_data() {
     app.await_migration().await;
     app.reload_model();
     app.prepare_frame();
-    assert_eq!(app.model.boards().len(), 1);
-    assert_eq!(app.model.boards()[0].name, "SecondBoard");
+    assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.boards_state().loaded_or_empty()[0].name,
+        "SecondBoard"
+    );
     assert_eq!(
         app.persistence.save_file.as_deref(),
         Some(second_json.as_str())

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -87,7 +87,8 @@ fn open_assign_dialog(app: &mut App) {
     let sprints = app.model.sprints().to_vec();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .first()
         .cloned()
         .expect("test app has at least one board");
@@ -200,7 +201,7 @@ fn test_dialog_renders_completed_in_green_and_ended_in_red() {
         .find(|s| s.id == fx.ended_id)
         .cloned()
         .unwrap();
-    let board = app.model.boards()[0].clone();
+    let board = app.model.boards_state().loaded_or_empty()[0].clone();
     let completed_name = completed.formatted_name(&board, Some("sprint"));
     let ended_name = ended.formatted_name(&board, Some("sprint"));
 
@@ -313,7 +314,13 @@ fn test_bulk_assign_bare_enter_is_a_no_op_and_does_not_mass_unassign() {
     // Pre-assign the card to a sprint so we can detect the regression
     // (unassign-on-open would clear sprint_id).
     let sprints = app.model.sprints().to_vec();
-    let board = app.model.boards().first().cloned().unwrap();
+    let board = app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .first()
+        .cloned()
+        .unwrap();
     let some_sprint = sprints
         .iter()
         .find(|s| s.board_id == board.id)
@@ -350,7 +357,13 @@ fn test_bulk_assign_handler_supports_completed_sprint() {
     // primed (no single "current" sprint in bulk mode).
     app.multi_select.selected_cards.insert(card_id);
     let sprints = app.model.sprints().to_vec();
-    let board = app.model.boards().first().cloned().unwrap();
+    let board = app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .first()
+        .cloned()
+        .unwrap();
     app.dialog_input
         .assign_sprint_picker
         .reset_for_bulk_card_assignment(&sprints, &board, Utc::now());
@@ -404,7 +417,7 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
         app.handle_assign_card_to_sprint_popup(KeyCode::Char('k'));
     }
 
-    let board = app.model.boards()[0].clone();
+    let board = app.model.boards_state().loaded_or_empty()[0].clone();
     let completed = app
         .model
         .sprints()
@@ -482,7 +495,7 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
 
     walk_cursor_to_sprint(&mut app, oldest_id, 50);
 
-    let board_after = app.model.boards()[0].clone();
+    let board_after = app.model.boards_state().loaded_or_empty()[0].clone();
     let oldest = app
         .model
         .sprints()

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -161,7 +161,8 @@ fn test_for_card_assignment_initial_selection_is_zero_when_card_has_no_sprint() 
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -187,7 +188,8 @@ fn test_for_card_assignment_initial_selection_is_index_of_current_sprint() {
         .expect("active sprint must appear in entries");
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -206,7 +208,8 @@ fn test_for_card_assignment_render_shows_current_suffix_for_card_sprint() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -229,7 +232,8 @@ fn test_for_new_card_preselects_sole_active_non_ended_sprint() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -253,7 +257,8 @@ fn test_for_new_card_preselects_none_when_no_active_sprints() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -274,7 +279,8 @@ fn test_for_new_card_preselects_none_when_multiple_active_sprints() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -294,7 +300,8 @@ fn test_value_at_returns_none_uuid_for_none_row() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -319,7 +326,8 @@ fn test_value_at_returns_sprint_id_for_sprint_row() {
         .expect("active sprint must appear");
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -336,7 +344,8 @@ fn test_index_of_sprint_returns_row_index_for_known_sprint() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -354,7 +363,8 @@ fn test_index_of_sprint_returns_none_entry_index_when_no_sprint_selected() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -374,7 +384,8 @@ fn test_index_of_sprint_returns_none_when_sprint_is_not_in_list() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -395,7 +406,8 @@ fn test_value_at_indices_match_build_entries_order() {
     let entries = build_entries(app.model.sprints(), board_id, now);
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -429,7 +441,8 @@ fn test_render_emits_active_planned_header_with_yellow_color() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -455,7 +468,8 @@ fn test_render_with_none_selection_leaves_all_rows_unselected() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()
@@ -479,7 +493,8 @@ fn test_render_with_out_of_bounds_selected_does_not_panic() {
     let now = Utc::now();
     let board = app
         .model
-        .boards()
+        .boards_state()
+        .loaded_or_empty()
         .iter()
         .find(|b| b.id == board_id)
         .cloned()

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -33,7 +33,7 @@ fn test_create_board_assigns_correct_id_to_columns() {
     app.create_board();
     app.prepare_frame();
 
-    let boards = app.model.boards();
+    let boards = app.model.boards_state().loaded_or_empty();
     assert_eq!(boards.len(), 1, "should have exactly one board");
     let board_id = boards[0].id;
 
@@ -62,7 +62,7 @@ fn test_create_board_selects_new_board() {
     app.create_board();
     app.prepare_frame();
 
-    let boards = app.model.boards();
+    let boards = app.model.boards_state().loaded_or_empty();
     assert_eq!(boards.len(), 2);
 
     let selected = app.board_list.get_selected_index();
@@ -217,7 +217,7 @@ fn test_create_column_selects_new_column() {
         .model
         .columns()
         .iter()
-        .filter(|c| c.board_id == app.model.boards()[0].id)
+        .filter(|c| c.board_id == app.model.boards_state().loaded_or_empty()[0].id)
         .count();
 
     app.input.set("New Column".to_string());
@@ -798,7 +798,12 @@ fn test_active_sprint_survives_deletion_of_an_earlier_sprint() {
         "the neighbour must not have been touched"
     );
     assert_eq!(
-        app.model.board_by_id(alpha_id).unwrap().active_sprint_id,
+        app.model
+            .board_by_id_state(alpha_id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .active_sprint_id,
         Some(a3_id)
     );
 }

--- a/crates/kanban-view/src/model/boards.rs
+++ b/crates/kanban-view/src/model/boards.rs
@@ -1,14 +1,6 @@
 use super::*;
 
 impl Model {
-    /// The single unified board collection (live AND archived heads). Which of
-    /// these are archived is recorded in `archived_board_ids`; consumers that
-    /// want only one subset filter this collection by that set (the projects
-    /// panel does so via `displayed_boards`). Mirrors the unified `all_cards()`.
-    pub fn boards(&self) -> &[Board] {
-        self.boards.loaded_or_empty()
-    }
-
     pub fn boards_state(&self) -> &LoadState<Vec<Board>> {
         &self.boards
     }
@@ -59,14 +51,6 @@ impl Model {
         } else {
             &self.displayed_boards_live
         }
-    }
-
-    /// Resolve a board by id from the single unified collection (live AND
-    /// archived heads). One index lookup — no live/archived re-join. It is
-    /// deliberately archival-agnostic: a board is a board regardless of whether
-    /// its head is archived.
-    pub fn board_by_id(&self, id: Uuid) -> Option<&Board> {
-        self.board_by_id_state(id).loaded().copied()
     }
 
     pub fn board_by_id_state(&self, id: Uuid) -> LoadState<&Board> {

--- a/crates/kanban-view/src/model/boards.rs
+++ b/crates/kanban-view/src/model/boards.rs
@@ -19,7 +19,8 @@ impl Model {
     /// so broadening `boards()` to the unified collection cannot leak archived
     /// heads into live semantics.
     pub fn live_boards(&self) -> impl Iterator<Item = &Board> {
-        self.boards()
+        self.boards_state()
+            .loaded_or_empty()
             .iter()
             .filter(|b| !self.archived_board_ids.contains(&b.id))
     }
@@ -135,7 +136,11 @@ mod tests {
         let m = Model::default();
         assert!(m.archived_boards().is_empty());
         assert!(m.archived_board_ids().is_empty());
-        assert!(m.board_by_id(Uuid::new_v4()).is_none());
+        assert!(m
+            .board_by_id_state(Uuid::new_v4())
+            .loaded()
+            .copied()
+            .is_none());
     }
 
     #[test]
@@ -157,12 +162,18 @@ mod tests {
         });
 
         // Both live and archived heads live in the single unified collection.
-        assert_eq!(m.boards().len(), 2);
+        assert_eq!(m.boards_state().loaded_or_empty().len(), 2);
 
         // The single index resolves both.
-        assert_eq!(m.board_by_id(live_id).map(|b| b.id), Some(live_id));
         assert_eq!(
-            m.board_by_id(archived_id).map(|b| b.name.clone()),
+            m.board_by_id_state(live_id).loaded().copied().map(|b| b.id),
+            Some(live_id)
+        );
+        assert_eq!(
+            m.board_by_id_state(archived_id)
+                .loaded()
+                .copied()
+                .map(|b| b.name.clone()),
             Some("Archived".to_string())
         );
 
@@ -189,7 +200,8 @@ mod tests {
         });
 
         let displayed: Vec<Uuid> = m
-            .boards()
+            .boards_state()
+            .loaded_or_empty()
             .iter()
             .filter(|b| m.archived_board_ids().contains(&b.id))
             .map(|b| b.id)
@@ -215,7 +227,8 @@ mod tests {
         });
 
         let live_only: Vec<Uuid> = m
-            .boards()
+            .boards_state()
+            .loaded_or_empty()
             .iter()
             .filter(|b| !m.archived_board_ids().contains(&b.id))
             .map(|b| b.id)
@@ -228,7 +241,11 @@ mod tests {
     fn test_board_by_id_missing_id_returns_none() {
         let mut m = Model::default();
         m.load_from_snapshot(Snapshot::default());
-        assert!(m.board_by_id(Uuid::new_v4()).is_none());
+        assert!(m
+            .board_by_id_state(Uuid::new_v4())
+            .loaded()
+            .copied()
+            .is_none());
     }
 
     #[test]
@@ -243,7 +260,7 @@ mod tests {
         m.load_from_snapshot(Snapshot::default());
         assert!(m.boards_state().is_loaded());
         assert!(m.boards_state().loaded().unwrap().is_empty());
-        assert!(m.boards().is_empty());
+        assert!(m.boards_state().loaded_or_empty().is_empty());
     }
 
     #[test]

--- a/crates/kanban-view/src/model/graph.rs
+++ b/crates/kanban-view/src/model/graph.rs
@@ -6,10 +6,6 @@ impl Model {
         EMPTY.get_or_init(DependencyGraph::default)
     }
 
-    pub fn graph(&self) -> &DependencyGraph {
-        self.graph.loaded().unwrap_or_else(|| Self::empty_graph())
-    }
-
     pub fn graph_state(&self) -> &LoadState<DependencyGraph> {
         &self.graph
     }

--- a/crates/kanban-view/src/model/graph.rs
+++ b/crates/kanban-view/src/model/graph.rs
@@ -37,8 +37,25 @@ mod tests {
     fn test_graph_accessor_returns_one_shared_empty_graph_when_not_loaded() {
         let a = Model::default();
         let b = Model::default();
-        assert!(std::ptr::eq(a.graph(), b.graph()));
-        assert_eq!(a.graph(), &DependencyGraph::default());
-        assert_eq!(b.graph(), &DependencyGraph::default());
+        assert!(std::ptr::eq(
+            a.graph_state()
+                .loaded()
+                .unwrap_or_else(|| Model::empty_graph()),
+            b.graph_state()
+                .loaded()
+                .unwrap_or_else(|| Model::empty_graph())
+        ));
+        assert_eq!(
+            a.graph_state()
+                .loaded()
+                .unwrap_or_else(|| Model::empty_graph()),
+            &DependencyGraph::default()
+        );
+        assert_eq!(
+            b.graph_state()
+                .loaded()
+                .unwrap_or_else(|| Model::empty_graph()),
+            &DependencyGraph::default()
+        );
     }
 }

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -147,7 +147,8 @@ impl Model {
         self.displayed_cards_archived = archived_cards;
 
         let (archived_boards, live_boards): (Vec<Board>, Vec<Board>) = self
-            .boards()
+            .boards_state()
+            .loaded_or_empty()
             .iter()
             .cloned()
             .partition(|b| self.archived_board_ids.contains(&b.id));
@@ -204,7 +205,7 @@ mod tests {
     #[test]
     fn test_default_model_returns_empty_slices() {
         let m = Model::default();
-        assert!(m.boards().is_empty());
+        assert!(m.boards_state().loaded_or_empty().is_empty());
         assert!(m.columns().is_empty());
         assert!(m.all_cards().is_empty());
         assert!(m.sprints().is_empty());
@@ -223,8 +224,8 @@ mod tests {
             columns: vec![col.clone()],
             ..Default::default()
         });
-        assert_eq!(m.boards().len(), 1);
-        assert_eq!(m.boards()[0].id, board.id);
+        assert_eq!(m.boards_state().loaded_or_empty().len(), 1);
+        assert_eq!(m.boards_state().loaded_or_empty()[0].id, board.id);
         assert_eq!(m.columns().len(), 1);
         assert_eq!(m.columns()[0].id, col.id);
     }
@@ -238,7 +239,7 @@ mod tests {
             boards: vec![board_a],
             ..Default::default()
         });
-        assert_eq!(m.boards().len(), 1);
+        assert_eq!(m.boards_state().loaded_or_empty().len(), 1);
 
         let board_b = Board::new("B", None::<String>);
         let board_c = Board::new("C", None::<String>);
@@ -247,8 +248,8 @@ mod tests {
             boards: vec![board_b, board_c],
             ..Default::default()
         });
-        assert_eq!(m.boards().len(), 2);
-        assert_eq!(m.boards()[0].name, "B");
+        assert_eq!(m.boards_state().loaded_or_empty().len(), 2);
+        assert_eq!(m.boards_state().loaded_or_empty()[0].name, "B");
     }
 
     #[test]
@@ -284,7 +285,7 @@ mod tests {
         );
         assert!(
             !graph_src.contains("pub fn graph(&self)"),
-            "Model::graph must be deleted; callers should use graph_state().loaded().unwrap_or_else(Model::empty_graph)"
+            "Model::graph must be deleted; callers should use graph_state().loaded().unwrap_or_else(|| Model::empty_graph())"
         );
     }
 }

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -269,4 +269,22 @@ mod tests {
         m.load_from_snapshot(Snapshot::default());
         assert!(m.card_by_id(old_id).is_none());
     }
+
+    #[test]
+    fn test_model_has_no_collapsing_boards_or_graph_accessors() {
+        let boards_src = include_str!("boards.rs");
+        let graph_src = include_str!("graph.rs");
+        assert!(
+            !boards_src.contains("pub fn boards(&self)"),
+            "Model::boards must be deleted; callers should use boards_state().loaded_or_empty()"
+        );
+        assert!(
+            !boards_src.contains("pub fn board_by_id(&self,"),
+            "Model::board_by_id must be deleted; callers should use board_by_id_state(id).loaded().copied()"
+        );
+        assert!(
+            !graph_src.contains("pub fn graph(&self)"),
+            "Model::graph must be deleted; callers should use graph_state().loaded().unwrap_or_else(Model::empty_graph)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Migrates every call site off `Model::boards()`, `Model::board_by_id()` and `Model::graph()` to the `*_state()` door (`boards_state().loaded_or_empty()`, `board_by_id_state(id).loaded().copied()`, `graph_state().loaded().unwrap_or_else(|| Model::empty_graph())`), then deletes all three accessors in the same PR.

Strictly behaviour-preserving: no rendering or handler semantics changed anywhere. `all_cards()` in `rebuild_displayed_partitions` is deliberately left untouched for KAN-1327.

## Counts

- Before: 147 occurrences of `.boards(`, `.board_by_id(` or `.graph(` across `crates/kanban-tui` and `crates/kanban-view` (`git grep -ohE '\.(boards|board_by_id|graph)\(' -- crates/kanban-tui crates/kanban-view | wc -l`).
- After: 0 (same command, zero lines).
- Split: 71 in the source trees, 76 in the kanban-tui integration test binaries. `cargo check --workspace --all-targets` is the completeness proof; a plain `cargo check --workspace` would not have compiled the integration-test binaries and would have let 76 unmigrated sites through unnoticed.
- No per-site tests were added for the 147 migrated call sites. Their existing suites (kanban-view unit tests, kanban-tui integration tests) are the regression net for this purely mechanical migration.

## Deviation from the handoff

The handoff's sanctioned `graph()` migration form was `graph_state().loaded().unwrap_or_else(Model::empty_graph)` (a bare function item). That form does not compile: passing `Model::empty_graph` (typed `fn() -> &'static DependencyGraph`) as the `unwrap_or_else` argument fixes `T = &'static DependencyGraph` before it unifies against the `Option<&'a DependencyGraph>` produced by `.loaded()`, which then forces the `self` borrow to outlive `'static`. The pre-existing `graph()` accessor sidesteps this by wrapping the call in a closure: `self.graph.loaded().unwrap_or_else(|| Self::empty_graph())`. Every migrated `graph()` call site uses that same closure form, `.unwrap_or_else(|| Model::empty_graph())`, which compiles and matches the existing precedent.

## Report-only: render-path collapse sites (input to KAN-1232)

Not touched in this PR, left exactly as they render today:

- `crates/kanban-tui/src/ui/card_detail.rs` (graph fallback rendered directly into the relationship section)
- `crates/kanban-tui/src/ui/dialogs/boards.rs` (renders `"?"` for a board that is Missing or one that was never loaded)
- `crates/kanban-tui/src/app/view_management.rs` inside `prepare_frame` (per-frame board resolution, silently `None` when not loaded)
- `crates/kanban-tui/src/app/card_selection.rs` (`get_board_card_count` / `get_sorted_board_cards` show a 0/empty panel for a not-loaded board list)

## Verification

- `cargo check --workspace --all-targets` clean
- `git grep -nE '\.(boards|board_by_id|graph)\(' -- crates/kanban-tui crates/kanban-view` returns zero lines
- `git grep -nE 'pub fn (boards|board_by_id|graph)\(' -- crates/kanban-view` returns zero real definitions
- `cargo test --all-features --workspace` green
- `cargo clippy --all-targets --all-features -- -D warnings` green
- `cargo fmt --all -- --check` green
- `cargo check --package kanban-cli --no-default-features --features json,sqlite` green