### PR TITLE
KAN-1405 fix(domain): CreateCard replay reconstructs its prefix row

### DIFF
--- a/.changeset/kan-1405-replay-prefix-row.md
+++ b/.changeset/kan-1405-replay-prefix-row.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: fix `CreateCard` replay leaving its card's prefix row unbacked. The row was previously only created by the service layer's number allocation, which never runs during command-log replay; `CreateCard::execute` now upserts the row itself, raising its counter to the card's frozen number without re-allocating one.

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -170,21 +170,12 @@ impl CreateCard {
         }
 
         let normalized_prefix = crate::Prefix::normalize(&card.prefix);
-        let mut rows = match context.store.get_prefix(&normalized_prefix)? {
-            Some(existing) => vec![existing],
-            None => vec![crate::Prefix::new(&normalized_prefix)],
-        };
-        crate::merge_counter_rows(
-            &mut rows,
-            &[crate::Prefix {
-                name: normalized_prefix,
-                card_counter: self.card_number,
-                sprint_counter: 0,
-            }],
-        );
-        context
+        let mut row = context
             .store
-            .upsert_prefix(rows.into_iter().next().expect("row always present"))?;
+            .get_prefix(&normalized_prefix)?
+            .unwrap_or_else(|| crate::Prefix::new(&normalized_prefix));
+        row.card_counter = row.card_counter.max(self.card_number);
+        context.store.upsert_prefix(row)?;
 
         context.store.upsert_board(board)?;
         context.store.upsert_card(card)?;
@@ -199,6 +190,7 @@ impl CreateCard {
         Some(crate::EntityIds {
             boards: [self.board_id].into(),
             cards: [self.id].into(),
+            prefixes: true,
             ..Default::default()
         })
     }

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -169,6 +169,23 @@ impl CreateCard {
             card.assign_to_sprint(sprint_id, sprint_number, sprint_name, sprint_status, now);
         }
 
+        let normalized_prefix = crate::Prefix::normalize(&card.prefix);
+        let mut rows = match context.store.get_prefix(&normalized_prefix)? {
+            Some(existing) => vec![existing],
+            None => vec![crate::Prefix::new(&normalized_prefix)],
+        };
+        crate::merge_counter_rows(
+            &mut rows,
+            &[crate::Prefix {
+                name: normalized_prefix,
+                card_counter: self.card_number,
+                sprint_counter: 0,
+            }],
+        );
+        context
+            .store
+            .upsert_prefix(rows.into_iter().next().expect("row always present"))?;
+
         context.store.upsert_board(board)?;
         context.store.upsert_card(card)?;
         Ok(())

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -161,6 +161,23 @@ mod tests {
     }
 
     #[test]
