### PR TITLE
KAN-1329 feat(backend-http): implement core HTTP DataStore reads with a distinct transport error

### DIFF
--- a/.changeset/kan-1329-http-datastore-core.md
+++ b/.changeset/kan-1329-http-datastore-core.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+backend-http: read boards, columns, cards and sprints from a remote kanban-server instead of declining every call, and report a transport failure (the server never answered) distinctly from an internal fault or a proven-absent record.

--- a/crates/kanban-api/src/v1/error.rs
+++ b/crates/kanban-api/src/v1/error.rs
@@ -213,4 +213,14 @@ mod tests {
         assert_eq!(ErrorCode::SerializationError.http_status(), 500);
         assert_eq!(ErrorCode::DatabaseError.http_status(), 500);
     }
+
+    #[test]
+    fn test_upstream_unavailable_maps_to_502() {
+        assert_eq!(ErrorCode::UpstreamUnavailable.http_status(), 502);
+        assert_eq!(ErrorCode::UpstreamUnavailable.to_string(), "UPSTREAM_UNAVAILABLE");
+        assert_ne!(
+            ErrorCode::UpstreamUnavailable.http_status(),
+            ErrorCode::InternalError.http_status()
+        );
+    }
 }

--- a/crates/kanban-api/src/v1/error.rs
+++ b/crates/kanban-api/src/v1/error.rs
@@ -28,6 +28,7 @@ pub enum ErrorCode {
     SerializationError,
     DatabaseError,
     InternalError,
+    UpstreamUnavailable,
 }
 
 impl std::fmt::Display for ErrorCode {
@@ -52,6 +53,7 @@ impl std::fmt::Display for ErrorCode {
             Self::SerializationError => "SERIALIZATION_ERROR",
             Self::DatabaseError => "DATABASE_ERROR",
             Self::InternalError => "INTERNAL_ERROR",
+            Self::UpstreamUnavailable => "UPSTREAM_UNAVAILABLE",
         };
         f.write_str(s)
     }
@@ -80,6 +82,7 @@ impl ErrorCode {
             | Self::SerializationError
             | Self::DatabaseError
             | Self::InternalError => 500,
+            Self::UpstreamUnavailable => 502,
         }
     }
 }
