### PR TITLE
KAN-1402 feat(domain): add DependencyGraph::filtered_to and merge_from

### DIFF
--- a/.changeset/kan-1402-dependency-graph-filter-merge.md
+++ b/.changeset/kan-1402-dependency-graph-filter-merge.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: add `DependencyGraph::filtered_to` and `DependencyGraph::merge_from`, the two whole-graph primitives that scoping an export and merging an import will build on. `filtered_to` keeps only edges whose endpoints are both in a given card set, preserving each edge's live/archived state, kind and metadata (`blocks` severity, `relates` kind). `merge_from` adds another graph's edges without disturbing existing ones, treating an edge already present as a no-op and rejecting a cycle-inducing edge as an error. Purely additive; no existing call site changes.

--- a/crates/kanban-domain/src/dependencies/dependency_graph.rs
+++ b/crates/kanban-domain/src/dependencies/dependency_graph.rs
@@ -749,4 +749,149 @@ mod tests {
         assert_eq!(g.children(a), vec![b]);
         assert_eq!(g.blocked(b), vec![c]);
     }
+
+    // --- filtered_to ---
+
+    #[test]
+    fn test_filtered_to_keeps_edges_with_both_endpoints_in_the_set() {
+        let (a, b, _) = ids();
+        let mut g = DependencyGraph::new();
+        g.set_parent(b, a).unwrap();
+        let keep: std::collections::HashSet<Uuid> = [a, b].into_iter().collect();
+        let filtered = g.filtered_to(&keep);
+        assert_eq!(filtered.children(a), vec![b]);
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn test_filtered_to_drops_edges_with_one_endpoint_outside_the_set() {
+        let (a, b, c) = ids();
+        let mut g = DependencyGraph::new();
+        g.set_parent(b, a).unwrap();
+        g.set_block(b, c).unwrap();
+        let keep: std::collections::HashSet<Uuid> = [a, b].into_iter().collect();
+        let filtered = g.filtered_to(&keep);
+        assert_eq!(filtered.children(a), vec![b]);
+        assert!(filtered.blocked(b).is_empty());
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn test_filtered_to_preserves_archived_edges_of_kept_cards() {
+        let (a, b, _) = ids();
+        let mut g = DependencyGraph::new();
+        g.set_block(a, b).unwrap();
+        g.archive_node(a);
+        assert!(!g.contains(a, b));
+        assert!(g.contains_archived(a, b));
+
+        let keep: std::collections::HashSet<Uuid> = [a, b].into_iter().collect();
+        let filtered = g.filtered_to(&keep);
+
+        assert!(
+            !filtered.contains(a, b),
+            "archived edge must not become active after filtering"
+        );
+        assert!(
+            filtered.contains_archived(a, b),
+            "archived edge between kept cards must survive filtered_to"
+        );
+    }
+
+    #[test]
+    fn test_filtered_to_preserves_all_three_edge_kinds() {
+        let (a, b, c) = ids();
+        let mut g = DependencyGraph::new();
+        g.set_parent(b, a).unwrap();
+        g.set_block(a, c).unwrap();
+        g.relate(a, c).unwrap();
+
+        let keep: std::collections::HashSet<Uuid> = [a, b, c].into_iter().collect();
+        let filtered = g.filtered_to(&keep);
+
+        assert_eq!(filtered.children(a), vec![b]);
+        assert_eq!(filtered.blocked(a), vec![c]);
+        assert_eq!(filtered.related(a), vec![c]);
+    }
+
+    #[test]
+    fn test_filtered_to_preserves_block_severity_and_relate_kind() {
+        let (a, b, c) = ids();
+        let mut g = DependencyGraph::new();
+        g.set_block_with_severity(a, b, super::super::Severity::Critical)
+            .unwrap();
+        g.relate_with_kind(a, c, super::super::RelatesKind::Duplicates)
+            .unwrap();
+
+        let keep: std::collections::HashSet<Uuid> = [a, b, c].into_iter().collect();
+        let filtered = g.filtered_to(&keep);
+
+        assert_eq!(
+            filtered.blocks_edges()[0].severity,
+            super::super::Severity::Critical
+        );
+        assert_eq!(
+            filtered.relates_edges()[0].kind,
+            super::super::RelatesKind::Duplicates
+        );
+    }
+
+    // --- merge_from ---
+
+    #[test]
+    fn test_merge_from_adds_edges_without_removing_existing_ones() {
+        let (a, b, c) = ids();
+        let mut base = DependencyGraph::new();
+        base.set_parent(b, a).unwrap();
+
+        let mut incoming = DependencyGraph::new();
+        incoming.set_block(a, c).unwrap();
+
+        base.merge_from(&incoming).unwrap();
+
+        assert_eq!(base.children(a), vec![b], "existing edge survives merge");
+        assert_eq!(base.blocked(a), vec![c], "new edge is added by merge");
+    }
+
+    #[test]
+    fn test_merge_from_is_idempotent_for_an_edge_already_present() {
+        let (a, b, _) = ids();
+        let mut base = DependencyGraph::new();
+        base.set_parent(b, a).unwrap();
+
+        let mut incoming = DependencyGraph::new();
+        incoming.set_parent(b, a).unwrap();
+
+        base.merge_from(&incoming).unwrap();
+
+        assert_eq!(base.children(a), vec![b]);
+        assert_eq!(base.len(), 1, "merging an already-present edge is a no-op");
+    }
+
+    #[test]
+    fn test_merge_from_rejects_a_cycle_inducing_edge() {
+        let (a, b, c) = ids();
+        let mut base = DependencyGraph::new();
+        base.set_parent(b, a).unwrap();
+        base.set_parent(c, b).unwrap();
+
+        let mut incoming = DependencyGraph::new();
+        incoming.set_parent(a, c).unwrap();
+
+        assert!(base.merge_from(&incoming).unwrap_err().is_cycle_detected());
+    }
+
+    #[test]
+    fn test_merge_from_preserves_archived_edges() {
+        let (a, b, _) = ids();
+        let mut source = DependencyGraph::new();
+        source.set_block(a, b).unwrap();
+        source.archive_node(a);
+
+        let mut base = DependencyGraph::new();
+        base.merge_from(&source).unwrap();
+
+        assert!(!base.contains(a, b));
+        assert!(base.contains_archived(a, b));
+    }
 }

--- a/crates/kanban-domain/src/dependencies/dependency_graph.rs
+++ b/crates/kanban-domain/src/dependencies/dependency_graph.rs
@@ -311,6 +311,100 @@ impl DependencyGraph {
         }
         Ok(graph)
     }
