### PR TITLE
KAN-1389 fix(tui): surface archive and delete failures during the completion animation

### DIFF
--- a/.changeset/kan-1389-animation-error-surfacing.md
+++ b/.changeset/kan-1389-animation-error-surfacing.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Surface an error banner when archiving or deleting cards fails during the completion animation

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -69,6 +69,7 @@ impl App {
             match self.execute_commands_batch(commands) {
                 Err(e) => {
                     tracing::error!("Failed to archive cards: {}", e);
+                    self.set_error(format!("Failed to archive cards: {}", e));
                     false
                 }
                 Ok(_) => true,
@@ -91,6 +92,7 @@ impl App {
             match self.execute_commands_batch(delete_commands) {
                 Err(e) => {
                     tracing::error!("Failed to delete cards: {}", e);
+                    self.set_error(format!("Failed to delete cards: {}", e));
                     false
                 }
                 Ok(_) => true,

--- a/crates/kanban-tui/tests/animation_tick_reload_tests.rs
+++ b/crates/kanban-tui/tests/animation_tick_reload_tests.rs
@@ -489,6 +489,124 @@ fn test_animation_tick_archive_selection_skips_a_card_restored_in_the_same_tick(
 }
 
 #[test]
+fn test_animation_tick_with_a_failed_archive_batch_sets_the_error_banner() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, card.id, AnimationType::Archiving);
+    // Delete the card out from under the pending archive animation so its
+    // batch fails at execution time (card not found).
+    app.ctx.data_store().delete_card(card.id).unwrap();
+
+    assert!(
+        app.ui_state.banner.is_none(),
+        "no banner should be set before the tick runs"
+    );
+
+    app.handle_animation_tick();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("a failed archive batch must set an error banner");
+    assert_eq!(banner.variant, kanban_tui::components::BannerVariant::Error);
+}
+
+#[test]
+fn test_animation_tick_with_a_failed_delete_batch_sets_the_error_banner() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "ToDelete".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, card.id, AnimationType::Deleting);
+    // Purge the card out from under the pending delete animation so its
+    // batch fails at execution time (card not found).
+    app.ctx.data_store().delete_card(card.id).unwrap();
+    app.ctx.data_store().delete_archived_card(card.id).unwrap();
+
+    assert!(
+        app.ui_state.banner.is_none(),
+        "no banner should be set before the tick runs"
+    );
+
+    app.handle_animation_tick();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("a failed delete batch must set an error banner");
+    assert_eq!(banner.variant, kanban_tui::components::BannerVariant::Error);
+}
+
+#[test]
+fn test_animation_tick_with_a_successful_batch_sets_no_error_banner() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    insert_completed_animation(&mut app, card.id, AnimationType::Archiving);
+
+    app.handle_animation_tick();
+
+    assert!(
+        app.ui_state.banner.is_none(),
+        "a successful archive must not set an error banner"
+    );
+}
+
+#[test]
 fn test_animation_tick_archive_succeeds_delete_fails_reloads_once_and_still_selects() {
     let mut app = App::test_default();
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();


### PR DESCRIPTION
An archive or delete that fails during the card-completion animation was logged and then discarded. In a terminal UI that is indistinguishable from a dropped keypress: the card is still there after the next refresh, with no message, so the user retries and it fails the same silent way.

Closes KAN-1389, part of KAN-1388.

Both call sites in `animation_tick.rs` now call `set_error` alongside the existing `tracing::error!`. The log and the banner serve different audiences and both are wanted. No control-flow or return-value changes.

## Notes for review

The tests force real failures rather than mocking: they delete the card out from under a pending animation so the batch genuinely fails, then assert the banner. `test_animation_tick_with_a_successful_batch_sets_no_error_banner` is the regression pin, so the fix cannot degenerate into always erroring.

The same swallow-and-log shape exists in `app/reload_watch.rs` on the auto-reload path. It is deliberately not touched here, since it is an unrelated path, and is tracked on KAN-1396.

`cargo test -p kanban-tui` green, `fmt --check` clean. Workspace gates left to CI.