@@ -217,7 +220,10 @@ mod tests {
     #[test]
     fn test_upstream_unavailable_maps_to_502() {
         assert_eq!(ErrorCode::UpstreamUnavailable.http_status(), 502);
-        assert_eq!(ErrorCode::UpstreamUnavailable.to_string(), "UPSTREAM_UNAVAILABLE");
+        assert_eq!(
+            ErrorCode::UpstreamUnavailable.to_string(),
+            "UPSTREAM_UNAVAILABLE"
+        );
         assert_ne!(
             ErrorCode::UpstreamUnavailable.http_status(),
             ErrorCode::InternalError.http_status()

--- a/crates/kanban-api/src/v1/error_mapping.rs
+++ b/crates/kanban-api/src/v1/error_mapping.rs
@@ -39,6 +39,7 @@ impl From<&KanbanError> for ApiError {
             KanbanError::ConflictDetected { .. } => ErrorCode::ConflictDetected,
             KanbanError::Database(_) => ErrorCode::DatabaseError,
             KanbanError::Internal(_) => ErrorCode::InternalError,
+            KanbanError::Transport(_) => ErrorCode::UpstreamUnavailable,
             // A backend gap is a server fault, not a client error.
             KanbanError::Unsupported { .. } => ErrorCode::InternalError,
             KanbanError::UnsupportedFutureVersion { .. } => ErrorCode::UnsupportedVersion,
@@ -71,8 +72,47 @@ impl From<&KanbanError> for ApiError {
             | ErrorCode::SerializationError
             | ErrorCode::DatabaseError
             | ErrorCode::InternalError => "internal server error".to_string(),
+            ErrorCode::UpstreamUnavailable => "upstream backend unreachable".to_string(),
         };
         ApiError::new(code, message)
+    }
+}
+
+impl From<ApiError> for KanbanError {
+    /// `ApiError` deliberately scrubs structure, so `DomainError::NotFound { entity, id }`
+    /// and its siblings cannot be rebuilt from a wire error. The code is preserved
+    /// verbatim in the message text instead of being guessed at.
+    ///
+    /// Exhaustive over `ErrorCode` (no `_`): a new code must be classified into
+    /// one of the two buckets before this compiles, even though `ErrorCode` is
+    /// `#[non_exhaustive]` outside this crate.
+    fn from(e: ApiError) -> Self {
+        match e.code {
+            ErrorCode::IoError
+            | ErrorCode::SerializationError
+            | ErrorCode::DatabaseError
+            | ErrorCode::InternalError
+            | ErrorCode::UpstreamUnavailable => {
+                KanbanError::Internal(format!("{}: {}", e.code, e.message))
+            }
+            ErrorCode::NotFound
+            | ErrorCode::NotFoundByName
+            | ErrorCode::Ambiguous
+            | ErrorCode::WipLimitExceeded
+            | ErrorCode::SprintBoardMismatch
+            | ErrorCode::ValidationFailed
+            | ErrorCode::BatchResolutionFailed
+            | ErrorCode::DependencyError
+            | ErrorCode::CycleDetected
+            | ErrorCode::SelfReference
+            | ErrorCode::EdgeNotFound
+            | ErrorCode::DuplicateEdge
+            | ErrorCode::ConflictDetected
+            | ErrorCode::AlreadyExists
+            | ErrorCode::UnsupportedVersion => KanbanError::Domain(DomainError::Validation(
+                format!("{}: {}", e.code, e.message),
+            )),
+        }
     }
 }
 

--- a/crates/kanban-api/src/v1/error_mapping.rs
+++ b/crates/kanban-api/src/v1/error_mapping.rs
@@ -239,6 +239,32 @@ mod tests {
     }
 
     #[test]
+    fn test_transport_error_maps_to_upstream_unavailable_not_internal_error() {
+        use kanban_domain::KanbanError;
+        let err = KanbanError::Transport("refused".into());
+        let api = ApiError::from(&err);
+        assert_eq!(api.code, ErrorCode::UpstreamUnavailable);
+        assert!(!api.message.contains("refused"), "msg: {}", api.message);
+    }
+
+    #[test]
+    fn test_api_error_converts_to_kanban_error_preserving_its_code_in_the_message() {
+        let wip = ApiError::new(ErrorCode::WipLimitExceeded, "column full");
+        let kanban_err = KanbanError::from(wip);
+        assert!(matches!(
+            kanban_err,
+            KanbanError::Domain(DomainError::Validation(_))
+        ));
+        let msg = kanban_err.to_string();
+        assert!(msg.contains("WIP_LIMIT_EXCEEDED"), "msg: {msg}");
+        assert!(msg.contains("column full"), "msg: {msg}");
+
+        let db = ApiError::new(ErrorCode::DatabaseError, "boom");
+        let kanban_err = KanbanError::from(db);
+        assert!(matches!(kanban_err, KanbanError::Internal(_)));
+    }
+
+    #[test]
     fn test_api_error_does_not_leak_internal_detail() {
         use kanban_domain::KanbanError;
         // Server faults must never echo internal text to the client.

--- a/crates/kanban-backend-http/src/conversions.rs
+++ b/crates/kanban-backend-http/src/conversions.rs
@@ -1,0 +1,141 @@
+use kanban_api::{BoardResponse, CardResponse, ColumnResponse, SprintResponse};
+use kanban_domain::{Board, Card, Column, Sprint};
+
+/// `BoardResponse` omits `sprint_names`, `sprint_name_used_count` and
+/// `next_sprint_number`; they are defaulted here to empty/zero/one. A board
+/// converted through this path cannot allocate sprint numbers or resolve
+/// sprint names -- that allocation state lives only on the server.
+pub(crate) fn board_from_response(resp: &BoardResponse) -> Board {
+    let BoardResponse {
+        id,
+        name,
+        description,
+        sprint_prefix,
+        card_prefix,
+        task_sort_field,
+        task_sort_order,
+        sprint_duration_days,
+        task_list_view,
+        active_sprint_id,
+        position,
+        created_at,
+        updated_at,
+        archived_at: _,
+    } = resp.clone();
+    Board {
+        id,
+        name,
+        description,
+        sprint_prefix,
+        card_prefix,
+        task_sort_field: task_sort_field.into(),
+        task_sort_order: task_sort_order.into(),
+        sprint_duration_days,
+        sprint_names: Vec::new(),
+        sprint_name_used_count: 0,
+        next_sprint_number: 1,
+        active_sprint_id,
+        task_list_view: task_list_view.into(),
+        position,
+        created_at,
+        updated_at,
+    }
+}
+
+pub(crate) fn column_from_response(resp: &ColumnResponse) -> Column {
+    let ColumnResponse {
+        id,
+        board_id,
+        name,
+        position,
+        wip_limit,
+        default_status,
+        created_at,
+        updated_at,
+    } = resp.clone();
+    Column {
+        id,
+        board_id,
+        name,
+        position,
+        wip_limit,
+        default_status: default_status.map(Into::into),
+        created_at,
+        updated_at,
+    }
+}
+
+/// No read endpoint exposes card history, so `sprint_logs` is always empty
+/// on a card converted through this path.
+pub(crate) fn card_from_response(resp: &CardResponse) -> Card {
+    let CardResponse {
+        id,
+        column_id,
+        board_id,
+        prefix,
+        title,
+        description,
+        priority,
+        status,
+        position,
+        due_date,
+        points,
+        card_number,
+        sprint_id,
+        created_at,
+        updated_at,
+        completed_at,
+        archived_at: _,
+    } = resp.clone();
+    Card {
+        id,
+        column_id,
+        board_id,
+        title,
+        description,
+        priority: priority.into(),
+        status: status.into(),
+        position,
+        due_date,
+        points,
+        card_number,
+        prefix,
+        sprint_id,
+        created_at,
+        updated_at,
+        completed_at,
+        sprint_logs: Vec::new(),
+    }
+}
+
+/// `SprintResponse` exposes a resolved `name` in place of `name_index`, so
+/// the index is unrecoverable here and a sprint converted through this path
+/// always renders unnamed.
+pub(crate) fn sprint_from_response(resp: &SprintResponse) -> Sprint {
+    let SprintResponse {
+        id,
+        board_id,
+        sprint_number,
+        name: _,
+        prefix,
+        card_prefix,
+        status,
+        start_date,
+        end_date,
+        created_at,
+        updated_at,
+    } = resp.clone();
+    Sprint {
+        id,
+        board_id,
+        sprint_number,
+        name_index: None,
+        prefix,
+        card_prefix,
+        status: status.into(),
+        start_date,
+        end_date,
+        created_at,
+        updated_at,
+    }
+}

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -58,6 +58,11 @@ impl DataStore for HttpBackend {
 
     fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
         self.block_on(async {
+            let board: Option<BoardResponse> =
+                self.get_json(&format!("/v1/boards/{board_id}")).await?;
+            let Some(_) = board else {
+                return Ok(Vec::new());
+            };
             let resp: Vec<ColumnResponse> = self
                 .get_json_list(&format!("/v1/boards/{board_id}/columns"))
                 .await?;
@@ -218,6 +223,11 @@ impl DataStore for HttpBackend {
 
     fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
         self.block_on(async {
+            let board: Option<BoardResponse> =
+                self.get_json(&format!("/v1/boards/{board_id}")).await?;
+            let Some(_) = board else {
+                return Ok(Vec::new());
+            };
             let resp: Vec<SprintResponse> = self
                 .get_json_list(&format!("/v1/boards/{board_id}/sprints"))
                 .await?;

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -1,4 +1,8 @@
+use crate::conversions::{
+    board_from_response, card_from_response, column_from_response, sprint_from_response,
+};
 use crate::HttpBackend;
+use kanban_api::{BoardResponse, CardResponse, ColumnResponse, SprintResponse};
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
     KanbanResult, Prefix, Snapshot, Sprint,
@@ -18,14 +22,25 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("upsert_prefix"))
     }
 
-    fn get_board(&self, _id: Uuid) -> KanbanResult<Option<Board>> {
-        Err(KanbanError::unsupported("get_board"))
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        self.block_on(async {
+            let resp: Option<BoardResponse> = self.get_json(&format!("/v1/boards/{id}")).await?;
+            Ok(resp.as_ref().map(board_from_response))
+        })
     }
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
-        Err(KanbanError::unsupported("list_boards"))
+        self.block_on(async {
+            let resp: Vec<BoardResponse> = self.get_json_list("/v1/boards").await?;
+            Ok(resp.iter().map(board_from_response).collect())
+        })
     }
 
+    /// `ReplaceBoardRequest` has no `position` and no `active_sprint_id`, both
+    /// of which `DataStore::upsert_board` must write verbatim, so a PUT-based
+    /// implementation here would silently drop them on every write.
+    /// `with_transaction` already declines and no `RemoteWrites` impl exists,
+    /// so this path is unreachable from `execute_with_extra` today regardless.
     fn upsert_board(&self, _board: Board) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_board"))
     }
@@ -34,18 +49,31 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("delete_board"))
     }
 
-    fn get_column(&self, _id: Uuid) -> KanbanResult<Option<Column>> {
-        Err(KanbanError::unsupported("get_column"))
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        self.block_on(async {
+            let resp: Option<ColumnResponse> = self.get_json(&format!("/v1/columns/{id}")).await?;
+            Ok(resp.as_ref().map(column_from_response))
+        })
     }
 
-    fn list_columns_by_board(&self, _board_id: Uuid) -> KanbanResult<Vec<Column>> {
-        Err(KanbanError::unsupported("list_columns_by_board"))
+    fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        self.block_on(async {
+            let resp: Vec<ColumnResponse> = self
+                .get_json_list(&format!("/v1/boards/{board_id}/columns"))
+                .await?;
+            Ok(resp.iter().map(column_from_response).collect())
+        })
     }
 
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
         Err(KanbanError::unsupported("list_all_columns"))
     }
 
+    /// `ReplaceColumnRequest` drops only the timestamps, but there is no route
+    /// that upserts a column by id outside its board (`PUT
+    /// /v1/boards/{bid}/columns/{id}`), and `DataStore::upsert_column` carries
+    /// no board_id to route through. `with_transaction` already declines and
+    /// no `RemoteWrites` impl exists, so this path is unreachable regardless.
     fn upsert_column(&self, _column: Column) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_column"))
     }
@@ -58,20 +86,53 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("delete_columns_by_board"))
     }
 
