### PR TITLE
KAN-1394 perf(domain): hoist per-card projections out of find_cards_by_identifier

### DIFF
--- a/.changeset/kan-1394-hoist-identifier-projections.md
+++ b/.changeset/kan-1394-hoist-identifier-projections.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: hoist the per-card column/board/sprint projections and the column-to-board index out of `find_cards_by_identifier`'s filter loop, building them once instead of on every card. No behavior change: match order, plurality, prefix normalization, and the has-board guard are all pinned by the existing and new regression tests.

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -4,6 +4,7 @@
 //! Used by both TUI and API for consistent search behavior.
 
 use crate::{Board, Card, Column, Sprint};
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 /// Trait for searching cards by various criteria.
@@ -255,6 +256,19 @@ pub fn find_cards_by_identifier<'a>(
     let Some(parsed) = parse_identifier(identifier) else {
         return vec![];
     };
+
+    let column_board: HashMap<Uuid, Uuid> = columns.iter().map(|c| (c.id, c.board_id)).collect();
+    let board_ids: HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
+    let column_pairs: Vec<(Uuid, Uuid)> = columns.iter().map(|c| (c.id, c.board_id)).collect();
+    let board_pairs: Vec<(Uuid, Option<String>)> = boards
+        .iter()
+        .map(|b| (b.id, b.card_prefix.clone()))
+        .collect();
+    let sprint_pairs: Vec<(Uuid, Option<String>)> = sprints
+        .iter()
+        .map(|s| (s.id, s.card_prefix.clone()))
+        .collect();
+
     cards
         .iter()
         .filter(|card| match &parsed {
@@ -262,13 +276,17 @@ pub fn find_cards_by_identifier<'a>(
                 // A card whose column resolves to no board is unaddressable by
                 // prefix, as before: `resolve_card_prefix` would hand back the
                 // default and match cards that never belonged to it.
-                let has_board = columns
-                    .iter()
-                    .find(|col| col.id == card.column_id)
-                    .is_some_and(|col| boards.iter().any(|b| b.id == col.board_id));
+                let has_board = column_board
+                    .get(&card.column_id)
+                    .is_some_and(|board_id| board_ids.contains(board_id));
                 has_board
-                    && crate::prefix::Prefix::normalize(&resolve_card_prefix(
-                        card, columns, boards, sprints, configured,
+                    && crate::prefix::Prefix::normalize(&resolve_card_prefix_by_ids(
+                        card.column_id,
+                        card.sprint_id,
+                        &column_pairs,
+                        &board_pairs,
+                        &sprint_pairs,
+                        configured,
                     )) == *prefix
                     && card.card_number == *number
             }
@@ -739,9 +757,7 @@ mod tests {
         let columns = vec![orphan_column];
         let cards = vec![card];
 
-        assert!(
-            find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[], None).is_empty()
-        );
+        assert!(find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[], None).is_empty());
     }
 
     #[test]

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -705,6 +705,46 @@ mod tests {
     }
 
     #[test]
+    fn test_find_cards_by_identifier_ambiguous_prefix_preserves_input_order() {
+        let mut board1 = Board::new("Board One", None::<String>);
+        board1.card_prefix = Some("KAN".to_string());
+        let col1 = crate::Column::new(board1.id, "Todo", 0);
+        let mut card1 = Card::new(board1.id, col1.id, "First", 0);
+        card1.card_number = 1;
+
+        let mut board2 = Board::new("Board Two", None::<String>);
+        board2.card_prefix = Some("KAN".to_string());
+        let col2 = crate::Column::new(board2.id, "Todo", 0);
+        let mut card2 = Card::new(board2.id, col2.id, "Second", 0);
+        card2.card_number = 1;
+
+        let boards = vec![board1, board2];
+        let columns = vec![col1, col2];
+        let cards = vec![card2.clone(), card1.clone()];
+
+        let result = find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[], None);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].id, card2.id);
+        assert_eq!(result[1].id, card1.id);
+    }
+
+    #[test]
+    fn test_find_cards_by_identifier_column_with_no_board_is_unaddressable() {
+        let mut board = Board::new("Project", None::<String>);
+        board.card_prefix = Some("KAN".to_string());
+        let orphan_column = crate::Column::new(Uuid::new_v4(), "Todo", 0);
+        let mut card = Card::new(board.id, orphan_column.id, "Some task", 0);
+        card.card_number = 1;
+        let boards = vec![board];
+        let columns = vec![orphan_column];
+        let cards = vec![card];
+
+        assert!(
+            find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[], None).is_empty()
+        );
+    }
+
+    #[test]
     fn test_find_cards_by_identifier_ambiguous_sprint_prefix_returns_both() {
         let mut board_a = Board::new("Board A", None::<String>);
         board_a.card_prefix = Some("PROJ".to_string());

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -257,42 +257,49 @@ pub fn find_cards_by_identifier<'a>(
         return vec![];
     };
 
