### PR TITLE
KAN-1319 feat(service,tui): declare builder-written prefix rows through execute_with_extra

### DIFF
--- a/.changeset/kan-1319.md
+++ b/.changeset/kan-1319.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+`KanbanContext`, `TuiContext` and `App` gain `execute_with_extra`, a variant of `execute_with` that lets the batch builder declare an extra `EntityIds` to union into the invalidation the batch derives. This is used by card creation to declare that it wrote a prefix row, so cache invalidation stays honest for builder writes no command in the batch describes.

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -105,6 +105,8 @@ entity ids from before the reload may no longer exist.
 
 ```rust
 ctx.execute(commands: Vec<Command>) -> KanbanResult<()>
+ctx.execute_with(build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<()>
+ctx.execute_with_extra(extra: EntityIds, build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<()>
 ctx.undo() -> KanbanResult<bool>   // Ok(false) if there was nothing to undo
 ctx.redo() -> KanbanResult<bool>   // Ok(false) if there was nothing to redo
 ctx.can_undo() -> bool
@@ -127,7 +129,11 @@ only, it records what happened but does not drive undo.
 
 Every path that commits a batch (`execute`, `undo`, `redo`) records the
 `Invalidation` that batch implies; `last_invalidation()` returns `None`
-until a batch has committed on this context.
+until a batch has committed on this context. A builder that writes state no
+command in the batch describes through `touched_entities` (a prefix row is
+the current example) declares it through `execute_with_extra`, whose
+`extra: EntityIds` is unioned into the derived invalidation unless that is
+already `Invalidation::All`.
 
 ### Board Operations
 

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -155,29 +155,36 @@ impl KanbanContext {
             .app_config()
             .effective_default_card_prefix()
             .to_string();
-        self.execute_with(|store| {
-            let (_prefix, card_number) =
-                Self::allocate_card_number(store, &board, spec.sprint_id, &default_card_prefix)?;
-            Ok(vec![Command::Card(CardCommand::Create(
-                kanban_domain::commands::CreateCard {
-                    id,
-                    card_number,
-                    board_id,
-                    column_id,
-                    title: spec.title,
-                    position,
-                    default_card_prefix: default_card_prefix.clone(),
-                    options: CreateCardOptions {
-                        description: spec.description,
-                        priority: Some(spec.priority),
-                        points: spec.points,
-                        due_date: spec.due_date,
-                        sprint_id: spec.sprint_id,
+        self.execute_with_extra(
+            kanban_domain::EntityIds::default().with_prefixes(),
+            |store| {
+                let (_prefix, card_number) = Self::allocate_card_number(
+                    store,
+                    &board,
+                    spec.sprint_id,
+                    &default_card_prefix,
+                )?;
+                Ok(vec![Command::Card(CardCommand::Create(
+                    kanban_domain::commands::CreateCard {
+                        id,
+                        card_number,
+                        board_id,
+                        column_id,
+                        title: spec.title,
+                        position,
+                        default_card_prefix: default_card_prefix.clone(),
+                        options: CreateCardOptions {
+                            description: spec.description,
+                            priority: Some(spec.priority),
+                            points: spec.points,
+                            due_date: spec.due_date,
+                            sprint_id: spec.sprint_id,
+                        },
+                        timestamp: chrono::Utc::now(),
                     },
-                    timestamp: chrono::Utc::now(),
-                },
-            ))])
-        })?;
+                ))])
+            },
+        )?;
         self.get_card_impl(id)?.ok_or_else(|| {
             KanbanError::Internal("Card creation succeeded but card not found".into())
         })

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -38,6 +38,19 @@ impl KanbanContext {
         &mut self,
         build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>,
     ) -> KanbanResult<()> {
+        self.execute_with_extra(kanban_domain::EntityIds::default(), build)
+    }
+
+    /// Like [`execute_with`](Self::execute_with), but for a builder that
+    /// writes state no command in the batch describes through
+    /// `touched_entities`. `extra` is unioned into the batch's derived
+    /// invalidation; `Invalidation::All` absorbs it rather than being
+    /// downgraded by it.
+    pub fn execute_with_extra(
+        &mut self,
+        extra: kanban_domain::EntityIds,
+        build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>,
+    ) -> KanbanResult<()> {
         if self.backend.remote_writes().is_some() {
             return Err(KanbanError::unsupported(
                 "this operation is not supported over the HTTP backend in v1 (only board/column/card create/update/delete are)",
@@ -72,7 +85,14 @@ impl KanbanContext {
             Ok(())
         }))?;
         let inverses: Vec<Command> = per_cmd_inverses.into_iter().rev().flatten().collect();
-        self.record_invalidation(invalidation_from_inverse(&inverses));
+        let invalidation = match invalidation_from_inverse(&inverses) {
+            Invalidation::All => Invalidation::All,
+            Invalidation::Entities(mut ids) => {
+                ids.merge(extra);
+                Invalidation::Entities(ids)
+            }
+        };
+        self.record_invalidation(invalidation);
 
         self.undo_stack.push(crate::undo_stack::UndoEntry {
             forward: commands,

--- a/crates/kanban-service/tests/execute_with_extra.rs
+++ b/crates/kanban-service/tests/execute_with_extra.rs
@@ -1,0 +1,115 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::commands::{CardCommand, Command, CreateCard, UpdateCard};
+use kanban_domain::{
+    CardUpdate, CreateCardOptions, EntityIds, Invalidation, KanbanOperations, KanbanResult,
+};
+use kanban_service::KanbanContext;
+use std::collections::HashSet;
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn make_ctx() -> KanbanContext {
+    KanbanContext::open(
+        Arc::new(InMemoryStore::new()),
+        kanban_core::AppConfig::default(),
+    )
+    .await
+    .unwrap()
+}
+
+fn entities(ctx: &KanbanContext) -> &EntityIds {
+    match ctx
+        .last_invalidation()
+        .expect("expected a recorded invalidation, found None")
+    {
+        Invalidation::Entities(ids) => ids,
+        Invalidation::All => panic!("expected Entities, got All"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_with_extra_merges_the_extra_into_the_derived_entities() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+
+    ctx.execute_with_extra(EntityIds::default().with_prefixes(), |_| {
+        Ok(vec![Command::Card(CardCommand::Update(UpdateCard {
+            card_id: card.id,
+            updates: CardUpdate {
+                title: Some("Renamed".into()),
+                ..Default::default()
+            },
+        }))])
+    })?;
+
+    let ids = entities(&ctx);
+    assert_eq!(ids.cards, HashSet::from([card.id]));
+    assert!(ids.prefixes);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_with_extra_does_not_downgrade_all_to_entities() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+
+    ctx.execute_with_extra(EntityIds::default().with_prefixes(), |_| {
+        Ok(vec![Command::Card(CardCommand::Create(CreateCard {
+            id: Uuid::new_v4(),
+            card_number: 1,
+            board_id: board.id,
+            column_id: col.id,
+            title: "c".into(),
+            position: 0,
+            options: CreateCardOptions::default(),
+            timestamp: chrono::Utc::now(),
+            default_card_prefix: "task".into(),
+        }))])
+    })?;
+
+    assert_eq!(ctx.last_invalidation(), Some(&Invalidation::All));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_plain_execute_with_records_no_prefixes() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+
+    ctx.execute_with(|_| {
+        Ok(vec![Command::Card(CardCommand::Update(UpdateCard {
+            card_id: card.id,
+            updates: CardUpdate {
+                title: Some("Renamed".into()),
+                ..Default::default()
+            },
+        }))])
+    })?;
+
+    let ids = entities(&ctx);
+    assert_eq!(ids.cards, HashSet::from([card.id]));
+    assert!(!ids.prefixes);
+    Ok(())
+}
+
+/// Passes unmodified today; a forward guard, not a discriminating test.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_service_create_card_records_an_invalidation_covering_prefixes() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+
+    let covers_prefixes = match ctx.last_invalidation() {
+        Some(Invalidation::All) => true,
+        Some(Invalidation::Entities(ids)) => ids.prefixes,
+        None => false,
+    };
+    assert!(covers_prefixes);
+    Ok(())
+}

--- a/crates/kanban-tui/src/app/command_execution.rs
+++ b/crates/kanban-tui/src/app/command_execution.rs
@@ -29,7 +29,20 @@ impl App {
             &dyn kanban_domain::DataStore,
         ) -> KanbanResult<Vec<kanban_domain::commands::Command>>,
     ) -> KanbanResult<()> {
-        self.ctx.execute_with(build)?;
+        self.execute_with_extra(kanban_domain::EntityIds::default(), build)
+    }
+
+    /// Like [`execute_with`](Self::execute_with), but `extra` is unioned
+    /// into the invalidation the batch derives. See
+    /// `KanbanContext::execute_with_extra`.
+    pub fn execute_with_extra(
+        &mut self,
+        extra: kanban_domain::EntityIds,
+        build: impl FnOnce(
+            &dyn kanban_domain::DataStore,
+        ) -> KanbanResult<Vec<kanban_domain::commands::Command>>,
+    ) -> KanbanResult<()> {
+        self.ctx.execute_with_extra(extra, build)?;
         Ok(())
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1197,6 +1197,47 @@ mod create_card_factory_tests {
         assert_eq!(after, before + 1);
     }
 
+    #[test]
+    fn test_tui_execute_with_extra_merges_the_extra_and_queues_a_flush() {
+        let mut app = App::test_default();
+        seed_active_board_with_column(&mut app);
+        let (board_id, column_id) = active_ids(&app);
+        let card = app
+            .ctx
+            .create_card(board_id, column_id, "A".into(), Default::default())
+            .unwrap();
+
+        let (_save_rx, _completion_rx) = app.ctx.save_coordinator.reset_save_channels();
+
+        app.execute_with_extra(
+            kanban_domain::EntityIds::default().with_prefixes(),
+            |_| {
+                Ok(vec![kanban_domain::commands::Command::Card(
+                    kanban_domain::commands::CardCommand::Update(
+                        kanban_domain::commands::UpdateCard {
+                            card_id: card.id,
+                            updates: kanban_domain::CardUpdate {
+                                title: Some("x".into()),
+                                ..Default::default()
+                            },
+                        },
+                    ),
+                )])
+            },
+        )
+        .unwrap();
+
+        assert!(app.ctx.save_coordinator.has_pending_saves());
+
+        match app.ctx.inner_mut().last_invalidation() {
+            Some(kanban_domain::Invalidation::Entities(ids)) => {
+                assert_eq!(ids.cards, std::collections::HashSet::from([card.id]));
+                assert!(ids.prefixes);
+            }
+            other => panic!("expected Entities with prefixes, got {other:?}"),
+        }
+    }
+
     /// The TUI batches the create with an optional auto-complete
     /// `UpdateCard` so a single undo reverses the whole action. Allocating
     /// the number through `execute_with` must not turn that into two undo

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -444,49 +444,52 @@ impl App {
                 // lands in one undo unit with the optional auto-complete.
                 let default_card_prefix =
                     self.app_config.effective_default_card_prefix().to_string();
-                let result = self.execute_with(|store| {
-                    let board = store
-                        .get_board(bid)?
-                        .ok_or_else(|| kanban_domain::KanbanError::not_found("Board", bid))?;
-                    let sprint_card_prefix = match sprint_id {
-                        Some(id) => store.get_sprint(id)?.and_then(|s| s.card_prefix.clone()),
-                        None => None,
-                    };
-                    let (_prefix, card_number) = kanban_domain::allocate_card_number(
-                        store,
-                        board.card_prefix.as_deref(),
-                        sprint_card_prefix.as_deref(),
-                        Some(&default_card_prefix),
-                    )?;
+                let result = self.execute_with_extra(
+                    kanban_domain::EntityIds::default().with_prefixes(),
+                    |store| {
+                        let board = store
+                            .get_board(bid)?
+                            .ok_or_else(|| kanban_domain::KanbanError::not_found("Board", bid))?;
+                        let sprint_card_prefix = match sprint_id {
+                            Some(id) => store.get_sprint(id)?.and_then(|s| s.card_prefix.clone()),
+                            None => None,
+                        };
+                        let (_prefix, card_number) = kanban_domain::allocate_card_number(
+                            store,
+                            board.card_prefix.as_deref(),
+                            sprint_card_prefix.as_deref(),
+                            Some(&default_card_prefix),
+                        )?;
 
-                    let mut commands: Vec<Command> = new_column_cmd.into_iter().collect();
-                    commands.push(Command::Card(CardCommand::Create(CreateCard {
-                        id: card_id,
-                        card_number,
-                        board_id: bid,
-                        column_id,
-                        title,
-                        position,
-                        options: kanban_domain::CreateCardOptions {
-                            sprint_id,
-                            ..Default::default()
-                        },
-                        timestamp: now,
-                        default_card_prefix: default_card_prefix.clone(),
-                    })));
-
-                    if mark_as_complete {
-                        commands.push(Command::Card(CardCommand::Update(UpdateCard {
-                            card_id,
-                            updates: CardUpdate {
-                                status: Some(CardStatus::Done),
+                        let mut commands: Vec<Command> = new_column_cmd.into_iter().collect();
+                        commands.push(Command::Card(CardCommand::Create(CreateCard {
+                            id: card_id,
+                            card_number,
+                            board_id: bid,
+                            column_id,
+                            title,
+                            position,
+                            options: kanban_domain::CreateCardOptions {
+                                sprint_id,
                                 ..Default::default()
                             },
+                            timestamp: now,
+                            default_card_prefix: default_card_prefix.clone(),
                         })));
-                    }
 
-                    Ok(commands)
-                });
+                        if mark_as_complete {
+                            commands.push(Command::Card(CardCommand::Update(UpdateCard {
+                                card_id,
+                                updates: CardUpdate {
+                                    status: Some(CardStatus::Done),
+                                    ..Default::default()
+                                },
+                            })));
+                        }
+
+                        Ok(commands)
+                    },
+                );
 
                 if let Err(e) = result {
                     tracing::error!("Failed to create card: {}", e);
@@ -1209,22 +1212,17 @@ mod create_card_factory_tests {
 
         let (_save_rx, _completion_rx) = app.ctx.save_coordinator.reset_save_channels();
 
-        app.execute_with_extra(
-            kanban_domain::EntityIds::default().with_prefixes(),
-            |_| {
-                Ok(vec![kanban_domain::commands::Command::Card(
-                    kanban_domain::commands::CardCommand::Update(
-                        kanban_domain::commands::UpdateCard {
-                            card_id: card.id,
-                            updates: kanban_domain::CardUpdate {
-                                title: Some("x".into()),
-                                ..Default::default()
-                            },
-                        },
-                    ),
-                )])
-            },
-        )
+        app.execute_with_extra(kanban_domain::EntityIds::default().with_prefixes(), |_| {
+            Ok(vec![kanban_domain::commands::Command::Card(
+                kanban_domain::commands::CardCommand::Update(kanban_domain::commands::UpdateCard {
+                    card_id: card.id,
+                    updates: kanban_domain::CardUpdate {
+                        title: Some("x".into()),
+                        ..Default::default()
+                    },
+                }),
+            )])
+        })
         .unwrap();
 
         assert!(app.ctx.save_coordinator.has_pending_saves());

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1200,6 +1200,24 @@ mod create_card_factory_tests {
         assert_eq!(after, before + 1);
     }
 
+    /// Passes unmodified today; a forward guard, not a discriminating test.
+    #[test]
+    fn test_tui_create_card_records_an_invalidation_covering_prefixes() {
+        let mut app = App::test_default();
+        seed_active_board_with_column(&mut app);
+
+        app.input.set("Ship it".to_string());
+        app.create_card();
+        app.input.clear();
+
+        let covers_prefixes = match app.ctx.inner_mut().last_invalidation() {
+            Some(kanban_domain::Invalidation::All) => true,
+            Some(kanban_domain::Invalidation::Entities(ids)) => ids.prefixes,
+            None => false,
+        };
+        assert!(covers_prefixes);
+    }
+
     #[test]
     fn test_tui_execute_with_extra_merges_the_extra_and_queues_a_flush() {
         let mut app = App::test_default();

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -53,7 +53,15 @@ impl TuiContext {
         &mut self,
         build: impl FnOnce(&dyn kanban_domain::DataStore) -> KanbanResult<Vec<Command>>,
     ) -> KanbanResult<()> {
-        self.inner.execute_with(build)?;
+        self.execute_with_extra(kanban_domain::EntityIds::default(), build)
+    }
+
+    pub fn execute_with_extra(
+        &mut self,
+        extra: kanban_domain::EntityIds,
+        build: impl FnOnce(&dyn kanban_domain::DataStore) -> KanbanResult<Vec<Command>>,
+    ) -> KanbanResult<()> {
+        self.inner.execute_with_extra(extra, build)?;
         if self.save_coordinator.has_save_channel() {
             self.save_coordinator.queue_flush();
         }


### PR DESCRIPTION
## Summary

- Adds `execute_with_extra(extra: EntityIds, build)` to `KanbanContext`, `TuiContext` and `App`. `extra` is unioned into the invalidation the batch derives from its captured inverses, unless that derivation is already `Invalidation::All`, which absorbs `extra` rather than being downgraded by it.
- `execute_with` at all three layers keeps its exact existing signature and is now a one-line delegation to `execute_with_extra` with `EntityIds::default()`, so the two cannot drift apart.
- The two non-command call sites that allocate a card number (and so upsert a prefix row) now declare that through `EntityIds::default().with_prefixes()`: the service's `create_card_from_spec` (`crates/kanban-service/src/context/cards.rs`) and the TUI's `create_card` dialog handler (`crates/kanban-tui/src/handlers/card_handlers.rs`).
- No command's `touched_entities()` is changed. The two in-command allocation sites (`CreateSubcardCommand` in `dependency_commands.rs`, `CreateSprint` in `sprint_commands.rs`) already declare `prefixes` correctly and are untouched.
- `crates/kanban-service/README.md` documents `execute_with_extra` in the Undo/Redo API block and states the contract in prose.

Re-ran the call-site census on the branch (`git grep -n "allocate_card_number\|allocate_sprint_number" -- crates/ | grep -v '/tests/'`); the four non-definition call sites are unchanged in number, with the two non-command ones now declaring `prefixes`.

## Notes on the added tests

Two are labelled forward guards, not red-turned-green proof:

- `test_service_create_card_records_an_invalidation_covering_prefixes` (`crates/kanban-service/tests/execute_with_extra.rs`)
- `test_tui_create_card_records_an_invalidation_covering_prefixes` (`crates/kanban-tui/src/handlers/card_handlers.rs`), driving the real `App::create_card` dialog handler the same way `test_tui_create_advances_the_prefix_row` does

Both create paths already derive `Invalidation::All` today, because `CreateCard`'s captured inverse is `DeleteCard`, whose `touched_entities()` is unenumerable (`None`). An assertion of the shape "All, or Entities with prefixes" is satisfied before this change and after it, and would stay green even if both call-site edits were reverted. Their value is that they start discriminating the moment `DeleteCard` becomes enumerable, or either create path's derivation changes.

The remaining four tests are the ones that actually pin the merge and short-circuit behaviour, and each was confirmed to fail to compile before the implementation:

- `test_execute_with_extra_merges_the_extra_into_the_derived_entities` (service)
- `test_execute_with_extra_does_not_downgrade_all_to_entities` (service)
- `test_plain_execute_with_records_no_prefixes` (service)
- `test_tui_execute_with_extra_merges_the_extra_and_queues_a_flush` (TUI)

A deliberate mutation of the merge and of the `All` short-circuit was confirmed to break the relevant discriminating test before being reverted.

KAN-1318 has already landed, so `record_invalidation`/`last_invalidation` already existed; this card reuses that sink and introduces no second one.

## Test plan

- `nix develop --command cargo fmt --all -- --check`
- `nix develop --command cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop --command cargo test --all-features --workspace`
- `nix develop --command cargo check --package kanban-cli --no-default-features --features json,sqlite`

All four green.
