### PR TITLE
KAN-1327 refactor(view,tui): migrate Model's card accessors to load-state

### DIFF
--- a/.changeset/kan-1327-b8b-cards-accessor-migration.md
+++ b/.changeset/kan-1327-b8b-cards-accessor-migration.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+view: every call site that read a `Model`'s cards or resolved a card by id now goes through the load-state accessors, so "never loaded" is named instead of silently collapsing into "empty" or "no such card". The collapsing `Model::all_cards` and `Model::card_by_id` accessors are removed. Behaviour is unchanged everywhere.

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -24,7 +24,7 @@ impl App {
             self.animation.animating.remove(&card_id);
             match animation_type {
                 AnimationType::Archiving => {
-                    let cards = self.model.all_cards();
+                    let cards = self.model.cards_state().loaded_or_empty();
                     if let Some(card_pos) = cards.iter().position(|c| c.id == card_id) {
                         let card = &cards[card_pos];
                         if !affected_columns.contains(&card.column_id) {

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -50,7 +50,12 @@ impl App {
     pub fn get_selected_card_in_context(&self) -> Option<Card> {
         if let Some(task_list) = self.view.strategy.get_active_task_list() {
             if let Some(card_id) = task_list.get_selected_card_id() {
-                return self.model.card_by_id(card_id).cloned();
+                return self
+                    .model
+                    .card_by_id_state(card_id)
+                    .loaded()
+                    .copied()
+                    .cloned();
             }
         }
         None
@@ -92,7 +97,7 @@ impl App {
     pub fn get_card_for_detail_view(&self) -> Option<Card> {
         self.selection
             .active_card_id
-            .and_then(|id| self.model.card_by_id(id).cloned())
+            .and_then(|id| self.model.card_by_id_state(id).loaded().copied().cloned())
     }
 
     /// Sets `active_card_id` to `id` if a card with that id exists in the
@@ -101,7 +106,7 @@ impl App {
     /// On miss the previously-active card is left untouched; sites that
     /// require clear-on-miss semantics must use [`Self::set_active_card_or_clear`].
     pub(crate) fn activate_card(&mut self, id: uuid::Uuid) -> bool {
-        if self.model.card_by_id(id).is_some() {
+        if self.model.card_by_id_state(id).loaded().copied().is_some() {
             self.selection.active_card_id = Some(id);
             true
         } else {
@@ -115,7 +120,12 @@ impl App {
     /// reload race), so downstream code that gates on
     /// `active_card_id.is_some()` does not act on a stale previous card.
     pub(crate) fn set_active_card_or_clear(&mut self, id: uuid::Uuid) {
-        self.selection.active_card_id = self.model.card_by_id(id).map(|c| c.id);
+        self.selection.active_card_id = self
+            .model
+            .card_by_id_state(id)
+            .loaded()
+            .copied()
+            .map(|c| c.id);
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {

--- a/crates/kanban-tui/src/app/clipboard.rs
+++ b/crates/kanban-tui/src/app/clipboard.rs
@@ -10,7 +10,7 @@ impl App {
     {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(board) = self.active_board() {
-                if let Some(card) = self.model.card_by_id(active_id) {
+                if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                     let sprints = self.model.sprints();
                     let output = get_output(
                         card,

--- a/crates/kanban-tui/src/app/file_io.rs
+++ b/crates/kanban-tui/src/app/file_io.rs
@@ -85,7 +85,7 @@ impl App {
         field: CardField,
     ) -> io::Result<()> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id(active_id) {
+            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 let temp_dir = std::env::temp_dir();
                 let (temp_file, current_content) = match field {
                     CardField::Title => {

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -3,7 +3,7 @@ use super::{App, AppMode};
 impl App {
     pub fn get_current_priority_selection_index(&self) -> usize {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id(active_id) {
+            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 use kanban_domain::CardPriority;
                 return match card.priority {
                     CardPriority::Low => 0,
@@ -20,7 +20,7 @@ impl App {
         use kanban_view::sprint_assign_list::{build_entries, sprint_id_of};
 
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id(active_id) {
+            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 if let Some(card_sprint_id) = card.sprint_id {
                     if let Some(board) = self.active_board() {
                         let sprints = self.model.sprints();

--- a/crates/kanban-tui/src/components/relationship_popup.rs
+++ b/crates/kanban-tui/src/components/relationship_popup.rs
@@ -85,7 +85,9 @@ fn render_relationship_card_list(app: &App, frame: &mut Frame, area: ratatui::la
             .iter()
             .filter(|card_id| {
                 app.model
-                    .card_by_id(**card_id)
+                    .card_by_id_state(**card_id)
+                    .loaded()
+                    .copied()
                     .map(|c| c.title.to_lowercase().contains(&search_lower))
                     .unwrap_or(false)
             })
@@ -95,7 +97,7 @@ fn render_relationship_card_list(app: &App, frame: &mut Frame, area: ratatui::la
 
     let mut lines = vec![];
     for (idx, card_id) in filtered_cards.iter().enumerate() {
-        if let Some(card) = app.model.card_by_id(*card_id) {
+        if let Some(card) = app.model.card_by_id_state(*card_id).loaded().copied() {
             let is_selected = app.relationship.selection.get() == Some(idx);
             let is_checked = app.relationship.selected.contains(card_id);
 

--- a/crates/kanban-tui/src/components/relationship_section.rs
+++ b/crates/kanban-tui/src/components/relationship_section.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 pub fn resolve_relationship_cards(model: &Model, card_ids: &[Uuid]) -> Vec<Card> {
     card_ids
         .iter()
-        .filter_map(|id| model.card_by_id(*id).cloned())
+        .filter_map(|id| model.card_by_id_state(*id).loaded().copied().cloned())
         .collect()
 }
 

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -184,7 +184,7 @@ impl App {
             let current_sprint_id = self
                 .selection
                 .active_card_id
-                .and_then(|id| self.model.card_by_id(id))
+                .and_then(|id| self.model.card_by_id_state(id).loaded().copied())
                 .and_then(|c| c.sprint_id);
             // Re-borrow board after the &mut self call above.
             if let Some(board) = self.active_board().cloned() {
@@ -332,7 +332,8 @@ impl App {
             .filter_map(|card_id| {
                 let card = self
                     .model
-                    .all_cards()
+                    .cards_state()
+                    .loaded_or_empty()
                     .iter()
                     .find(|c| c.id == *card_id)?
                     .clone();
@@ -386,7 +387,7 @@ impl App {
                 let (column_id, position, mark_as_complete, new_column_cmd) = match existing_column
                 {
                     Some(col) => {
-                        let cards = self.model.all_cards();
+                        let cards = self.model.cards_state().loaded_or_empty();
                         let position =
                             kanban_domain::card_lifecycle::next_position_in_column(cards, col.id);
                         let columns = self.model.columns();
@@ -533,7 +534,7 @@ impl App {
             // Use the pure helper only to resolve the target column for the
             // given direction; the service handles any status sync.
             let columns = self.model.columns();
-            let cards = self.model.all_cards();
+            let cards = self.model.cards_state().loaded_or_empty();
             let move_result = kanban_domain::card_lifecycle::compute_card_column_move(
                 &card, board, columns, cards, direction,
             );
@@ -608,7 +609,7 @@ impl App {
         // Use the pure helper only to resolve the per-card target column;
         // status sync is chained by the service layer's `update_cards`.
         let columns = self.model.columns();
-        let cards = self.model.all_cards();
+        let cards = self.model.cards_state().loaded_or_empty();
         let updates: Vec<(uuid::Uuid, CardUpdate)> = card_ids
             .iter()
             .filter_map(|card_id| {
@@ -677,7 +678,8 @@ impl App {
     fn cursor_archive_anchor(&self) -> Option<(uuid::Uuid, i32)> {
         let card_id = self.get_selected_card_id()?;
         self.model
-            .all_cards()
+            .cards_state()
+            .loaded_or_empty()
             .iter()
             .find(|c| c.id == card_id)
             .map(|c| (c.column_id, c.position))
@@ -697,7 +699,13 @@ impl App {
         use kanban_domain::AnimationType;
         use std::time::Instant;
 
-        if self.model.all_cards().iter().any(|c| c.id == card_id) {
+        if self
+            .model
+            .cards_state()
+            .loaded_or_empty()
+            .iter()
+            .any(|c| c.id == card_id)
+        {
             self.animation.animating.insert(
                 card_id,
                 CardAnimation {
@@ -804,11 +812,11 @@ impl App {
         // it keeps its current column/position on restore; there is no "original"
         // location to reconstruct. Read the live card for its column/position and
         // to resolve the restore target if its column was removed.
-        let (current_column_id, current_position, card_title) = match self.model.card_by_id(card_id)
-        {
-            Some(card) => (card.column_id, card.position, card.title.clone()),
-            None => return false,
-        };
+        let (current_column_id, current_position, card_title) =
+            match self.model.card_by_id_state(card_id).loaded().copied() {
+                Some(card) => (card.column_id, card.position, card.title.clone()),
+                None => return false,
+            };
 
         let board_id = self.active_board().map(|b| b.id);
 
@@ -945,7 +953,7 @@ impl App {
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
-        let cards = self.model.all_cards();
+        let cards = self.model.cards_state().loaded_or_empty();
         let eligible_cards: Vec<_> = cards
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -272,7 +272,7 @@ impl App {
                         let current_sprint_id = self
                             .selection
                             .active_card_id
-                            .and_then(|id| self.model.card_by_id(id))
+                            .and_then(|id| self.model.card_by_id_state(id).loaded().copied())
                             .and_then(|c| c.sprint_id);
                         self.dialog_input
                             .assign_sprint_picker
@@ -744,8 +744,12 @@ impl App {
                     .filter(|s| s.board_id == board.id)
                     .count();
                 if sprint_count > 0 {
-                    let current_sprint_id =
-                        self.model.card_by_id(card_id).and_then(|c| c.sprint_id);
+                    let current_sprint_id = self
+                        .model
+                        .card_by_id_state(card_id)
+                        .loaded()
+                        .copied()
+                        .and_then(|c| c.sprint_id);
                     self.dialog_input
                         .assign_sprint_picker
                         .reset_for_card_assignment(
@@ -912,8 +916,12 @@ impl App {
                             }
                         }
                         CardListAction::Complete(card_id) => {
-                            if let Some(card) =
-                                self.model.all_cards().iter().find(|c| c.id == card_id)
+                            if let Some(card) = self
+                                .model
+                                .cards_state()
+                                .loaded_or_empty()
+                                .iter()
+                                .find(|c| c.id == card_id)
                             {
                                 use kanban_domain::{CardStatus, CardUpdate, KanbanOperations};
                                 let new_status = if card.status == CardStatus::Done {
@@ -977,7 +985,8 @@ impl App {
                         CardListAction::MoveColumn(card_id, is_right) => {
                             if let Some(card) = self
                                 .model
-                                .all_cards()
+                                .cards_state()
+                                .loaded_or_empty()
                                 .iter()
                                 .find(|c| c.id == card_id)
                                 .cloned()
@@ -989,7 +998,7 @@ impl App {
                                 };
 
                                 let columns = self.model.columns();
-                                let cards = self.model.all_cards();
+                                let cards = self.model.cards_state().loaded_or_empty();
                                 let move_result = self.active_board().and_then(|board| {
                                     kanban_domain::card_lifecycle::compute_card_column_move(
                                         &card, board, columns, cards, direction,
@@ -1070,7 +1079,7 @@ impl App {
 
     pub fn handle_manage_parents(&mut self) {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id(active_id) {
+            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
@@ -1104,7 +1113,8 @@ impl App {
 
                     let eligible_cards: Vec<_> = self
                         .model
-                        .all_cards()
+                        .cards_state()
+                        .loaded_or_empty()
                         .iter()
                         .filter(|c| column_ids.contains(&c.column_id))
                         .filter(|c| c.id != card_id)
@@ -1139,7 +1149,7 @@ impl App {
 
     pub fn handle_manage_children(&mut self) {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id(active_id) {
+            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 let card_id = card.id;
                 let card_column_id = card.column_id;
 
@@ -1173,7 +1183,8 @@ impl App {
 
                     let eligible_cards: Vec<_> = self
                         .model
-                        .all_cards()
+                        .cards_state()
+                        .loaded_or_empty()
                         .iter()
                         .filter(|c| column_ids.contains(&c.column_id))
                         .filter(|c| c.id != card_id)
@@ -1208,7 +1219,7 @@ impl App {
 
     pub fn get_current_card_parents(&self) -> Vec<uuid::Uuid> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id(active_id) {
+            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 return self
                     .model
                     .graph_state()
@@ -1222,7 +1233,7 @@ impl App {
 
     pub fn get_current_card_children(&self) -> Vec<uuid::Uuid> {
         if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id(active_id) {
+            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 return self
                     .model
                     .graph_state()
@@ -1314,7 +1325,8 @@ impl App {
             .filter_map(|card_id| {
                 let card = self
                     .model
-                    .all_cards()
+                    .cards_state()
+                    .loaded_or_empty()
                     .iter()
                     .find(|c| c.id == *card_id)?
                     .clone();

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -199,7 +199,7 @@ impl App {
                 let card_id = self
                     .selection
                     .active_card_id
-                    .and_then(|id| self.model.card_by_id(id))
+                    .and_then(|id| self.model.card_by_id_state(id).loaded().copied())
                     .map(|c| c.id)
                     .or_else(|| self.get_selected_card_in_context().map(|c| c.id));
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -51,7 +51,8 @@ impl App {
             KeyCode::Enter => {
                 if let Some(priority_idx) = self.dialog_input.priority_selection.get() {
                     if let Some(active_id) = self.selection.active_card_id {
-                        if let Some(card) = self.model.card_by_id(active_id) {
+                        if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied()
+                        {
                             use kanban_domain::{CardPriority, CardUpdate};
                             let priority = match priority_idx {
                                 0 => CardPriority::Low,
@@ -355,7 +356,12 @@ impl App {
                         return;
                     }
                 };
-                let card_id = match self.model.card_by_id(active_card_id) {
+                let card_id = match self
+                    .model
+                    .card_by_id_state(active_card_id)
+                    .loaded()
+                    .copied()
+                {
                     Some(card) => card.id,
                     None => return,
                 };
@@ -607,7 +613,8 @@ impl App {
                 .iter()
                 .filter(|card_id| {
                     self.model
-                        .all_cards()
+                        .cards_state()
+                        .loaded_or_empty()
                         .iter()
                         .find(|c| c.id == **card_id)
                         .map(|c| c.title.to_lowercase().contains(&search_lower))
@@ -668,7 +675,9 @@ impl App {
                 if let Some(idx) = self.relationship.selection.get() {
                     if let Some(selected_card_id) = filtered_cards.get(idx).copied() {
                         if let Some(active_id) = self.selection.active_card_id {
-                            if let Some(current_card) = self.model.card_by_id(active_id) {
+                            if let Some(current_card) =
+                                self.model.card_by_id_state(active_id).loaded().copied()
+                            {
                                 let current_card_id = current_card.id;
 
                                 let (child_id, parent_id) = if is_parent_mode {
@@ -721,7 +730,8 @@ impl App {
                 .iter()
                 .filter(|card_id| {
                     self.model
-                        .all_cards()
+                        .cards_state()
+                        .loaded_or_empty()
                         .iter()
                         .find(|c| c.id == **card_id)
                         .map(|c| c.title.to_lowercase().contains(&search_lower))

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -172,7 +172,9 @@ impl RenderStrategy for SinglePanelRenderer {
                                 }
 
                                 if let Some(card_id) = task_list.cards.get(*card_idx) {
-                                    if let Some(card) = app.model.card_by_id(*card_id) {
+                                    if let Some(card) =
+                                        app.model.card_by_id_state(*card_id).loaded().copied()
+                                    {
                                         let is_selected =
                                             task_list.get_selected_index() == Some(*card_idx);
                                         let animation_type = app
@@ -263,7 +265,9 @@ impl RenderStrategy for SinglePanelRenderer {
 
                         for card_idx in &render_info.visible_card_indices {
                             if let Some(card_id) = task_list.cards.get(*card_idx) {
-                                if let Some(card) = app.model.card_by_id(*card_id) {
+                                if let Some(card) =
+                                    app.model.card_by_id_state(*card_id).loaded().copied()
+                                {
                                     let animation_type = app
                                         .animation
                                         .animating
@@ -402,7 +406,9 @@ impl RenderStrategy for MultiPanelRenderer {
 
                         for card_idx in &render_info.visible_card_indices {
                             if let Some(card_id) = task_list.cards.get(*card_idx) {
-                                if let Some(card) = app.model.card_by_id(*card_id) {
+                                if let Some(card) =
+                                    app.model.card_by_id_state(*card_id).loaded().copied()
+                                {
                                     let is_selected = if is_focused_column {
                                         task_list.get_selected_index() == Some(*card_idx)
                                     } else {

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -45,7 +45,7 @@ pub struct ReloadResortFixture {
 }
 
 /// Simulates the KAN-534 scenario: an external write triggers a TUI
-/// reload that reorders `model.all_cards()`, leaving `ActiveCard.index`
+/// reload that reorders `model.cards_state()`, leaving `ActiveCard.index`
 /// pointing at a different card than `ActiveCard.id`.
 ///
 /// Seeds five cards in the same column with edges P -> A -> D, sets the

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -207,7 +207,7 @@ fn calculate_task_panel_points(task_list: &kanban_view::card_list::CardList, mod
     let filtered: Vec<&kanban_domain::Card> = task_list
         .cards
         .iter()
-        .filter_map(|card_id| model.card_by_id(*card_id))
+        .filter_map(|card_id| model.card_by_id_state(*card_id).loaded().copied())
         .collect();
     kanban_domain::calculate_points(&filtered)
 }
@@ -242,7 +242,7 @@ pub(super) fn render_sprint_task_panel_with_selection(
 
         for card_idx in &render_info.visible_card_indices {
             if let Some(card_id) = task_list.cards.get(*card_idx) {
-                if let Some(card) = app.model.card_by_id(*card_id) {
+                if let Some(card) = app.model.card_by_id_state(*card_id).loaded().copied() {
                     let is_selected = selected_idx == Some(*card_idx) && is_focused;
                     let animation_type = app
                         .animation

--- a/crates/kanban-tui/tests/animation_tick_reload_tests.rs
+++ b/crates/kanban-tui/tests/animation_tick_reload_tests.rs
@@ -272,8 +272,18 @@ fn test_animation_tick_restoring_many_cards_puts_each_in_the_right_column() {
 
     app.handle_animation_tick();
 
-    let restored_a = app.model.card_by_id(card_a.id).expect("card A restored");
-    let restored_b = app.model.card_by_id(card_b.id).expect("card B restored");
+    let restored_a = app
+        .model
+        .card_by_id_state(card_a.id)
+        .loaded()
+        .copied()
+        .expect("card A restored");
+    let restored_b = app
+        .model
+        .card_by_id_state(card_b.id)
+        .loaded()
+        .copied()
+        .expect("card B restored");
     assert_eq!(
         restored_a.column_id, column_a.id,
         "card A must be restored to its own column"
@@ -382,7 +392,12 @@ fn test_animation_tick_archive_and_delete_are_separate_undo_entries() {
     // Both completed in the same tick: the live card was archived, and the
     // already-archived card was permanently deleted.
     assert!(app.model.live_cards().iter().all(|c| c.id != live_card.id));
-    assert!(app.model.card_by_id(archived_card.id).is_none());
+    assert!(app
+        .model
+        .card_by_id_state(archived_card.id)
+        .loaded()
+        .copied()
+        .is_none());
 
     // One `u` press must revert exactly one of those two user actions, not
     // both at once.
@@ -391,7 +406,12 @@ fn test_animation_tick_archive_and_delete_are_separate_undo_entries() {
     // Exactly one of the two user actions must have been reverted by the
     // single undo, never both and never neither.
     let archive_reverted = app.model.live_cards().iter().any(|c| c.id == live_card.id);
-    let delete_reverted = app.model.card_by_id(archived_card.id).is_some();
+    let delete_reverted = app
+        .model
+        .card_by_id_state(archived_card.id)
+        .loaded()
+        .copied()
+        .is_some();
     assert!(
         archive_reverted ^ delete_reverted,
         "a single undo must revert exactly one of the two batched user actions"

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -45,10 +45,10 @@ fn test_archived_card_visible_via_card_by_id() {
     app.reload_model();
     app.prepare_frame();
 
-    let found = app.model.card_by_id(card_id);
+    let found = app.model.card_by_id_state(card_id).loaded().copied();
     assert!(
         found.is_some(),
-        "card_by_id should return archived card, got None"
+        "card_by_id_state should return archived card, got None"
     );
     assert_eq!(found.unwrap().title, "ArchiveMe");
 }
@@ -151,12 +151,20 @@ fn test_permanent_delete_removes_archived_card() {
         "archived cards should be empty after permanent delete"
     );
     assert!(
-        app.model.all_cards().iter().all(|c| c.id != card_id),
+        app.model
+            .cards_state()
+            .loaded_or_empty()
+            .iter()
+            .all(|c| c.id != card_id),
         "card should not be restored to active cards"
     );
     assert!(
-        app.model.card_by_id(card_id).is_none(),
-        "card_by_id should return None for permanently deleted card"
+        app.model
+            .card_by_id_state(card_id)
+            .loaded()
+            .copied()
+            .is_none(),
+        "card_by_id_state should return None for permanently deleted card"
     );
 }
 
@@ -200,10 +208,14 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
     app.reload_model();
     app.prepare_frame();
 
-    // Unified model: the row stays in `all_cards()`; archival is recorded by the
+    // Unified model: the row stays in `cards_state()`; archival is recorded by the
     // id set. "Archived" means present in `archived_card_ids`, not removed.
     assert!(
-        app.model.all_cards().iter().any(|c| c.id == card_id)
+        app.model
+            .cards_state()
+            .loaded_or_empty()
+            .iter()
+            .any(|c| c.id == card_id)
             && app.model.archived_card_ids().contains(&card_id),
         "card must be archived (marked) after animation completion"
     );
@@ -213,7 +225,11 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
     app.prepare_frame();
 
     assert!(
-        app.model.all_cards().iter().any(|c| c.id == card_id)
+        app.model
+            .cards_state()
+            .loaded_or_empty()
+            .iter()
+            .any(|c| c.id == card_id)
             && !app.model.archived_card_ids().contains(&card_id),
         "card must be live again after one undo press — archive + compact must \
          live in a single undo batch"
@@ -292,7 +308,7 @@ fn test_multi_column_archive_compacts_every_affected_column() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let k1 = cards.iter().find(|c| c.id == keep1.id).unwrap();
     let k2 = cards.iter().find(|c| c.id == keep2.id).unwrap();
     assert_eq!(

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -192,7 +192,12 @@ fn test_archived_board_card_action_works() {
     let snap = app.ctx.snapshot().unwrap();
     app.model.load_from_snapshot(snap);
 
-    let card = app.model.card_by_id(card_id).expect("card still live");
+    let card = app
+        .model
+        .card_by_id_state(card_id)
+        .loaded()
+        .copied()
+        .expect("card still live");
     assert!(
         card.is_completed(),
         "card action on an archived board's card takes effect"

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -85,7 +85,13 @@ fn test_archived_card_priority_via_shared_handler_changes_state() {
     let (_, _, _, card_id) = seed_archived_card(&mut app);
 
     // Baseline priority.
-    let before = app.model.card_by_id(card_id).unwrap().priority;
+    let before = app
+        .model
+        .card_by_id_state(card_id)
+        .loaded()
+        .copied()
+        .unwrap()
+        .priority;
     assert_ne!(before, CardPriority::Critical, "precondition: not Critical");
 
     // `p` opens the priority dialog targeting the archived card.
@@ -103,7 +109,12 @@ fn test_archived_card_priority_via_shared_handler_changes_state() {
     app.prepare_frame();
 
     assert_eq!(
-        app.model.card_by_id(card_id).unwrap().priority,
+        app.model
+            .card_by_id_state(card_id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .priority,
         CardPriority::Critical,
         "priority change on an archived card takes real effect via the shared handler"
     );
@@ -167,7 +178,12 @@ fn test_move_in_archived_view_matches_c1() {
     let (_, col1, col2, card_id) = seed_archived_card(&mut app);
 
     assert_eq!(
-        app.model.card_by_id(card_id).unwrap().column_id,
+        app.model
+            .card_by_id_state(card_id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .column_id,
         col1,
         "precondition: archived card starts in col1"
     );
@@ -177,7 +193,12 @@ fn test_move_in_archived_view_matches_c1() {
     app.prepare_frame();
 
     assert_eq!(
-        app.model.card_by_id(card_id).unwrap().column_id,
+        app.model
+            .card_by_id_state(card_id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .column_id,
         col2,
         "moving right from the archived view lands the card in col2 (coherent), \
          not a wrong/live-only-computed column"
@@ -190,7 +211,7 @@ fn test_move_in_archived_view_matches_c1() {
 fn test_create_not_offered_in_archived_view() {
     let mut app = App::test_default();
     let (_, _, _, _) = seed_archived_card(&mut app);
-    let live_before = app.model.all_cards().len();
+    let live_before = app.model.cards_state().loaded_or_empty().len();
 
     app.handle_archived_cards_view_mode(KeyCode::Char('n'));
 
@@ -202,7 +223,7 @@ fn test_create_not_offered_in_archived_view() {
     app.reload_model();
     app.prepare_frame();
     assert_eq!(
-        app.model.all_cards().len(),
+        app.model.cards_state().loaded_or_empty().len(),
         live_before,
         "`n` must not create an invisible live card from the archived view"
     );

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -43,7 +43,7 @@ fn test_card_description_appears_in_detail_view() {
     // Verify the card has the description
     app.reload_model();
     app.prepare_frame();
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     assert_eq!(cards.len(), 1);
     let displayed_card = &cards[0];
 
@@ -89,7 +89,7 @@ fn test_card_description_preserved_after_edit() {
     // Verify description exists
     app.reload_model();
     app.prepare_frame();
-    let cards_before = app.model.all_cards();
+    let cards_before = app.model.cards_state().loaded_or_empty();
     assert_eq!(
         cards_before[0].description,
         Some("Original description".to_string())
@@ -112,7 +112,7 @@ fn test_card_description_preserved_after_edit() {
     // Verify description is still there after update
     app.reload_model();
     app.prepare_frame();
-    let cards_after = app.model.all_cards();
+    let cards_after = app.model.cards_state().loaded_or_empty();
     assert_eq!(cards_after.len(), 1);
     assert_eq!(cards_after[0].title, "Updated Title");
     assert_eq!(
@@ -203,7 +203,7 @@ fn test_card_with_empty_string_description_displays_placeholder() {
     // Verify the card has an empty string description (not None)
     app.reload_model();
     app.prepare_frame();
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     assert_eq!(cards[0].description, Some("".to_string()));
 
     // Verify rendering shows placeholder text instead of blank

--- a/crates/kanban-tui/tests/cold_start_reload_tests.rs
+++ b/crates/kanban-tui/tests/cold_start_reload_tests.rs
@@ -70,7 +70,8 @@ async fn test_cold_start_after_a_sprint_log_migration_loads_the_migrated_state()
 
     let migrated_log_present = app
         .model
-        .all_cards()
+        .cards_state()
+        .loaded_or_empty()
         .iter()
         .find(|c| c.id == card.id)
         .map(|c| !c.sprint_logs.is_empty())

--- a/crates/kanban-tui/tests/columnless_board_card_tests.rs
+++ b/crates/kanban-tui/tests/columnless_board_card_tests.rs
@@ -162,7 +162,8 @@ fn test_the_column_field_names_the_column_the_card_actually_lands_in() {
     app.reload_model();
     let card = app
         .model
-        .all_cards()
+        .cards_state()
+        .loaded_or_empty()
         .iter()
         .find(|c| c.title == "Task")
         .expect("card created")
@@ -311,7 +312,8 @@ fn test_an_edited_column_name_is_used_for_the_created_column() {
     assert_eq!(cols[0].default_status, Some(CardStatus::Todo));
     let card = app
         .model
-        .all_cards()
+        .cards_state()
+        .loaded_or_empty()
         .iter()
         .find(|c| c.title == "Probe")
         .unwrap();
@@ -344,7 +346,8 @@ fn test_an_emptied_column_name_falls_back_to_the_template_name() {
     assert_eq!(cols[0].name, "TODO");
     let card = app
         .model
-        .all_cards()
+        .cards_state()
+        .loaded_or_empty()
         .iter()
         .find(|c| c.title == "Probe")
         .unwrap();
@@ -362,13 +365,13 @@ fn test_undoing_the_card_create_also_removes_the_invented_column() {
     }
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
-    assert_eq!(app.model.all_cards().len(), 1);
+    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.columns().len(), 1);
 
     app.ctx.undo().unwrap();
     app.reload_model();
 
-    assert!(app.model.all_cards().is_empty());
+    assert!(app.model.cards_state().loaded_or_empty().is_empty());
     assert!(app.model.columns().is_empty());
 }
 
@@ -519,7 +522,8 @@ fn test_a_board_with_existing_columns_gains_no_new_column() {
     assert_eq!(cols.len(), 2);
     let card = app
         .model
-        .all_cards()
+        .cards_state()
+        .loaded_or_empty()
         .iter()
         .find(|c| c.title == "Task")
         .unwrap();

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -51,7 +51,7 @@ fn test_create_card_dialog_auto_assigns_sole_active_sprint_on_open() {
 
     confirm_create_card_dialog(&mut app, "Task");
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let created = cards
         .iter()
         .find(|c| c.title == "Task")
@@ -86,7 +86,7 @@ fn test_create_card_dialog_space_on_pre_checked_sprint_unchecks_it() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let created = cards
         .iter()
         .find(|c| c.title == "Task")
@@ -105,7 +105,7 @@ fn test_create_card_dialog_leaves_card_unassigned_when_no_active_sprint() {
 
     confirm_create_card_dialog(&mut app, "Plain");
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let created = cards
         .iter()
         .find(|c| c.title == "Plain")
@@ -126,7 +126,7 @@ fn test_create_card_dialog_leaves_card_unassigned_when_multiple_active_sprints()
 
     confirm_create_card_dialog(&mut app, "Ambig");
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let created = cards
         .iter()
         .find(|c| c.title == "Ambig")
@@ -223,7 +223,7 @@ fn test_j_on_sprint_focus_navigates_picker_like_down() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let created = cards
         .iter()
         .find(|c| c.title == "Vim")
@@ -268,7 +268,7 @@ fn test_arrow_to_none_row_then_space_explicitly_leaves_card_unassigned() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let created = cards
         .iter()
         .find(|c| c.title == "NoSprint")
@@ -310,7 +310,7 @@ fn test_arrow_down_then_space_assigns_navigated_sprint() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let created = cards
         .iter()
         .find(|c| c.title == "Picked")

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -5,7 +5,7 @@
 //! live list).
 //!
 //! Before the fix, `export_all_boards_with_filename` / `auto_save` read the
-//! live-scoped `model.boards_state().loaded_or_empty()` / `model.all_cards()`, so an archived board's head
+//! live-scoped `model.boards_state().loaded_or_empty()` / `model.cards_state().loaded_or_empty()`, so an archived board's head
 //! and subtree were omitted and the exported `archived_boards` marker referenced
 //! a board absent from the file → orphan / silent data loss on re-import. These
 //! tests drive the ACTUAL TUI export entry point (not the snapshot path

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -182,8 +182,11 @@ fn test_import_valid_format() {
         "Imported Board"
     );
     assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.all_cards().len(), 1);
-    assert_eq!(app.model.all_cards()[0].title, "Imported Task");
+    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.cards_state().loaded_or_empty()[0].title,
+        "Imported Task"
+    );
 }
 
 #[test]
@@ -463,8 +466,11 @@ fn test_backward_compat_old_export_format() {
     );
 
     // Verify cards still work
-    assert_eq!(app.model.all_cards().len(), 1);
-    assert_eq!(app.model.all_cards()[0].title, "Old Card");
+    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.cards_state().loaded_or_empty()[0].title,
+        "Old Card"
+    );
 }
 
 #[test]

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -103,7 +103,12 @@ fn test_card_mutation_is_visible_in_model_without_a_further_redraw() {
     app.input.set("New card".to_string());
     app.create_card();
 
-    let title_present = app.model.all_cards().iter().any(|c| c.title == "New card");
+    let title_present = app
+        .model
+        .cards_state()
+        .loaded_or_empty()
+        .iter()
+        .any(|c| c.title == "New card");
     assert!(
         title_present,
         "create_card's own reload_model must make the new card visible without a further redraw"
@@ -216,7 +221,9 @@ fn test_move_card_between_columns_is_visible_in_model_without_a_further_redraw()
 
     let moved = app
         .model
-        .card_by_id(card.id)
+        .card_by_id_state(card.id)
+        .loaded()
+        .copied()
         .map(|c| c.column_id == col_b.id)
         .unwrap_or(false);
     assert!(
@@ -264,7 +271,9 @@ fn test_sprint_assignment_is_visible_in_model_without_a_further_redraw() {
 
     let assigned = app
         .model
-        .card_by_id(card.id)
+        .card_by_id_state(card.id)
+        .loaded()
+        .copied()
         .and_then(|c| c.sprint_id)
         .map(|id| id == sprint.id)
         .unwrap_or(false);

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -137,8 +137,11 @@ async fn test_v2_format_is_imported_correctly() {
         "My Project"
     );
     assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.all_cards().len(), 1);
-    assert_eq!(app.model.all_cards()[0].title, "Important Task");
+    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.cards_state().loaded_or_empty()[0].title,
+        "Important Task"
+    );
     assert!(
         app.persistence.save_file.is_some(),
         "save_file should remain enabled after successful V2 import"

--- a/crates/kanban-tui/tests/lifecycle_reload_tests.rs
+++ b/crates/kanban-tui/tests/lifecycle_reload_tests.rs
@@ -57,8 +57,11 @@ fn test_import_board_from_file_refreshes_the_whole_model_without_a_further_reloa
         "Imported Board"
     );
     assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.all_cards().len(), 1);
-    assert_eq!(app.model.all_cards()[0].title, "Imported Task");
+    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.cards_state().loaded_or_empty()[0].title,
+        "Imported Task"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -33,8 +33,16 @@ fn test_prepare_frame_populates_model_from_snapshot() {
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.boards_state().loaded_or_empty()[0].name, "Board");
     assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.all_cards().len(), 1);
-    assert_eq!(app.model.card_by_id(card.id).unwrap().title, "Task");
+    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model
+            .card_by_id_state(card.id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .title,
+        "Task"
+    );
 }
 
 #[test]
@@ -66,7 +74,15 @@ fn test_model_reflects_mutation_after_prepare_frame() {
     app.reload_model();
     app.prepare_frame();
 
-    assert_eq!(app.model.card_by_id(card.id).unwrap().title, "Original");
+    assert_eq!(
+        app.model
+            .card_by_id_state(card.id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .title,
+        "Original"
+    );
 
     let cmd = kanban_domain::commands::Command::Card(kanban_domain::commands::CardCommand::Update(
         kanban_domain::commands::UpdateCard {
@@ -82,7 +98,12 @@ fn test_model_reflects_mutation_after_prepare_frame() {
     app.prepare_frame();
 
     assert_eq!(
-        app.model.card_by_id(card.id).unwrap().title,
+        app.model
+            .card_by_id_state(card.id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .title,
         "Updated",
         "model must reflect the mutated title after prepare_frame"
     );
@@ -121,7 +142,12 @@ fn test_model_description_reflects_mutation() {
     app.prepare_frame();
 
     assert_eq!(
-        app.model.card_by_id(card.id).unwrap().description,
+        app.model
+            .card_by_id_state(card.id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .description,
         Some("Initial desc".to_string())
     );
 
@@ -139,7 +165,12 @@ fn test_model_description_reflects_mutation() {
     app.prepare_frame();
 
     assert_eq!(
-        app.model.card_by_id(card.id).unwrap().description,
+        app.model
+            .card_by_id_state(card.id)
+            .loaded()
+            .copied()
+            .unwrap()
+            .description,
         Some("Updated desc".to_string()),
         "model must reflect the updated description after prepare_frame"
     );

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -11,7 +11,7 @@ fn test_empty_model_returns_empty_slices() {
     let model = Model::default();
     assert!(model.boards_state().loaded_or_empty().is_empty());
     assert!(model.columns().is_empty());
-    assert!(model.all_cards().is_empty());
+    assert!(model.cards_state().loaded_or_empty().is_empty());
     assert!(model.sprints().is_empty());
     assert!(model.archived_card_markers().is_empty());
     assert_eq!(
@@ -49,8 +49,8 @@ fn test_load_from_snapshot_populates_all_fields() {
     assert_eq!(model.boards_state().loaded_or_empty()[0].name, "Board1");
     assert_eq!(model.columns().len(), 1);
     assert_eq!(model.columns()[0].name, "Col1");
-    assert_eq!(model.all_cards().len(), 1);
-    assert_eq!(model.all_cards()[0].title, "Card1");
+    assert_eq!(model.cards_state().loaded_or_empty().len(), 1);
+    assert_eq!(model.cards_state().loaded_or_empty()[0].title, "Card1");
     assert_eq!(model.sprints().len(), 1);
     assert_eq!(model.sprints()[0].sprint_number, 1);
 }
@@ -72,8 +72,14 @@ fn test_card_lookup_by_id() {
         ..Default::default()
     });
 
-    assert_eq!(model.card_by_id(id1).unwrap().title, "First");
-    assert_eq!(model.card_by_id(id2).unwrap().title, "Second");
+    assert_eq!(
+        model.card_by_id_state(id1).loaded().copied().unwrap().title,
+        "First"
+    );
+    assert_eq!(
+        model.card_by_id_state(id2).loaded().copied().unwrap().title,
+        "Second"
+    );
 }
 
 #[test]
@@ -88,7 +94,11 @@ fn test_card_lookup_missing_id_returns_none() {
         ..Default::default()
     });
 
-    assert!(model.card_by_id(Uuid::new_v4()).is_none());
+    assert!(model
+        .card_by_id_state(Uuid::new_v4())
+        .loaded()
+        .copied()
+        .is_none());
 }
 
 #[test]
@@ -105,7 +115,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
         cards: vec![card_a],
         ..Default::default()
     });
-    assert!(model.card_by_id(id_a).is_some());
+    assert!(model.card_by_id_state(id_a).loaded().copied().is_some());
 
     let card_b = make_card(&board, column_id, "B", 0);
     let id_b = card_b.id;
@@ -116,10 +126,18 @@ fn test_load_from_snapshot_rebuilds_card_index() {
     });
 
     assert!(
-        model.card_by_id(id_a).is_none(),
+        model.card_by_id_state(id_a).loaded().copied().is_none(),
         "old card should not be found"
     );
-    assert_eq!(model.card_by_id(id_b).unwrap().title, "B");
+    assert_eq!(
+        model
+            .card_by_id_state(id_b)
+            .loaded()
+            .copied()
+            .unwrap()
+            .title,
+        "B"
+    );
 }
 
 // Helper mirroring the archived-cards view: the archived subset of the unified
@@ -128,7 +146,8 @@ fn test_load_from_snapshot_rebuilds_card_index() {
 fn archived_titles(model: &Model) -> Vec<String> {
     let ids = model.archived_card_ids();
     model
-        .all_cards()
+        .cards_state()
+        .loaded_or_empty()
         .iter()
         .filter(|c| ids.contains(&c.id))
         .map(|c| c.title.clone())
@@ -211,8 +230,14 @@ fn test_card_by_id_resolves_archived_card() {
         ..Default::default()
     });
 
-    assert_eq!(model.card_by_id(id1).unwrap().title, "Archived1");
-    assert_eq!(model.card_by_id(id2).unwrap().title, "Archived2");
+    assert_eq!(
+        model.card_by_id_state(id1).loaded().copied().unwrap().title,
+        "Archived1"
+    );
+    assert_eq!(
+        model.card_by_id_state(id2).loaded().copied().unwrap().title,
+        "Archived2"
+    );
     assert!(model.archived_card_ids().contains(&id1));
     assert!(model.archived_card_ids().contains(&id2));
 }
@@ -233,5 +258,9 @@ fn test_card_by_id_missing_returns_none() {
         ..Default::default()
     });
 
-    assert!(model.card_by_id(Uuid::new_v4()).is_none());
+    assert!(model
+        .card_by_id_state(Uuid::new_v4())
+        .loaded()
+        .copied()
+        .is_none());
 }

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -92,7 +92,7 @@ fn test_manage_parents_popup_enter_creates_parent_edge() {
         )
         .unwrap();
 
-    // Wire the model so popup_handlers' `self.model.all_cards()` reflects
+    // Wire the model so popup_handlers' `self.model.cards_state().loaded_or_empty()` reflects
     // the data store. `selection.active_card` points at child.
     let snapshot = Snapshot {
         archived_boards: Vec::new(),

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -49,7 +49,7 @@ fn test_resolve_relationship_cards_returns_only_the_related_cards() {
     app.ctx.attach_child(subject, child).unwrap();
     app.reload_model();
 
-    assert_eq!(app.model.all_cards().len(), 50);
+    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 50);
 
     let ids = [
         app.model
@@ -175,7 +175,14 @@ fn test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan() {
 
     let expected: Vec<Uuid> = ids
         .iter()
-        .filter_map(|id| app.model.all_cards().iter().find(|c| c.id == *id).cloned())
+        .filter_map(|id| {
+            app.model
+                .cards_state()
+                .loaded_or_empty()
+                .iter()
+                .find(|c| c.id == *id)
+                .cloned()
+        })
         .map(|c| c.id)
         .collect();
     assert_eq!(expected.len(), 3);
@@ -197,7 +204,7 @@ fn test_resolve_relationship_cards_with_no_ids_returns_empty() {
     }
     app.reload_model();
 
-    assert_eq!(app.model.all_cards().len(), 50);
+    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 50);
 
     let resolved = resolve_relationship_cards(&app.model, &[]);
     assert!(resolved.is_empty());

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -82,7 +82,7 @@ fn open_assign_dialog(app: &mut App) {
     let current_sprint_id = app
         .selection
         .active_card_id
-        .and_then(|id| app.model.card_by_id(id))
+        .and_then(|id| app.model.card_by_id_state(id).loaded().copied())
         .and_then(|c| c.sprint_id);
     let sprints = app.model.sprints().to_vec();
     let board = app

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -85,7 +85,7 @@ fn test_create_card_selects_newly_created_card() {
         "a card should be selected after creation"
     );
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let created = cards.iter().find(|c| c.title == "My Card");
     assert!(created.is_some(), "card should exist in model");
     assert_eq!(selected_id.unwrap(), created.unwrap().id);
@@ -109,7 +109,7 @@ fn test_create_card_selects_newly_created_card_when_prior_selection_exists() {
     app.create_card();
     app.prepare_frame();
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let second = cards
         .iter()
         .find(|c| c.title == "Second")
@@ -174,7 +174,7 @@ fn test_create_card_auto_completes_in_done_column() {
     app.create_card();
     app.prepare_frame();
 
-    let cards = app.model.all_cards();
+    let cards = app.model.cards_state().loaded_or_empty();
     let done_card = cards
         .iter()
         .find(|c| c.title == "Done Card" && c.column_id == done_col.id);
@@ -268,7 +268,8 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
 
     let card_id = app
         .model
-        .all_cards()
+        .cards_state()
+        .loaded_or_empty()
         .iter()
         .find(|c| c.title == "Task")
         .unwrap()
@@ -336,7 +337,8 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
 
     let card_id = app
         .model
-        .all_cards()
+        .cards_state()
+        .loaded_or_empty()
         .iter()
         .find(|c| c.title == "Task")
         .unwrap()

--- a/crates/kanban-view/src/model/apply.rs
+++ b/crates/kanban-view/src/model/apply.rs
@@ -183,8 +183,18 @@ mod tests {
         });
 
         assert_eq!(m.cards_state().loaded().unwrap().len(), 2);
-        assert_eq!(m.card_by_id(card_a.id).unwrap().title, "edited");
-        assert_eq!(m.card_by_id(card_b.id).unwrap(), &card_b);
+        assert_eq!(
+            m.card_by_id_state(card_a.id)
+                .loaded()
+                .copied()
+                .unwrap()
+                .title,
+            "edited"
+        );
+        assert_eq!(
+            m.card_by_id_state(card_b.id).loaded().copied().unwrap(),
+            &card_b
+        );
         assert!(m.cards_state().is_loaded());
         let _ = (board, column);
     }
@@ -257,11 +267,11 @@ mod tests {
         for (i, card) in m.cards_state().loaded().unwrap().iter().enumerate() {
             assert_eq!(m.card_index[&card.id], i);
         }
-        assert!(m.card_by_id(a.id).is_none());
+        assert!(m.card_by_id_state(a.id).loaded().copied().is_none());
         assert!(m.card_by_id_state(a.id).is_missing());
-        assert_eq!(m.card_by_id(c.id).unwrap(), &c);
-        assert_eq!(m.card_by_id(d.id).unwrap(), &d);
-        assert_eq!(m.card_by_id(e.id).unwrap(), &e);
+        assert_eq!(m.card_by_id_state(c.id).loaded().copied().unwrap(), &c);
+        assert_eq!(m.card_by_id_state(d.id).loaded().copied().unwrap(), &d);
+        assert_eq!(m.card_by_id_state(e.id).loaded().copied().unwrap(), &e);
     }
 
     #[test]
@@ -291,8 +301,8 @@ mod tests {
         });
 
         assert!(m.card_by_id_state(b.id).is_missing());
-        assert_eq!(m.card_by_id(c.id).unwrap().id, c.id);
-        assert_eq!(m.card_by_id(a.id).unwrap().id, a.id);
+        assert_eq!(m.card_by_id_state(c.id).loaded().copied().unwrap().id, c.id);
+        assert_eq!(m.card_by_id_state(a.id).loaded().copied().unwrap().id, a.id);
     }
 
     #[test]

--- a/crates/kanban-view/src/model/cards.rs
+++ b/crates/kanban-view/src/model/cards.rs
@@ -4,10 +4,6 @@ impl Model {
     /// The full unified live+archived collection. Only for callers that
     /// genuinely need id resolution regardless of archival status — see
     /// `live_cards`/`archived_cards` for the common display case.
-    pub fn all_cards(&self) -> &[Card] {
-        self.cards.loaded_or_empty()
-    }
-
     pub fn cards_state(&self) -> &LoadState<Vec<Card>> {
         &self.cards
     }
@@ -15,10 +11,6 @@ impl Model {
     /// Resolve a card by id from the single unified collection (live AND
     /// archived rows). One index lookup — no live/archived re-join. A card is
     /// a card regardless of whether its head is archived.
-    pub fn card_by_id(&self, id: Uuid) -> Option<&Card> {
-        self.card_by_id_state(id).loaded().copied()
-    }
-
     pub fn card_by_id_state(&self, id: Uuid) -> LoadState<&Card> {
         match self.cards.as_ref() {
             LoadState::Loaded(cards) => {
@@ -40,7 +32,7 @@ impl Model {
         self.archived_cards.as_deref().unwrap_or(&[])
     }
 
-    /// Ids of the archived cards. Rows themselves live in the unified `all_cards()`
+    /// Ids of the archived cards. Rows themselves live in the unified `cards_state()`
     /// collection; this set records which of them are archived (built from the
     /// markers). The live/archived partition is precomputed on load and served by
     /// [`displayed_cards`](Self::displayed_cards); this set backs that split.
@@ -95,14 +87,14 @@ mod tests {
             cards: vec![card_a, card_b],
             ..Default::default()
         });
-        let found = m.card_by_id(card_b_id).unwrap();
+        let found = m.card_by_id_state(card_b_id).loaded().copied().unwrap();
         assert_eq!(found.id, card_b_id);
     }
 
     #[test]
     fn test_card_by_id_resolves_live_and_archived_from_one_collection() {
-        // After unification `all_cards()` holds live AND archived rows, and
-        // `card_by_id` resolves either from the single collection — no
+        // After unification `cards_state()` holds live AND archived rows, and
+        // `card_by_id_state` resolves either from the single collection — no
         // `or_else(archived_card())` re-join.
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
@@ -119,11 +111,20 @@ mod tests {
         });
 
         // Both live and archived rows live in the single unified collection.
-        assert_eq!(m.all_cards().len(), 2);
+        assert_eq!(m.cards_state().loaded_or_empty().len(), 2);
 
         // The single index resolves both.
-        assert_eq!(m.card_by_id(live_id).map(|c| c.id), Some(live_id));
-        assert_eq!(m.card_by_id(archived_id).map(|c| c.id), Some(archived_id));
+        assert_eq!(
+            m.card_by_id_state(live_id).loaded().copied().map(|c| c.id),
+            Some(live_id)
+        );
+        assert_eq!(
+            m.card_by_id_state(archived_id)
+                .loaded()
+                .copied()
+                .map(|c| c.id),
+            Some(archived_id)
+        );
 
         // The archived-id set records which rows are archived.
         assert!(!m.archived_card_ids().contains(&live_id));
@@ -132,9 +133,9 @@ mod tests {
 
     #[test]
     fn test_archived_view_filter_shows_archived_card_from_unified_collection() {
-        // `archived_card_ids` records the archived subset of the unified `all_cards()`
+        // `archived_card_ids` records the archived subset of the unified `cards_state()`
         // collection (the same set that backs `displayed_cards`). Assert an
-        // archived card is reachable by filtering `all_cards()` through that set.
+        // archived card is reachable by filtering `cards_state()` through that set.
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
@@ -149,7 +150,8 @@ mod tests {
         });
 
         let displayed: Vec<Uuid> = m
-            .all_cards()
+            .cards_state()
+            .loaded_or_empty()
             .iter()
             .filter(|c| m.archived_card_ids().contains(&c.id))
             .map(|c| c.id)
@@ -160,7 +162,11 @@ mod tests {
     #[test]
     fn test_card_by_id_missing_id_returns_none() {
         let m = Model::default();
-        assert!(m.card_by_id(Uuid::new_v4()).is_none());
+        assert!(m
+            .card_by_id_state(Uuid::new_v4())
+            .loaded()
+            .copied()
+            .is_none());
     }
 
     #[test]
@@ -200,7 +206,7 @@ mod tests {
         m.load_from_snapshot(Snapshot::default());
         assert!(m.cards_state().is_loaded());
         assert!(m.cards_state().loaded().unwrap().is_empty());
-        assert!(m.all_cards().is_empty());
+        assert!(m.cards_state().loaded_or_empty().is_empty());
     }
 
     #[test]

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -310,4 +310,17 @@ mod tests {
             "Model::graph must be deleted; callers should use graph_state().loaded().unwrap_or_else(|| Model::empty_graph())"
         );
     }
+
+    #[test]
+    fn test_model_has_no_collapsing_card_accessors() {
+        let cards_src = include_str!("cards.rs");
+        assert!(
+            !cards_src.contains("pub fn all_cards(&self)"),
+            "Model::all_cards must be deleted; callers should use cards_state().loaded_or_empty()"
+        );
+        assert!(
+            !cards_src.contains("pub fn card_by_id(&self,"),
+            "Model::card_by_id must be deleted; callers should use card_by_id_state(id).loaded().copied()"
+        );
+    }
 }

--- a/crates/kanban-view/src/model/mod.rs
+++ b/crates/kanban-view/src/model/mod.rs
@@ -82,7 +82,7 @@ impl Model {
         // archived — with archival recorded by markers in `snapshot.archived_cards`
         // (keyed by `entity_id`). Unify: one collection holds all rows, and an
         // id set records which are archived. The live/archived distinction is a
-        // consumption decision applied by filtering `all_cards()` on this set.
+        // consumption decision applied by filtering `cards_state()` on this set.
         let archived_card_ids: HashSet<Uuid> = snapshot
             .archived_cards
             .iter()
@@ -158,7 +158,8 @@ impl Model {
 
     fn rebuild_card_partitions(&mut self) {
         let (archived_cards, live_cards): (Vec<Card>, Vec<Card>) = self
-            .all_cards()
+            .cards_state()
+            .loaded_or_empty()
             .iter()
             .cloned()
             .partition(|c| self.archived_card_ids.contains(&c.id));
@@ -229,7 +230,7 @@ mod tests {
         let m = Model::default();
         assert!(m.boards_state().loaded_or_empty().is_empty());
         assert!(m.columns().is_empty());
-        assert!(m.all_cards().is_empty());
+        assert!(m.cards_state().loaded_or_empty().is_empty());
         assert!(m.sprints().is_empty());
         assert!(m.archived_card_markers().is_empty());
         assert!(m.archived_card_ids().is_empty());
@@ -286,11 +287,11 @@ mod tests {
             cards: vec![card],
             ..Default::default()
         });
-        assert!(m.card_by_id(old_id).is_some());
+        assert!(m.card_by_id_state(old_id).loaded().copied().is_some());
 
         // Reload with no cards — stale index entry must be gone
         m.load_from_snapshot(Snapshot::default());
-        assert!(m.card_by_id(old_id).is_none());
+        assert!(m.card_by_id_state(old_id).loaded().copied().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Deleted `Model::all_cards` and `Model::card_by_id` from `crates/kanban-view/src/model/cards.rs` and migrated every call site to `cards_state().loaded_or_empty()` and `card_by_id_state(id).loaded().copied()`.
- Moved both accessors' doc comments onto their load-state survivors, `cards_state()` and `card_by_id_state()`.
- Repointed every stale doc-comment/prose mention of the deleted accessors (in production code and test comments) at `cards_state()` / `card_by_id_state`, so this PR does not need a follow-up docs PR the way KAN-1326 did.
- Added `test_model_has_no_collapsing_card_accessors` to `crates/kanban-view/src/model/mod.rs`, a source-text guard mirroring the merged `test_model_has_no_collapsing_boards_or_graph_accessors`.

This is the third slice of the KAN-1218 lazily-populated-model epic, following the same pattern as the merged KAN-1326 (boards and graph). The thesis: "the card list was never fetched" must not be silently written as "empty", and "no such card" must not be silently written as "the fetch errored" or vice versa. `LoadState<T>` keeps those states distinct; this PR routes every `Model` card consumer through it instead of the collapsing convenience wrappers.

## Before / after site count

```
git grep -oh '\.all_cards()\|\.card_by_id(' -- crates/ | wc -l
```

Before: 140 raw matches (139 real call sites plus 1 doc-comment mention), split 45 production / 94 test.
After: 0.

```
git grep -n 'pub fn all_cards\|pub fn card_by_id(' -- crates/
```
Before: two definitions in `crates/kanban-view/src/model/cards.rs`. After: none.

## Completeness proof

`cargo check --workspace --all-targets` is clean. This matters specifically because 76 of the 140 raw matches live in `crates/kanban-tui/tests/*.rs` integration-test binaries, which a plain `cargo check` (without `--all-targets`) never compiles.

## Notes on scope

- No handler or rendering behavior changed. Every migrated site collapses exactly as before: `card_by_id_state(id).loaded().copied()` still discards `NotLoaded` at the call site, same as the old `card_by_id` did. Fixing that per-site is out of scope for this card (KAN-1232's job).
- `list_all_cards` (the `DataStore` trait method), the `all_cards` field on `ViewRefreshContext`, and local `all_cards` bindings were left untouched; they are different symbols that happen to share a substring.
- The three prescribed "Red" behavioral tests for `card_by_id_state`'s NotLoaded/Missing/Loaded distinction already exist on develop from KAN-1325 and were not duplicated. The only new Red test in this PR is the source-text guard.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] `cargo check --package kanban-cli --no-default-features --features json,sqlite`
- [x] `nix develop --command check-crate-list-sync`
- [x] `nix develop --command check-factory-compile-lock`
- [x] Mutation check: reinserted the deleted `all_cards` function, confirmed `test_model_has_no_collapsing_card_accessors` fails, reverted.
