### PR TITLE
KAN-1376 refactor(core,view,tui): rename core Page/PageInfo to Viewport/ViewportInfo

### DIFF
--- a/.changeset/kan-1376-rename-core-page-viewport.md
+++ b/.changeset/kan-1376-rename-core-page-viewport.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+core: rename the internal TUI scroll-viewport type from Page/PageInfo to Viewport/ViewportInfo to stop it colliding in name with the REST API's Page pagination envelope.

--- a/crates/kanban-core/README.md
+++ b/crates/kanban-core/README.md
@@ -64,12 +64,12 @@ pub struct PaginatedList<T> {
 - `resolve_page_params(page: Option<u32>, page_size: Option<u32>) -> CoreResult<(usize, usize)>` — applies defaults (`page=1`, `page_size=50`) and validates.
 - Constants: `DEFAULT_PAGE = 1`, `DEFAULT_PAGE_SIZE = 50`, `MAX_PAGE_SIZE = 500`.
 
-### `Page` / `PageInfo`
+### `Viewport` / `ViewportInfo`
 
 TUI viewport pagination — manages which items are visible in a terminal viewport given a scroll offset. **Pure in-memory state — lives only in the TUI process.**
 
 ```rust
-pub struct PageInfo {
+pub struct ViewportInfo {
     pub visible_indices: Vec<usize>,
     pub first_visible: usize,
     pub last_visible: usize,
@@ -83,7 +83,7 @@ pub struct PageInfo {
 }
 ```
 
-`Page` computes a `PageInfo` for a given item count, viewport height, and scroll offset.
+`Viewport` computes a `ViewportInfo` for a given item count, viewport height, and scroll offset.
 
 ### `InputState`
 

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -12,10 +12,10 @@ pub mod health;
 pub mod input;
 pub mod logging;
 pub mod paginated_list;
-pub mod pagination;
 pub mod selection;
 pub mod traits;
 pub mod version;
+pub mod viewport;
 
 pub use config::{
     validate_branch_prefix, AppConfig, DEFAULT_JSON_FILENAME, DEFAULT_SERVER_ADDR,
@@ -33,7 +33,7 @@ pub use logging::{LogEntry, Loggable};
 pub use paginated_list::{
     resolve_page_params, PaginatedList, DEFAULT_PAGE, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
-pub use pagination::{Page, PageInfo};
 pub use selection::SelectionState;
 pub use traits::Editable;
 pub use version::{CLI_VERSION_DISPLAY, KANBAN_COMMIT, KANBAN_VERSION};
+pub use viewport::{Viewport, ViewportInfo};

--- a/crates/kanban-core/src/paginated_list.rs
+++ b/crates/kanban-core/src/paginated_list.rs
@@ -1,7 +1,7 @@
 //! API-level pagination for CLI and MCP responses.
 //!
 //! [`PaginatedList<T>`] is the serialized response envelope returned by list
-//! endpoints. It is distinct from [`super::pagination`], which manages TUI
+//! endpoints. It is distinct from [`super::viewport`], which manages TUI
 //! viewport scroll state and is never serialized.
 
 use crate::{CoreError, CoreResult};

--- a/crates/kanban-core/src/viewport.rs
+++ b/crates/kanban-core/src/viewport.rs
@@ -1,12 +1,12 @@
 //! TUI viewport pagination — scroll state for the terminal UI.
 //!
-//! [`Page`] and [`PageInfo`] manage which items are visible in a terminal
+//! [`Viewport`] and [`ViewportInfo`] manage which items are visible in a terminal
 //! viewport given a scroll offset. They are pure in-memory state and are never
 //! serialized or exposed through the CLI/MCP API.
 //!
 //! [`scroll_offset_to_keep_visible`] is the pure scroll-math primitive used by
-//! `Page::scroll_to_visible` and by callers that track a scroll offset outside
-//! of [`Page`].
+//! `Viewport::scroll_to_visible` and by callers that track a scroll offset outside
+//! of [`Viewport`].
 //!
 //! For the serialized pagination envelope used by CLI and MCP list responses,
 //! see [`super::paginated_list`].
@@ -16,7 +16,7 @@
 /// visible, the offset is unchanged; otherwise it shifts just enough to bring
 /// `selected` to the nearest edge of the viewport.
 ///
-/// This is the pure form of [`Page::scroll_to_visible`] and the canonical
+/// This is the pure form of [`Viewport::scroll_to_visible`] and the canonical
 /// helper for any scrollable list that wants the same behavior as the main
 /// card list.
 pub fn scroll_offset_to_keep_visible(
@@ -39,7 +39,7 @@ pub fn scroll_offset_to_keep_visible(
 
 /// Information about the visible portion of a paginated list.
 #[derive(Debug, Clone)]
-pub struct PageInfo {
+pub struct ViewportInfo {
     /// Indices of items visible in the current viewport.
     pub visible_indices: Vec<usize>,
     /// Index of the first visible item.
@@ -62,7 +62,7 @@ pub struct PageInfo {
     pub total_pages: usize,
 }
 
-impl PageInfo {
+impl ViewportInfo {
     /// Create an empty page info (no items).
     pub fn empty() -> Self {
         Self {
@@ -85,14 +85,14 @@ impl PageInfo {
 /// This is a pure data component that knows nothing about rendering.
 /// It only tracks which items should be visible based on scroll position.
 #[derive(Clone)]
-pub struct Page {
+pub struct Viewport {
     /// Total number of items in the list.
     pub total_items: usize,
     /// Current scroll offset (index of first visible item).
     pub scroll_offset: usize,
 }
 
-impl Page {
+impl Viewport {
     /// Create a new page with the given item count.
     pub fn new(total_items: usize) -> Self {
         Self {
@@ -113,9 +113,9 @@ impl Page {
     ///
     /// # Arguments
     /// * `viewport_height` - Number of items that fit in the viewport
-    pub fn get_page_info(&self, viewport_height: usize) -> PageInfo {
+    pub fn get_page_info(&self, viewport_height: usize) -> ViewportInfo {
         if self.total_items == 0 || viewport_height == 0 {
-            return PageInfo::empty();
+            return ViewportInfo::empty();
         }
 
         let render_start = self.scroll_offset;
@@ -149,7 +149,7 @@ impl Page {
         };
         let current_page = self.scroll_offset.checked_div(viewport_height).unwrap_or(0);
 
-        PageInfo {
+        ViewportInfo {
             visible_indices,
             first_visible,
             last_visible,
@@ -199,7 +199,7 @@ impl Page {
     }
 }
 
-impl Default for Page {
+impl Default for Viewport {
     fn default() -> Self {
         Self::new(0)
     }
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_page_info_empty() {
-        let page = Page::new(0);
+        let page = Viewport::new(0);
         let info = page.get_page_info(10);
 
         assert!(info.visible_indices.is_empty());
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_single_page_fits_all() {
-        let page = Page::new(5);
+        let page = Viewport::new(5);
         let info = page.get_page_info(10);
 
         assert_eq!(info.visible_indices, vec![0, 1, 2, 3, 4]);
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_first_page_multi_page() {
-        let page = Page::new(20);
+        let page = Viewport::new(20);
         let info = page.get_page_info(5);
 
         assert_eq!(info.visible_indices, vec![0, 1, 2, 3, 4]);
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_middle_page() {
-        let mut page = Page::new(20);
+        let mut page = Viewport::new(20);
         page.set_scroll_offset(5);
         let info = page.get_page_info(5);
 
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_last_page() {
-        let mut page = Page::new(20);
+        let mut page = Viewport::new(20);
         page.set_scroll_offset(15);
         let info = page.get_page_info(5);
 
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_scroll_to_visible() {
-        let mut page = Page::new(20);
+        let mut page = Viewport::new(20);
         page.scroll_to_visible(15, 5);
 
         assert_eq!(page.scroll_offset, 11); // 15 - (5 - 1)
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn test_set_total_items_clamps_scroll() {
-        let mut page = Page::new(20);
+        let mut page = Viewport::new(20);
         page.set_scroll_offset(15);
 
         page.set_total_items(10);
@@ -320,32 +320,32 @@ mod tests {
 
     #[test]
     fn test_adjusted_viewport_height_empty_list() {
-        let page = Page::new(0);
+        let page = Viewport::new(0);
         assert_eq!(page.get_adjusted_viewport_height(5), 5);
     }
 
     #[test]
     fn test_adjusted_viewport_height_zero_raw() {
-        let page = Page::new(10);
+        let page = Viewport::new(10);
         assert_eq!(page.get_adjusted_viewport_height(0), 0);
     }
 
     #[test]
     fn test_adjusted_viewport_height_all_fit() {
-        let page = Page::new(5);
+        let page = Viewport::new(5);
         assert_eq!(page.get_adjusted_viewport_height(10), 10);
     }
 
     #[test]
     fn test_adjusted_viewport_height_at_top_with_below() {
-        let page = Page::new(10);
+        let page = Viewport::new(10);
         // offset=0: no above indicator; 0+5=5 < 10 → below indicator → raw-1
         assert_eq!(page.get_adjusted_viewport_height(5), 4);
     }
 
     #[test]
     fn test_adjusted_viewport_height_middle_both_indicators() {
-        let mut page = Page::new(10);
+        let mut page = Viewport::new(10);
         page.set_scroll_offset(3);
         // offset=3: above indicator; available=4; 3+4=7 < 10 → below indicator → raw-2
         assert_eq!(page.get_adjusted_viewport_height(5), 3);
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_adjusted_viewport_height_near_end_above_only() {
-        let mut page = Page::new(10);
+        let mut page = Viewport::new(10);
         page.set_scroll_offset(6);
         // offset=6: above indicator; available=4; 6+4=10 >= 10 → no below → raw-1
         assert_eq!(page.get_adjusted_viewport_height(5), 4);

--- a/crates/kanban-core/tests/no_page_type_guard.rs
+++ b/crates/kanban-core/tests/no_page_type_guard.rs
@@ -15,6 +15,10 @@ fn test_no_type_named_page_exists_in_kanban_core() {
                 || trimmed.starts_with("pub enum Page")
                 || trimmed.starts_with("type Page")
                 || trimmed.starts_with("pub type Page")
+                || trimmed.starts_with("pub(crate) struct Page")
+                || trimmed.starts_with("pub(super) struct Page")
+                || trimmed.starts_with("trait Page")
+                || trimmed.starts_with("pub trait Page")
             {
                 offenders.push(format!("{}:{}: {}", entry.display(), line_no + 1, trimmed));
             }

--- a/crates/kanban-core/tests/no_page_type_guard.rs
+++ b/crates/kanban-core/tests/no_page_type_guard.rs
@@ -1,0 +1,46 @@
+use std::path::Path;
+
+#[test]
+fn test_no_type_named_page_exists_in_kanban_core() {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+
+    for entry in walk_rs_files(&src_dir) {
+        let contents = std::fs::read_to_string(&entry).expect("readable source file");
+        for (line_no, line) in contents.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("struct Page")
+                || trimmed.starts_with("pub struct Page")
+                || trimmed.starts_with("enum Page")
+                || trimmed.starts_with("pub enum Page")
+                || trimmed.starts_with("type Page")
+                || trimmed.starts_with("pub type Page")
+            {
+                offenders.push(format!("{}:{}: {}", entry.display(), line_no + 1, trimmed));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "found type(s) named `Page` in kanban-core, which is reserved for kanban-api's wire pagination envelope:\n{}",
+        offenders.join("\n")
+    );
+}
+
+fn walk_rs_files(dir: &Path) -> Vec<std::path::PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        for entry in std::fs::read_dir(&current).expect("readable src directory") {
+            let entry = entry.expect("readable dir entry");
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                files.push(path);
+            }
+        }
+    }
+    files
+}

--- a/crates/kanban-tui/src/components/filter_popup.rs
+++ b/crates/kanban-tui/src/components/filter_popup.rs
@@ -1,7 +1,7 @@
 use crate::app::App;
 use crate::components::centered_rect;
 use crate::theme::*;
-use kanban_core::pagination::scroll_offset_to_keep_visible;
+use kanban_core::viewport::scroll_offset_to_keep_visible;
 use kanban_view::filters::FilterDialogState;
 use ratatui::{
     layout::{Constraint, Direction, Layout},

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -1,7 +1,7 @@
 use crate::app::{App, BoardFocus};
 use crate::components::*;
 use crate::theme::*;
-use kanban_core::pagination::scroll_offset_to_keep_visible;
+use kanban_core::viewport::scroll_offset_to_keep_visible;
 use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::{Sprint, SprintStatus};
 use ratatui::{

--- a/crates/kanban-view/src/list_component.rs
+++ b/crates/kanban-view/src/list_component.rs
@@ -1,13 +1,13 @@
 use kanban_core::SelectionState;
-use kanban_core::{Page, PageInfo};
+use kanban_core::{Viewport, ViewportInfo};
 use std::collections::HashSet;
 
-pub type ListRenderInfo = PageInfo;
+pub type ListRenderInfo = ViewportInfo;
 
 #[derive(Clone)]
 pub struct ListComponent {
     pub selection: SelectionState,
-    page: Page,
+    page: Viewport,
     pub multi_selected: HashSet<usize>,
     pub allow_multi_select: bool,
 }
@@ -16,7 +16,7 @@ impl ListComponent {
     pub fn new(allow_multi_select: bool) -> Self {
         Self {
             selection: SelectionState::new(),
-            page: Page::new(0),
+            page: Viewport::new(0),
             multi_selected: HashSet::new(),
             allow_multi_select,
         }


### PR DESCRIPTION
## Summary

kanban-core's `Page` tracked TUI scroll-viewport state (fields: `total_items`, `scroll_offset`) and shared a name with kanban-api's `Page<T>` REST pagination envelope, even though the two concepts are unrelated. This renames the core-side type to match what it actually is.

- `kanban-core::Page` -> `Viewport`
- `kanban-core::PageInfo` -> `ViewportInfo`
- `kanban-core/src/pagination.rs` -> `viewport.rs`, `lib.rs` module declaration and re-export updated
- `kanban-api`'s `Page<T>` and `PageParams` are untouched; `page`/`per_page` is correct REST vocabulary there

The rename's only external consumer is `kanban-view/src/list_component.rs` (verified before starting: `git grep -ln 'PageInfo\|pagination::Page' -- 'crates/*/src/*'` returned exactly `kanban-core/src/lib.rs`, `kanban-core/src/pagination.rs`, and `kanban-view/src/list_component.rs`). Two more call sites in `kanban-tui` (`components/filter_popup.rs`, `ui/board_detail.rs`) imported `kanban_core::pagination::scroll_offset_to_keep_visible` by module path and needed updating once the module moved.

No behavioural change: the diff is renames, an import-path update, and one stale doc-comment cross-reference.

## Test plan

- [x] Red: `crates/kanban-core/tests/no_page_type_guard.rs` added and confirmed failing before the rename
- [x] Green: rename applied, all call sites updated, build green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] `cargo check --package kanban-cli --no-default-features --features json,sqlite`
- [x] `nix develop --command check-crate-list-sync`
- [x] `nix develop --command check-factory-compile-lock`
- [x] Changeset added (`kan-1376-rename-core-page-viewport.md`, patch)