### PR TITLE
KAN-1302 feat(service): opt-in entity cache on KanbanContext

### DIFF
--- a/.changeset/kan-1302-context-cache-wiring.md
+++ b/.changeset/kan-1302-context-cache-wiring.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: `KanbanContext` gains an opt-in per-entity read cache. Surfaces call `with_entity_cache()` to enable it and `resolve(plan)` to fetch only what a plan still needs; committed command batches, undos and redos now drop the entities they touched from that cache. Contexts that do not opt in behave exactly as before.

--- a/crates/kanban-service/src/context/core.rs
+++ b/crates/kanban-service/src/context/core.rs
@@ -21,6 +21,7 @@ impl KanbanContext {
             session_id: Uuid::new_v4(),
             app_type: AppType::Unknown,
             last_invalidation: None,
+            cache: None,
         }
     }
 

--- a/crates/kanban-service/src/context/entity_cache.rs
+++ b/crates/kanban-service/src/context/entity_cache.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod tests;

--- a/crates/kanban-service/src/context/entity_cache.rs
+++ b/crates/kanban-service/src/context/entity_cache.rs
@@ -1,2 +1,43 @@
+use super::KanbanContext;
+use crate::cache::EntityCache;
+use kanban_domain::{FetchPlan, Invalidation, KanbanResult, Resolved};
+
+impl KanbanContext {
+    /// Opt in to per-entity caching. A context built without this call holds
+    /// no cache and resolves nothing.
+    pub fn with_entity_cache(mut self) -> Self {
+        self.cache = Some(EntityCache::new());
+        self
+    }
+
+    pub fn has_cache(&self) -> bool {
+        self.cache.is_some()
+    }
+
+    /// Drops the named entities from the cache. A no-op when no cache is
+    /// configured.
+    pub fn invalidate(&mut self, invalidation: Invalidation) {
+        if let Some(cache) = self.cache.as_mut() {
+            cache.invalidate(invalidation);
+        }
+    }
+
+    /// Runs `plan` against the cache, fetching from the backend whatever the
+    /// plan still needs. The result names only what this pass fetched, so a
+    /// pass that fetched nothing returns `Resolved::default()`.
+    ///
+    /// Total: a context with no cache configured is a supported
+    /// configuration, so it returns `Resolved::default()` rather than an
+    /// error. Callers that must branch on it use
+    /// [`has_cache`](Self::has_cache).
+    pub fn resolve(&mut self, plan: &dyn FetchPlan) -> KanbanResult<Resolved> {
+        let backend = std::sync::Arc::clone(&self.backend);
+        match self.cache.as_mut() {
+            Some(cache) => cache.resolve(plan, backend.as_data_store()),
+            None => Ok(Resolved::default()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/kanban-service/src/context/entity_cache/tests.rs
+++ b/crates/kanban-service/src/context/entity_cache/tests.rs
@@ -1,0 +1,222 @@
+use std::sync::Arc;
+
+use kanban_core::AppConfig;
+use kanban_domain::{
+    requestable, Board, BoardUpdate, Card, Column, DataStore, EntityIds, FetchPlan, FetchRound,
+    Invalidation, KanbanOperations, LoadedState,
+};
+use uuid::Uuid;
+
+use crate::read_recorder::{assert_ops, ReadOp, RecordingStore};
+use crate::{KanbanBackend, KanbanContext};
+
+struct BoardListPlan;
+
+impl FetchPlan for BoardListPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        FetchRound {
+            board_list: requestable(loaded.board_list()),
+            ..Default::default()
+        }
+    }
+}
+
+struct CardsByIdPlan {
+    ids: Vec<Uuid>,
+}
+
+impl FetchPlan for CardsByIdPlan {
+    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        FetchRound {
+            cards: self
+                .ids
+                .iter()
+                .copied()
+                .filter(|&id| requestable(loaded.card(id)))
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+fn ctx_over(store: &Arc<RecordingStore>) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> = Arc::clone(store) as Arc<dyn KanbanBackend>;
+    KanbanContext::open_deferred(backend, AppConfig::default())
+}
+
+#[test]
+fn test_a_default_context_has_no_cache() {
+    let store = Arc::new(RecordingStore::new());
+    let ctx = ctx_over(&store);
+
+    assert!(!ctx.has_cache());
+}
+
+#[test]
+fn test_opting_in_enables_the_cache() {
+    let store = Arc::new(RecordingStore::new());
+    let ctx = ctx_over(&store);
+    assert!(!ctx.has_cache());
+
+    let ctx = ctx.with_entity_cache();
+
+    assert!(ctx.has_cache());
+}
+
+#[test]
+fn test_resolve_on_a_cacheless_context_returns_default_resolved() {
+    let store = Arc::new(RecordingStore::new());
+    let board = Board::new("board", None::<String>);
+    store.upsert_board(board).unwrap();
+    store.clear_log();
+    let mut ctx = ctx_over(&store);
+
+    let resolved = ctx.resolve(&BoardListPlan).unwrap();
+
+    assert!(resolved.boards.is_untouched());
+    assert!(resolved.columns.is_untouched());
+    assert!(resolved.cards.is_untouched());
+    assert!(resolved.sprints.is_untouched());
+    assert!(resolved.graph.is_not_loaded());
+    assert_ops(&store.ops(), &[]);
+}
+
+#[test]
+fn test_resolve_after_invalidate_all_reads_the_backend() {
+    let store = Arc::new(RecordingStore::new());
+    let board = Board::new("board", None::<String>);
+    store.upsert_board(board).unwrap();
+    store.clear_log();
+    let mut ctx = ctx_over(&store).with_entity_cache();
+
+    ctx.resolve(&BoardListPlan).unwrap();
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_boards",
+            ids: vec![],
+        }],
+    );
+
+    store.clear_log();
+    ctx.resolve(&BoardListPlan).unwrap();
+    assert_ops(&store.ops(), &[]);
+
+    ctx.invalidate(Invalidation::All);
+    store.clear_log();
+    let resolved = ctx.resolve(&BoardListPlan).unwrap();
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_boards",
+            ids: vec![],
+        }],
+    );
+    assert!(resolved.boards.all.is_loaded());
+}
+
+#[test]
+fn test_resolve_with_nothing_invalidated_reads_nothing() {
+    let store = Arc::new(RecordingStore::new());
+    let board = Board::new("board", None::<String>);
+    store.upsert_board(board).unwrap();
+    store.clear_log();
+    let mut ctx = ctx_over(&store).with_entity_cache();
+
+    ctx.resolve(&BoardListPlan).unwrap();
+    store.clear_log();
+
+    let resolved = ctx.resolve(&BoardListPlan).unwrap();
+
+    assert_ops(&store.ops(), &[]);
+    assert!(resolved.boards.is_untouched());
+}
+
+#[test]
+fn test_invalidating_entities_re_reads_only_those_ids() {
+    let store = Arc::new(RecordingStore::new());
+    let board = Board::new("board", None::<String>);
+    let board_id = board.id;
+    store.upsert_board(board).unwrap();
+    let column = Column::new(board_id, "col", 0);
+    let column_id = column.id;
+    store.upsert_column(column).unwrap();
+    let card_a = Card::new(board_id, column_id, "a", 0);
+    let card_b = Card::new(board_id, column_id, "b", 0);
+    let a_id = card_a.id;
+    let b_id = card_b.id;
+    store.upsert_card(card_a).unwrap();
+    store.upsert_card(card_b).unwrap();
+    store.clear_log();
+    let mut ctx = ctx_over(&store).with_entity_cache();
+    let plan = CardsByIdPlan {
+        ids: vec![a_id, b_id],
+    };
+
+    ctx.resolve(&plan).unwrap();
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_card",
+                ids: vec![a_id],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![b_id],
+            },
+        ],
+    );
+
+    store.clear_log();
+    ctx.invalidate(Invalidation::Entities(EntityIds::cards([a_id])));
+    ctx.resolve(&plan).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![a_id],
+        }],
+    );
+}
+
+#[test]
+fn test_command_execution_invalidates_the_cache() {
+    let store = Arc::new(RecordingStore::new());
+    let board = Board::new("board", None::<String>);
+    let board_id = board.id;
+    store.upsert_board(board.clone()).unwrap();
+    store.clear_log();
+    let mut ctx = ctx_over(&store).with_entity_cache();
+
+    ctx.resolve(&BoardListPlan).unwrap();
+
+    store.clear_log();
+    ctx.resolve(&BoardListPlan).unwrap();
+    assert_ops(&store.ops(), &[]);
+
+    ctx.update_board(
+        board_id,
+        BoardUpdate {
+            name: Some("renamed".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    store.clear_log();
+    let resolved = ctx.resolve(&BoardListPlan).unwrap();
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_boards",
+            ids: vec![],
+        }],
+    );
+    assert_eq!(
+        resolved.boards.all.loaded().unwrap()[0].name,
+        "renamed".to_string()
+    );
+}

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -71,6 +71,9 @@ pub struct KanbanContext {
     /// The invalidation implied by the most recent command batch that
     /// committed, forward or inverse. `None` until one has.
     pub(super) last_invalidation: Option<Invalidation>,
+    /// Per-entity read cache. `None` unless the surface opted in with
+    /// [`KanbanContext::with_entity_cache`].
+    pub(super) cache: Option<crate::cache::EntityCache>,
 }
 
 // The `KanbanOperations` trait impl must live in a single block (Rust forbids

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -18,6 +18,7 @@ mod cards_batch_detailed;
 mod columns;
 pub use columns::ColumnCreateOutcome;
 mod core;
