### PR TITLE
KAN-1395 fix(api): reject the legacy completion_column_ids key and correct the guidance

### DIFF
--- a/.changeset/kan-1395-reject-legacy-completion-column-ids.md
+++ b/.changeset/kan-1395-reject-legacy-completion-column-ids.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+api,server: reject a legacy `completion_column_ids` key on board writes (`POST /v1/boards`, `PATCH /v1/boards/:id`, `PUT /v1/boards/:id`) with a 422 naming `default_status` as the replacement, instead of silently ignoring it. This is a breaking wire change for 0.8.x clients that still send `completion_column_ids`; the write already had no effect, so the field is now refused instead of swallowed. Set `default_status` on a column via the column endpoints (`POST /v1/boards/:board_id/columns`, `PATCH /v1/columns/:id`, `PUT /v1/boards/:board_id/columns/:id`) and read it back on `ColumnResponse.default_status`. Also corrects the `CreateBoardRequest` doc comment, which pointed integrators at `update_board`, a request that has no such field and never did.

--- a/crates/kanban-api/src/v1/boards/requests.rs
+++ b/crates/kanban-api/src/v1/boards/requests.rs
@@ -124,15 +124,13 @@ mod tests {
     }
 
     #[test]
-    fn test_create_board_request_has_no_completion_column_ids_field() {
-        // A board created via CreateBoardRequest always has zero columns, so
-        // completion_column_ids can never be set to something real -- it must
-        // be structurally absent, not just runtime-rejected. Any JSON supplied
-        // for it is simply ignored (no `deny_unknown_fields`), matching the
-        // "extra field, no-op" convention used elsewhere in this API.
+    fn test_create_board_request_rejects_a_legacy_completion_column_ids_key() {
         let json = r#"{"name":"Ignored","completion_column_ids":["00000000-0000-0000-0000-000000000000"]}"#;
-        let back: CreateBoardRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(back.name, "Ignored");
+        let err = serde_json::from_str::<CreateBoardRequest>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("default_status"),
+            "error must name the default_status replacement: {err}"
+        );
     }
 
     #[test]
@@ -183,28 +181,24 @@ mod tests {
     }
 
     #[test]