+    fn test_create_card_touched_entities_marks_prefixes_dirty() {
+        let cmd = Command::Card(CardCommand::Create(CreateCard {
+            id: Uuid::new_v4(),
+            card_number: 1,
+            board_id: Uuid::new_v4(),
+            column_id: Uuid::new_v4(),
+            title: "t".into(),
+            position: 0,
+            options: CreateCardOptions::default(),
+            timestamp: Utc::now(),
+            default_card_prefix: "kan".into(),
+        }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert!(ids.prefixes);
+    }
+
+    #[test]
     fn test_create_sprint_touched_entities_includes_the_owning_board() {
         let id = Uuid::new_v4();
         let board_id = Uuid::new_v4();

--- a/crates/kanban-domain/tests/common/prefix_write_order.rs
+++ b/crates/kanban-domain/tests/common/prefix_write_order.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 pub struct PrefixWriteOrderStore {
     inner: InMemoryStore,
     unbacked_at_write: Mutex<Vec<(u32, String)>>,
+    prefix_upsert_names: Mutex<Vec<String>>,
     swallow_prefix_writes: bool,
 }
 
@@ -18,6 +19,7 @@ impl PrefixWriteOrderStore {
         Self {
             inner: InMemoryStore::default(),
             unbacked_at_write: Mutex::new(Vec::new()),
+            prefix_upsert_names: Mutex::new(Vec::new()),
             swallow_prefix_writes: false,
         }
     }
@@ -26,12 +28,19 @@ impl PrefixWriteOrderStore {
         Self {
             inner: InMemoryStore::default(),
             unbacked_at_write: Mutex::new(Vec::new()),
+            prefix_upsert_names: Mutex::new(Vec::new()),
             swallow_prefix_writes: true,
         }
     }
 
     pub fn unbacked_at_write(&self) -> Vec<(u32, String)> {
         self.unbacked_at_write.lock().unwrap().clone()
+    }
+
+    /// The exact `Prefix::name` string passed to each `upsert_prefix` call,
+    /// in call order, before any storage-layer normalisation runs.
+    pub fn prefix_upsert_names(&self) -> Vec<String> {
+        self.prefix_upsert_names.lock().unwrap().clone()
     }
 }
 
@@ -62,6 +71,10 @@ impl DataStore for PrefixWriteOrderStore {
         self.inner.list_prefixes()
     }
     fn upsert_prefix(&self, prefix: Prefix) -> KanbanResult<()> {
+        self.prefix_upsert_names
+            .lock()
+            .unwrap()
+            .push(prefix.name.clone());
         if self.swallow_prefix_writes {
             return Ok(());
         }

--- a/crates/kanban-domain/tests/prefix_write_order.rs
+++ b/crates/kanban-domain/tests/prefix_write_order.rs
@@ -342,6 +342,31 @@ fn test_clear_sprint_from_archived_cards_default_leaves_its_namespace_backed() {
 }
 
 #[test]
+fn test_creating_a_card_with_mixed_case_prefix_upserts_a_normalised_row_name() {
+    let store = PrefixWriteOrderStore::new();
+    let board = Board::new("B", Some("Kan"));
+    let column = Column::new(board.id, "Todo", 0);
+    store.upsert_board(board.clone()).unwrap();
+    store.upsert_column(column.clone()).unwrap();
+
+    let cmd = Command::Card(CardCommand::Create(CreateCard {
+        id: Uuid::new_v4(),
+        card_number: 1,
+        board_id: board.id,
+        column_id: column.id,
+        title: "New card".to_string(),
+        position: 0,
+        options: CreateCardOptions::default(),
+        timestamp: chrono::Utc::now(),
+        default_card_prefix: "task".to_string(),
+    }));
+    let context = CommandContext { store: &store };
+    cmd.execute(&context).unwrap();
+
+    assert_eq!(store.prefix_upsert_names(), vec!["kan".to_string()]);
+}
+
+#[test]
 fn test_the_probe_reports_a_card_written_before_its_prefix_row() {
     let store = PrefixWriteOrderStore::new();
     let mut card = Card::new(Uuid::new_v4(), Uuid::new_v4(), "C", 0);

--- a/crates/kanban-service/tests/create_card_replay_prefix_row.rs
+++ b/crates/kanban-service/tests/create_card_replay_prefix_row.rs
@@ -2,9 +2,11 @@
 //! against a backing row, so `JsonDataStore` and `SqliteBackend` are used here
 //! instead: both reject an unbacked prefix.
 
-use kanban_domain::commands::CommandContext;
+use kanban_domain::commands::{CardCommand, Command, CommandContext};
 use kanban_domain::data_store::DataStore;
-use kanban_domain::{CreateCardOptions, KanbanOperations, KanbanResult, Snapshot};
+use kanban_domain::{
+    CommandBatch, CreateCardOptions, KanbanOperations, KanbanResult, Prefix, Snapshot,
+};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
@@ -42,11 +44,16 @@ fn path_for(backend: &Backend, dir: &std::path::Path, stem: &str) -> std::path::
     }
 }
 
-async fn assert_replay_reconstructs_prefix_row(backend: Backend) {
-    let dir = tempdir().unwrap();
-    let mut ctx = open(&backend, &path_for(&backend, dir.path(), "src")).await;
+async fn record_one_card_creation(
+    backend: &Backend,
+    dir: &std::path::Path,
+    board_prefix: &str,
+) -> Vec<CommandBatch> {
+    let mut ctx = open(backend, &path_for(backend, dir, "src")).await;
 
-    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let board = ctx
+        .create_board("B".into(), Some(board_prefix.into()))
+        .unwrap();
     let column = ctx.create_column(board.id, "TODO".into(), None).unwrap();
     let card = ctx
         .create_card(
@@ -60,16 +67,24 @@ async fn assert_replay_reconstructs_prefix_row(backend: Backend) {
 
     let (batches, count) = ctx.backend().load_all_batches().unwrap();
     assert!(count > 0, "should have recorded at least one command batch");
+    batches
+}
 
-    let replay_store = fresh_destination(&backend, &path_for(&backend, dir.path(), "replay")).await;
-    let cmd_ctx = CommandContext {
-        store: replay_store.as_ref(),
-    };
-    for batch in &batches {
+fn replay_onto(store: &dyn DataStore, batches: &[CommandBatch]) {
+    let cmd_ctx = CommandContext { store };
+    for batch in batches {
         for cmd in &batch.commands {
             cmd.execute(&cmd_ctx).unwrap();
         }
     }
+}
+
+async fn assert_replay_reconstructs_prefix_row(backend: Backend) {
+    let dir = tempdir().unwrap();
+    let batches = record_one_card_creation(&backend, dir.path(), "KAN").await;
+
+    let replay_store = fresh_destination(&backend, &path_for(&backend, dir.path(), "replay")).await;
+    replay_onto(replay_store.as_ref(), &batches);
 
     let row = replay_store
         .get_prefix("kan")
@@ -78,6 +93,84 @@ async fn assert_replay_reconstructs_prefix_row(backend: Backend) {
     assert_eq!(
         row.card_counter, 1,
         "the reconstructed row must cover the card number it names"
+    );
+}
+
+/// A replay must never lower a namespace's counter below what the
+/// destination already recorded. A naive implementation that overwrites
+/// `card_counter` with the replayed command's number, instead of taking the
+/// max, would silently rewind it here and later reissue a number already
+/// handed out.
+async fn assert_replay_never_lowers_an_existing_counter(backend: Backend) {
+    let dir = tempdir().unwrap();
+    let batches = record_one_card_creation(&backend, dir.path(), "KAN").await;
+
+    let replay_store = fresh_destination(&backend, &path_for(&backend, dir.path(), "replay")).await;
+    replay_store
+        .upsert_prefix(Prefix {
+            name: "kan".into(),
+            card_counter: 10,
+            sprint_counter: 0,
+        })
+        .unwrap();
+
+    replay_onto(replay_store.as_ref(), &batches);
+
+    let row = replay_store
+        .get_prefix("kan")
+        .unwrap()
+        .unwrap_or_else(|| panic!("the pre-seeded 'kan' prefix row must still be backed"));
+    assert_eq!(
+        row.card_counter, 10,
+        "replaying a lower card number must not roll the counter back"
+    );
+}
+
+/// `get_prefix` normalises its own query, so looking a row up by `"kan"`
+/// succeeds regardless of what case it was stored under and cannot detect a
+/// second namespace. Only `list_prefixes` can show that a mixed-case board
+/// prefix landed under one normalised row rather than minting a duplicate.
+async fn assert_replay_stores_one_normalised_row_for_a_mixed_case_prefix(backend: Backend) {
+    let dir = tempdir().unwrap();
+    let batches = record_one_card_creation(&backend, dir.path(), "Kan").await;
+
+    let replay_store = fresh_destination(&backend, &path_for(&backend, dir.path(), "replay")).await;
+    replay_onto(replay_store.as_ref(), &batches);
+
+    let rows = replay_store.list_prefixes().unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "a mixed-case prefix must resolve to exactly one row, got {rows:?}"
+    );
+    assert_eq!(
+        rows[0].name, "kan",
+        "the row must be stored under its normalised name"
+    );
+}
+
+async fn assert_replaying_twice_is_idempotent(backend: Backend) {
+    let dir = tempdir().unwrap();
+    let batches = record_one_card_creation(&backend, dir.path(), "KAN").await;
+
+    let replay_store = fresh_destination(&backend, &path_for(&backend, dir.path(), "replay")).await;
+    replay_onto(replay_store.as_ref(), &batches);
+    let first = replay_store.get_prefix("kan").unwrap().unwrap();
+
+    let create_card = batches
+        .iter()
+        .flat_map(|b| &b.commands)
+        .find(|c| matches!(c, Command::Card(CardCommand::Create(_))))
+        .expect("batches must contain the CreateCard command");
+    let cmd_ctx = CommandContext {
+        store: replay_store.as_ref(),
+    };
+    create_card.execute(&cmd_ctx).unwrap();
+    let second = replay_store.get_prefix("kan").unwrap().unwrap();
+
+    assert_eq!(
+        first, second,
+        "re-executing the same CreateCard command must leave the prefix row unchanged"
     );
 }
 
@@ -90,5 +183,42 @@ async fn test_json_replay_from_baseline_reconstructs_prefix_row() -> KanbanResul
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sqlite_replay_from_baseline_reconstructs_prefix_row() -> KanbanResult<()> {
     assert_replay_reconstructs_prefix_row(Backend::Sqlite).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_replay_never_lowers_an_existing_counter() -> KanbanResult<()> {
+    assert_replay_never_lowers_an_existing_counter(Backend::Json).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_replay_never_lowers_an_existing_counter() -> KanbanResult<()> {
+    assert_replay_never_lowers_an_existing_counter(Backend::Sqlite).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_replay_stores_one_normalised_row_for_a_mixed_case_prefix() -> KanbanResult<()> {
+    assert_replay_stores_one_normalised_row_for_a_mixed_case_prefix(Backend::Json).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_replay_stores_one_normalised_row_for_a_mixed_case_prefix() -> KanbanResult<()>
+{
+    assert_replay_stores_one_normalised_row_for_a_mixed_case_prefix(Backend::Sqlite).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_replaying_twice_is_idempotent() -> KanbanResult<()> {
+    assert_replaying_twice_is_idempotent(Backend::Json).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_replaying_twice_is_idempotent() -> KanbanResult<()> {
+    assert_replaying_twice_is_idempotent(Backend::Sqlite).await;
     Ok(())
 }

--- a/crates/kanban-service/tests/create_card_replay_prefix_row.rs
+++ b/crates/kanban-service/tests/create_card_replay_prefix_row.rs
@@ -110,7 +110,7 @@ async fn assert_replay_never_lowers_an_existing_counter(backend: Backend) {
         .upsert_prefix(Prefix {
             name: "kan".into(),
             card_counter: 10,
-            sprint_counter: 0,
+            sprint_counter: 7,
         })
         .unwrap();
 
@@ -121,15 +121,18 @@ async fn assert_replay_never_lowers_an_existing_counter(backend: Backend) {
         .unwrap()
         .unwrap_or_else(|| panic!("the pre-seeded 'kan' prefix row must still be backed"));
     assert_eq!(
+        row.sprint_counter, 7,
+        "replaying a card create must not touch the sprint counter"
+    );
+    assert_eq!(
         row.card_counter, 10,
         "replaying a lower card number must not roll the counter back"
     );
 }
 
-/// `get_prefix` normalises its own query, so looking a row up by `"kan"`
-/// succeeds regardless of what case it was stored under and cannot detect a
-/// second namespace. Only `list_prefixes` can show that a mixed-case board
-/// prefix landed under one normalised row rather than minting a duplicate.
+/// End-to-end outcome only: every backend storage layer normalises on
+/// write, so this cannot isolate `lifecycle.rs`'s own normalisation --
+/// see `prefix_write_order.rs` for that.
 async fn assert_replay_stores_one_normalised_row_for_a_mixed_case_prefix(backend: Backend) {
     let dir = tempdir().unwrap();
     let batches = record_one_card_creation(&backend, dir.path(), "Kan").await;

--- a/crates/kanban-service/tests/create_card_replay_prefix_row.rs
+++ b/crates/kanban-service/tests/create_card_replay_prefix_row.rs
@@ -1,0 +1,94 @@
+//! `InMemoryStore`, used by `command_replay.rs`, never checks a card's prefix
+//! against a backing row, so `JsonDataStore` and `SqliteBackend` are used here
+//! instead: both reject an unbacked prefix.
+
+use kanban_domain::commands::CommandContext;
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{CreateCardOptions, KanbanOperations, KanbanResult, Snapshot};
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_persistence_sqlite::SqliteBackend;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+enum Backend {
+    Json,
+    Sqlite,
+}
+
+async fn open(backend: &Backend, path: &std::path::Path) -> KanbanContext {
+    let inner: Arc<dyn KanbanBackend> = match backend {
+        Backend::Json => Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path)))),
+        Backend::Sqlite => Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap()),
+    };
+    KanbanContext::open(inner, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+async fn fresh_destination(backend: &Backend, path: &std::path::Path) -> Arc<dyn DataStore> {
+    let store: Arc<dyn DataStore> = match backend {
+        Backend::Json => Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path)))),
+        Backend::Sqlite => Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap()),
+    };
+    store.apply_snapshot(Snapshot::new()).unwrap();
+    store
+}
+
+fn path_for(backend: &Backend, dir: &std::path::Path, stem: &str) -> std::path::PathBuf {
+    match backend {
+        Backend::Json => dir.join(format!("{stem}.json")),
+        Backend::Sqlite => dir.join(format!("{stem}.sqlite")),
+    }
+}
+
+async fn assert_replay_reconstructs_prefix_row(backend: Backend) {
+    let dir = tempdir().unwrap();
+    let mut ctx = open(&backend, &path_for(&backend, dir.path(), "src")).await;
+
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let column = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+    let card = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "card 1".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(card.card_number, 1);
+
+    let (batches, count) = ctx.backend().load_all_batches().unwrap();
+    assert!(count > 0, "should have recorded at least one command batch");
+
+    let replay_store = fresh_destination(&backend, &path_for(&backend, dir.path(), "replay")).await;
+    let cmd_ctx = CommandContext {
+        store: replay_store.as_ref(),
+    };
+    for batch in &batches {
+        for cmd in &batch.commands {
+            cmd.execute(&cmd_ctx).unwrap();
+        }
+    }
+
+    let row = replay_store
+        .get_prefix("kan")
+        .unwrap()
+        .unwrap_or_else(|| panic!("replay must reconstruct the 'kan' prefix row"));
+    assert_eq!(
+        row.card_counter, 1,
+        "the reconstructed row must cover the card number it names"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_replay_from_baseline_reconstructs_prefix_row() -> KanbanResult<()> {
+    assert_replay_reconstructs_prefix_row(Backend::Json).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_replay_from_baseline_reconstructs_prefix_row() -> KanbanResult<()> {
+    assert_replay_reconstructs_prefix_row(Backend::Sqlite).await;
+    Ok(())
+}


### PR DESCRIPTION
Prefix rows were created by the service layer, inside `execute_with_extra`'s builder closure via `allocate_card_number`, and never captured as a command. Only the resulting number was frozen into `CreateCard`. So replaying a command log against an empty baseline produced a card whose prefix had no backing row.

Closes KAN-1405. It also unblocks KAN-1391, whose contract test was red for exactly this reason.

`CreateCard::execute` now ensures the row exists for the already-decided number: normalise, read, raise the counter with `max`, upsert, before the board and card writes so SQLite's foreign key from `cards.prefix` is satisfied.

## Notes for review

**It does not re-allocate.** Calling `allocate_card_number` here would have been the obvious way to mirror `CreateSprint`, and it would have handed replayed cards a different number from the one frozen in the command, breaking the guarantee replay exists to provide. Ensuring a row for an already-decided number and allocating a new one are different operations.

**The counter is raised, never set.** A namespace whose counter has moved past the replayed card keeps its value. `test_*_replay_never_lowers_an_existing_counter` was verified diagnostic by mutation: changing the fix to a plain assignment fails that test and only that test.

**The normalisation test asserts on `list_prefixes()`, not `get_prefix()`.** `get_prefix` normalises its query, so a lookup cannot distinguish a row written as `kan` from one written as `Kan` and would have passed either way. Asserting exactly one row named `kan` after creating a board with prefix `Kan` is what actually catches a duplicate namespace.

**Tests run against JSON and SQLite, deliberately not in-memory.** `command_replay.rs` is in-memory-only, and in-memory does not check prefix backing, which is why this shipped invisibly. Both backends were confirmed genuinely red first, with different failure modes: SQLite rejects inline in `execute`, JSON at flush.

`touched_entities()` now declares the prefix write, since `redo()` derives cache invalidation from it alone.

Live-path impact was reviewed specifically: the extra get-and-merge on every card create cannot double-bump (`N.max(N)`), cannot clobber a concurrently-raised counter (it takes the max), and is one indexed read plus an upsert inside the already-open transaction.