-    fn get_card(&self, _id: Uuid) -> KanbanResult<Option<Card>> {
-        Err(KanbanError::unsupported("get_card"))
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        self.block_on(async {
+            let resp: Option<CardResponse> = self.get_json(&format!("/v1/cards/{id}")).await?;
+            Ok(resp.as_ref().map(card_from_response))
+        })
     }
 
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
         Err(KanbanError::unsupported("list_all_cards"))
     }
 
-    fn list_cards_by_column(&self, _column_id: Uuid) -> KanbanResult<Vec<Card>> {
-        Err(KanbanError::unsupported("list_cards_by_column"))
+    fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.block_on(async {
+            let column: Option<ColumnResponse> =
+                self.get_json(&format!("/v1/columns/{column_id}")).await?;
+            let Some(column) = column else {
+                return Ok(Vec::new());
+            };
+            let resp: Vec<CardResponse> = self
+                .get_json_list(&format!(
+                    "/v1/boards/{}/cards?column_id={}",
+                    column.board_id, column_id
+                ))
+                .await?;
+            let mut cards: Vec<Card> = resp.iter().map(card_from_response).collect();
+            cards.sort_by_key(|c| c.position);
+            Ok(cards)
+        })
     }
 
-    fn list_cards_by_sprint(&self, _sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
-        Err(KanbanError::unsupported("list_cards_by_sprint"))
+    fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.block_on(async {
+            let sprint: Option<SprintResponse> =
+                self.get_json(&format!("/v1/sprints/{sprint_id}")).await?;
+            let Some(sprint) = sprint else {
+                return Ok(Vec::new());
+            };
+            let resp: Vec<CardResponse> = self
+                .get_json_list(&format!(
+                    "/v1/boards/{}/cards?sprint_id={}",
+                    sprint.board_id, sprint_id
+                ))
+                .await?;
+            let mut cards: Vec<Card> = resp.iter().map(card_from_response).collect();
+            cards.sort_by_key(|c| c.position);
+            Ok(cards)
+        })
     }
 
     fn count_cards_in_column(&self, _column_id: Uuid) -> KanbanResult<usize> {
@@ -86,6 +147,12 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("count_cards_in_column_excluding"))
     }
 
+    /// The only card-write route (`PUT /v1/columns/{cid}/cards/{id}`) takes
+    /// `CreateCardRequest`, which has no `status`, `position`, `card_number`,
+    /// `prefix`, `completed_at` or `board_id` -- a PUT-based upsert here would
+    /// silently drop six fields of the row it was told to write.
+    /// `with_transaction` already declines and no `RemoteWrites` impl exists,
+    /// so this path is unreachable regardless.
     fn upsert_card(&self, _card: Card) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_card"))
     }
@@ -142,18 +209,31 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("unarchive_board"))
     }
 
-    fn get_sprint(&self, _id: Uuid) -> KanbanResult<Option<Sprint>> {
-        Err(KanbanError::unsupported("get_sprint"))
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        self.block_on(async {
+            let resp: Option<SprintResponse> = self.get_json(&format!("/v1/sprints/{id}")).await?;
+            Ok(resp.as_ref().map(sprint_from_response))
+        })
     }
 
-    fn list_sprints_by_board(&self, _board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
-        Err(KanbanError::unsupported("list_sprints_by_board"))
+    fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        self.block_on(async {
+            let resp: Vec<SprintResponse> = self
+                .get_json_list(&format!("/v1/boards/{board_id}/sprints"))
+                .await?;
+            Ok(resp.iter().map(sprint_from_response).collect())
+        })
     }
 
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
         Err(KanbanError::unsupported("list_all_sprints"))
     }
 
+    /// `ReplaceSprintRequest` has no `status`, `start_date`, `end_date`,
+    /// `sprint_number` or `name_index` -- a PUT-based upsert here would
+    /// silently drop five fields of the row it was told to write.
+    /// `with_transaction` already declines and no `RemoteWrites` impl exists,
+    /// so this path is unreachable regardless.
     fn upsert_sprint(&self, _sprint: Sprint) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_sprint"))
     }
