### PR TITLE
KAN-1321 feat(service): multi-round resolve with cache-enforced narrowing

### DIFF
--- a/.changeset/kan-1321.md
+++ b/.changeset/kan-1321.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: EntityCache::resolve now keeps consulting the fetch plan until it has nothing left to ask for, so a need whose ids only become knowable after an earlier read (the cards named by the dependency graph, the subtree under a highlighted board) is served by a single call instead of silently returning short. The returned result accumulates every round rather than only the last, and the cache narrows each round itself so a plan that keeps naming an entity it already received cannot loop; an id the backend does not have costs exactly one read for the lifetime of the cache. Internal building block, nothing outside kanban-service is wired to it yet.

--- a/crates/kanban-service/src/cache/mod.rs
+++ b/crates/kanban-service/src/cache/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use kanban_domain::resolved::Collection;
@@ -71,6 +72,39 @@ impl LoadedState for LoadedView<'_> {
     }
 }
 
+#[derive(Default)]
+struct Fetched {
+    board_list: bool,
+    column_list: bool,
+    card_list: bool,
+    sprint_list: bool,
+    graph: bool,
+    columns: HashSet<Uuid>,
+    cards: HashSet<Uuid>,
+    sprints: HashSet<Uuid>,
+}
+
+impl Fetched {
+    fn record(&mut self, round: &FetchRound) {
+        self.board_list |= round.board_list;
+        self.column_list |= round.column_list;
+        self.card_list |= round.card_list;
+        self.sprint_list |= round.sprint_list;
+        self.graph |= round.graph;
+        self.columns.extend(round.columns.iter().copied());
+        self.cards.extend(round.cards.iter().copied());
+        self.sprints.extend(round.sprints.iter().copied());
+    }
+}
+
+fn outstanding<T>(ids: Vec<Uuid>, fetched: &HashSet<Uuid>, cached: &Collection<T>) -> Vec<Uuid> {
+    ids.into_iter()
+        .filter(|id| {
+            !fetched.contains(id) && !matches!(cached.by_id.get(id), Some(LoadState::Missing))
+        })
+        .collect()
+}
+
 impl EntityCache {
     pub fn new() -> Self {
         Self::default()
@@ -80,9 +114,7 @@ impl EntityCache {
         LoadedView(self)
     }
 
-    fn fetch_round(&mut self, round: &FetchRound, store: &dyn DataStore) -> Resolved {
-        let mut resolved = Resolved::default();
-
+    fn fetch_round(&mut self, round: &FetchRound, store: &dyn DataStore, resolved: &mut Resolved) {
         if round.board_list {
             let state = match store.list_boards() {
                 Ok(v) => LoadState::Loaded(v),
@@ -151,25 +183,56 @@ impl EntityCache {
             self.sprints.by_id.insert(id, state.clone());
             resolved.sprints.by_id.insert(id, state);
         }
-
-        resolved
     }
 
+    /// Drops anything this call has already fetched, plus any id cached as
+    /// `LoadState::Missing`, which stays terminal in every scope. `Loaded`
+    /// and `Failed` ids remain re-requestable by a later `resolve` call.
+    fn narrow_to_outstanding(&self, round: FetchRound, fetched: &Fetched) -> FetchRound {
+        FetchRound {
+            board_list: round.board_list && !fetched.board_list,
+            column_list: round.column_list && !fetched.column_list,
+            card_list: round.card_list && !fetched.card_list,
+            sprint_list: round.sprint_list && !fetched.sprint_list,
+            graph: round.graph && !fetched.graph,
+            columns: outstanding(round.columns, &fetched.columns, &self.columns),
+            cards: outstanding(round.cards, &fetched.cards, &self.cards),
+            sprints: outstanding(round.sprints, &fetched.sprints, &self.sprints),
+        }
+    }
+
+    /// Loops until the plan has nothing left to ask for: each round is
+    /// narrowed to what this call has not already fetched, and every fetch
+    /// writes a terminal state, so the requestable set strictly shrinks and
+    /// the loop halts structurally rather than on a round cap. A plan that
+    /// keeps naming an entity it already received in this call is therefore
+    /// harmless, and a need whose ids only become knowable after an earlier
+    /// round resolves in the same call.
+    ///
     /// Each entity reflects the backend as of its own individual fetch, not as
     /// of the resolve pass as a whole: two entities in the same `Resolved` may
     /// have been read moments apart. `resolve` deliberately does not wrap the
-    /// round in one transaction, because that would hold a connection open
-    /// across render-adjacent I/O today and, once resolve is multi-round,
-    /// across an unbounded number of rounds. The consequence of a torn read is
-    /// a stale entity, never a fabricated one: every value returned came from
-    /// a real backend response.
+    /// rounds in one transaction, because that would hold a connection open
+    /// across render-adjacent I/O today and across an unbounded number of
+    /// rounds. The consequence of a torn read is a stale entity, never a
+    /// fabricated one: every value returned came from a real backend
+    /// response.
     pub fn resolve(
         &mut self,
         plan: &dyn FetchPlan,
         store: &dyn DataStore,
     ) -> KanbanResult<Resolved> {
-        let round = plan.next_round(&self.loaded_view());
-        Ok(self.fetch_round(&round, store))
+        let mut resolved = Resolved::default();
+        let mut fetched = Fetched::default();
+        loop {
+            let round = self.narrow_to_outstanding(plan.next_round(&self.loaded_view()), &fetched);
+            if round.is_empty() {
+                break;
+            }
+            self.fetch_round(&round, store, &mut resolved);
+            fetched.record(&round);
+        }
+        Ok(resolved)
     }
 
     /// An `Entities` value naming no ids is treated as `All`: an

--- a/crates/kanban-service/src/cache/tests/mod.rs
+++ b/crates/kanban-service/src/cache/tests/mod.rs
@@ -9,6 +9,7 @@ use crate::read_recorder::RecordingStore;
 
 mod invalidate;
 mod loaded_view;
+mod multi_round;
 mod resolve;
 mod result_mapping;
 mod retry;
@@ -145,6 +146,66 @@ impl FetchPlan for GraphThenCardPlan {
         if requestable(loaded.graph()) {
             FetchRound {
                 graph: true,
+                ..Default::default()
+            }
+        } else if requestable(loaded.card(self.card_id)) {
+            FetchRound {
+                cards: vec![self.card_id],
+                ..Default::default()
+            }
+        } else {
+            FetchRound::default()
+        }
+    }
+}
+
+struct ChainPlan {
+    ids: Vec<Uuid>,
+}
+
+impl FetchPlan for ChainPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        match self
+            .ids
+            .iter()
+            .find(|&&id| loaded.card(id) != FetchStatus::Loaded)
+        {
+            Some(&id) => FetchRound {
+                cards: vec![id],
+                ..Default::default()
+            },
+            None => FetchRound::default(),
+        }
+    }
+}
+
+struct StickyThenNextPlan {
+    first: Uuid,
+    second: Uuid,
+}
+
+impl FetchPlan for StickyThenNextPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        let mut cards = vec![self.first];
+        if loaded.card(self.first) == FetchStatus::Loaded && requestable(loaded.card(self.second)) {
+            cards.push(self.second);
+        }
+        FetchRound {
+            cards,
+            ..Default::default()
+        }
+    }
+}
+
+struct CardListThenCardPlan {
+    card_id: Uuid,
+}
+
+impl FetchPlan for CardListThenCardPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        if requestable(loaded.card_list()) {
+            FetchRound {
+                card_list: true,
                 ..Default::default()
             }
         } else if requestable(loaded.card(self.card_id)) {

--- a/crates/kanban-service/src/cache/tests/multi_round.rs
+++ b/crates/kanban-service/src/cache/tests/multi_round.rs
@@ -2,8 +2,8 @@ use kanban_domain::FetchRound;
 use uuid::Uuid;
 
 use super::{
-    seed_board_with_column, seed_card, store, CardListThenCardPlan, ChainPlan, FixedPlan,
-    GraphThenCardPlan, StickyThenNextPlan,
+    seed_board_with_column, seed_card, store, CardListThenCardPlan, CardsByIdPlan, ChainPlan,
+    FixedPlan, GraphThenCardPlan, StickyThenNextPlan,
 };
 use crate::cache::EntityCache;
 use crate::read_recorder::{assert_ops, ReadOp};
@@ -190,4 +190,64 @@ fn test_a_later_round_does_not_clobber_a_collection_loaded_by_an_earlier_round()
     assert!(resolved.cards.all.is_loaded());
     assert_eq!(resolved.cards.all.loaded().unwrap().len(), 1);
     assert!(resolved.cards.by_id[&card.id].is_loaded());
+}
+
+#[test]
+fn test_narrowing_does_not_drop_a_not_loaded_id() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![card.id],
+        ..Default::default()
+    });
+
+    cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![card.id],
+        }],
+    );
+    assert!(cache.card(card.id).is_loaded());
+}
+
+#[test]
+fn test_an_empty_first_round_performs_zero_reads() {
+    let store = store();
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound::default());
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert!(store.ops().lock().unwrap().is_empty());
+    assert!(resolved.boards.is_untouched());
+    assert!(resolved.columns.is_untouched());
+    assert!(resolved.cards.is_untouched());
+    assert!(resolved.sprints.is_untouched());
+    assert!(resolved.graph.is_not_loaded());
+}
+
+#[test]
+fn test_a_failed_entity_is_not_refetched_within_a_single_resolve() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    store.fail_card(card.id);
+    let mut cache = EntityCache::new();
+    let plan = CardsByIdPlan { ids: vec![card.id] };
+
+    cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![card.id],
+        }],
+    );
+    assert!(cache.card(card.id).is_failed());
 }

