### PR TITLE
KAN-1408 fix(tui): hide the sprint picker in the create-card dialog when the board has no active or planned sprints

### DIFF
--- a/.changeset/kan-1408-hide-sprint-picker-when-no-sprints.md
+++ b/.changeset/kan-1408-hide-sprint-picker-when-no-sprints.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: hide the Sprint section in the create-card dialog when the active board has no active or planned sprints, shrinking the dialog to just Title/Column instead of a fixed-height picker with nothing to pick. Focus and Esc-to-close now key off the last VISIBLE field rather than assuming Sprint always closes the dialog, so a board with no such sprints (and, when its column is also fixed, no editable Column either) still cancels correctly; the latter case falls through to the existing title-only popup. The section reappears once sprints load or a re-open finds a different, sprint-bearing board. The picker's own row count is unchanged when the section is shown.

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -26,6 +26,7 @@ pub struct DialogInputState {
     pub create_card_focus: CreateCardFocus,
     pub create_card_column_input: InputState,
     create_card_column_editable: bool,
+    create_card_sprint_visible: bool,
     /// Picker for the assign-to-existing-card dialogs (single and
     /// bulk). Configured with SprintFilter::All so the user can pick
     /// from completed/ended sprints as well, which the create-card
@@ -53,6 +54,7 @@ impl Default for DialogInputState {
             create_card_focus: CreateCardFocus::default(),
             create_card_column_input: InputState::default(),
             create_card_column_editable: false,
+            create_card_sprint_visible: true,
             assign_sprint_picker: SprintPicker::with_filter(SprintFilter::All),
             board_delete_counts: None,
         }
@@ -76,18 +78,28 @@ impl DialogInputState {
         self.create_card_column_editable
     }
 
+    pub fn create_card_sprint_is_visible(&self) -> bool {
+        self.create_card_sprint_visible
+    }
+
     pub fn advance_create_card_focus(&mut self) {
         self.create_card_focus = match self.create_card_focus {
-            CreateCardFocus::Title => {
-                if self.create_card_column_editable {
-                    CreateCardFocus::Column
-                } else {
-                    CreateCardFocus::Sprint
-                }
+            CreateCardFocus::Title if self.create_card_column_editable => CreateCardFocus::Column,
+            CreateCardFocus::Title | CreateCardFocus::Column if self.create_card_sprint_visible => {
+                CreateCardFocus::Sprint
             }
-            CreateCardFocus::Column => CreateCardFocus::Sprint,
-            CreateCardFocus::Sprint => CreateCardFocus::Title,
+            _ => CreateCardFocus::Title,
         };
+    }
+
+    pub fn create_card_focus_is_last_visible(&self) -> bool {
+        match self.create_card_focus {
+            CreateCardFocus::Sprint => true,
+            CreateCardFocus::Column => !self.create_card_sprint_visible,
+            CreateCardFocus::Title => {
+                !self.create_card_column_editable && !self.create_card_sprint_visible
+            }
+        }
     }
 
     pub fn reset_create_card_focus(&mut self) {
@@ -97,5 +109,9 @@ impl DialogInputState {
     pub fn prime_create_card_column_field(&mut self, name: String, editable: bool) {
         self.create_card_column_editable = editable;
         self.create_card_column_input.set(name);
+    }
+
+    pub fn prime_create_card_sprint_field(&mut self, visible: bool) {
+        self.create_card_sprint_visible = visible;
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -21,6 +21,7 @@ impl App {
                 );
             }
             self.prime_create_card_column_field();
+            self.prime_create_card_sprint_field();
             self.open_dialog(DialogMode::CreateCard);
             self.input.clear();
         }
@@ -69,6 +70,18 @@ impl App {
                 true,
             ),
         }
+    }
+
+    pub(crate) fn prime_create_card_sprint_field(&mut self) {
+        let visible = match self.active_board() {
+            Some(board) => kanban_view::sprint_assign_list::sprint_section_is_visible(
+                self.model.sprints_state(),
+                board.id,
+                chrono::Utc::now(),
+            ),
+            None => true,
+        };
+        self.dialog_input.prime_create_card_sprint_field(visible);
     }
 
     pub fn handle_toggle_card_completion(&mut self) {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1022,6 +1022,7 @@ impl App {
                         }
                         CardListAction::Create => {
                             self.prime_create_card_column_field();
+                            self.prime_create_card_sprint_field();
                             self.open_dialog(DialogMode::CreateCard);
                             self.input.clear();
                         }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -29,17 +29,21 @@ impl App {
         }
     }
 
+    fn close_create_card_dialog(&mut self) {
+        self.pop_mode();
+        self.input.clear();
+        self.dialog_input.create_card_column_input.clear();
+        self.dialog_input.create_card_sprint_picker.clear();
+        self.dialog_input.reset_create_card_focus();
+    }
+
     pub fn handle_create_card_dialog(&mut self, key_code: KeyCode) {
         // Enter always submits and Tab always toggles focus, regardless of
         // which sub-field currently has focus.
         match key_code {
             KeyCode::Enter => {
                 self.create_card();
-                self.pop_mode();
-                self.input.clear();
-                self.dialog_input.create_card_column_input.clear();
-                self.dialog_input.create_card_sprint_picker.clear();
-                self.dialog_input.reset_create_card_focus();
+                self.close_create_card_dialog();
                 return;
             }
             KeyCode::Tab => {
@@ -52,8 +56,12 @@ impl App {
         if self.dialog_input.create_card_focus_is_title() {
             // Title focus: Down/Esc drop focus into the next field so the
             // visual cursor moves out of the text input; all other keys edit
-            // the title.
+            // the title. Esc closes instead when Title is the last visible
+            // field (no editable column, no sprints).
             match key_code {
+                KeyCode::Esc if self.dialog_input.create_card_focus_is_last_visible() => {
+                    self.close_create_card_dialog();
+                }
                 KeyCode::Down | KeyCode::Esc => {
                     self.dialog_input.advance_create_card_focus();
                 }
@@ -66,6 +74,9 @@ impl App {
 
         if self.dialog_input.create_card_focus_is_column() {
             match key_code {
+                KeyCode::Esc if self.dialog_input.create_card_focus_is_last_visible() => {
+                    self.close_create_card_dialog();
+                }
                 KeyCode::Down | KeyCode::Esc => {
                     self.dialog_input.advance_create_card_focus();
                 }
@@ -84,11 +95,7 @@ impl App {
         // everything else is ignored so a stray keystroke does not modify
         // the title behind the user's back.
         if matches!(key_code, KeyCode::Esc) {
-            self.pop_mode();
-            self.input.clear();
-            self.dialog_input.create_card_column_input.clear();
-            self.dialog_input.create_card_sprint_picker.clear();
-            self.dialog_input.reset_create_card_focus();
+            self.close_create_card_dialog();
             return;
         }
         if let Some(board) = self

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -19,11 +19,27 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         return;
     };
 
-    let area = crate::components::centered_rect_abs(
-        60,
-        (frame.area().height * 60 / 100).max(18),
-        frame.area(),
-    );
+    let column_editable = app.dialog_input.create_card_column_is_editable();
+    let sprint_visible = app.dialog_input.create_card_sprint_is_visible();
+
+    if !column_editable && !sprint_visible {
+        render_input_popup(
+            frame,
+            "Create New Task",
+            "Task Title:",
+            app.input.as_str(),
+            app.input.cursor_byte_offset(),
+        );
+        return;
+    }
+
+    let border_and_margin = 6;
+    let dialog_height = if sprint_visible {
+        (frame.area().height * 60 / 100).max(18)
+    } else {
+        1 + 3 + 1 + 3 + border_and_margin
+    };
+    let area = crate::components::centered_rect_abs(60, dialog_height, frame.area());
     frame.render_widget(Clear, area);
 
     let block = Block::default()
@@ -34,17 +50,20 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    let mut constraints = vec![
+        Constraint::Length(1),
+        Constraint::Length(3),
+        Constraint::Length(1),
+        Constraint::Length(3),
+    ];
+    if sprint_visible {
+        constraints.push(Constraint::Length(1));
+        constraints.push(Constraint::Min(0));
+    }
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Length(3),
-            Constraint::Length(1),
-            Constraint::Length(3),
-            Constraint::Length(1),
-            Constraint::Min(0),
-        ])
+        .constraints(constraints)
         .split(inner);
 
     let title_focused = app.dialog_input.create_card_focus_is_title();
@@ -80,7 +99,7 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         chunks[2],
     );
 
-    let column_text_style = if app.dialog_input.create_card_column_is_editable() {
+    let column_text_style = if column_editable {
         crate::theme::normal_text()
     } else {
         crate::theme::label_text()
@@ -108,27 +127,29 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
         frame.set_cursor_position((cursor_x, cursor_y));
     }
 
-    frame.render_widget(
-        Paragraph::new("Sprint:").style(Style::default().fg(Color::Yellow)),
-        chunks[4],
-    );
+    if sprint_visible {
+        frame.render_widget(
+            Paragraph::new("Sprint:").style(Style::default().fg(Color::Yellow)),
+            chunks[4],
+        );
 
-    let picker_block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(if sprint_focused {
-            crate::theme::focused_border()
-        } else {
-            unfocused_border
-        });
-    let picker_inner = picker_block.inner(chunks[5]);
-    frame.render_widget(picker_block, chunks[5]);
-    app.dialog_input.create_card_sprint_picker.render(
-        frame,
-        picker_inner,
-        app.model.sprints(),
-        board,
-        chrono::Utc::now(),
-    );
+        let picker_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(if sprint_focused {
+                crate::theme::focused_border()
+            } else {
+                unfocused_border
+            });
+        let picker_inner = picker_block.inner(chunks[5]);
+        frame.render_widget(picker_block, chunks[5]);
+        app.dialog_input.create_card_sprint_picker.render(
+            frame,
+            picker_inner,
+            app.model.sprints(),
+            board,
+            chrono::Utc::now(),
+        );
+    }
 }
 
 pub(crate) fn render_set_card_points_popup(app: &App, frame: &mut Frame) {

--- a/crates/kanban-tui/tests/columnless_board_card_tests.rs
+++ b/crates/kanban-tui/tests/columnless_board_card_tests.rs
@@ -12,6 +12,7 @@ use ratatui::Terminal;
 fn setup_app_without_columns() -> App {
     let mut app = App::test_default();
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.ctx.create_sprint(board.id, None, None).unwrap();
     app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
@@ -30,6 +31,7 @@ fn setup_app_with_two_columns() -> App {
         .ctx
         .create_column(board.id, "Doing".to_string(), Some(1))
         .unwrap();
+    app.ctx.create_sprint(board.id, None, None).unwrap();
     app.reload_model();
     app.prepare_frame();
     app.board_list.inner_mut().set_selected_index(Some(0));
@@ -504,6 +506,55 @@ fn test_the_sprint_picker_shows_real_sprints_not_just_none_on_a_taller_terminal(
     assert!(
         sprint_names.iter().any(|name| grid.contains(name)),
         "no seeded sprint name is visible in the rendered picker at {width}x{height}:\n{grid}"
+    );
+}
+
+fn picker_interior_row_count(grid: &str) -> usize {
+    let lines: Vec<&str> = grid.lines().collect();
+    let sprint_row = lines
+        .iter()
+        .position(|l| l.contains("Sprint:"))
+        .expect("Sprint label must be present");
+    let top = lines
+        .iter()
+        .enumerate()
+        .skip(sprint_row + 1)
+        .find(|(_, l)| l.contains('┌'))
+        .map(|(i, _)| i)
+        .expect("picker top border must be present");
+    let bottom = lines
+        .iter()
+        .enumerate()
+        .skip(top + 1)
+        .find(|(_, l)| l.contains('└'))
+        .map(|(i, _)| i)
+        .expect("picker bottom border must be present");
+    bottom - top - 1
+}
+
+#[test]
+fn test_the_sprint_picker_row_count_on_a_120x40_terminal_is_at_least_what_it_was_before_the_dialog_became_conditional(
+) {
+    let width = 120u16;
+    let height = 40u16;
+
+    let mut app = setup_app_with_two_columns();
+    let board_id = app.selection.active_board_id.unwrap();
+    for i in 0..8 {
+        app.ctx
+            .create_sprint(board_id, None, Some(format!("Probe Sprint {i}")))
+            .unwrap();
+    }
+    app.reload_model();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    let grid = render_to_string(&mut app, width, height);
+
+    assert!(
+        picker_interior_row_count(&grid) >= 7,
+        "the sprint picker must not shrink below its pre-conditional-rendering \
+         row count of 7 at 120x40 just because the dialog height computation \
+         changed:\n{grid}"
     );
 }
 

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -1,8 +1,10 @@
 use crossterm::event::KeyCode;
-use kanban_domain::KanbanOperations;
+use kanban_domain::{CreateCardOptions, KanbanOperations};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::App;
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
 
 fn setup_app_with_board() -> App {
     let mut app = App::test_default();
@@ -26,6 +28,50 @@ fn setup_app_with_board() -> App {
 
 fn board_id(app: &App) -> uuid::Uuid {
     app.model.boards_state().loaded_or_empty()[0].id
+}
+
+fn setup_app_with_board_and_sprint() -> App {
+    let mut app = setup_app_with_board();
+    let bid = board_id(&app);
+    app.ctx.create_sprint(bid, None, None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+    app
+}
+
+fn setup_app_with_board_no_columns() -> App {
+    let mut app = App::test_default();
+    let _board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.selection.active_board_id = app
+        .ctx
+        .data_store()
+        .list_boards()
+        .unwrap()
+        .first()
+        .map(|b| b.id);
+    app
+}
+
+fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
 }
 
 fn confirm_create_card_dialog(app: &mut App, title: &str) {
@@ -139,20 +185,20 @@ fn test_create_card_dialog_leaves_card_unassigned_when_multiple_active_sprints()
 
 #[test]
 fn test_tab_toggles_focus_between_title_and_sprint_picker() {
-    let mut app = setup_app_with_board();
+    let mut app = setup_app_with_board_and_sprint();
     app.focus.active = Focus::Cards;
     app.handle_create_card_key();
 
     assert!(app.dialog_input.create_card_focus_is_title());
     app.handle_create_card_dialog(KeyCode::Tab);
-    assert!(!app.dialog_input.create_card_focus_is_title());
+    assert!(app.dialog_input.create_card_focus_is_sprint());
     app.handle_create_card_dialog(KeyCode::Tab);
     assert!(app.dialog_input.create_card_focus_is_title());
 }
 
 #[test]
 fn test_esc_on_title_focus_moves_focus_to_sprint_picker_without_closing() {
-    let mut app = setup_app_with_board();
+    let mut app = setup_app_with_board_and_sprint();
     app.focus.active = Focus::Cards;
     app.handle_create_card_key();
     assert!(app.dialog_input.create_card_focus_is_title());
@@ -160,16 +206,16 @@ fn test_esc_on_title_focus_moves_focus_to_sprint_picker_without_closing() {
     app.handle_create_card_dialog(KeyCode::Esc);
 
     assert!(matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)));
-    assert!(!app.dialog_input.create_card_focus_is_title());
+    assert!(app.dialog_input.create_card_focus_is_sprint());
 }
 
 #[test]
 fn test_esc_on_sprint_focus_closes_the_dialog() {
-    let mut app = setup_app_with_board();
+    let mut app = setup_app_with_board_and_sprint();
     app.focus.active = Focus::Cards;
     app.handle_create_card_key();
     app.handle_create_card_dialog(KeyCode::Tab);
-    assert!(!app.dialog_input.create_card_focus_is_title());
+    assert!(app.dialog_input.create_card_focus_is_sprint());
 
     app.handle_create_card_dialog(KeyCode::Esc);
 
@@ -181,23 +227,23 @@ fn test_esc_on_sprint_focus_closes_the_dialog() {
 
 #[test]
 fn test_down_on_title_focus_moves_focus_to_sprint_picker() {
-    let mut app = setup_app_with_board();
+    let mut app = setup_app_with_board_and_sprint();
     app.focus.active = Focus::Cards;
     app.handle_create_card_key();
     assert!(app.dialog_input.create_card_focus_is_title());
 
     app.handle_create_card_dialog(KeyCode::Down);
 
-    assert!(!app.dialog_input.create_card_focus_is_title());
+    assert!(app.dialog_input.create_card_focus_is_sprint());
 }
 
 #[test]
 fn test_typing_on_sprint_focus_does_not_modify_title_input() {
-    let mut app = setup_app_with_board();
+    let mut app = setup_app_with_board_and_sprint();
     app.focus.active = Focus::Cards;
     app.handle_create_card_key();
     app.handle_create_card_dialog(KeyCode::Tab);
-    assert!(!app.dialog_input.create_card_focus_is_title());
+    assert!(app.dialog_input.create_card_focus_is_sprint());
 
     app.handle_create_card_dialog(KeyCode::Char('x'));
     assert_eq!(app.input.as_str(), "");
@@ -370,4 +416,143 @@ fn test_create_card_does_not_carry_sprint_id_from_a_different_board() {
     );
     // Ditto column on B exists for completeness of the scenario.
     let _ = col_b;
+}
+
+#[test]
+fn test_create_card_dialog_hides_the_sprint_section_when_the_board_has_none() {
+    let mut app = setup_app_with_board_no_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    let rendered = render_to_string(&mut app, 80, 24);
+
+    assert!(rendered.contains("Task Title:"));
+    assert!(
+        !rendered.contains("Sprint:"),
+        "sprintless board must not render a Sprint section:\n{rendered}"
+    );
+}
+
+#[test]
+fn test_esc_closes_the_dialog_from_the_last_visible_field_when_there_are_no_sprints() {
+    let mut app = setup_app_with_board_no_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    // Column is editable here (no existing columns), so Tab walks
+    // Title -> Column before the cycle would otherwise wrap.
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert!(app.dialog_input.create_card_focus_is_column());
+
+    app.handle_create_card_dialog(KeyCode::Esc);
+
+    assert!(
+        !matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)),
+        "Esc on Column, the last visible field when there are no sprints, must close the dialog"
+    );
+}
+
+#[test]
+fn test_create_card_dialog_hides_the_sprint_section_when_only_another_board_has_sprints() {
+    let mut app = setup_app_with_board_no_columns();
+    let other_board = app.ctx.create_board("Other".to_string(), None).unwrap();
+    app.ctx.create_sprint(other_board.id, None, None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    let rendered = render_to_string(&mut app, 80, 24);
+
+    assert!(
+        !rendered.contains("Sprint:"),
+        "a sprint on a different board must not make the section visible here:\n{rendered}"
+    );
+}
+
+#[test]
+fn test_create_card_focus_skips_sprint_when_the_section_is_hidden() {
+    let mut app = setup_app_with_board_no_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    assert!(app.dialog_input.create_card_focus_is_title());
+
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert!(app.dialog_input.create_card_focus_is_column());
+
+    app.handle_create_card_dialog(KeyCode::Tab);
+    assert!(
+        app.dialog_input.create_card_focus_is_title(),
+        "focus must cycle straight back to Title, never landing on the hidden Sprint field"
+    );
+}
+
+fn seed_sprint_detail(app: &mut App) -> uuid::Uuid {
+    let board = app
+        .ctx
+        .create_board("Sprint Board".to_string(), None)
+        .unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Existing".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.assign_card_to_sprint(card.id, sprint.id).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+    app.selection.active_board_id = Some(board.id);
+    app.selection.active_sprint_id = Some(sprint.id);
+    app.populate_sprint_task_lists(sprint.id);
+    app.sprint_view
+        .uncompleted_component
+        .set_selected_index(Some(0));
+    board.id
+}
+
+#[test]
+fn test_create_card_dialog_opened_from_the_sprint_detail_view_reprimes_sprint_visibility() {
+    let mut app = setup_app_with_board_no_columns();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+    let sprintless = render_to_string(&mut app, 80, 24);
+    assert!(!sprintless.contains("Sprint:"));
+    app.handle_create_card_dialog(KeyCode::Esc);
+    app.handle_create_card_dialog(KeyCode::Esc);
+
+    seed_sprint_detail(&mut app);
+    app.handle_sprint_detail_key(KeyCode::Char('n'));
+
+    let rendered = render_to_string(&mut app, 80, 24);
+    assert!(
+        rendered.contains("Sprint:"),
+        "opening from a board that has sprints must not carry over the stale hidden flag:\n{rendered}"
+    );
+}
+
+#[test]
+fn test_create_card_dialog_is_title_only_when_column_is_fixed_and_no_sprints() {
+    let mut app = setup_app_with_board();
+    app.focus.active = Focus::Cards;
+    app.handle_create_card_key();
+
+    let rendered = render_to_string(&mut app, 80, 24);
+
+    assert!(rendered.contains("Task Title:"));
+    assert!(!rendered.contains("Column:"), "{rendered}");
+    assert!(!rendered.contains("Sprint:"), "{rendered}");
+
+    app.handle_create_card_dialog(KeyCode::Esc);
+    assert!(
+        !matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)),
+        "the title-only popup must itself be cancellable"
+    );
 }

--- a/crates/kanban-view/src/sprint_assign_list.rs
+++ b/crates/kanban-view/src/sprint_assign_list.rs
@@ -125,6 +125,23 @@ pub fn sprint_id_of(entry: &SprintAssignEntry) -> Option<Uuid> {
     }
 }
 
+/// Whether the create-card dialog's Sprint section should be shown for
+/// `board_id`. `NotLoaded`/`Missing`/`Failed` all show the section rather
+/// than collapse to hidden, since the board may turn out to have sprints
+/// once loading completes.
+pub fn sprint_section_is_visible(
+    sprints_state: &LoadState<Vec<Sprint>>,
+    board_id: Uuid,
+    now: DateTime<Utc>,
+) -> bool {
+    match sprints_state.loaded() {
+        Some(sprints) => build_entries_active_only(sprints, board_id, now)
+            .iter()
+            .any(|e| sprint_id_of(e).is_some()),
+        None => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-view/src/sprint_assign_list.rs
+++ b/crates/kanban-view/src/sprint_assign_list.rs
@@ -1,6 +1,6 @@
 use crate::list_nav;
 use chrono::{DateTime, Utc};
-use kanban_domain::{Sprint, SprintStatus};
+use kanban_domain::{LoadState, Sprint, SprintStatus};
 use uuid::Uuid;
 
 /// Entry in the sprint-assignment dialog list. Headers are non-selectable;
@@ -413,6 +413,58 @@ mod tests {
         assert_eq!(
             section_header_for(&entries, 4),
             Some((3, COMPLETED_ENDED_HEADER))
+        );
+    }
+
+    #[test]
+    fn test_sprint_section_is_visible_false_when_board_has_no_sprints() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let state = LoadState::Loaded(Vec::new());
+        assert!(!sprint_section_is_visible(&state, board, now));
+    }
+
+    #[test]
+    fn test_sprint_section_is_visible_true_when_board_has_an_active_sprint() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let sprint = make_sprint(1, board, SprintStatus::Planning, None);
+        let state = LoadState::Loaded(vec![sprint]);
+        assert!(sprint_section_is_visible(&state, board, now));
+    }
+
+    #[test]
+    fn test_sprint_section_is_visible_false_when_only_another_board_has_sprints() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let other_board = Uuid::new_v4();
+        let sprint = make_sprint(1, other_board, SprintStatus::Planning, None);
+        let state = LoadState::Loaded(vec![sprint]);
+        assert!(!sprint_section_is_visible(&state, board, now));
+    }
+
+    #[test]
+    fn test_sprint_section_is_visible_true_when_sprints_are_not_loaded() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let state: LoadState<Vec<Sprint>> = LoadState::NotLoaded;
+        assert!(sprint_section_is_visible(&state, board, now));
+    }
+
+    #[test]
+    fn test_sprint_section_is_visible_false_when_only_a_completed_sprint_exists() {
+        let now = ts("2026-05-07T00:00:00Z");
+        let board = Uuid::new_v4();
+        let sprint = make_sprint(
+            1,
+            board,
+            SprintStatus::Completed,
+            Some(ts("2026-04-01T00:00:00Z")),
+        );
+        let state = LoadState::Loaded(vec![sprint]);
+        assert!(
+            !sprint_section_is_visible(&state, board, now),
+            "the create-card picker's ActiveOnly filter excludes Completed sprints entirely"
         );
     }
 }


### PR DESCRIPTION
The Create New Task dialog always reserved space for a Sprint picker. On a board with no sprints that was a labelled, bordered, empty picker the user had to tab past. It is now hidden, the dialog shrinks to fit, focus skips it, and Esc closes from whichever field is last visible.

Closes KAN-1408, part of KAN-1388.

## Three traps this card was written around

**The obvious emptiness test is a silent no-op.** `build_entries` always emits a `SprintAssignEntry::None` row and `is_selectable()` excludes only headers, so `entries.is_empty()` is never true and `any(is_selectable)` is never false, even with zero sprints. The predicate is `any(|e| sprint_id_of(e).is_some())`, which returns `None` for both headers and the no-sprint row.

**Hiding the field breaks Esc-to-close.** Esc means leave this field, and the focus cycle terminated because Sprint closed the dialog. Removing Sprint would have left Enter, which submits, as the only exit. `create_card_focus_is_last_visible` covers all four combinations of column-editable and sprint-visible, including the column-fixed plus no-sprints case where Title itself must close.

**`model.sprints()` collapses not-loaded into empty.** The predicate takes `sprints_state()` and shows the section for every non-Loaded variant, so a dialog opened before sprints arrive does not hide a picker the board actually needs.

## Notes for review

**The picker is not smaller than it was.** An earlier revision used a fixed row allowance, which shrank the picker on large terminals: at 120x40 it went from 7 rows to 4. The dialog now reuses the original height formula and `Min(0)` verbatim whenever the section is shown, so the previous sizing is guaranteed by construction rather than by a maintained invariant. Only the hidden case computes a smaller height. Measured: 80x24 gives 1 row before and after, 120x40 gives 7 before and after, and a test pins the 120x40 count.

**Existing tests were repointed, not deleted.** `setup_app_with_board()` builds a sprintless board, so several tests were exercising sprint-focus behaviour on exactly the shape this change alters. They now use a sprint-bearing fixture and assert `create_card_focus_is_sprint()` rather than `!is_title()`, which was only non-vacuous by accident of those fixtures having a non-editable column. Four tests in `columnless_board_card_tests.rs` needed the same treatment; its dialog-shape test asserts parity between two fixtures, so seeding restores the assertion rather than hiding a change.

**Title says active or planned, deliberately.** The predicate uses the ActiveOnly filter, so a board whose only sprints are Completed also hides the section. That is intended and unit-tested.

The detail-view open path still does not call `reset_for_board`; that gap is pre-existing and deliberately untouched.