@@ -180,5 +260,65 @@ impl DataStore for HttpBackend {
 
     fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
         Err(KanbanError::unsupported("apply_snapshot"))
+    }
+
+    /// No route filters cards by a bare `board_id` + `card_number` pair, and
+    /// the inherited default would fetch every card in the workspace
+    /// (`list_all_cards`, itself `unsupported` here) to answer a one-row
+    /// lookup. Declines under its own name instead of inheriting.
+    fn get_card_by_board_and_number(
+        &self,
+        _board_id: Uuid,
+        _card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        Err(KanbanError::unsupported("get_card_by_board_and_number"))
+    }
+
+    /// One list request plus a client-side find, bounded to one sprint --
+    /// the same shape as the inherited default, written out so it declines
+    /// under its own name if `list_cards_by_sprint` ever stops answering it.
+    fn get_card_by_sprint_and_number(
+        &self,
+        sprint_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        Ok(self
+            .list_cards_by_sprint(sprint_id)?
+            .into_iter()
+            .find(|c| c.card_number == card_number))
+    }
+
+    /// No route filters cards by a bare `card_number` across every namespace,
+    /// and the inherited default would fetch every card in the workspace to
+    /// answer a one-row lookup. Declines under its own name instead of
+    /// inheriting.
+    fn list_cards_by_number(&self, _card_number: u32) -> KanbanResult<Vec<Card>> {
+        Err(KanbanError::unsupported("list_cards_by_number"))
+    }
+
+    /// No route filters cards by `(prefix, card_number)`, and the inherited
+    /// default would both fetch every card in the workspace AND re-implement
+    /// `Prefix::normalize` client-side, a second source of truth for a server
+    /// rule. Declines under its own name instead of inheriting.
+    fn list_cards_by_prefix_and_number(
+        &self,
+        _prefix: &str,
+        _card_number: u32,
+    ) -> KanbanResult<Vec<Card>> {
+        Err(KanbanError::unsupported("list_cards_by_prefix_and_number"))
+    }
+
+    /// The cards route accepts a single `column_id` filter
+    /// (`CardQuery.column_id: Option<Uuid>`), so one request per column is
+    /// the floor until a multi-column filter exists -- and each of those is
+    /// itself two requests, because `list_cards_by_column` must resolve the
+    /// column to its board first. Written out so a future backend change to
+    /// `list_cards_by_column` doesn't silently change this cost too.
+    fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
+        let mut out = Vec::new();
+        for col_id in column_ids {
+            out.extend(self.list_cards_by_column(*col_id)?);
+        }
+        Ok(out)
     }
 }

