### PR TITLE
KAN-1326 docs(view,tui): repoint stale doc comments at surviving Model accessors

### DIFF
--- a/.changeset/kan-1326-stale-accessor-doc-refs.md
+++ b/.changeset/kan-1326-stale-accessor-doc-refs.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Repoint doc comments left over from PR #650, which renamed `Model::boards()`, `Model::board_by_id()` and `Model::graph()` to `boards_state()`, `board_by_id_state()` and `graph_state()` but left several comments in `kanban-view` and `kanban-tui` still naming the deleted accessors. No executable code changed.

--- a/crates/kanban-tui/src/app/selection.rs
+++ b/crates/kanban-tui/src/app/selection.rs
@@ -4,8 +4,8 @@ use std::cell::Cell;
 #[derive(Default)]
 pub struct SelectionHub {
     /// The board the user is currently viewing/acting on, tracked by IDENTITY so
-    /// it is archival-agnostic: it resolves through `Model::board_by_id`, which
-    /// finds the board whether its head is live or archived. `None` while
+    /// it is archival-agnostic: it resolves through `Model::board_by_id_state`,
+    /// which finds the board whether its head is live or archived. `None` while
     /// browsing the projects list without a board opened. An archived board is
     /// substitutable for a live one everywhere — there is no separate archived
     /// active-board state (Liskov).

--- a/crates/kanban-tui/tests/archive_board_view_tests.rs
+++ b/crates/kanban-tui/tests/archive_board_view_tests.rs
@@ -29,7 +29,7 @@ fn test_toggle_into_archived_boards_view_and_back() {
     app.reload_model();
     app.prepare_frame();
     // The live boards view (unified collection filtered by the archived-id set)
-    // excludes the archived head, even though `boards()` now carries it.
+    // excludes the archived head, even though `boards_state()` now carries it.
     assert!(app
         .model
         .boards_state()

--- a/crates/kanban-view/src/model/boards.rs
+++ b/crates/kanban-view/src/model/boards.rs
@@ -8,8 +8,8 @@ impl Model {
     /// The LIVE boards (unified collection minus the archived heads), in board
     /// order. The live projects panel and every live-only quantity (first-board
     /// default selection, new-board position, live counts) resolve through this,
-    /// so broadening `boards()` to the unified collection cannot leak archived
-    /// heads into live semantics.
+    /// so broadening `boards_state()` to the unified collection cannot leak
+    /// archived heads into live semantics.
     pub fn live_boards(&self) -> impl Iterator<Item = &Board> {
         self.boards_state()
             .loaded_or_empty()
@@ -33,7 +33,7 @@ impl Model {
     }
 
     /// Ids of the archived boards. The heads themselves live in the unified
-    /// `boards()` collection; this set records which of them are archived (built
+    /// `boards_state()` collection; this set records which of them are archived (built
     /// from the markers). The live/archived partition is precomputed on load and
     /// served by [`displayed_boards`](Self::displayed_boards); this set backs that
     /// split.
@@ -129,8 +129,8 @@ mod tests {
 
     #[test]
     fn test_board_by_id_resolves_live_and_archived_from_one_collection() {
-        // After unification `boards()` holds live AND archived heads, and
-        // `board_by_id` resolves either from the single collection — no
+        // After unification `boards_state()` holds live AND archived heads, and
+        // `board_by_id_state` resolves either from the single collection — no
         // `or_else(archived_board())` re-join.
         use kanban_domain::Archived;
         let mut m = Model::default();

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -100,7 +100,7 @@ impl Model {
         // head (live + archived) in one collection; `snapshot.archived_boards`
         // are markers keyed by `entity_id`, and the id set records which heads
         // are archived. The live/archived distinction is a consumption decision
-        // applied by filtering `boards()` on this set (the projects panel does so
+        // applied by filtering `boards_state()` on this set (the projects panel does so
         // via `displayed_boards`).
         let archived_board_ids: HashSet<Uuid> = snapshot
             .archived_boards


### PR DESCRIPTION
## Summary

PR #650 (KAN-1326, squash commit 3ff19b35 on develop) deleted three public accessors from `Model` in `kanban-view`: `boards()`, `board_by_id()`, and `graph()`, replacing them with `boards_state()`, `board_by_id_state()`, and `graph_state()`. The PR left several doc and inline comments in `kanban-view` and `kanban-tui` still naming the deleted symbols, so a reader hits a cross-reference that no longer resolves. This is a documentation-only cleanup, no executable code changed.

## Changes

- `crates/kanban-view/src/model/boards.rs`: three comments repointed (`live_boards` doc, `archived_board_ids` doc, and a test comment) from `boards()`/`board_by_id` to `boards_state()`/`board_by_id_state`
- `crates/kanban-view/src/model/mod.rs`: one comment in `load_from_snapshot` repointed from `boards()` to `boards_state()`
- `crates/kanban-tui/src/app/selection.rs`: `SelectionHub::active_board_id` doc repointed from `Model::board_by_id` to `Model::board_by_id_state`
- `crates/kanban-tui/tests/archive_board_view_tests.rs`: one test comment repointed from `boards()` to `boards_state()`

Verified no other stale references remain via a workspace-wide grep for the three deleted symbol names inside comments, and confirmed several superficially similar hits (`KanbanContext::boards()`, `list_boards()`, `displayed_boards()`, `get_graph()`, `live_boards()`) are distinct, still-existing symbols on other types that were correctly left untouched. Also added a changeset, matching the convention observed on prior docs-only PRs in this repo.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p kanban-view -p kanban-tui --all-targets --all-features -- -D warnings` — clean
- [x] `cargo doc -p kanban-view -p kanban-tui --no-deps` — no new broken intra-doc links (four pre-existing unrelated warnings confirmed unchanged by this diff)