--- a/crates/kanban-service/src/cache/tests/multi_round.rs
+++ b/crates/kanban-service/src/cache/tests/multi_round.rs
@@ -1,0 +1,193 @@
+use kanban_domain::FetchRound;
+use uuid::Uuid;
+
+use super::{
+    seed_board_with_column, seed_card, store, CardListThenCardPlan, ChainPlan, FixedPlan,
+    GraphThenCardPlan, StickyThenNextPlan,
+};
+use crate::cache::EntityCache;
+use crate::read_recorder::{assert_ops, ReadOp};
+
+#[test]
+fn test_resolve_serves_a_need_whose_ids_depend_on_an_earlier_round() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = GraphThenCardPlan { card_id: card.id };
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_graph",
+                ids: vec![],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![card.id],
+            },
+        ],
+    );
+    assert!(cache.graph().is_loaded());
+    assert_eq!(cache.card(card.id).loaded().map(|c| c.id), Some(card.id));
+    assert!(resolved.cards.by_id[&card.id].is_loaded());
+}
+
+#[test]
+fn test_resolve_walks_a_chain_of_twelve_dependent_links() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let ids: Vec<Uuid> = (0..12)
+        .map(|i| seed_card(&store, &board, &column, &format!("c{i}")).id)
+        .collect();
+    let mut cache = EntityCache::new();
+    let plan = ChainPlan { ids: ids.clone() };
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    for id in &ids {
+        assert!(cache.card(*id).is_loaded());
+    }
+    assert_eq!(store.ops().lock().unwrap().len(), 12);
+    assert_eq!(resolved.cards.by_id.len(), 12);
+}
+
+#[test]
+fn test_a_permanently_missing_id_costs_exactly_one_read_across_repeated_resolves() {
+    let store = store();
+    let absent = Uuid::new_v4();
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![absent],
+        ..Default::default()
+    });
+
+    cache.resolve(&plan, &store).unwrap();
+    cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![absent],
+        }],
+    );
+    assert!(cache.card(absent).is_missing());
+}
+
+#[test]
+fn test_a_missing_id_is_read_once_across_calls_while_a_loaded_sibling_is_refetched() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let present = seed_card(&store, &board, &column, "present");
+    let absent = Uuid::new_v4();
+    let mut cache = EntityCache::new();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![absent, present.id],
+        ..Default::default()
+    });
+
+    cache.resolve(&plan, &store).unwrap();
+    cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_card",
+                ids: vec![absent],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![present.id],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![present.id],
+            },
+        ],
+    );
+    assert!(cache.card(absent).is_missing());
+    assert!(cache.card(present.id).is_loaded());
+}
+
+#[test]
+fn test_a_plan_that_keeps_naming_a_loaded_card_fetches_it_once_and_still_serves_the_dependent_need()
+{
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let first = seed_card(&store, &board, &column, "first");
+    let second = seed_card(&store, &board, &column, "second");
+    let mut cache = EntityCache::new();
+    let plan = StickyThenNextPlan {
+        first: first.id,
+        second: second.id,
+    };
+
+    cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_card",
+                ids: vec![first.id],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![second.id],
+            },
+        ],
+    );
+    assert!(cache.card(first.id).is_loaded());
+    assert!(cache.card(second.id).is_loaded());
+}
+
+#[test]
+fn test_resolve_returns_entities_from_every_round_not_only_the_last() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = GraphThenCardPlan { card_id: card.id };
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert!(resolved.graph.is_loaded());
+    assert!(resolved
+        .cards
+        .by_id
+        .get(&card.id)
+        .is_some_and(|s| s.is_loaded()));
+}
+
+#[test]
+fn test_a_later_round_does_not_clobber_a_collection_loaded_by_an_earlier_round() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let mut cache = EntityCache::new();
+    let plan = CardListThenCardPlan { card_id: card.id };
+
+    let resolved = cache.resolve(&plan, &store).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "list_all_cards",
+                ids: vec![],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![card.id],
+            },
+        ],
+    );
+    assert!(resolved.cards.all.is_loaded());
+    assert_eq!(resolved.cards.all.loaded().unwrap().len(), 1);
+    assert!(resolved.cards.by_id[&card.id].is_loaded());
+}

