### PR TITLE
KAN-1332 feat(server): 404 nested collection GETs when the board does not exist

### DIFF
--- a/.changeset/kan-1332-nested-collection-404.md
+++ b/.changeset/kan-1332-nested-collection-404.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+BREAKING: `GET /v1/boards/{id}/columns` and `GET /v1/boards/{id}/cards` now return 404 when the board does not exist, instead of an empty page. This matches the sprints route and lets a client tell a deleted board from an empty one.

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -161,7 +161,7 @@ All request/response bodies are JSON. Errors share one envelope (see [Error Hand
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/v1/boards/{board_id}/columns` | List a board's columns. Returns `Page<ColumnResponse>`; accepts `?page=&page_size=`. |
+| `GET` | `/v1/boards/{board_id}/columns` | List a board's columns. 404s if `board_id` doesn't exist (does not collapse into an empty list). Returns `Page<ColumnResponse>`; accepts `?page=&page_size=`. |
 | `GET` | `/v1/boards/{board_id}/columns/{id}` | Get a column by UUID. 404s if the column exists but belongs to a different board. |
 
 Column writes (create/update/delete) aren't implemented yet.
@@ -184,7 +184,7 @@ Column writes (create/update/delete) aren't implemented yet.
 
 | Method | Path | Description | Body |
 |---|---|---|---|
-| `GET` | `/v1/boards/{board_id}/cards` | List a board's cards. Supports `?column_id=`, `?sprint_id=` and `?archived=` filters alongside pagination. Returns `Page<CardResponse>`; accepts `?page=&page_size=`. | — |
+| `GET` | `/v1/boards/{board_id}/cards` | List a board's cards. 404s if `board_id` doesn't exist (does not collapse into an empty list). Supports `?column_id=`, `?sprint_id=` and `?archived=` filters alongside pagination. Returns `Page<CardResponse>`; accepts `?page=&page_size=`. | — |
 
 The remaining card routes (get/create/replace/update/delete, and the flat `/v1/cards/{id}` aliases) exist but aren't documented in this table yet.
 

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -38,6 +38,8 @@ async fn list_cards(
         ..Default::default()
     };
     let ctx = state.ctx.lock().await;
+    ctx.require_board(board_id)
+        .map_err(|e| AppError::from(&e))?;
     let cards = ctx
         .list_cards_detailed(filter)
         .map_err(|e| AppError::from(&e))?;

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -16,6 +16,8 @@ async fn list_columns(
     Query(params): Query<PageParams>,
 ) -> Result<Json<Page<ColumnResponse>>, AppError> {
     let ctx = state.ctx.lock().await;
+    ctx.require_board(board_id)
+        .map_err(|e| AppError::from(&e))?;
     let cols = ctx.list_columns(board_id).map_err(|e| AppError::from(&e))?;
     paginate_response(cols.iter().map(ColumnResponse::from).collect(), &params)
 }

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -18,6 +18,8 @@ async fn list_sprints(
     Query(params): Query<PageParams>,
 ) -> Result<Json<Page<SprintResponse>>, AppError> {
     let ctx = state.ctx.lock().await;
+    ctx.require_board(board_id)
+        .map_err(|e| AppError::from(&e))?;
     let sprints = ctx.list_sprints(board_id).map_err(|e| AppError::from(&e))?;
     let names = resolve_sprint_names(&*ctx, board_id, &sprints).map_err(|e| AppError::from(&e))?;
     let responses: Vec<SprintResponse> = sprints

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -285,7 +285,7 @@ async fn test_list_cards_archived_include_returns_live_and_archived_with_archive
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_cards_unknown_board_id_returns_200_empty_page() {
+async fn test_list_cards_unknown_board_returns_404() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -299,14 +299,42 @@ async fn test_list_cards_unknown_board_id_returns_200_empty_page() {
     )
     .await;
 
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
     assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "unknown board_id should return 200, not 404"
+        json["message"],
+        format!("Board {random_board_id} not found")
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_empty_board_returns_200_empty_page() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Empty Board".to_string(), Some("EB".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
     assert_eq!(json["items"], serde_json::json!([]));
     assert_eq!(json["total"], 0);
+    assert_eq!(json["total_pages"], 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/columns_read.rs
+++ b/crates/kanban-server/tests/columns_read.rs
@@ -93,7 +93,7 @@ async fn test_list_columns_empty_board_returns_200_empty_page() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_list_columns_unknown_board_id_returns_200_empty_page() {
+async fn test_list_columns_unknown_board_returns_404() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -107,14 +107,48 @@ async fn test_list_columns_unknown_board_id_returns_200_empty_page() {
     )
     .await;
 
-    assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "unknown board_id should return 200, not 404"
-    );
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let json = json_of(response).await;
-    assert_eq!(json["items"], serde_json::json!([]));
-    assert_eq!(json["total"], 0);
+    assert_eq!(json["code"], "NOT_FOUND");
+    assert_eq!(
+        json["message"],
+        format!("Board {random_board_id} not found")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_columns_archived_board_returns_200_with_its_columns() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Archived Board".to_string(), Some("AB".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_column(board_id, "Column 1".to_string(), Some(0))
+            .unwrap();
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/columns", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json["items"].as_array().expect("items should be an array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "archived board should still serve its columns"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/pagination.rs
+++ b/crates/kanban-server/tests/pagination.rs
@@ -412,6 +412,54 @@ async fn test_list_sprints_unknown_board_with_paging_still_returns_404() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_list_columns_unknown_board_with_paging_still_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_board_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{random_board_id}/columns?page=1&page_size=2"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+    assert!(
+        json.get("items").is_none(),
+        "a missing board must not render as an empty page"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_unknown_board_with_paging_still_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_board_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{random_board_id}/cards?page=1&page_size=2"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+    assert!(
+        json.get("items").is_none(),
+        "a missing board must not render as an empty page"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_list_boards_page_envelope_is_absent_on_the_single_entity_get() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));


### PR DESCRIPTION
## Summary

`GET /v1/boards/{id}/columns` and `GET /v1/boards/{id}/cards` now return `404 NOT_FOUND` (message `Board <uuid> not found`) when the board does not exist, instead of `200` with an empty `Page`. This matches the existing sprints behaviour. `list_sprints` now carries its own explicit `require_board` guard rather than relying incidentally on `resolve_sprint_names`.

The guard is `KanbanContext::require_board`, the already-canonical board FK check used elsewhere in the service tier, called as the first statement inside each handler's existing lock scope. No new lock is taken and no new server-side helper is introduced.

## What changed

- `crates/kanban-server/src/routes/columns.rs`, `cards.rs`, `sprints.rs`: insert `ctx.require_board(board_id)` before the list lookup in each `list_*` handler.
- `crates/kanban-server/tests/columns_read.rs`, `cards_read.rs`: replaced `test_list_columns_unknown_board_id_returns_200_empty_page` and `test_list_cards_unknown_board_id_returns_200_empty_page` (both pinned the old behaviour) with `test_list_columns_unknown_board_returns_404` and `test_list_cards_unknown_board_returns_404`.
- Added `test_list_cards_empty_board_returns_200_empty_page`, closing a coverage gap (cards had no empty-board pin, columns and sprints already did). This test is green both before and after the fix.
- Added `test_list_columns_archived_board_returns_200_with_its_columns`, pinning that the guard uses the unfiltered `get_board` path (via `require_board`) and not a filtered `list_boards`, since `ArchiveBoards` keeps the board head live and its subtree in place. Also green before and after the fix.
- `crates/kanban-server/tests/pagination.rs`: added `test_list_columns_unknown_board_with_paging_still_returns_404` and `test_list_cards_unknown_board_with_paging_still_returns_404`, mirroring the existing sprints one, pinning that the board guard runs before pagination validation.
- `crates/kanban-server/README.md`: columns and cards list rows now carry the same "404s if `board_id` doesn't exist" clause the sprints row already had.
- `.changeset/kan-1332-nested-collection-404.md`: minor bump, breaking change note.

## Investigation: nested POST routes

The card asked whether `POST /v1/boards/{unknown}/columns` and `.../sprints` already 404 for an unknown board. They do, already, via deliberate service-tier guards (`create_column_from_spec` calls `self.require_board(...)`, `create_sprint_from_spec` has its own explicit board check), and both are already covered by green tests (`test_post_column_unknown_board_returns_404`, `test_post_sprint_unknown_board_returns_404`). No route-level change was needed or made there.

## Out of scope, reported not fixed

`crates/kanban-server/README.md:167` says "Column writes (create/update/delete) aren't implemented yet," which is stale (they are implemented). Left untouched since it's unrelated to this change.

## Red proof

Before the implementation commit, the four genuinely-red tests failed:

```
test_list_cards_unknown_board_returns_404 ... FAILED
  left: 200
 right: 404

test_list_columns_unknown_board_returns_404 ... FAILED
test_list_columns_unknown_board_with_paging_still_returns_404 ... FAILED
test_list_cards_unknown_board_with_paging_still_returns_404 ... FAILED
```

Everything else in the crate passed unchanged on that commit, including the two green-before-and-after pins.

## Verification

```
nix develop --command cargo fmt --all -- --check           # clean
nix develop --command cargo clippy --all-targets --all-features -- -D warnings   # clean
nix develop --command cargo test --all-features --workspace # 180 passed, 0 failed
nix develop --command cargo check --package kanban-cli --no-default-features --features json,sqlite  # clean
```

Mutation check: reverted the `require_board` guard in `columns.rs` and `cards.rs` individually, confirmed the corresponding red tests failed each time, then restored the guard.