-    fn test_update_board_request_ignores_a_legacy_completion_column_ids_key() {
+    fn test_update_board_request_rejects_a_legacy_completion_column_ids_key() {
         let json = r#"{"name":"Renamed","completion_column_ids":["00000000-0000-0000-0000-000000000000"]}"#;
-        let back: UpdateBoardRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(back.name, Some("Renamed".to_string()));
-        let round_tripped = serde_json::to_value(&back).unwrap();
+        let err = serde_json::from_str::<UpdateBoardRequest>(json).unwrap_err();
         assert!(
-            round_tripped.get("completion_column_ids").is_none(),
-            "a legacy completion_column_ids key must be ignored, not carried through: {round_tripped}"
+            err.to_string().contains("default_status"),
+            "error must name the default_status replacement: {err}"
         );
     }
 
     #[test]
-    fn test_replace_board_request_ignores_a_legacy_completion_column_ids_key() {
+    fn test_replace_board_request_rejects_a_legacy_completion_column_ids_key() {
         let json = r#"{"name":"Fresh","task_sort_field":"priority",
             "task_sort_order":"ascending","task_list_view":"flat",
             "completion_column_ids":["00000000-0000-0000-0000-000000000000"]}"#;
-        let back: ReplaceBoardRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(back.name, "Fresh");
-        let round_tripped = serde_json::to_value(&back).unwrap();
+        let err = serde_json::from_str::<ReplaceBoardRequest>(json).unwrap_err();
         assert!(
-            round_tripped.get("completion_column_ids").is_none(),
-            "a legacy completion_column_ids key must be ignored, not carried through: {round_tripped}"
+            err.to_string().contains("default_status"),
+            "error must name the default_status replacement: {err}"
         );
     }
 

--- a/crates/kanban-api/src/v1/boards/requests.rs
+++ b/crates/kanban-api/src/v1/boards/requests.rs
@@ -2,14 +2,26 @@ use super::super::{Patch, SortFieldDto, SortOrderDto, TaskListViewDto};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+const LEGACY_COMPLETION_COLUMN_IDS_MESSAGE: &str = "`completion_column_ids` was removed: a column's completion status is now derived from `default_status` (see `is_completion_column` in kanban-domain). Set `default_status` via `POST /v1/boards/:board_id/columns`, `PATCH /v1/columns/:id`, or `PUT /v1/boards/:board_id/columns/:id`, and read it back on `ColumnResponse.default_status`.";
+
+fn reject_legacy_completion_column_ids(value: &serde_json::Value) -> Result<(), String> {
+    if value.get("completion_column_ids").is_some() {
+        return Err(LEGACY_COMPLETION_COLUMN_IDS_MESSAGE.to_string());
+    }
+    Ok(())
+}
+
 /// Request body for a pure `POST /v1/boards` create (also MCP's
 /// `tool_create_board`): a board created this way always has zero columns, so
 /// `completion_column_ids` has no field here — it can never be set to
-/// something real by construction. Set it afterward via `update_board` once
-/// the board has columns, or use `PUT /v1/boards/:id` with [`ReplaceBoardRequest`]
-/// to replace an existing board (which may already have columns).
+/// something real by construction. A column's completion status is derived
+/// from `default_status` (see `is_completion_column` in kanban-domain); set
+/// it via the column endpoints once the board has columns, e.g.
+/// `POST /v1/boards/:board_id/columns` or `PATCH /v1/columns/:id`, and read
+/// it back on `ColumnResponse.default_status`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(remote = "Self")]
 pub struct CreateBoardRequest {
     /// Client-supplied id, honoured when present. An id that already exists
     /// is a conflict (`AlreadyExists` -> 409), not an idempotent replace —
@@ -33,6 +45,26 @@ pub struct CreateBoardRequest {
     pub task_list_view: Option<TaskListViewDto>,
 }
 
+impl Serialize for CreateBoardRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Self::serialize(self, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for CreateBoardRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        reject_legacy_completion_column_ids(&value).map_err(serde::de::Error::custom)?;
+        Self::deserialize(value).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Request body for `PATCH /v1/boards/:id` — JSON Merge Patch (RFC 7386):
 /// absent field = no change, `null` = clear, value = set (see [`Patch`]).
 ///
@@ -40,6 +72,7 @@ pub struct CreateBoardRequest {
 /// intentionally excluded from the wire contract: they are computed by the
 /// server (sprint activation, board ordering) and never accepted from a client.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(remote = "Self")]
 pub struct UpdateBoardRequest {
     #[serde(default)]
     pub name: Option<String>,
@@ -59,6 +92,26 @@ pub struct UpdateBoardRequest {
     pub task_list_view: Option<TaskListViewDto>,
 }
 
+impl Serialize for UpdateBoardRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Self::serialize(self, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for UpdateBoardRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        reject_legacy_completion_column_ids(&value).map_err(serde::de::Error::custom)?;
+        Self::deserialize(value).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Request body for `PUT /v1/boards/:id` — a true full replace per
 /// [RFC 9110 §9.3.4](https://www.rfc-editor.org/info/rfc9110/): the body is the
 /// complete client-editable state. Nullable fields are cleared when omitted;
@@ -67,6 +120,7 @@ pub struct UpdateBoardRequest {
 /// body is a PATCH, not a PUT. Server-managed fields are excluded as in
 /// [`UpdateBoardRequest`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(remote = "Self")]
 pub struct ReplaceBoardRequest {
     pub name: String,
     #[serde(default)]
@@ -80,6 +134,26 @@ pub struct ReplaceBoardRequest {
     #[serde(default)]
     pub sprint_duration_days: Option<u32>,
     pub task_list_view: TaskListViewDto,
+}
+
+impl Serialize for ReplaceBoardRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Self::serialize(self, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReplaceBoardRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        reject_legacy_completion_column_ids(&value).map_err(serde::de::Error::custom)?;
+        Self::deserialize(value).map_err(serde::de::Error::custom)
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -365,7 +365,7 @@ async fn test_post_board_persists_to_disk() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_patch_board_ignores_a_legacy_completion_column_ids_key() {
+async fn test_patch_board_rejects_a_legacy_completion_column_ids_key() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -386,10 +386,12 @@ async fn test_patch_board_ignores_a_legacy_completion_column_ids_key() {
 
     assert_eq!(
         response.status(),
-        StatusCode::OK,
-        "a legacy completion_column_ids key must be ignored, not rejected"
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "a legacy completion_column_ids key must be rejected with a 422"
     );
     let body = json_of(response).await;
-    assert_eq!(body["name"], "Renamed");
-    assert!(body.get("completion_column_ids").is_none());
+    assert!(
+        body["message"].as_str().unwrap().contains("default_status"),
+        "the error must name the default_status replacement: {body}"
+    );
 }


### PR DESCRIPTION
Two residues from the completion-column model change. Closes KAN-1395, part of KAN-1388.

Completion columns are derived, not stored: a column is a completion column iff `default_status == Some(CardStatus::Done)` (`completion_derivation.rs`). `completion_column_ids` was correctly removed from the board DTOs when that landed. What was left behind was a doc comment pointing integrators at an endpoint that discards the field, and silent acceptance of the field itself.

## Breaking change for 0.8.x clients

A `completion_column_ids` key on create, update or replace is now **rejected with a 422** instead of being silently ignored. Both behaviours are breaking for a client still sending it, since the write never took effect either way. The difference is that the client now finds out from an error naming `default_status` rather than from a debugging session.

The error names the replacement path explicitly:

> `completion_column_ids` was removed: a column's completion status is now derived from `default_status` (see `is_completion_column` in kanban-domain). Set `default_status` via `POST /v1/boards/:board_id/columns`, `PATCH /v1/columns/:id`, or `PUT /v1/boards/:board_id/columns/:id`, and read it back on `ColumnResponse.default_status`.

## Notes for review

**The `#[serde(remote = "Self")]` idiom is the load-bearing part.** Rejection has to happen during deserialization, before serde discards the unknown key. Each DTO keeps its derived logic as inherent `Self::serialize`/`Self::deserialize`, gains a thin forwarding `impl Serialize`, and a hand-written `impl Deserialize` that checks for the legacy key before delegating. Serialization output is unchanged, which `test_update_board_request_omits_no_change_patch_fields_on_serialize` continues to pin.

**No server change was needed.** `AppJson` already maps any `JsonRejection` to `ValidationFailed` and a 422.

**Four tests were renamed rather than deleted.** They encoded the old ignore-the-key contract; deleting them would have lost the specification. Three are in `kanban-api`, and a fourth end-to-end pin in `kanban-server/tests/boards_write.rs` was brought in line too. It was not on the card's list but asserted the same now-false behaviour.

`cargo test -p kanban-api` 135/135, `kanban-server` 14/14 on the affected suite, `kanban-mcp` checks clean. Workspace gates left to CI.