### PR TITLE
KAN-1394 refactor(domain): derive the column-id lookup from the pair projection

### DIFF
--- a/.changeset/refactor-kan-1394-review-nits.md
+++ b/.changeset/refactor-kan-1394-review-nits.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: `find_cards_by_identifier` derives its column-id lookup from the pair projection it already builds, rather than scanning `columns` a second time to build the same data twice. Also corrects a comment that named `resolve_card_prefix` in a path that calls `resolve_card_prefix_by_ids`.

--- a/crates/kanban-domain/src/search/mod.rs
+++ b/crates/kanban-domain/src/search/mod.rs
@@ -259,11 +259,10 @@ pub fn find_cards_by_identifier<'a>(
 
     match &parsed {
         ParsedIdentifier::PrefixAndNumber { prefix, number } => {
-            let column_board: HashMap<Uuid, Uuid> =
-                columns.iter().map(|c| (c.id, c.board_id)).collect();
-            let board_ids: HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
             let column_pairs: Vec<(Uuid, Uuid)> =
                 columns.iter().map(|c| (c.id, c.board_id)).collect();
+            let column_board: HashMap<Uuid, Uuid> = column_pairs.iter().copied().collect();
+            let board_ids: HashSet<Uuid> = boards.iter().map(|b| b.id).collect();
             let board_pairs: Vec<(Uuid, Option<String>)> = boards
                 .iter()
                 .map(|b| (b.id, b.card_prefix.clone()))
@@ -277,8 +276,8 @@ pub fn find_cards_by_identifier<'a>(
                 .iter()
                 .filter(|card| {
                     // A card whose column resolves to no board is unaddressable by
-                    // prefix, as before: `resolve_card_prefix` would hand back the
-                    // default and match cards that never belonged to it.
+                    // prefix, as before: `resolve_card_prefix_by_ids` would hand
+                    // back the default and match cards that never belonged to it.
                     let has_board = column_board
                         .get(&card.column_id)
                         .is_some_and(|board_id| board_ids.contains(board_id));


### PR DESCRIPTION
Two review nits from #669, both in `find_cards_by_identifier` and both cosmetic.

`column_board` and `column_pairs` were built from identical map expressions over `columns`, so the slice was scanned twice to produce the same data in two shapes. The lookup is now derived from the pairs: one scan, one source of truth.

The comment above the has-board guard named `resolve_card_prefix`, but that path now calls `resolve_card_prefix_by_ids`. The counterfactual it describes is still accurate; only the function name was stale.

No behaviour change. Both existing pins still hold, including the mutation-verified has-board guard test and the input-order test.