-    let column_board: HashMap<Uuid, Uuid> = columns.iter().map(|c| (c.id, c.board_id)).collect();
-    let board_ids: HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
-    let column_pairs: Vec<(Uuid, Uuid)> = columns.iter().map(|c| (c.id, c.board_id)).collect();
-    let board_pairs: Vec<(Uuid, Option<String>)> = boards
-        .iter()
-        .map(|b| (b.id, b.card_prefix.clone()))
-        .collect();
-    let sprint_pairs: Vec<(Uuid, Option<String>)> = sprints
-        .iter()
-        .map(|s| (s.id, s.card_prefix.clone()))
-        .collect();
+    match &parsed {
+        ParsedIdentifier::PrefixAndNumber { prefix, number } => {
+            let column_board: HashMap<Uuid, Uuid> =
+                columns.iter().map(|c| (c.id, c.board_id)).collect();
+            let board_ids: HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
+            let column_pairs: Vec<(Uuid, Uuid)> =
+                columns.iter().map(|c| (c.id, c.board_id)).collect();
+            let board_pairs: Vec<(Uuid, Option<String>)> = boards
+                .iter()
+                .map(|b| (b.id, b.card_prefix.clone()))
+                .collect();
+            let sprint_pairs: Vec<(Uuid, Option<String>)> = sprints
+                .iter()
+                .map(|s| (s.id, s.card_prefix.clone()))
+                .collect();
 
-    cards
-        .iter()
-        .filter(|card| match &parsed {
-            ParsedIdentifier::PrefixAndNumber { prefix, number } => {
-                // A card whose column resolves to no board is unaddressable by
-                // prefix, as before: `resolve_card_prefix` would hand back the
-                // default and match cards that never belonged to it.
-                let has_board = column_board
-                    .get(&card.column_id)
-                    .is_some_and(|board_id| board_ids.contains(board_id));
-                has_board
-                    && crate::prefix::Prefix::normalize(&resolve_card_prefix_by_ids(
-                        card.column_id,
-                        card.sprint_id,
-                        &column_pairs,
-                        &board_pairs,
-                        &sprint_pairs,
-                        configured,
-                    )) == *prefix
-                    && card.card_number == *number
-            }
-            ParsedIdentifier::NumberOnly(number) => card.card_number == *number,
-        })
-        .collect()
+            cards
+                .iter()
+                .filter(|card| {
+                    // A card whose column resolves to no board is unaddressable by
+                    // prefix, as before: `resolve_card_prefix` would hand back the
+                    // default and match cards that never belonged to it.
+                    let has_board = column_board
+                        .get(&card.column_id)
+                        .is_some_and(|board_id| board_ids.contains(board_id));
+                    has_board
+                        && crate::prefix::Prefix::normalize(&resolve_card_prefix_by_ids(
+                            card.column_id,
+                            card.sprint_id,
+                            &column_pairs,
+                            &board_pairs,
+                            &sprint_pairs,
+                            configured,
+                        )) == *prefix
+                        && card.card_number == *number
+                })
+                .collect()
+        }
+        ParsedIdentifier::NumberOnly(number) => cards
+            .iter()
+            .filter(|card| card.card_number == *number)
+            .collect(),
+    }
 }
 
 /// The prefix a card is addressed by TODAY, resolved dynamically through
@@ -686,6 +693,19 @@ mod tests {
     }
 
     #[test]