--- a/crates/kanban-service/src/cache/tests/resolve.rs
+++ b/crates/kanban-service/src/cache/tests/resolve.rs
@@ -3,7 +3,6 @@ use uuid::Uuid;
 
 use super::{
     seed_board, seed_board_with_column, seed_card, seed_sprint, store, BoardListPlan, FixedPlan,
-    GraphThenCardPlan,
 };
 use crate::cache::EntityCache;
 use crate::read_recorder::{assert_ops, ReadOp};
@@ -269,26 +268,4 @@ fn test_a_loaded_card_collection_does_not_report_an_unfetched_card_id_as_loaded(
 
     assert!(cache.card_list().is_loaded());
     assert!(cache.card(a.id).is_not_loaded());
-}
-
-#[test]
-fn test_a_single_round_resolve_cannot_serve_a_dependent_need() {
-    let store = store();
-    let (board, column) = seed_board_with_column(&store);
-    let card = seed_card(&store, &board, &column, "a");
-    let mut cache = EntityCache::new();
-    let plan = GraphThenCardPlan { card_id: card.id };
-
-    let resolved = cache.resolve(&plan, &store).unwrap();
-
-    assert!(cache.graph().is_loaded());
-    assert!(cache.card(card.id).is_not_loaded());
-    assert!(resolved.cards.by_id.is_empty());
-    assert_ops(
-        &store.ops(),
-        &[ReadOp {
-            method: "get_graph",
-            ids: vec![],
-        }],
-    );
 }


