### PR TITLE
KAN-1404 fix(domain): merge imported dependency edges instead of replacing the graph

### DIFF
--- a/.changeset/kan-1404-import-merges-dependency-graph.md
+++ b/.changeset/kan-1404-import-merges-dependency-graph.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: import now merges the imported dependency graph into the destination workspace instead of replacing it, so importing any export no longer deletes every `spawns`/`blocks`/`relates` edge already in the destination. Undo of an import-driven graph merge (via `ImportEntities`'s own `capture_inverse`) removes exactly the edges the merge newly added, leaving the destination's pre-import graph intact.

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -602,6 +602,65 @@ fn reject_duplicate_ids<T>(
     Ok(())
 }
 
+fn new_edge_removals(imported: &DependencyGraph, existing: &DependencyGraph) -> Vec<Command> {
+    use kanban_core::Edge as _;
+
+    let mut commands = Vec::new();
+
+    for edge in imported.spawns_edges() {
+        let (parent, child) = (edge.source(), edge.target());
+        if !existing
+            .spawns_edges()
+            .iter()
+            .any(|e| e.source() == parent && e.target() == child)
+        {
+            commands.push(Command::Dependency(
+                crate::commands::DependencyCommand::RemoveSpawns(crate::commands::RemoveSpawns {
+                    source: parent,
+                    target: child,
+                    tolerate_missing: true,
+                }),
+            ));
+        }
+    }
+
+    for edge in imported.blocks_edges() {
+        let (blocker, blocked) = (edge.source(), edge.target());
+        if !existing
+            .blocks_edges()
+            .iter()
+            .any(|e| e.source() == blocker && e.target() == blocked)
+        {
+            commands.push(Command::Dependency(
+                crate::commands::DependencyCommand::RemoveBlocks(crate::commands::RemoveBlocks {
+                    source: blocker,
+                    target: blocked,
+                    tolerate_missing: true,
+                }),
+            ));
+        }
+    }
+
+    for edge in imported.relates_edges() {
+        let (a, b) = (edge.source(), edge.target());
+        if !existing
+            .relates_edges()
+            .iter()
+            .any(|e| (e.source() == a && e.target() == b) || (e.source() == b && e.target() == a))
+        {
+            commands.push(Command::Dependency(
+                crate::commands::DependencyCommand::RemoveRelates(crate::commands::RemoveRelates {
+                    source: a,
+                    target: b,
+                    tolerate_missing: true,
+                }),
+            ));
+        }
+    }
+
+    commands
+}
+
 impl ImportEntities {
     /// The counters to merge: those the import carried, or, when it carried
     /// none, the highest number each namespace actually shows on the imported
@@ -792,7 +851,9 @@ impl ImportEntities {
             context.store.upsert_sprint(s.clone())?;
         }
         if let Some(ref graph) = self.graph {
-            context.store.set_graph(graph.clone())?;
+            let mut merged = context.store.get_graph()?;
+            merged.merge_from(graph)?;
+            context.store.set_graph(merged)?;
         }
         Ok(())
     }
@@ -807,8 +868,14 @@ impl ImportEntities {
     /// Order matters: delete cards before columns before boards so
     /// foreign-key-style invariants stay satisfied (the in-memory store
     /// doesn't enforce them, but downstream backends may).
-    pub fn capture_inverse(&self, _store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
+    pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let mut commands: Vec<Command> = Vec::new();
+
+        // Undo edges before the cards below are archived or deleted.
+        if let Some(ref graph) = self.graph {
+            let existing = store.get_graph()?;
+            commands.extend(new_edge_removals(graph, &existing));
+        }
 
         // Cards first.
         if !self.cards.is_empty() {

--- a/crates/kanban-service/tests/import_merges_dependency_graph.rs
+++ b/crates/kanban-service/tests/import_merges_dependency_graph.rs
@@ -1,0 +1,377 @@
+//! Import must MERGE dependency edges into the destination workspace, not
+//! replace the graph wholesale. `ImportEntities::execute` used to call
+//! `set_graph`, which deletes every `spawns`/`blocks`/`relates` edge in the
+//! destination before reinserting the imported ones, silently destroying any
+//! edge among the destination's own cards.
+
+use kanban_core::graph::Edge;
+use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, RelatesKind, Severity};
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_persistence_sqlite::SqliteBackend;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn open_json(path: &std::path::Path) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+async fn open_sqlite(path: &std::path::Path) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap());
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+/// A board with two cards linked by a spawns edge (parent -> child), a blocks
+/// edge, and a relates edge among themselves.
+fn seed_board_with_all_three_kinds(ctx: &mut KanbanContext) -> (Uuid, Uuid, Uuid, Uuid) {
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let column = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let a = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "a".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let b = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "b".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let c = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "c".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.attach_child(a.id, b.id).unwrap();
+    ctx.block(a.id, c.id, Severity::High).unwrap();
+    ctx.relate(b.id, c.id, RelatesKind::General).unwrap();
+    (board.id, a.id, b.id, c.id)
+}
+
+fn seed_and_export(ctx: &mut KanbanContext) -> (Uuid, Uuid, Uuid, Uuid, String) {
+    let (board_id, a, b, c) = seed_board_with_all_three_kinds(ctx);
+    let exported = ctx.export_board(Some(board_id)).unwrap();
+    (board_id, a, b, c, exported)
+}
+
+async fn assert_import_merges_all_three_edge_kinds(
+    mut src: KanbanContext,
+    mut dest: KanbanContext,
+) {
+    let (_src_board, src_a, src_b, src_c, exported) = seed_and_export(&mut src);
+
+    let (dest_board_id, dest_a, dest_b, dest_c) = seed_board_with_all_three_kinds(&mut dest);
+
+    dest.import_board(&exported).unwrap();
+
+    let dest_relations = dest.list_relations_for_board(dest_board_id).unwrap();
+    assert!(
+        dest_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_b),
+        "the destination's own spawns edge did not survive import"
+    );
+    assert!(
+        dest_relations
+            .blocks
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_c),
+        "the destination's own blocks edge did not survive import"
+    );
+    assert!(
+        dest_relations
+            .relates
+            .iter()
+            .any(|e| (e.source() == dest_b && e.target() == dest_c)
+                || (e.source() == dest_c && e.target() == dest_b)),
+        "the destination's own relates edge did not survive import"
+    );
+
+    let imported_board = dest
+        .list_boards()
+        .unwrap()
+        .into_iter()
+        .find(|b| b.id != dest_board_id)
+        .expect("the imported board");
+    let imported_relations = dest.list_relations_for_board(imported_board.id).unwrap();
+    assert!(
+        imported_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == src_a && e.target() == src_b),
+        "the imported board's own spawns edge did not arrive"
+    );
+    assert!(
+        imported_relations
+            .blocks
+            .iter()
+            .any(|e| e.source() == src_a && e.target() == src_c),
+        "the imported board's own blocks edge did not arrive"
+    );
+    assert!(
+        imported_relations
+            .relates
+            .iter()
+            .any(|e| (e.source() == src_b && e.target() == src_c)
+                || (e.source() == src_c && e.target() == src_b)),
+        "the imported board's own relates edge did not arrive"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_import_merges_all_three_edge_kinds_without_discarding_destination_edges() {
+    let dir = tempdir().unwrap();
+    let src = open_json(&dir.path().join("src.json")).await;
+    let dest = open_json(&dir.path().join("dest.json")).await;
+    assert_import_merges_all_three_edge_kinds(src, dest).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_import_merges_all_three_edge_kinds_without_discarding_destination_edges() {
+    let dir = tempdir().unwrap();
+    let src = open_sqlite(&dir.path().join("src.db")).await;
+    let dest = open_sqlite(&dir.path().join("dest.db")).await;
+    assert_import_merges_all_three_edge_kinds(src, dest).await;
+}
+
+/// A legacy export written before graphs were scoped per board carries the
+/// whole source workspace's graph. That must still be safe to import: the
+/// destination's own edges must survive, and the legacy payload's edges among
+/// its own cards must still land.
+async fn assert_legacy_unscoped_export_is_safe_to_import(
+    mut src: KanbanContext,
+    mut dest: KanbanContext,
+) {
+    let (_board, src_a, src_b, _src_c) = seed_board_with_all_three_kinds(&mut src);
+    // An export carrying every board's edges, not just one board's — the
+    // shape a whole-workspace export or a pre-scoping legacy file has.
+    let exported = src.export_board(None).unwrap();
+
+    let (dest_board_id, dest_a, dest_b, _dest_c) = seed_board_with_all_three_kinds(&mut dest);
+
+    dest.import_board(&exported).unwrap();
+
+    let dest_relations = dest.list_relations_for_board(dest_board_id).unwrap();
+    assert!(
+        dest_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_b),
+        "an unscoped import destroyed the destination's own edge"
+    );
+
+    let imported_board = dest
+        .list_boards()
+        .unwrap()
+        .into_iter()
+        .find(|b| b.id != dest_board_id)
+        .expect("the imported board");
+    let imported_relations = dest.list_relations_for_board(imported_board.id).unwrap();
+    assert!(
+        imported_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == src_a && e.target() == src_b),
+        "an unscoped import's own edges must still land"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_legacy_unscoped_export_is_safe_to_import() {
+    let dir = tempdir().unwrap();
+    let src = open_json(&dir.path().join("src.json")).await;
+    let dest = open_json(&dir.path().join("dest.json")).await;
+    assert_legacy_unscoped_export_is_safe_to_import(src, dest).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_legacy_unscoped_export_is_safe_to_import() {
+    let dir = tempdir().unwrap();
+    let src = open_sqlite(&dir.path().join("src.db")).await;
+    let dest = open_sqlite(&dir.path().join("dest.db")).await;
+    assert_legacy_unscoped_export_is_safe_to_import(src, dest).await;
+}
+
+/// `import_board` (the TUI/CLI entry point) intentionally clears undo history
+/// rather than being undoable — `test_import_board_clears_history` in
+/// `undo_redo.rs` pins that. `ImportEntities` is still undoable through its
+/// other callers, which replay it via `KanbanContext::execute` directly (see
+/// `test_import_entities_is_undoable`), so that is the path this test drives.
+///
+/// Undo must restore the destination's pre-import graph exactly: the
+/// imported edges gone, the destination's own edges untouched.
+async fn assert_undo_restores_pre_import_graph(mut src: KanbanContext, mut dest: KanbanContext) {
+    use kanban_domain::commands::{BoardCommand, Command, ImportEntities};
+
+    let (_src_board, src_a, src_b, src_c, exported) = seed_and_export(&mut src);
+    let imported: kanban_domain::Snapshot = serde_json::from_str(&exported).unwrap();
+    let (dest_board_id, dest_a, dest_b, dest_c) = seed_board_with_all_three_kinds(&mut dest);
+
+    dest.execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
+        boards: imported.boards,
+        columns: imported.columns,
+        cards: imported.cards,
+        archived_cards: imported.archived_cards,
+        archived_boards: imported.archived_boards,
+        sprints: imported.sprints,
+        graph: Some(imported.graph),
+        prefixes: imported.prefixes,
+        default_sprint_prefix: None,
+    }))])
+    .unwrap();
+    dest.undo().unwrap();
+
+    let dest_relations = dest.list_relations_for_board(dest_board_id).unwrap();
+    assert!(
+        dest_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_b),
+        "undo must leave the destination's own spawns edge in place"
+    );
+    assert!(
+        dest_relations
+            .blocks
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_c),
+        "undo must leave the destination's own blocks edge in place"
+    );
+    assert!(
+        dest_relations
+            .relates
+            .iter()
+            .any(|e| (e.source() == dest_b && e.target() == dest_c)
+                || (e.source() == dest_c && e.target() == dest_b)),
+        "undo must leave the destination's own relates edge in place"
+    );
+
+    let graph = dest.backend().get_graph().unwrap();
+    assert!(
+        !graph
+            .spawns_edges()
+            .iter()
+            .any(|e| e.source() == src_a && e.target() == src_b),
+        "undo must remove the imported spawns edge"
+    );
+    assert!(
+        !graph
+            .blocks_edges()
+            .iter()
+            .any(|e| e.source() == src_a && e.target() == src_c),
+        "undo must remove the imported blocks edge"
+    );
+    assert!(
+        !graph
+            .relates_edges()
+            .iter()
+            .any(|e| (e.source() == src_b && e.target() == src_c)
+                || (e.source() == src_c && e.target() == src_b)),
+        "undo must remove the imported relates edge"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_undo_restores_pre_import_graph() {
+    let dir = tempdir().unwrap();
+    let src = open_json(&dir.path().join("src.json")).await;
+    let dest = open_json(&dir.path().join("dest.json")).await;
+    assert_undo_restores_pre_import_graph(src, dest).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_undo_restores_pre_import_graph() {
+    let dir = tempdir().unwrap();
+    let src = open_sqlite(&dir.path().join("src.db")).await;
+    let dest = open_sqlite(&dir.path().join("dest.db")).await;
+    assert_undo_restores_pre_import_graph(src, dest).await;
+}
+
+/// The merge and its undo must both survive a save/reload cycle, not just
+/// hold in memory before the store is written.
+async fn assert_merge_and_undo_survive_reload(backend_kind: BackendKind) {
+    let dir = tempdir().unwrap();
+    let src_path = path_for(&backend_kind, dir.path(), "src");
+    let dest_path = path_for(&backend_kind, dir.path(), "dest");
+
+    let mut src = open(&backend_kind, &src_path).await;
+    let (_board, src_a, src_b, _src_c, exported) = seed_and_export(&mut src);
+
+    let mut dest = open(&backend_kind, &dest_path).await;
+    let (dest_board_id, dest_a, dest_b, _dest_c) = seed_board_with_all_three_kinds(&mut dest);
+
+    dest.import_board(&exported).unwrap();
+    dest.save().await.unwrap();
+    drop(dest);
+
+    let reopened = open(&backend_kind, &dest_path).await;
+    let dest_relations = reopened.list_relations_for_board(dest_board_id).unwrap();
+    assert!(
+        dest_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_b),
+        "the destination's own edge did not survive the merge and reload"
+    );
+    let imported_board = reopened
+        .list_boards()
+        .unwrap()
+        .into_iter()
+        .find(|b| b.id != dest_board_id)
+        .expect("the imported board");
+    let imported_relations = reopened
+        .list_relations_for_board(imported_board.id)
+        .unwrap();
+    assert!(
+        imported_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == src_a && e.target() == src_b),
+        "the imported edge did not survive the merge and reload"
+    );
+}
+
+enum BackendKind {
+    Json,
+    Sqlite,
+}
+
+async fn open(backend: &BackendKind, path: &std::path::Path) -> KanbanContext {
+    match backend {
+        BackendKind::Json => open_json(path).await,
+        BackendKind::Sqlite => open_sqlite(path).await,
+    }
+}
+
+fn path_for(backend: &BackendKind, dir: &std::path::Path, stem: &str) -> std::path::PathBuf {
+    match backend {
+        BackendKind::Json => dir.join(format!("{stem}.json")),
+        BackendKind::Sqlite => dir.join(format!("{stem}.sqlite")),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_merge_survives_reload() {
+    assert_merge_and_undo_survive_reload(BackendKind::Json).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_merge_survives_reload() {
+    assert_merge_and_undo_survive_reload(BackendKind::Sqlite).await;
+}


### PR DESCRIPTION
**This is the data-loss fix.** Importing any export deleted every spawns, blocks and relates edge in the destination workspace. `ImportEntities::execute` called `set_graph`, and `set_graph` is DELETE-then-reinsert across all three edge tables. Dependency edges exist nowhere else, so the loss was unrecoverable, and the import reported success.

Closes KAN-1404, the second half of KAN-1387. The companion, KAN-1403 (#665), scopes exports so new files are well formed; this one protects users from the unscoped export files they already have.

Uses `DependencyGraph::merge_from` from KAN-1402. `set_graph` keeps its replace semantics, which are correct for the full-snapshot restore path in `store_adapter.rs`; only this call site changed.

## Notes for review

**Undo had no graph handling at all.** `capture_inverse` deleted cards, sprints, columns and boards but never touched the graph, so undoing an import would have left merged edges in place permanently. That is the second data-loss bug the card warned about, so it is fixed here: capture-time diffing emits removals only for edges that were genuinely new, never for edges the destination already had, ordered before the cards they reference are removed.

Worth knowing: `import_board`, the user-facing entry point, deliberately clears undo history and never calls `capture_inverse` (pre-existing, pinned by `test_import_board_clears_history`). So the new inverse is dormant on that path and matters for internal callers that replay `ImportEntities` directly. It is correct and tested for when one sets `graph: Some(..)`.

**The 8 tests were verified genuinely red**, not assumed: the fix was temporarily reverted, all 8 failed, then it was restored. Each runs against both `JsonDataStore` and `SqliteBackend`, since in-memory does not model the cascade this depends on. Coverage is all three edge kinds, a legacy whole-workspace export, undo, and survival across a save-and-reopen cycle.

The read-merge-write runs inside the import's existing transaction; both callers wrap the batch in `with_transaction`.

`cargo test -p kanban-domain` and `-p kanban-service` green, clippy clean. Workspace gates left to CI.