### PR TITLE
KAN-1392 test(persistence-json,persistence-sqlite): whole-graph and cross-backend migration coverage

### DIFF
--- a/.changeset/kan-1392-whole-graph-migration-coverage.md
+++ b/.changeset/kan-1392-whole-graph-migration-coverage.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+persistence-json,persistence-sqlite: whole-graph and cross-backend coverage for the V14-V18 JSON migration chain (schema 9-13 on SQLite). Every prior test in this chain fixtured a bare board plus cards with empty columns/sprints/edges; the new tests seed a non-trivial graph (two columns, one WIP-limited, several cards, a sprint with bound cards, an archived card, and one edge of each of the three kinds) and assert it survives the full chain intact, plus a cross-backend agreement test comparing the JSON and SQLite prefix rows and card-prefix stamps for the same scenario. No migration defects found; the new tests are regression pins.

--- a/crates/kanban-persistence-json/tests/whole_graph_migration.rs
+++ b/crates/kanban-persistence-json/tests/whole_graph_migration.rs
@@ -1,0 +1,260 @@
+//! Whole-graph coverage for the V14 -> V18 migration chain (prefixes
+//! backfill, card-prefix stamping, legacy-counter drop, prefix-row repair).
+//!
+//! Every other test in this chain fixtures a bare board plus cards, with
+//! empty `columns`, `sprints`, and edge arrays, so the chain is proven only
+//! to preserve boards and cards. This seeds a NON-TRIVIAL graph -- two
+//! columns (one WIP-limited), five cards spread across them, a sprint with
+//! two cards bound to it, one archived card (live under the reference-marker
+//! model, per `kanban_domain::archived_card`), and one edge of each of the
+//! three kinds -- and asserts every one of those survives the full chain
+//! with ids, positions, WIP limits, sprint bindings, and edges intact.
+//!
+//! Modeled on `tests/v15_migration.rs` (the V14 fixture shape) and
+//! `tests/v10_migration.rs` (the archived-card reference-marker shape).
+
+use kanban_persistence::{FormatVersion, PersistenceStore};
+use kanban_persistence_json::migration::Migrator;
+use kanban_persistence_json::JsonFileStore;
+use serde_json::{json, Value};
+use tempfile::tempdir;
+
+const BOARD: &str = "11111111-1111-1111-1111-111111111111";
+const COL_TODO: &str = "22222222-2222-2222-2222-222222222222";
+const COL_DOING: &str = "33333333-3333-3333-3333-333333333333";
+const SPRINT: &str = "44444444-4444-4444-4444-444444444444";
+
+const CARD_A: &str = "a0000000-0000-0000-0000-000000000001";
+const CARD_B: &str = "a0000000-0000-0000-0000-000000000002";
+const CARD_C: &str = "a0000000-0000-0000-0000-000000000003";
+const CARD_D: &str = "a0000000-0000-0000-0000-000000000004";
+const CARD_ARCHIVED: &str = "a0000000-0000-0000-0000-000000000005";
+
+fn card(id: &str, column_id: &str, position: i64, sprint_id: Option<&str>) -> Value {
+    json!({
+        "id": id,
+        "column_id": column_id,
+        "board_id": BOARD,
+        "title": format!("Card {id}"),
+        "description": null,
+        "priority": "Medium",
+        "status": "Todo",
+        "position": position,
+        "due_date": null,
+        "points": null,
+        "card_number": position + 1,
+        "sprint_id": sprint_id,
+        "sprint_logs": [],
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z",
+        "completed_at": null
+    })
+}
+
+fn v14_whole_graph_fixture() -> Value {
+    json!({
+        "version": 14,
+        "metadata": {
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "saved_at": "2024-01-01T00:00:00Z"
+        },
+        "data": {
+            "boards": [{
+                "id": BOARD, "name": "Kanban", "card_prefix": "KAN", "card_counter": 5,
+                "description": null, "sprint_prefix": null,
+                "task_sort_field": "Position", "task_sort_order": "Ascending",
+                "sprint_duration_days": null, "sprint_names": ["Sprint One"],
+                "sprint_name_used_count": 1, "sprint_counters": {"kan": 1},
+                "next_sprint_number": 2, "active_sprint_id": null,
+                "task_list_view": "Flat", "position": 0,
+                "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+            }],
+            "columns": [
+                {
+                    "id": COL_TODO, "board_id": BOARD, "name": "Todo", "position": 0,
+                    "wip_limit": null,
+                    "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+                },
+                {
+                    "id": COL_DOING, "board_id": BOARD, "name": "Doing", "position": 1,
+                    "wip_limit": 3,
+                    "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+                }
+            ],
+            "cards": [
+                card(CARD_A, COL_TODO, 0, None),
+                card(CARD_B, COL_TODO, 1, Some(SPRINT)),
+                card(CARD_C, COL_DOING, 0, Some(SPRINT)),
+                card(CARD_D, COL_DOING, 1, None),
+                card(CARD_ARCHIVED, COL_DOING, 2, None)
+            ],
+            "sprints": [{
+                "id": SPRINT, "board_id": BOARD, "name": "Sprint One", "number": 1,
+                "status": "Active", "card_prefix": null,
+                "start_date": null, "end_date": null,
+                "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+            }],
+            "archived_cards": [{
+                "entity_id": CARD_ARCHIVED,
+                "board_id": BOARD,
+                "archived_at": "2024-01-02T00:00:00Z"
+            }],
+            "graph": {
+                "spawns": { "edges": [
+                    { "source": CARD_A, "target": CARD_B, "created_at": "2024-01-01T00:00:00Z", "archived_at": null }
+                ] },
+                "blocks": { "edges": [
+                    { "source": CARD_B, "target": CARD_C, "severity": "High", "created_at": "2024-01-01T00:00:00Z", "archived_at": null }
+                ] },
+                "relates": { "edges": [
+                    { "source": CARD_C, "target": CARD_D, "kind": "Duplicates", "created_at": "2024-01-01T00:00:00Z", "archived_at": null }
+                ] }
+            }
+        }
+    })
+}
+
+fn write_fixture(path: &std::path::Path) {
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&v14_whole_graph_fixture()).unwrap(),
+    )
+    .unwrap();
+}
+
+fn read_json(path: &std::path::Path) -> Value {
+    serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+}
+
+fn ids_in(arr: &Value, key: &str) -> Vec<String> {
+    arr.as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|e| e.get(key).and_then(Value::as_str).map(str::to_string))
+        .collect()
+}
+
+fn card_by_id<'a>(env: &'a Value, id: &str) -> &'a Value {
+    env["data"]["cards"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["id"] == id)
+        .unwrap_or_else(|| panic!("card {id} missing after migration"))
+}
+
+/// Not a red step: the migrations are believed correct and this is a
+/// regression pin over a graph shape no fixture in this chain previously
+/// covered. If any assertion below had failed, that would have been a real
+/// migration defect worth stopping for, not something to paper over here.
+#[tokio::test]
+async fn test_migrate_v14_to_v18_preserves_the_whole_entity_graph() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("board.json");
+    write_fixture(&path);
+
+    Migrator::migrate(FormatVersion::V14, FormatVersion::MAX, &path)
+        .await
+        .expect("V14 -> V18 must succeed over a non-trivial graph");
+
+    let after = read_json(&path);
+    assert_eq!(after["version"], 18);
+
+    let board_ids = ids_in(&after["data"]["boards"], "id");
+    assert_eq!(board_ids, vec![BOARD.to_string()], "the board survives");
+
+    let columns = after["data"]["columns"].as_array().unwrap();
+    assert_eq!(columns.len(), 2, "both columns survive");
+    let todo = columns.iter().find(|c| c["id"] == COL_TODO).unwrap();
+    assert_eq!(todo["wip_limit"], Value::Null);
+    let doing = columns.iter().find(|c| c["id"] == COL_DOING).unwrap();
+    assert_eq!(doing["wip_limit"], 3, "the WIP limit on Doing survives");
+
+    let card_ids = ids_in(&after["data"]["cards"], "id");
+    for id in [CARD_A, CARD_B, CARD_C, CARD_D, CARD_ARCHIVED] {
+        assert!(card_ids.contains(&id.to_string()), "card {id} survives");
+    }
+    assert_eq!(card_by_id(&after, CARD_C)["position"], 0);
+    assert_eq!(card_by_id(&after, CARD_D)["position"], 1);
+
+    let sprint_ids = ids_in(&after["data"]["sprints"], "id");
+    assert_eq!(sprint_ids, vec![SPRINT.to_string()], "the sprint survives");
+    assert_eq!(card_by_id(&after, CARD_B)["sprint_id"], SPRINT);
+    assert_eq!(card_by_id(&after, CARD_C)["sprint_id"], SPRINT);
+    assert_eq!(card_by_id(&after, CARD_A)["sprint_id"], Value::Null);
+
+    let archived = after["data"]["archived_cards"].as_array().unwrap();
+    assert_eq!(archived.len(), 1);
+    assert_eq!(archived[0]["entity_id"], CARD_ARCHIVED);
+    assert_eq!(archived[0]["board_id"], BOARD);
+
+    let spawns = after["data"]["graph"]["spawns"]["edges"]
+        .as_array()
+        .unwrap();
+    assert_eq!(spawns.len(), 1, "the spawns edge survives");
+    assert_eq!(spawns[0]["source"], CARD_A);
+    assert_eq!(spawns[0]["target"], CARD_B);
+
+    let blocks = after["data"]["graph"]["blocks"]["edges"]
+        .as_array()
+        .unwrap();
+    assert_eq!(blocks.len(), 1, "the blocks edge survives");
+    assert_eq!(blocks[0]["source"], CARD_B);
+    assert_eq!(blocks[0]["target"], CARD_C);
+    assert_eq!(blocks[0]["severity"], "High");
+
+    let relates = after["data"]["graph"]["relates"]["edges"]
+        .as_array()
+        .unwrap();
+    assert_eq!(relates.len(), 1, "the relates edge survives");
+    assert_eq!(relates[0]["source"], CARD_C);
+    assert_eq!(relates[0]["target"], CARD_D);
+    assert_eq!(relates[0]["kind"], "Duplicates");
+
+    let prefixes = after["data"]["prefixes"].as_array().unwrap();
+    assert!(
+        prefixes.iter().any(|p| p["name"] == "kan"),
+        "the board's namespace was backfilled: {prefixes:#?}"
+    );
+    for id in [CARD_A, CARD_B, CARD_C, CARD_D, CARD_ARCHIVED] {
+        assert_eq!(
+            card_by_id(&after, id)["prefix"],
+            "KAN",
+            "card {id} was stamped with its board's namespace"
+        );
+    }
+
+    let board = &after["data"]["boards"][0];
+    assert!(board.get("card_counter").is_none());
+    assert!(board.get("sprint_counters").is_none());
+}
+
+/// Mirrors `test_sync_and_async_chains_produce_identical_v15_prefixes_output`
+/// in `tests/v15_migration.rs`, but over the whole graph rather than a
+/// boards-and-sprints-only fixture: the async orchestrator and the sync
+/// `load_sync` entry point must reach byte-identical output on a graph that
+/// also carries columns, sprint-bound cards, an archived card, and edges of
+/// every kind.
+#[tokio::test]
+async fn test_sync_and_async_chains_agree_on_the_whole_graph() {
+    let dir = tempdir().unwrap();
+    let async_path = dir.path().join("async.json");
+    let sync_path = dir.path().join("sync.json");
+    write_fixture(&async_path);
+    write_fixture(&sync_path);
+
+    Migrator::migrate(FormatVersion::V14, FormatVersion::MAX, &async_path)
+        .await
+        .expect("async V14 -> V18 must succeed");
+
+    let sync_store = JsonFileStore::new(&sync_path);
+    let _ = sync_store.load_sync().unwrap().expect("file exists");
+
+    let async_after = read_json(&async_path);
+    let sync_after = read_json(&sync_path);
+
+    assert_eq!(
+        async_after, sync_after,
+        "the async and sync migration chains must produce identical output over the whole graph"
+    );
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -31,6 +31,8 @@ mod prefix_repair;
 mod snapshot_atomicity;
 mod snapshot_prefix_ordering;
 mod transaction;
+mod whole_graph_cross_backend_agreement;
+mod whole_graph_migration_v12_to_v13;
 
 /// Ordered `board_completion_columns.column_id`s for a board, straight from
 /// the join table. Takes a raw pool rather than a `SqliteStore` because by

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/whole_graph_cross_backend_agreement.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/whole_graph_cross_backend_agreement.rs
@@ -1,0 +1,294 @@
+//! Whole-graph cross-backend agreement: one board, two columns, four cards
+//! (two bound to a sprint) driven through BOTH the SQLite and the JSON
+//! prefix-backfill and card-prefix-stamp transforms, asserting the two
+//! backends agree on the resulting `prefixes` rows and per-card stamped
+//! prefixes.
+//!
+//! `cross_backend_prefix_agreement.rs` and `cross_backend_card_stamp_agreement.rs`
+//! already prove backend agreement, but only over boards-and-sprints-only or
+//! single-column scenarios. This adds the missing multi-column,
+//! sprint-bound-card shape to that same comparison, reusing the identical
+//! transform entry points those files use.
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{Pool, Sqlite};
+use tempfile::TempDir;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+const TS: &str = "2024-01-01T00:00:00Z";
+
+const BOARD: &str = "11111111-1111-1111-1111-111111111111";
+const COL_TODO: &str = "22222222-2222-2222-2222-222222222222";
+const COL_DOING: &str = "33333333-3333-3333-3333-333333333333";
+const SPRINT: &str = "44444444-4444-4444-4444-444444444444";
+const CARD1: &str = "aaaaaaaa-1111-1111-1111-111111111111";
+const CARD2: &str = "aaaaaaaa-2222-2222-2222-222222222222";
+const CARD3: &str = "aaaaaaaa-3333-3333-3333-333333333333";
+const CARD4: &str = "aaaaaaaa-4444-4444-4444-444444444444";
+
+struct CardRow {
+    id: &'static str,
+    column_id: &'static str,
+    sprint_id: Option<&'static str>,
+    number: i64,
+}
+
+fn scenario_cards() -> Vec<CardRow> {
+    vec![
+        CardRow {
+            id: CARD1,
+            column_id: COL_TODO,
+            sprint_id: None,
+            number: 1,
+        },
+        CardRow {
+            id: CARD2,
+            column_id: COL_TODO,
+            sprint_id: Some(SPRINT),
+            number: 2,
+        },
+        CardRow {
+            id: CARD3,
+            column_id: COL_DOING,
+            sprint_id: Some(SPRINT),
+            number: 3,
+        },
+        CardRow {
+            id: CARD4,
+            column_id: COL_DOING,
+            sprint_id: None,
+            number: 4,
+        },
+    ]
+}
+
+type PrefixRow = (String, i64, i64);
+type StampRow = (String, String);
+
+const V9_SCHEMA: &str = "
+    CREATE TABLE metadata (
+        id INTEGER PRIMARY KEY CHECK (id = 1), instance_id TEXT NOT NULL,
+        saved_at TEXT NOT NULL, schema_version INTEGER NOT NULL,
+        writer_version TEXT, writer_commit TEXT
+    );
+    CREATE TABLE boards (
+        id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT,
+        sprint_prefix TEXT, card_prefix TEXT,
+        task_sort_field TEXT NOT NULL DEFAULT 'Default',
+        task_sort_order TEXT NOT NULL DEFAULT 'Ascending',
+        sprint_duration_days INTEGER,
+        sprint_name_used_count INTEGER NOT NULL DEFAULT 0,
+        next_sprint_number INTEGER NOT NULL DEFAULT 1,
+        active_sprint_id TEXT, task_list_view TEXT NOT NULL DEFAULT 'Flat',
+        card_counter INTEGER NOT NULL DEFAULT 1, position INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+    );
+    CREATE TABLE columns (
+        id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
+        position INTEGER NOT NULL, wip_limit INTEGER, default_status TEXT,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+    );
+    CREATE TABLE cards (
+        id TEXT PRIMARY KEY, column_id TEXT NOT NULL, board_id TEXT NOT NULL,
+        title TEXT NOT NULL, description TEXT,
+        priority TEXT NOT NULL DEFAULT 'Medium', status TEXT NOT NULL DEFAULT 'Todo',
+        position INTEGER NOT NULL, due_date TEXT,
+        points INTEGER CHECK (points >= 0 AND points <= 255),
+        card_number INTEGER NOT NULL DEFAULT 0, sprint_id TEXT,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL, completed_at TEXT
+    );
+    CREATE TABLE sprints (
+        id TEXT PRIMARY KEY, board_id TEXT NOT NULL, name TEXT NOT NULL,
+        number INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'Planned',
+        start_date TEXT, end_date TEXT,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+    );
+    CREATE TABLE spawns_edges (
+        source_id TEXT NOT NULL, target_id TEXT NOT NULL,
+        PRIMARY KEY (source_id, target_id)
+    );";
+
+async fn build_v9_db(path: &std::path::Path) -> Pool<Sqlite> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true),
+        )
+        .await
+        .unwrap();
+    sqlx::raw_sql(V9_SCHEMA).execute(&pool).await.unwrap();
+    sqlx::raw_sql(&format!(
+        "INSERT INTO metadata (id, instance_id, saved_at, schema_version)
+             VALUES (1, '00000000-0000-0000-0000-000000000001', '{TS}', 9);
+         INSERT INTO boards (id, name, card_prefix, created_at, updated_at)
+             VALUES ('{BOARD}', 'Board', 'KAN', '{TS}', '{TS}');
+         INSERT INTO columns (id, board_id, name, position, created_at, updated_at)
+             VALUES ('{COL_TODO}', '{BOARD}', 'Todo', 0, '{TS}', '{TS}'),
+                    ('{COL_DOING}', '{BOARD}', 'Doing', 1, '{TS}', '{TS}');
+         INSERT INTO sprints (id, board_id, name, number, created_at, updated_at)
+             VALUES ('{SPRINT}', '{BOARD}', 'Sprint One', 1, '{TS}', '{TS}');"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    for c in scenario_cards() {
+        sqlx::query(
+            "INSERT INTO cards (id, column_id, board_id, title, position, card_number, sprint_id,
+                                created_at, updated_at)
+             VALUES (?, ?, ?, 'Card', 0, ?, ?, ?, ?)",
+        )
+        .bind(c.id)
+        .bind(c.column_id)
+        .bind(BOARD)
+        .bind(c.number)
+        .bind(c.sprint_id)
+        .bind(TS)
+        .bind(TS)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    pool
+}
+
+async fn sqlite_prefix_rows() -> Vec<PrefixRow> {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v9.db");
+    build_v9_db(&path).await.close().await;
+    let store = SqliteStore::open(&path).await.unwrap();
+    let mut rows: Vec<PrefixRow> =
+        sqlx::query_as("SELECT name, card_counter, sprint_counter FROM prefixes")
+            .fetch_all(store.pool())
+            .await
+            .unwrap();
+    rows.sort();
+    rows
+}
+
+async fn sqlite_card_stamps() -> Vec<StampRow> {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v9.db");
+    build_v9_db(&path).await.close().await;
+    let store = SqliteStore::open(&path).await.unwrap();
+    let mut rows: Vec<StampRow> = sqlx::query_as("SELECT id, prefix FROM cards")
+        .fetch_all(store.pool())
+        .await
+        .unwrap();
+    rows.sort();
+    rows
+}
+
+fn json_envelope_v14() -> serde_json::Value {
+    let columns = serde_json::json!([
+        { "id": COL_TODO, "board_id": BOARD },
+        { "id": COL_DOING, "board_id": BOARD }
+    ]);
+    let cards: Vec<serde_json::Value> = scenario_cards()
+        .into_iter()
+        .map(|c| {
+            serde_json::json!({
+                "id": c.id, "column_id": c.column_id, "board_id": BOARD,
+                "sprint_id": c.sprint_id, "card_number": c.number,
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "version": 14,
+        "metadata": { "instance_id": "00000000-0000-0000-0000-000000000001", "saved_at": TS },
+        "data": {
+            "boards": [{ "id": BOARD, "name": "Board", "card_prefix": "KAN" }],
+            "columns": columns,
+            "cards": cards,
+            "archived_cards": [],
+            "sprints": [{ "id": SPRINT, "board_id": BOARD, "card_prefix": null }],
+            "graph": { "spawns": { "edges": [] }, "blocks": { "edges": [] }, "relates": { "edges": [] } }
+        }
+    })
+}
+
+async fn json_prefix_rows() -> Vec<PrefixRow> {
+    use kanban_persistence::FormatVersion;
+    use kanban_persistence_json::migration::Migrator;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("board.json");
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&json_envelope_v14()).unwrap(),
+    )
+    .unwrap();
+    Migrator::migrate(FormatVersion::V14, FormatVersion::MAX, &path)
+        .await
+        .unwrap();
+    let env: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    let mut rows: Vec<PrefixRow> = env["data"]["prefixes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                r["name"].as_str().unwrap().to_string(),
+                r["card_counter"].as_i64().unwrap(),
+                r["sprint_counter"].as_i64().unwrap(),
+            )
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+fn json_card_stamps() -> Vec<StampRow> {
+    let mut env = json_envelope_v14();
+    env["version"] = serde_json::json!(15);
+    kanban_persistence_json::migration_test_support::try_transform_v15_to_v16(&mut env).unwrap();
+    let mut rows: Vec<StampRow> = env["data"]["cards"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| {
+            (
+                c["id"].as_str().unwrap().to_string(),
+                c["prefix"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+#[test]
+fn test_both_backends_agree_on_prefix_rows_for_the_whole_graph() {
+    let rt = make_rt();
+    let sqlite = rt.block_on(sqlite_prefix_rows());
+    let json = rt.block_on(json_prefix_rows());
+    assert_eq!(
+        sqlite, json,
+        "prefix rows diverged over the whole-graph scenario.\nsqlite: {sqlite:#?}\njson: {json:#?}"
+    );
+}
+
+#[test]
+fn test_both_backends_agree_on_card_stamps_for_the_whole_graph() {
+    let rt = make_rt();
+    let sqlite = rt.block_on(sqlite_card_stamps());
+    let json = json_card_stamps();
+    assert_eq!(
+        sqlite, json,
+        "card stamps diverged over the whole-graph scenario.\nsqlite: {sqlite:#?}\njson: {json:#?}"
+    );
+    assert_eq!(
+        json,
+        vec![
+            (CARD1.to_string(), "KAN".to_string()),
+            (CARD2.to_string(), "KAN".to_string()),
+            (CARD3.to_string(), "KAN".to_string()),
+            (CARD4.to_string(), "KAN".to_string()),
+        ],
+        "agreement alone would pass if both backends stamped the wrong value; \
+         pin the actual expected prefix too"
+    );
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/whole_graph_migration_v12_to_v13.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/whole_graph_migration_v12_to_v13.rs
@@ -1,0 +1,244 @@
+//! Whole-graph coverage for the schema 12 -> 13 migration (the `cards`
+//! rebuild that backs `prefix` with a foreign key to `prefixes(name)`),
+//! matching `kanban-persistence-json/tests/whole_graph_migration.rs` on the
+//! SQLite side of the same risk area: `cards` is dropped and rebuilt, so a
+//! test that seeds only one card and one edge kind cannot prove the rebuild
+//! carries a real graph through intact.
+//!
+//! Extends the seed/revert pattern from `migration_v12_to_v13.rs` (seed the
+//! full graph through a real `SqliteStore::open`, then revert only `cards`
+//! to its pre-FK shape) with a second column carrying a WIP limit, a
+//! sprint-bound card, and a blocks edge and a relates edge alongside the
+//! existing spawns edge.
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{Pool, Sqlite};
+use std::path::Path;
+use tempfile::TempDir;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+const BOARD: &str = "00000000-0000-0000-0000-0000000000b1";
+const COLUMN_TODO: &str = "00000000-0000-0000-0000-0000000000c1";
+const COLUMN_DOING: &str = "00000000-0000-0000-0000-0000000000c2";
+const SPRINT: &str = "00000000-0000-0000-0000-000000000051";
+const CARD1: &str = "00000000-0000-0000-0000-0000000000a1";
+const CARD2: &str = "00000000-0000-0000-0000-0000000000a2";
+const CARD3: &str = "00000000-0000-0000-0000-0000000000a3";
+const CARD4: &str = "00000000-0000-0000-0000-0000000000a4";
+const TS: &str = "2024-01-01T00:00:00Z";
+
+async fn raw(path: &Path) -> Pool<Sqlite> {
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(false),
+        )
+        .await
+        .unwrap()
+}
+
+async fn count(pool: &Pool<Sqlite>, sql: &str) -> i64 {
+    sqlx::query_scalar(sql).fetch_one(pool).await.unwrap()
+}
+
+async fn seed_v12_with_whole_graph(path: &Path) {
+    {
+        let store = SqliteStore::open(path).await.unwrap();
+        let pool = store.pool();
+        sqlx::raw_sql(&format!(
+            "INSERT INTO boards (id, name, card_prefix, created_at, updated_at)
+                 VALUES ('{BOARD}','Board','KAN','{TS}','{TS}');
+             INSERT INTO columns (id, board_id, name, position, wip_limit, created_at, updated_at)
+                 VALUES ('{COLUMN_TODO}','{BOARD}','Todo',0,NULL,'{TS}','{TS}'),
+                        ('{COLUMN_DOING}','{BOARD}','Doing',1,3,'{TS}','{TS}');
+             INSERT INTO sprints (id, board_id, sprint_number, status, created_at, updated_at)
+                 VALUES ('{SPRINT}','{BOARD}',3,'Planning','{TS}','{TS}');
+             INSERT INTO prefixes (name, card_counter, sprint_counter)
+                 VALUES ('kan', 4, 1);
+             INSERT INTO cards (id, column_id, board_id, title, position, priority, status,
+                                card_number, prefix, sprint_id, created_at, updated_at)
+                 VALUES ('{CARD1}','{COLUMN_TODO}','{BOARD}','One',0,'medium','todo',1,'KAN',NULL,'{TS}','{TS}'),
+                        ('{CARD2}','{COLUMN_TODO}','{BOARD}','Two',1,'medium','todo',2,'KAN','{SPRINT}','{TS}','{TS}'),
+                        ('{CARD3}','{COLUMN_DOING}','{BOARD}','Three',0,'medium','todo',3,'KAN','{SPRINT}','{TS}','{TS}'),
+                        ('{CARD4}','{COLUMN_DOING}','{BOARD}','Four',1,'medium','todo',4,'KAN',NULL,'{TS}','{TS}');
+             INSERT INTO spawns_edges (source_id, target_id, created_at)
+                 VALUES ('{CARD1}','{CARD2}','{TS}');
+             INSERT INTO blocks_edges (source_id, target_id, severity, created_at)
+                 VALUES ('{CARD2}','{CARD3}','High','{TS}');
+             INSERT INTO relates_edges (source_id, target_id, kind, created_at)
+                 VALUES ('{CARD3}','{CARD4}','Duplicates','{TS}');
+             INSERT INTO sprint_logs (card_id, sprint_id, sprint_number, started_at, status)
+                 VALUES ('{CARD2}','{SPRINT}',3,'{TS}','Active');
+             INSERT INTO archived_cards (card_id, board_id, archived_at, original_column_id, original_position)
+                 VALUES ('{CARD4}','{BOARD}','{TS}','{COLUMN_DOING}',1);"
+        ))
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    let pool = raw(path).await;
+    let index_ddl: Vec<(String,)> = sqlx::query_as(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'cards' AND sql IS NOT NULL",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    sqlx::raw_sql(
+        "PRAGMA foreign_keys = OFF;
+        BEGIN;
+        CREATE TABLE cards_legacy (
+            id TEXT PRIMARY KEY,
+            column_id TEXT NOT NULL,
+            board_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            priority TEXT NOT NULL DEFAULT 'Medium',
+            status TEXT NOT NULL DEFAULT 'Todo',
+            position INTEGER NOT NULL,
+            due_date TEXT,
+            points INTEGER CHECK (points >= 0 AND points <= 255),
+            card_number INTEGER NOT NULL DEFAULT 0,
+            prefix TEXT NOT NULL DEFAULT '',
+            sprint_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT,
+            FOREIGN KEY (sprint_id) REFERENCES sprints(id) ON DELETE SET NULL
+        );
+        INSERT INTO cards_legacy (id, column_id, board_id, title, description, priority, status,
+            position, due_date, points, card_number, prefix, sprint_id, created_at, updated_at, completed_at)
+            SELECT id, column_id, board_id, title, description, priority, status,
+                position, due_date, points, card_number, prefix, sprint_id, created_at, updated_at, completed_at
+            FROM cards;
+        DROP TABLE cards;
+        ALTER TABLE cards_legacy RENAME TO cards;
+        COMMIT;
+        PRAGMA foreign_keys = ON;",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    for (sql,) in index_ddl {
+        sqlx::raw_sql(&sql).execute(&pool).await.unwrap();
+    }
+
+    sqlx::raw_sql("UPDATE metadata SET schema_version = 12;")
+        .execute(&pool)
+        .await
+        .unwrap();
+    pool.close().await;
+}
+
+/// Not a red step: the migration is believed correct and this is a
+/// regression pin over a graph shape this migration's own suite did not
+/// previously cover (a second column with a WIP limit, a sprint-bound card,
+/// and all three edge kinds rather than just `spawns`). A genuine failure
+/// here would be a real defect in the `cards` rebuild, not something to work
+/// around in the test.
+#[test]
+fn test_the_rebuild_preserves_the_whole_graph_across_two_columns_and_every_edge_kind() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("v12.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        seed_v12_with_whole_graph(&path).await;
+
+        let store = SqliteStore::open(&path).await.unwrap();
+        let pool = store.pool();
+
+        let schema_version: i64 =
+            sqlx::query_scalar("SELECT schema_version FROM metadata WHERE id = 1")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(schema_version, 13);
+
+        for (what, sql, expected) in [
+            ("columns", "SELECT COUNT(*) FROM columns", 2),
+            ("cards", "SELECT COUNT(*) FROM cards", 4),
+            ("sprints", "SELECT COUNT(*) FROM sprints", 1),
+            ("sprint_logs", "SELECT COUNT(*) FROM sprint_logs", 1),
+            ("archived_cards", "SELECT COUNT(*) FROM archived_cards", 1),
+            ("spawns_edges", "SELECT COUNT(*) FROM spawns_edges", 1),
+            ("blocks_edges", "SELECT COUNT(*) FROM blocks_edges", 1),
+            ("relates_edges", "SELECT COUNT(*) FROM relates_edges", 1),
+        ] {
+            assert_eq!(
+                count(pool, sql).await,
+                expected,
+                "{what} did not survive the rebuild"
+            );
+        }
+
+        let wip_limit: Option<i64> =
+            sqlx::query_scalar("SELECT wip_limit FROM columns WHERE id = ?")
+                .bind(COLUMN_DOING)
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(wip_limit, Some(3), "the Doing column's WIP limit survives");
+
+        for (card_id, expected_position) in [(CARD3, 0i64), (CARD4, 1i64)] {
+            let position: i64 = sqlx::query_scalar("SELECT position FROM cards WHERE id = ?")
+                .bind(card_id)
+                .fetch_one(pool)
+                .await
+                .unwrap();
+            assert_eq!(
+                position, expected_position,
+                "position of {card_id} survives"
+            );
+        }
+
+        for card_id in [CARD2, CARD3] {
+            let sprint_id: Option<String> =
+                sqlx::query_scalar("SELECT sprint_id FROM cards WHERE id = ?")
+                    .bind(card_id)
+                    .fetch_one(pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                sprint_id.as_deref(),
+                Some(SPRINT),
+                "{card_id}'s sprint binding survives"
+            );
+        }
+
+        let (source, target): (String, String) = sqlx::query_as(
+            "SELECT source_id, target_id FROM blocks_edges WHERE source_id = ? AND target_id = ?",
+        )
+        .bind(CARD2)
+        .bind(CARD3)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        assert_eq!((source.as_str(), target.as_str()), (CARD2, CARD3));
+
+        let (source, target): (String, String) = sqlx::query_as(
+            "SELECT source_id, target_id FROM relates_edges WHERE source_id = ? AND target_id = ?",
+        )
+        .bind(CARD3)
+        .bind(CARD4)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        assert_eq!((source.as_str(), target.as_str()), (CARD3, CARD4));
+
+        for card_id in [CARD1, CARD2, CARD3, CARD4] {
+            let prefix: String = sqlx::query_scalar("SELECT prefix FROM cards WHERE id = ?")
+                .bind(card_id)
+                .fetch_one(pool)
+                .await
+                .unwrap();
+            assert_eq!(prefix, "KAN", "{card_id} keeps its stamped prefix");
+        }
+    });
+}


### PR DESCRIPTION
No migration test seeded a non-trivial entity graph. Every fixture was a bare board plus cards, with empty columns, sprints and edge arrays, so the migrations were proven to preserve boards and cards and unproven for everything a board owns. That is the gap CLAUDE.md's full-graph rule exists to close, after KAN-863 shipped silent data loss past a suite that asserted the root came back without asserting its contents did.

Closes KAN-1392, part of KAN-1388.

## Notes for review

**These are regression pins, not reds.** Every new test passed on first run. The migrations are correct; they were simply unproven. Calling them reds would misrepresent what happened.

Coverage added: the JSON V14 to V18 chain over a board, two columns with a WIP limit, five cards including an archived one, a sprint with two bindings, an archived-card marker, one edge of each of spawns/blocks/relates, and the backfilled prefix. Plus sync/async chain agreement, the SQLite v12 to v13 rebuild extended past spawns-only to every edge kind, and two cross-backend agreement tests comparing prefix rows and per-card stamps across the SQLite v9-v13 and JSON V14-V18 chains.

**One cross-backend test initially failed and it was the test's fault, not a migration defect.** It compared SQLite's full `open()` chain against only the JSON V14 to V15 step, missing the later V17 to V18 high-water-mark raise. Running the full chain on both sides made them agree. Worth stating because a discrepancy here would otherwise read as a real defect.

The SQLite work is scoped to schema versions 9 to 13, the structural equivalent of the JSON V14 to V18 range, rather than a literal version-number match.

Note `cargo test -p kanban-persistence-sqlite` needs `--features test-helpers` locally; the `pool()` accessor and the existing test modules are gated behind it. CI runs `--all-features`.