+
+    /// Every edge whose endpoints are both in `keep`, preserving each
+    /// edge's live/archived state, kind and metadata (`blocks`
+    /// severity, `relates` kind). An edge with one endpoint outside
+    /// `keep` is dropped.
+    pub fn filtered_to(&self, keep: &std::collections::HashSet<CardId>) -> Self {
+        use kanban_core::Edge as _;
+
+        let both_kept =
+            |source: Uuid, target: Uuid| keep.contains(&source) && keep.contains(&target);
+
+        let spawns = self
+            .spawns_edges()
+            .iter()
+            .filter(|e| both_kept(e.source(), e.target()))
+            .cloned()
+            .collect();
+        let blocks = self
+            .blocks_edges()
+            .iter()
+            .filter(|e| both_kept(e.source(), e.target()))
+            .cloned()
+            .collect();
+        let relates = self
+            .relates_edges()
+            .iter()
+            .filter(|e| both_kept(e.source(), e.target()))
+            .cloned()
+            .collect();
+
+        Self::from_validated_per_kind_edges(spawns, blocks, relates)
+            .expect("a subset of an already-valid graph cannot violate structural invariants")
+    }
+
+    /// Add `other`'s edges to `self`, leaving existing edges intact.
+    ///
+    /// An edge already present between the same endpoints (in either
+    /// live or archived state) is a no-op: `self`'s copy wins and
+    /// `other`'s is not applied. Adding a genuinely new edge routes
+    /// through the same per-edge setters as interactive use
+    /// (`set_parent`, `set_block_with_severity`, `relate_with_kind`,
+    /// or their archived-preserving counterparts), so a cycle-inducing
+    /// edge is rejected exactly as it would be interactively.
+    pub fn merge_from(&mut self, other: &DependencyGraph) -> KanbanResult<()> {
+        use kanban_core::Edge as _;
+
+        for edge in other.spawns_edges() {
+            let (parent, child) = (edge.source(), edge.target());
+            if self
+                .spawns_edges()
+                .iter()
+                .any(|e| e.source() == parent && e.target() == child)
+            {
+                continue;
+            }
+            if edge.is_active() {
+                self.set_parent(child, parent)?;
+            } else {
+                self.add_archived_spawns(parent, child)?;
+            }
+        }
+
+        for edge in other.blocks_edges() {
+            let (blocker, blocked) = (edge.source(), edge.target());
+            if self
+                .blocks_edges()
+                .iter()
+                .any(|e| e.source() == blocker && e.target() == blocked)
+            {
+                continue;
+            }
+            if edge.is_active() {
+                self.set_block_with_severity(blocker, blocked, edge.severity)?;
+            } else {
+                self.add_archived_blocks(blocker, blocked, edge.severity)?;
+            }
+        }
+
+        for edge in other.relates_edges() {
+            let (a, b) = (edge.source(), edge.target());
+            if self.relates_edges().iter().any(|e| {
+                (e.source() == a && e.target() == b) || (e.source() == b && e.target() == a)
+            }) {
+                continue;
+            }
+            if edge.is_active() {
+                self.relate_with_kind(a, b, edge.kind)?;
+            } else {
+                self.add_archived_relates(a, b, edge.kind)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 /// Wrap a structural `GraphError` from a load path with the kind tag


### PR DESCRIPTION
Adds the two `DependencyGraph` primitives that KAN-1403 and KAN-1404 both need. Purely additive: no existing call site changes and no existing behaviour changes.

Closes KAN-1402. Part of KAN-1387, which fixes a path where importing a board export deletes the destination workspace's dependency edges.

```rust
pub fn filtered_to(&self, keep: &HashSet<CardId>) -> Self;
pub fn merge_from(&mut self, other: &DependencyGraph) -> KanbanResult<()>;
```

## Notes for review

**Archived edges are the subtle part.** The graph carries archived edges alongside live ones, across all three buckets. An implementation that rebuilds from active edges only would silently drop the archived relationships of kept cards and still pass an obvious test, so `test_filtered_to_preserves_archived_edges_of_kept_cards` exists specifically to catch that. `test_filtered_to_preserves_block_severity_and_relate_kind` covers the edge metadata for the same reason.

**`merge_from` goes through the existing per-edge setters** rather than a bulk insert, so cycle rejection comes for free via `DagGraph::add_edge_with_metadata` and `would_create_cycle`. A cycle-inducing edge aborts the merge with an error rather than being skipped, which is deliberate: silently dropping an edge is the defect KAN-1387 exists to fix, and reintroducing it one layer down would be worse than the original.

**Merge conflicts resolve as "self wins, no overwrite."** An edge already present between the same endpoints is a no-op, including when the incoming copy disagrees on severity, kind or archived state. This also makes the operation idempotent.

**One `expect` was added**, on the rebuild inside `filtered_to`. The filtered edge set is a subset of an already-valid graph, so it cannot introduce a cycle, duplicate or self-reference. Returning a `KanbanResult` here would push a cannot-happen error onto every caller; degrading to an empty graph would be the silent-failure pattern this project has been removing. The message states the invariant.

9 new tests. `cargo test --workspace`, `clippy -D warnings` and `fmt --check` all green.