--- a/crates/kanban-backend-http/src/http.rs
+++ b/crates/kanban-backend-http/src/http.rs
@@ -1,3 +1,82 @@
+use crate::HttpBackend;
+use kanban_api::{ApiError, Page};
+use kanban_domain::{KanbanError, KanbanResult};
+use serde::de::DeserializeOwned;
+
+fn map_error_response(status: reqwest::StatusCode, body: &str) -> KanbanError {
+    match serde_json::from_str::<ApiError>(body) {
+        Ok(api_err) => KanbanError::from(api_err),
+        Err(_) => KanbanError::Internal(format!("HTTP {status}: {body}")),
+    }
+}
+
+impl HttpBackend {
+    pub(crate) async fn get_json<T: DeserializeOwned>(
+        &self,
+        path: &str,
+    ) -> KanbanResult<Option<T>> {
+        let url = format!("{}{}", self.base_url(), path);
+        let resp = self
+            .client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| KanbanError::Transport(e.to_string()))?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| KanbanError::Transport(e.to_string()))?;
+        if !status.is_success() {
+            return Err(map_error_response(status, &body));
+        }
+        serde_json::from_str(&body)
+            .map(Some)
+            .map_err(|e| KanbanError::Serialization(e.to_string()))
+    }
+
+    /// Deserializes each response as `Page<T>` and follows `total_pages` to
+    /// completion, since `DataStore::list_*` returns the whole collection and
+    /// cannot honestly return one page at a time.
+    pub(crate) async fn get_json_list<T: DeserializeOwned>(
+        &self,
+        path: &str,
+    ) -> KanbanResult<Vec<T>> {
+        let url = format!("{}{}", self.base_url(), path);
+        let mut out = Vec::new();
+        let mut page = 1u32;
+        loop {
+            let resp = self
+                .client()
+                .get(&url)
+                .query(&[("page", page)])
+                .send()
+                .await
+                .map_err(|e| KanbanError::Transport(e.to_string()))?;
+            let status = resp.status();
+            let body = resp
+                .text()
+                .await
+                .map_err(|e| KanbanError::Transport(e.to_string()))?;
+            if !status.is_success() {
+                return Err(map_error_response(status, &body));
+            }
+            let page_data: Page<T> = serde_json::from_str(&body)
+                .map_err(|e| KanbanError::Serialization(e.to_string()))?;
+            let total_pages = page_data.total_pages;
+            out.extend(page_data.items);
+            if page >= total_pages {
+                break;
+            }
+            page += 1;
+        }
+        Ok(out)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::HttpBackend;

--- a/crates/kanban-backend-http/src/http.rs
+++ b/crates/kanban-backend-http/src/http.rs
@@ -1,0 +1,26 @@
+#[cfg(test)]
+mod tests {
+    use crate::HttpBackend;
+    use kanban_api::BoardResponse;
+    use kanban_server::test_helpers::TestServer;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_json_maps_a_non_404_error_status_to_err_rather_than_ok_none() {
+        let server = TestServer::start().await;
+        let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+        let result: kanban_domain::KanbanResult<Option<BoardResponse>> =
+            tokio::task::spawn_blocking(move || {
+                backend.block_on(backend.get_json::<BoardResponse>("/v1/boards/not-a-uuid"))
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_err(),
+            "a 400 from the Path extractor must not be reported as Ok(None): {result:?}"
+        );
+
+        server.shutdown().await;
+    }
+}

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -55,7 +55,10 @@ impl HttpBackend {
     }
 
     /// Bridge a synchronous DataStore/CommandStore call onto the dedicated
-    /// runtime -- never the caller's ambient one.
+    /// runtime -- never the caller's ambient one. Must not be called from a
+    /// thread already inside a Tokio runtime; doing so panics with "Cannot
+    /// start a runtime from within a runtime". An async caller reaches this
+    /// through `tokio::task::spawn_blocking`.
     pub(crate) fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
         self.runtime.block_on(fut)
     }

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -1,10 +1,5 @@
-// Every field and the client()/base_url() accessors below are only reached
-// by this crate's own tests today; the DataStore/CommandStore stubs return
-// early without touching them. Sibling cards implementing real reads/writes
-// exercise them from production code.
-#![allow(dead_code)]
-
 mod command_store;
+mod conversions;
 mod data_store;
 mod http;
 mod remote_writes;
@@ -130,7 +125,7 @@ mod tests {
     fn test_http_backend_stub_method_returns_unsupported_error() -> kanban_domain::KanbanResult<()>
     {
         let backend = HttpBackend::new("http://example.com")?;
-        let result = backend.list_boards();
+        let result = backend.upsert_board(kanban_domain::Board::new("x", None::<String>));
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.is_unsupported());

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod command_store;
 mod data_store;
+mod http;
 mod remote_writes;
 
 pub struct HttpBackend {

--- a/crates/kanban-backend-http/tests/decline_rulings.rs
+++ b/crates/kanban-backend-http/tests/decline_rulings.rs
@@ -1,0 +1,45 @@
+use kanban_backend_http::HttpBackend;
+use kanban_domain::{DataStore, KanbanError};
+use uuid::Uuid;
+
+fn unreachable_backend() -> HttpBackend {
+    HttpBackend::new("http://127.0.0.1:1").unwrap()
+}
+
+fn assert_declines_under_its_own_name<T>(result: kanban_domain::KanbanResult<T>, expected: &str) {
+    match result {
+        Err(KanbanError::Unsupported { operation }) => {
+            assert_eq!(operation, expected, "declined under the wrong name");
+        }
+        other => panic!("expected Unsupported({expected:?}), got {other:?}"),
+    }
+}
+
+#[test]
+fn test_get_card_by_board_and_number_declines_under_its_own_name() {
+    let backend = unreachable_backend();
+    let result = backend.get_card_by_board_and_number(Uuid::new_v4(), 1);
+    assert_declines_under_its_own_name(result, "get_card_by_board_and_number");
+}
+
+#[test]
+fn test_list_cards_by_number_declines_under_its_own_name() {
+    let backend = unreachable_backend();
+    let result = backend.list_cards_by_number(1);
+    assert_declines_under_its_own_name(result, "list_cards_by_number");
+}
+
+#[test]
+fn test_list_cards_by_prefix_and_number_declines_under_its_own_name() {
+    let backend = unreachable_backend();
+    let result = backend.list_cards_by_prefix_and_number("kan", 1);
+    assert_declines_under_its_own_name(result, "list_cards_by_prefix_and_number");
+}
+
+#[test]
+fn test_list_all_cards_and_siblings_stay_unsupported_under_their_own_names() {
+    let backend = unreachable_backend();
+    assert_declines_under_its_own_name(backend.list_all_cards(), "list_all_cards");
+    assert_declines_under_its_own_name(backend.list_all_columns(), "list_all_columns");
+    assert_declines_under_its_own_name(backend.list_all_sprints(), "list_all_sprints");
+}

--- a/crates/kanban-backend-http/tests/decline_rulings.rs
+++ b/crates/kanban-backend-http/tests/decline_rulings.rs
@@ -11,7 +11,8 @@ fn assert_declines_under_its_own_name<T>(result: kanban_domain::KanbanResult<T>,
         Err(KanbanError::Unsupported { operation }) => {
             assert_eq!(operation, expected, "declined under the wrong name");
         }
-        other => panic!("expected Unsupported({expected:?}), got {other:?}"),
+        Err(other) => panic!("expected Unsupported({expected:?}), got {other:?}"),
+        Ok(_) => panic!("expected Unsupported({expected:?}), got Ok"),
     }
 }
 

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -254,6 +254,18 @@ async fn test_list_columns_by_board_returns_columns_in_position_order() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_list_columns_by_board_returns_empty_for_an_unknown_board() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let columns: Vec<Column> =
+        blocking(move || backend.list_columns_by_board(Uuid::new_v4()).unwrap()).await;
+    assert!(columns.is_empty());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_get_card_round_trips_board_id_and_prefix() {
     let server = TestServer::start().await;
     let board_id = seed_board(&server, "Card Board").await;
@@ -370,6 +382,18 @@ async fn test_list_sprints_by_board_returns_the_boards_sprints() {
 
     assert_eq!(sprints.len(), 2);
     assert!(sprints.iter().all(|s| s.board_id == board_a));
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_by_board_returns_empty_for_an_unknown_board() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let sprints: Vec<Sprint> =
+        blocking(move || backend.list_sprints_by_board(Uuid::new_v4()).unwrap()).await;
+    assert!(sprints.is_empty());
 
     server.shutdown().await;
 }

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -61,7 +61,12 @@ async fn seed_column(
     column.id
 }
 
-async fn seed_card(server: &TestServer, column_id: Uuid, title: &str, sprint_id: Option<Uuid>) -> Uuid {
+async fn seed_card(
+    server: &TestServer,
+    column_id: Uuid,
+    title: &str,
+    sprint_id: Option<Uuid>,
+) -> Uuid {
     let req = CreateCardRequest {
         id: None,
         title: title.to_string(),
@@ -161,7 +166,12 @@ async fn test_list_boards_follows_pagination_past_the_first_page() {
     let boards: Vec<Board> = blocking(move || backend.list_boards().unwrap()).await;
 
     let unique: std::collections::HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
-    assert_eq!(unique.len(), 51, "expected all 51 boards, got {}", boards.len());
+    assert_eq!(
+        unique.len(),
+        51,
+        "expected all 51 boards, got {}",
+        boards.len()
+    );
 
     server.shutdown().await;
 }
@@ -318,8 +328,7 @@ async fn test_list_cards_by_sprint_returns_only_that_sprints_cards() {
     seed_card(&server, column_id, "Not in sprint", None).await;
     let backend = HttpBackend::new(&server.base_url()).unwrap();
 
-    let cards: Vec<Card> =
-        blocking(move || backend.list_cards_by_sprint(sprint_id).unwrap()).await;
+    let cards: Vec<Card> = blocking(move || backend.list_cards_by_sprint(sprint_id).unwrap()).await;
 
     assert_eq!(cards.len(), 2);
     let titles: Vec<&str> = cards.iter().map(|c| c.title.as_str()).collect();
@@ -400,8 +409,12 @@ async fn test_list_cards_by_columns_returns_cards_from_every_requested_column() 
     seed_card(&server, col_b, "B1", None).await;
     let backend = HttpBackend::new(&server.base_url()).unwrap();
 
-    let cards: Vec<Card> =
-        blocking(move || backend.list_cards_by_columns(&[col_a, col_b, col_c]).unwrap()).await;
+    let cards: Vec<Card> = blocking(move || {
+        backend
+            .list_cards_by_columns(&[col_a, col_b, col_c])
+            .unwrap()
+    })
+    .await;
 
     assert_eq!(cards.len(), 2);
     let titles: Vec<&str> = cards.iter().map(|c| c.title.as_str()).collect();
@@ -415,7 +428,9 @@ async fn test_list_cards_by_columns_returns_cards_from_every_requested_column() 
 fn test_a_read_against_an_unreachable_server_maps_to_a_transport_error() {
     let backend = HttpBackend::new("http://127.0.0.1:1").unwrap();
 
-    let err = backend.list_boards().expect_err("no server is listening on port 1");
+    let err = backend
+        .list_boards()
+        .expect_err("no server is listening on port 1");
 
     assert!(err.is_transport(), "expected transport error, got {err:?}");
     assert!(!err.is_unsupported());

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -1,0 +1,422 @@
+use kanban_api::{
+    CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintRequest, SortFieldDto,
+    SortOrderDto, TaskListViewDto,
+};
+use kanban_backend_http::HttpBackend;
+use kanban_domain::{Board, Card, Column, DataStore, Sprint};
+use kanban_server::test_helpers::TestServer;
+use uuid::Uuid;
+
+async fn blocking<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    tokio::task::spawn_blocking(f).await.unwrap()
+}
+
+async fn seed_board(server: &TestServer, name: &str) -> Uuid {
+    let req = CreateBoardRequest {
+        id: None,
+        name: name.to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: Some(SortFieldDto::Default),
+        task_sort_order: Some(SortOrderDto::Ascending),
+        sprint_duration_days: None,
+        task_list_view: Some(TaskListViewDto::Flat),
+    };
+    let resp = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    let board: kanban_api::BoardResponse = resp.json().await.unwrap();
+    board.id
+}
+
+async fn seed_column(
+    server: &TestServer,
+    board_id: Uuid,
+    name: &str,
+    wip_limit: Option<i32>,
+    default_status: Option<kanban_api::CardStatusDto>,
+) -> Uuid {
+    let req = CreateColumnRequest {
+        id: None,
+        name: name.to_string(),
+        wip_limit,
+        default_status,
+    };
+    let resp = server
+        .client()
+        .post(format!(
+            "{}/v1/boards/{board_id}/columns",
+            server.base_url()
+        ))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    let column: kanban_api::ColumnResponse = resp.json().await.unwrap();
+    column.id
+}
+
+async fn seed_card(server: &TestServer, column_id: Uuid, title: &str, sprint_id: Option<Uuid>) -> Uuid {
+    let req = CreateCardRequest {
+        id: None,
+        title: title.to_string(),
+        description: None,
+        priority: None,
+        due_date: None,
+        points: None,
+        sprint_id,
+    };
+    let resp = server
+        .client()
+        .post(format!(
+            "{}/v1/columns/{column_id}/cards",
+            server.base_url()
+        ))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    let card: kanban_api::CardResponse = resp.json().await.unwrap();
+    card.id
+}
+
+async fn seed_sprint(server: &TestServer, board_id: Uuid, name: &str) -> Uuid {
+    let req = CreateSprintRequest {
+        id: None,
+        name: Some(name.to_string()),
+        prefix: None,
+        card_prefix: None,
+    };
+    let resp = server
+        .client()
+        .post(format!(
+            "{}/v1/boards/{board_id}/sprints",
+            server.base_url()
+        ))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    let sprint: kanban_api::SprintResponse = resp.json().await.unwrap();
+    sprint.id
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_datastore_call_from_a_blocking_thread_inside_an_ambient_runtime_returns_data() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Bridge Board").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let boards: Vec<Board> = blocking(move || backend.list_boards().unwrap()).await;
+
+    assert_eq!(boards.len(), 1);
+    assert_eq!(boards[0].id, board_id);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "Cannot start a runtime from within a runtime")]
+async fn test_a_datastore_call_directly_on_a_runtime_worker_thread_panics() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let _ = backend.list_boards();
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_returns_every_seeded_board() {
+    let server = TestServer::start().await;
+    let a = seed_board(&server, "Board A").await;
+    let b = seed_board(&server, "Board B").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let boards: Vec<Board> = blocking(move || backend.list_boards().unwrap()).await;
+
+    let ids: Vec<Uuid> = boards.iter().map(|b| b.id).collect();
+    assert!(ids.contains(&a));
+    assert!(ids.contains(&b));
+    let names: Vec<&str> = boards.iter().map(|b| b.name.as_str()).collect();
+    assert!(names.contains(&"Board A"));
+    assert!(names.contains(&"Board B"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_follows_pagination_past_the_first_page() {
+    let server = TestServer::start().await;
+    for i in 0..51 {
+        seed_board(&server, &format!("Board {i}")).await;
+    }
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let boards: Vec<Board> = blocking(move || backend.list_boards().unwrap()).await;
+
+    let unique: std::collections::HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
+    assert_eq!(unique.len(), 51, "expected all 51 boards, got {}", boards.len());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_returns_the_seeded_board() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Solo Board").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let board: Option<Board> = blocking(move || backend.get_board(board_id).unwrap()).await;
+    let board = board.expect("board should be found");
+    assert_eq!(board.id, board_id);
+    assert_eq!(board.name, "Solo Board");
+    assert_eq!(board.card_prefix, None);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_returns_ok_none_for_an_unknown_id() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let board: Option<Board> = blocking(move || backend.get_board(Uuid::new_v4()).unwrap()).await;
+    assert!(board.is_none());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_column_round_trips_default_status_and_wip_limit() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Column Board").await;
+    let column_id = seed_column(
+        &server,
+        board_id,
+        "In Progress",
+        Some(3),
+        Some(kanban_api::CardStatusDto::InProgress),
+    )
+    .await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let column: Option<Column> = blocking(move || backend.get_column(column_id).unwrap()).await;
+    let column = column.expect("column should be found");
+    assert_eq!(column.id, column_id);
+    assert_eq!(column.board_id, board_id);
+    assert_eq!(column.wip_limit, Some(3));
+    assert_eq!(
+        column.default_status,
+        Some(kanban_domain::CardStatus::InProgress)
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_columns_by_board_returns_columns_in_position_order() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Columns Board").await;
+    seed_column(&server, board_id, "Todo", None, None).await;
+    seed_column(&server, board_id, "Doing", None, None).await;
+    seed_column(&server, board_id, "Done", None, None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let columns: Vec<Column> =
+        blocking(move || backend.list_columns_by_board(board_id).unwrap()).await;
+
+    assert_eq!(columns.len(), 3);
+    let positions: Vec<i32> = columns.iter().map(|c| c.position).collect();
+    assert!(
+        positions.windows(2).all(|w| w[0] <= w[1]),
+        "expected ascending positions, got {positions:?}"
+    );
+    let names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["Todo", "Doing", "Done"]);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_round_trips_board_id_and_prefix() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Card Board").await;
+    let column_id = seed_column(&server, board_id, "Todo", None, None).await;
+    let card_id = seed_card(&server, column_id, "Ship it", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let card: Option<Card> = blocking(move || backend.get_card(card_id).unwrap()).await;
+    let card = card.expect("card should be found");
+    assert_eq!(card.board_id, board_id);
+    assert!(!card.prefix.is_empty());
+    assert!(card.card_number > 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_returns_ok_none_for_an_unknown_id() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let card: Option<Card> = blocking(move || backend.get_card(Uuid::new_v4()).unwrap()).await;
+    assert!(card.is_none());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_by_column_returns_only_that_columns_cards() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Multi Column Board").await;
+    let col_a = seed_column(&server, board_id, "A", None, None).await;
+    let col_b = seed_column(&server, board_id, "B", None, None).await;
+    seed_card(&server, col_a, "A1", None).await;
+    seed_card(&server, col_a, "A2", None).await;
+    seed_card(&server, col_b, "B1", None).await;
+    seed_card(&server, col_b, "B2", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let cards: Vec<Card> = blocking(move || backend.list_cards_by_column(col_a).unwrap()).await;
+
+    assert_eq!(cards.len(), 2);
+    let titles: Vec<&str> = cards.iter().map(|c| c.title.as_str()).collect();
+    assert!(titles.contains(&"A1"));
+    assert!(titles.contains(&"A2"));
+    assert!(!titles.contains(&"B1"));
+    assert!(!titles.contains(&"B2"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_by_column_returns_empty_for_an_unknown_column() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let cards: Vec<Card> =
+        blocking(move || backend.list_cards_by_column(Uuid::new_v4()).unwrap()).await;
+    assert!(cards.is_empty());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_by_sprint_returns_only_that_sprints_cards() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Sprint Board").await;
+    let column_id = seed_column(&server, board_id, "Todo", None, None).await;
+    let sprint_id = seed_sprint(&server, board_id, "Sprint 1").await;
+    seed_card(&server, column_id, "In sprint 1", Some(sprint_id)).await;
+    seed_card(&server, column_id, "In sprint 2", Some(sprint_id)).await;
+    seed_card(&server, column_id, "Not in sprint", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let cards: Vec<Card> =
+        blocking(move || backend.list_cards_by_sprint(sprint_id).unwrap()).await;
+
+    assert_eq!(cards.len(), 2);
+    let titles: Vec<&str> = cards.iter().map(|c| c.title.as_str()).collect();
+    assert!(titles.contains(&"In sprint 1"));
+    assert!(titles.contains(&"In sprint 2"));
+    assert!(!titles.contains(&"Not in sprint"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_returns_the_seeded_sprint_with_name_index_none() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Sprint Board").await;
+    let sprint_id = seed_sprint(&server, board_id, "Alpha").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let sprint: Option<Sprint> = blocking(move || backend.get_sprint(sprint_id).unwrap()).await;
+    let sprint = sprint.expect("sprint should be found");
+    assert_eq!(sprint.board_id, board_id);
+    assert_eq!(sprint.name_index, None);
+    assert_eq!(sprint.status, kanban_domain::SprintStatus::Planning);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_by_board_returns_the_boards_sprints() {
+    let server = TestServer::start().await;
+    let board_a = seed_board(&server, "Board A").await;
+    let board_b = seed_board(&server, "Board B").await;
+    seed_sprint(&server, board_a, "S1").await;
+    seed_sprint(&server, board_a, "S2").await;
+    seed_sprint(&server, board_b, "S3").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let sprints: Vec<Sprint> =
+        blocking(move || backend.list_sprints_by_board(board_a).unwrap()).await;
+
+    assert_eq!(sprints.len(), 2);
+    assert!(sprints.iter().all(|s| s.board_id == board_a));
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_by_sprint_and_number_returns_the_matching_card() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Sprint Number Board").await;
+    let column_id = seed_column(&server, board_id, "Todo", None, None).await;
+    let sprint_id = seed_sprint(&server, board_id, "Sprint 1").await;
+    let card_a_id = seed_card(&server, column_id, "Card A", Some(sprint_id)).await;
+    seed_card(&server, column_id, "Card B", Some(sprint_id)).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let card: Option<Card> = blocking(move || {
+        let card_a_number = backend.get_card(card_a_id).unwrap().unwrap().card_number;
+        backend
+            .get_card_by_sprint_and_number(sprint_id, card_a_number)
+            .unwrap()
+    })
+    .await;
+    let card = card.expect("card should be found");
+    assert_eq!(card.id, card_a_id);
+    assert_eq!(card.title, "Card A");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_by_columns_returns_cards_from_every_requested_column() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Columns Union Board").await;
+    let col_a = seed_column(&server, board_id, "A", None, None).await;
+    let col_b = seed_column(&server, board_id, "B", None, None).await;
+    let col_c = seed_column(&server, board_id, "C", None, None).await;
+    seed_card(&server, col_a, "A1", None).await;
+    seed_card(&server, col_b, "B1", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let cards: Vec<Card> =
+        blocking(move || backend.list_cards_by_columns(&[col_a, col_b, col_c]).unwrap()).await;
+
+    assert_eq!(cards.len(), 2);
+    let titles: Vec<&str> = cards.iter().map(|c| c.title.as_str()).collect();
+    assert!(titles.contains(&"A1"));
+    assert!(titles.contains(&"B1"));
+
+    server.shutdown().await;
+}
+
+#[test]
+fn test_a_read_against_an_unreachable_server_maps_to_a_transport_error() {
+    let backend = HttpBackend::new("http://127.0.0.1:1").unwrap();
+
+    let err = backend.list_boards().expect_err("no server is listening on port 1");
+
+    assert!(err.is_transport(), "expected transport error, got {err:?}");
+    assert!(!err.is_unsupported());
+}

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -426,6 +426,14 @@ mod tests {
     }
 
     #[test]
+    fn test_transport_error_is_neither_internal_nor_unsupported() {
+        let err = KanbanError::Transport("connection refused".into());
+        assert!(err.is_transport());
+        assert!(!err.is_unsupported());
+        assert!(!matches!(err, KanbanError::Internal(_)));
+    }
+
+    #[test]
     fn test_unsupported_error_is_unsupported_and_not_not_found() {
         let err = KanbanError::unsupported("archive_board");
         assert!(err.is_unsupported());

--- a/crates/kanban-domain/src/error.rs
+++ b/crates/kanban-domain/src/error.rs
@@ -228,6 +228,13 @@ pub enum KanbanError {
     #[error("internal error: {0}")]
     Internal(String),
 
+    /// A request to a remote backend produced no response: connection
+    /// refused, DNS failure, TLS failure, or timeout. Distinct from
+    /// `Internal`, which is a fault in this process, and from a 404, which is
+    /// proven absence rather than an unanswered request.
+    #[error("transport error: {0}")]
+    Transport(String),
+
     /// A `DataStore`/backend method that a backend has not implemented yet.
     /// The shared affordance behind the default trait bodies added by later
     /// slices (D6). This is a server/infrastructure fault (a backend gap), so
@@ -307,6 +314,10 @@ impl KanbanError {
 
     pub fn is_unsupported(&self) -> bool {
         matches!(self, KanbanError::Unsupported { .. })
+    }
+
+    pub fn is_transport(&self) -> bool {
+        matches!(self, KanbanError::Transport(_))
     }
 
     /// True for both `NotFound` (by UUID) and `NotFoundByName`.


### PR DESCRIPTION
## Summary

Turns `HttpBackend`'s all-`unsupported` `DataStore` impl into a working read path against the live kanban-server REST surface.

- Adds `KanbanError::Transport(String)` (kanban-domain) and `ErrorCode::UpstreamUnavailable` / 502 (kanban-api), classified in the existing exhaustive `KanbanError -> ApiError` match, plus `From<ApiError> for KanbanError` so a wire error can be turned back into a domain error without guessing at its structure.
- Adds a `get_json` / `get_json_list` helper pair on `HttpBackend`'s dedicated runtime. `get_json` maps a 404 to `Ok(None)`, any other non-2xx to `Err` carrying the server's error code, and a send failure to `KanbanError::Transport`. `get_json_list` follows `Page<T>.total_pages` to completion at the server's default page size.
- Implements nine core `DataStore` reads against the live server: `get_board`, `list_boards`, `get_column`, `list_columns_by_board`, `get_card`, `list_cards_by_column`, `list_cards_by_sprint`, `get_sprint`, `list_sprints_by_board`. The two-request card lists resolve their parent (column or sprint) first and return an empty list for an unknown parent, matching the in-memory contract.
- Rules explicitly on the five inherited `DataStore` defaults this card owns, so none of them can silently go live as a full-workspace scan now that their delegates answer real data: `get_card_by_board_and_number`, `list_cards_by_number` and `list_cards_by_prefix_and_number` decline under their own name; `get_card_by_sprint_and_number` and `list_cards_by_columns` keep the same shape as the inherited default but are written out explicitly with cost-stating doc comments.
- `upsert_board` / `upsert_column` / `upsert_card` / `upsert_sprint` stay `unsupported`: every available `PUT` route drops fields `DataStore::upsert_*` must write verbatim, and the path is unreachable today regardless (`with_transaction` already declines and there is no `RemoteWrites` impl).
- Removes the crate's blanket `#![allow(dead_code)]` now that `block_on`, `base_url` and `client` have production callers.

Board, sprint and card conversions are lossy in documented, tested ways: a remotely-fetched board cannot allocate sprint numbers or resolve sprint names (`BoardResponse` omits `sprint_names`/`sprint_name_used_count`/`next_sprint_number`), and a remotely-fetched sprint always renders unnamed (`SprintResponse` exposes a resolved `name` instead of `name_index`).

## Counts (re-derived)

`DataStore` trait methods, excluding the crate's own `#[cfg(test)]` module:

```
awk '/^pub trait DataStore/,/^}/' crates/kanban-domain/src/data_store.rs | grep -oP '^\s{4}fn \K\w+' | sort -u | wc -l
# 52
```

`impl DataStore for HttpBackend`, same exclusion (this crate has no `#[cfg(test)]` module in `data_store.rs`):

```
awk '/^impl DataStore for HttpBackend/,/^}/' crates/kanban-backend-http/src/data_store.rs | grep -oP '^\s{4}fn \K\w+' | sort -u | wc -l
# 47
```

`comm -23` of the two gives exactly the 5 names still inherited.

## D3 table

| # | Method | Status | Owner |
|---|---|---|---|
| 1 | `get_card_by_board_and_number` | explicit decline, own name | this card |
| 2 | `get_card_by_sprint_and_number` | explicit override, same shape as default | this card |
| 3 | `list_cards_by_number` | explicit decline, own name | this card |
| 4 | `list_cards_by_prefix_and_number` | explicit decline, own name | this card |
| 5 | `list_cards_by_columns` | explicit override, same shape as default | this card |
| 6 | `list_cards_by_column_filtered` | still inherited | split-1241-b |
| 7 | `count_cards_in_column_filtered` | still inherited | split-1241-b |
| 8 | `list_archived_cards_by_board` | still inherited | split-1241-b |
| 9 | `clear_sprint_from_archived_cards` | still inherited | split-1241-b |
| 10 | `modify_graph` | still inherited | split-1241-b |

## Reachability finding

`impl KanbanBackend for HttpBackend` declines `with_transaction` (`crates/kanban-backend-http/src/lib.rs`), and no `impl RemoteWrites for HttpBackend` exists, so the `self.backend.remote_writes().is_some()` guard at `crates/kanban-service/src/context/undo.rs` does not fire and `execute_with_extra` returns before reaching any `upsert_*`. The four `upsert_*` declines added in this PR are therefore unreachable from production today, which is consistent with the routes available (every one would otherwise be a lossy write) and is reported here rather than worked around.

## Test plan

- Every test in the handoff's red_tests list was observed failing at the Red commit (kanban-domain and kanban-api fail to compile; the backend-http suite exercises still-`unsupported` methods).
- Green commit implements the read path; full suite green locally: `cargo test --all-features --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`.
- Mutation-checked the pagination loop, the decline-name assertion, the Transport error classification and the get_json 404-vs-error branch by deliberately breaking each, confirming the relevant test failed, then restoring.