+mod entity_cache;
 mod filters;
 mod graph;
 pub use graph::BoardRelations;

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -169,6 +169,7 @@ impl KanbanContext {
     }
 
     fn record_invalidation(&mut self, invalidation: Invalidation) {
+        self.invalidate(invalidation.clone());
         self.last_invalidation = Some(invalidation);
     }
 

--- a/crates/kanban-service/src/read_recorder.rs
+++ b/crates/kanban-service/src/read_recorder.rs
@@ -5,10 +5,12 @@ use std::sync::{Arc, Mutex};
 
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
-    ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
-    KanbanResult, Prefix, Snapshot, Sprint,
+    ArchivedBoard, ArchivedCard, Board, Card, Column, CommandBatch, CommandStore, DataStore,
+    DependencyGraph, KanbanError, KanbanResult, Prefix, Snapshot, Sprint,
 };
 use uuid::Uuid;
+
+use crate::backend::{KanbanBackend, TransactionFn};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReadOp {
@@ -266,6 +268,27 @@ impl DataStore for RecordingStore {
     }
     fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
         self.inner.apply_snapshot(snapshot)
+    }
+}
+
+impl CommandStore for RecordingStore {
+    fn append_batch(&self, batch: &CommandBatch) -> KanbanResult<u64> {
+        self.inner.append_batch(batch)
+    }
+    fn batch_count(&self) -> KanbanResult<u64> {
+        self.inner.batch_count()
+    }
+    fn load_batches(&self, offset: u64, limit: u64) -> KanbanResult<Vec<CommandBatch>> {
+        self.inner.load_batches(offset, limit)
+    }
+}
+
+impl KanbanBackend for RecordingStore {
+    fn as_data_store(&self) -> &dyn DataStore {
+        self
+    }
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
+        self.inner.with_transaction(f)
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a private, opt-in `Option<EntityCache>` field to `KanbanContext` plus four methods: `with_entity_cache`, `has_cache`, `invalidate`, and `resolve`.
- `resolve` is total: it returns `kanban_domain::Resolved` and never errors on a context that has not opted into caching, returning `Resolved::default()` instead.
- Wires command-triggered invalidation at the single funnel `KanbanContext::record_invalidation`, which covers `execute_with_extra`, `undo`, and `redo` in one place. No consumer crate changes.
- Extends the existing `RecordingStore` test double (`crates/kanban-service/src/read_recorder.rs`) with `CommandStore` and `KanbanBackend` implementations so it can back a `KanbanContext` in tests, rather than introducing a second test double.

## Decision: eager invalidation

Invalidation is applied eagerly, inside `record_invalidation`, rather than lazily derived from `last_invalidation` at the next `resolve` call. Reasons:

- `record_invalidation` is provably the single funnel for all three command paths (`execute_with_extra`, `undo`, `redo`), so one wire covers all of them.
- Eager invalidation keeps `last_invalidation` a pure audit field with no "consumed" flag to track.
- `EntityCache::invalidate` is a handful of cheap map removals, so there is no performance reason to defer it.

## Test plan

- [x] Seven new unit tests in `crates/kanban-service/src/context/entity_cache/tests.rs` covering: no-cache default, opt-in, cache-less resolve reads nothing, resolve-after-invalidate-all re-reads, warm-cache resolve reads nothing, entity-scoped invalidation re-reads only the invalidated ids, and command execution invalidating the cache.
- [x] `cargo test --all-features --workspace` green.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo check --package kanban-cli --no-default-features --features json,sqlite` green.
- [x] `check-crate-list-sync` and `check-factory-compile-lock` guard scripts clean.
- [x] Diff scope confirmed against `origin/develop`: only the seven files touched by this change, none under `kanban-cli`, `kanban-mcp`, or `kanban-server`.