+    fn test_find_cards_by_identifier_bare_number_ignores_column_and_board_data() {
+        let board = Board::new("Project", None::<String>);
+        let column = crate::Column::new(Uuid::new_v4(), "Todo", 0);
+        let mut card = Card::new(board.id, column.id, "Some task", 0);
+        card.card_number = 1;
+        let cards = vec![card.clone()];
+
+        let result = find_cards_by_identifier("1", &cards, &[], &[], &[], None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, card.id);
+    }
+
+    #[test]
     fn test_find_cards_by_identifier_ambiguous_bare_number_returns_both() {
         let mut board1 = Board::new("Board One", None::<String>);
         board1.card_prefix = Some("AAA".to_string());
@@ -748,16 +768,22 @@ mod tests {
 
     #[test]
     fn test_find_cards_by_identifier_column_with_no_board_is_unaddressable() {
-        let mut board = Board::new("Project", None::<String>);
-        board.card_prefix = Some("KAN".to_string());
-        let orphan_column = crate::Column::new(Uuid::new_v4(), "Todo", 0);
-        let mut card = Card::new(board.id, orphan_column.id, "Some task", 0);
-        card.card_number = 1;
-        let boards = vec![board];
-        let columns = vec![orphan_column];
-        let cards = vec![card];
+        let board = Board::new("Project", None::<String>);
+        let live_column = crate::Column::new(board.id, "Todo", 0);
+        let mut live_card = Card::new(board.id, live_column.id, "Some task", 0);
+        live_card.card_number = 1;
 
-        assert!(find_cards_by_identifier("KAN-1", &cards, &columns, &boards, &[], None).is_empty());
+        let orphan_column = crate::Column::new(Uuid::new_v4(), "Todo", 0);
+        let mut orphan_card = Card::new(board.id, orphan_column.id, "Orphan task", 0);
+        orphan_card.card_number = 1;
+
+        let boards = vec![board];
+        let columns = vec![live_column, orphan_column];
+        let cards = vec![live_card.clone(), orphan_card];
+
+        let result = find_cards_by_identifier("task-1", &cards, &columns, &boards, &[], None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, live_card.id);
     }
 
     #[test]


### PR DESCRIPTION
`find_cards_by_identifier`'s prefix branch filtered every card and, per card, rebuilt work that does not depend on that card: a linear scan of columns, a linear scan of boards, and a `resolve_card_prefix` call that allocated three fresh Vecs of every column, board and sprint, cloning each board and sprint prefix String.

Those are now built once, inside the branch that uses them. The has-board guard is a map probe.

Closes KAN-1394, part of KAN-1388.

## Two corrections to this PR's original framing

**This function has no production callers.** Every `find_cards_by_identifier` in the workspace resolves to the trait method on `KanbanContext`, whose impl parses the identifier itself and dispatches to indexed backend lookups (`list_cards_by_prefix_and_number` / `list_cards_by_number`). The free function is re-exported from `kanban-domain`'s lib and called only by its own tests. The card claimed it sat on the MCP and CLI identifier path; it does not. The change is still correct and the function is public API, but there is no user-visible speedup to claim. Whether it should exist at all, given the indexed path, is a separate question worth its own card.

**The allocation claim was overstated.** Allocations for the prefix branch drop from O(cards x entities) to O(entities) plus roughly three per card, since `resolve_card_prefix_by_ids` still clones the matched board and sprint prefix and `Prefix::normalize` allocates. The per-card linear scans over the pair slices also remain. What genuinely improved: the per-card Vec rebuilds and String clones are gone, and the has-board guard is O(1).

## Notes for review

**Pure refactor. The tests are regression pins, not reds**, and were run against the pre-refactor commit to confirm they pass there too.

Review found two defects that are fixed in `bcba1306`:

**The has-board pin could not fail.** It queried `KAN-1` against an orphan column, but with no board the prefix resolves to the `task` default, which never matches `kan` - so the test passed with or without the guard it was named for. It now queries the default prefix with one live and one orphan column, and was verified by mutation: neutralising the guard fails it with `left: 2, right: 1`.

**The hoisting made bare-number queries slower.** All five projections were built unconditionally, but `NumberOnly` uses none of them, so that path went from zero allocation to cloning every board and sprint prefix. The match is now at the top level with two independent pipelines. The new pin queries a bare number against empty columns and boards slices, which can only pass if that path never touches them.