### PR TITLE
KAN-1403 fix(service): scope a single-board export to its own dependency edges

### DIFF
--- a/.changeset/kan-1403-export-edge-scoping.md
+++ b/.changeset/kan-1403-export-edge-scoping.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: single-board export now scopes dependency-graph edges (spawns, blocks, relates) to the exported board's own live and archived cards instead of carrying the whole workspace graph, using the merged `DependencyGraph::filtered_to`. Dropped cross-board edges are logged at `warn` level. Full-workspace export is unaffected.

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -269,7 +269,21 @@ impl KanbanContext {
             // If the board itself is archived, carry its marker.
             let archived_boards = self.backend.get_archived_board(id)?.into_iter().collect();
             let sprints = self.backend.list_sprints_by_board(id)?;
-            let graph = self.backend.get_graph()?;
+            let keep: std::collections::HashSet<_> = cards
+                .iter()
+                .map(|c| c.id)
+                .chain(archived_card_ids.iter().copied())
+                .collect();
+            let full_graph = self.backend.get_graph()?;
+            let graph = full_graph.filtered_to(&keep);
+            let dropped = full_graph.len() - graph.len();
+            if dropped > 0 {
+                tracing::warn!(
+                    board_id = %id,
+                    dropped_edges = dropped,
+                    "single-board export dropped dependency edges not wholly within the board"
+                );
+            }
             // Only the namespaces these entities are actually addressed by.
             // The whole table would transplant unrelated boards' numbering into
             // whatever store this export is later imported into.

--- a/crates/kanban-service/tests/export_board_edge_scoping.rs
+++ b/crates/kanban-service/tests/export_board_edge_scoping.rs
@@ -1,0 +1,132 @@
+//! Single-board export must scope the dependency-graph edges it carries to
+//! the exported board's own cards, not the whole workspace graph.
+
+use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, KanbanResult};
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+async fn open_json(path: &std::path::Path) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+fn new_board_with_two_cards(
+    ctx: &mut KanbanContext,
+    name: &str,
+) -> KanbanResult<(uuid::Uuid, uuid::Uuid, uuid::Uuid)> {
+    let board = ctx.create_board(name.into(), None)?;
+    let column = ctx.create_column(board.id, "TODO".into(), None)?;
+    let a = ctx.create_card(
+        board.id,
+        column.id,
+        "A".into(),
+        CreateCardOptions::default(),
+    )?;
+    let b = ctx.create_card(
+        board.id,
+        column.id,
+        "B".into(),
+        CreateCardOptions::default(),
+    )?;
+    Ok((board.id, a.id, b.id))
+}
+
+fn spawns_edges(export: &str) -> Vec<serde_json::Value> {
+    let value: serde_json::Value = serde_json::from_str(export).unwrap();
+    value["graph"]["spawns"]["edges"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn has_edge(edges: &[serde_json::Value], source: uuid::Uuid, target: uuid::Uuid) -> bool {
+    edges.iter().any(|e| {
+        e["source"] == serde_json::Value::String(source.to_string())
+            && e["target"] == serde_json::Value::String(target.to_string())
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_single_board_export_omits_other_boards_edges() {
+    let dir = tempdir().unwrap();
+    let mut ctx = open_json(&dir.path().join("test.json")).await;
+
+    let (board_a, a1, a2) = new_board_with_two_cards(&mut ctx, "Board A").unwrap();
+    let (_board_b, b1, b2) = new_board_with_two_cards(&mut ctx, "Board B").unwrap();
+
+    ctx.attach_child(a1, a2).unwrap();
+    ctx.attach_child(b1, b2).unwrap();
+
+    let exported = ctx.export_board(Some(board_a)).unwrap();
+    let edges = spawns_edges(&exported);
+
+    assert!(
+        has_edge(&edges, a1, a2),
+        "board A's own edge must be present"
+    );
+    assert!(
+        !has_edge(&edges, b1, b2),
+        "board B's edge must not leak into board A's export"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_single_board_export_drops_cross_board_edge() {
+    let dir = tempdir().unwrap();
+    let mut ctx = open_json(&dir.path().join("test.json")).await;
+
+    let (board_a, a1, _a2) = new_board_with_two_cards(&mut ctx, "Board A").unwrap();
+    let (_board_b, _b1, b2) = new_board_with_two_cards(&mut ctx, "Board B").unwrap();
+
+    ctx.attach_child(a1, b2).unwrap();
+
+    let exported = ctx.export_board(Some(board_a)).unwrap();
+    let edges = spawns_edges(&exported);
+
+    assert!(
+        !has_edge(&edges, a1, b2),
+        "an edge with only one endpoint on the exported board must be dropped"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_single_board_export_keeps_its_own_archived_edges() {
+    let dir = tempdir().unwrap();
+    let mut ctx = open_json(&dir.path().join("test.json")).await;
+
+    let (board_a, a1, a2) = new_board_with_two_cards(&mut ctx, "Board A").unwrap();
+    ctx.attach_child(a1, a2).unwrap();
+    ctx.archive_card(a1).unwrap();
+    ctx.archive_card(a2).unwrap();
+
+    let exported = ctx.export_board(Some(board_a)).unwrap();
+    let edges = spawns_edges(&exported);
+
+    assert!(
+        has_edge(&edges, a1, a2),
+        "an archived edge between two archived cards on the exported board must survive"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_full_workspace_export_carries_every_edge() {
+    let dir = tempdir().unwrap();
+    let mut ctx = open_json(&dir.path().join("test.json")).await;
+
+    let (_board_a, a1, a2) = new_board_with_two_cards(&mut ctx, "Board A").unwrap();
+    let (_board_b, b1, b2) = new_board_with_two_cards(&mut ctx, "Board B").unwrap();
+
+    ctx.attach_child(a1, a2).unwrap();
+    ctx.attach_child(b1, b2).unwrap();
+
+    let exported = ctx.export_board(None).unwrap();
+    let edges = spawns_edges(&exported);
+
+    assert!(has_edge(&edges, a1, a2), "board A's edge must be present");
+    assert!(has_edge(&edges, b1, b2), "board B's edge must be present");
+}


### PR DESCRIPTION
A single-board export called `get_graph()` unscoped, so it carried the entire workspace's dependency graph. Every other read on that branch of `export_board_impl` is board-scoped; this one was not.

Closes KAN-1403, part of KAN-1387. The companion fix, KAN-1404, makes import merge rather than replace, which is the half that prevents data loss from export files users already have.

Uses `DependencyGraph::filtered_to` from KAN-1402. Archived cards are included in the kept set, since they are exported and their edges are part of the board's structure.

## Notes for review

**Cross-board edges are dropped, not carried.** An edge with one endpoint outside the exported board cannot survive: keeping it would create an edge pointing at a card id that does not exist in the destination, and a dangling edge is a corrupt state that looks fine until something traverses it. A missing cross-board edge is at least an honest one. The count is logged at warn.

**The count is logged, deliberately not returned.** `export_board` returns `KanbanResult<String>` from a trait implemented in four crates, so threading a count out of it would turn this into a cross-crate interface change. Surfacing it in the UI is noted as a follow-up on the card.

**`test_full_workspace_export_carries_every_edge` is the regression pin** for the `board_id = None` path, which legitimately carries the whole graph and must keep doing so. All four tests assert on the exported graph's contents rather than on log output.

`cargo test -p kanban-service` green, clippy and fmt clean. Workspace gates left to CI.