### PR DESCRIPTION
## Summary

`EntityCache::resolve` now loops, consulting the plan repeatedly and fetching each narrowed round, until a round comes back empty. Previously it consulted the plan once and returned, so any need whose ids only become knowable after an earlier fetch (a dependency graph read followed by fetching the ids it names, a board list followed by its subtree) required a second call from outside the cache to finish.

- `fetch_round` now writes into a caller-owned `&mut Resolved` accumulator instead of returning a fresh one per round, so the value `resolve` returns carries every round's entities, not only the last.
- `resolve` loops: each iteration asks the plan for the next round, narrows it against what this call has already fetched, breaks once the narrowed round is empty, otherwise fetches and records it.
- The narrowing is done by the cache (`narrow_to_outstanding`), not the plan, using a new `Fetched` tracker plus the existing `Collection` state. It drops what this call already fetched, plus any id already cached as `LoadState::Missing`. There is no round cap or counter; the loop halts because the requestable set strictly shrinks (every fetch produces a terminal state, and this call never asks for the same thing twice).

## Deviation from the card

The card's literal `narrow_to_non_terminal` (filtering on `LoadState::is_terminal()`) does not work: `Failed` and `Loaded` are both terminal, and narrowing the very first round of a call on terminality would make two already-merged tests in `cache/tests/retry.rs` regress:

- `test_a_failed_card_is_refetched_and_recovers_once_the_backend_does` expects a `Failed` card to be retried on a later `resolve` call.
- `test_a_refetched_collection_replaces_the_previously_cached_contents` expects a `Loaded` collection to be refetched on a later call with no intervening `invalidate`.

The predicate implemented instead is call-scoped: within one `resolve` call, drop anything already fetched this call, plus anything permanently `Missing`. `Loaded` and `Failed` remain re-requestable by a later call. This still satisfies the card's own terminality table read literally (`Missing` never re-requested, in any scope), it's only the "Loaded -> re-requestable: no" row that had to be read as "no, within this call."

## Tests

Seven new red tests in `crates/kanban-service/src/cache/tests/multi_round.rs`, each failing by assertion (not hang or compile error) against develop, now green. The superseded single-round test `test_a_single_round_resolve_cannot_serve_a_dependent_need` was removed from `resolve.rs`. Three additional guard tests pin the empty-first-round, not-loaded, and within-call-Failed-is-not-refetched cases. All 43 cache tests, the full `kanban-service` suite, and the full workspace test suite are green; clippy and fmt are clean.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`
- `cargo check --package kanban-cli --no-default-features --features json,sqlite`

All four clean.