### PR TITLE
KAN-1393 docs(domain): spawns is a DAG, not a hierarchy

### DIFF
--- a/.changeset/kan-1393-spawns-is-a-dag.md
+++ b/.changeset/kan-1393-spawns-is-a-dag.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: documentation only. The `spawns` relation is described as a directed acyclic graph rather than a hierarchy, and the doc comments on `SpawnsEdge` and `CardEdgeType::Spawns` now state that a card may have more than one parent. No behaviour changed; the code already supported this and the prose did not say so, which led a reviewer to report the absence of a single-parent check as a defect.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ VS Code is known not to work in the current implementation.
 - Multiple boards, each with custom columns and WIP limits
 - Rich cards: title, description, priority (Low/Medium/High/Critical), status (Todo/InProgress/Blocked/Done), story points, due dates
 - Card numbering with configurable prefix (e.g. `KAN-42`)
-- Card relations: parent/child (Spawns), blocking (with severity), and undirected relates (with sub-kind) — each with cycle / self-reference detection and dedicated `kanban relation` CLI + MCP tools
+- Card relations: parent/child (Spawns, a directed acyclic graph — a card may have more than one parent), blocking (with severity), and undirected relates (with sub-kind) — each with cycle / self-reference detection and dedicated `kanban relation` CLI + MCP tools
 - Archive and restore cards
 - Configurable completion columns per board: `board update <board> --completion-columns Done,Decision` — status=done files cards under the first entry; `''` disables the status/column sync
 - `board create --with-default-columns` seeds TODO/Doing/Complete and sets Complete as the completion column in one step; a board created without the flag has no columns and no completion column until you run `column create` and `board update --completion-columns` yourself

--- a/crates/kanban-domain/README.md
+++ b/crates/kanban-domain/README.md
@@ -205,6 +205,8 @@ Used throughout all `*Update` structs to distinguish "not provided" from "explic
 
 Container for all card-relation edges, stored alongside the board snapshot. Three discrete sub-graphs, each with its own structural rules and its own concrete edge kind (carrying any per-kind metadata):
 
+`parent_child` (Spawns) is a directed acyclic graph, not a tree: a card may have more than one parent. `add_edge_with_metadata` rejects a duplicate `(parent, child)` pair and any edge that would close a cycle, but a second, different parent for the same child is a supported relation, not a defect — the "Parents" panel in `kanban-tui` and `list_parents_of` returning `Vec<Uuid>` exist precisely to represent it.
+
 ```rust
 pub struct DependencyGraph {
     parent_child: DagGraph<SpawnsEdge>,

--- a/crates/kanban-domain/src/dependencies/card_edge.rs
+++ b/crates/kanban-domain/src/dependencies/card_edge.rs
@@ -24,13 +24,14 @@ pub enum CardEdgeType {
     /// General relationship (informational, allows cycles)
     RelatesTo,
 
-    /// Hierarchy edge: source spawns target as a sub-item.
-    /// Transitive: if A spawns B and B spawns C, then A is an
-    /// ancestor of C. Enforces DAG: no cycles allowed (a card can't
-    /// be its own ancestor). The user-facing API still uses
-    /// parent/child language (`set_parent`, `parents`, `children`) —
-    /// that's how the relationship reads from either side; this
-    /// variant names the directed edge itself.
+    /// Parent/child edge: source spawns target as a sub-item, in a
+    /// directed acyclic graph rather than a tree — target may have
+    /// more than one parent. Transitive: if A spawns B and B spawns
+    /// C, then A is an ancestor of C. Enforces DAG: no cycles allowed
+    /// (a card can't be its own ancestor). The user-facing API still
+    /// uses parent/child language (`set_parent`, `parents`,
+    /// `children`) — that's how the relationship reads from either
+    /// side; this variant names the directed edge itself.
     #[default]
     Spawns,
     // Future edge types can be added here:

--- a/crates/kanban-domain/src/dependencies/edges.rs
+++ b/crates/kanban-domain/src/dependencies/edges.rs
@@ -19,13 +19,13 @@ use uuid::Uuid;
 
 use super::edge_meta::{RelatesKind, Severity};
 
-/// Edge representing a parent->child hierarchy relationship.
+/// Edge representing a directed parent->child relationship in a DAG,
+/// not a tree: a child may have more than one parent.
 ///
 /// Lives in the `parent_child: DagGraph<SpawnsEdge>` sub-graph.
 /// Carries no metadata today; future kind-specific fields (e.g. a
-/// per-child position within sibling ordering, if multiple parents
-/// become permitted) extend this struct without affecting
-/// `BlocksEdge` / `RelatesEdge`.
+/// per-child position within sibling ordering) extend this struct
+/// without affecting `BlocksEdge` / `RelatesEdge`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SpawnsEdge {
     #[serde(flatten)]


### PR DESCRIPTION
Documentation only. No behaviour change, no logic touched.

A release sweep reported as a HIGH defect that `DagGraph::add_edge_with_metadata` rejects a repeated (parent, child) pair but never a second, different parent for the same child. That is not a defect: multiple parents are a built feature. The card-detail view renders a Parents panel from a slice, there are keybindings to focus and set it, `list_parents_of` returns a Vec at every layer, and `DagGraph` is a directed acyclic graph where multiple parents are permitted by definition. The constraint that matters, cycle detection, sits beside the duplicate check and is correct.

The code was right. The prose called `spawns` a hierarchy, which means a tree, and that wording is what made a competent reviewer read a correct check as a missing one.

Closes KAN-1393, part of KAN-1388.

## Notes for review

Four passages corrected: the root README, the `kanban-domain` README's DependencyGraph section, and the doc comments on `SpawnsEdge` and `CardEdgeType::Spawns`.

Worth singling out: the `SpawnsEdge` comment referred to "if multiple parents become permitted" as a future possibility. They already are permitted, so the comment described the code as not doing something it does.

Hierarchy vocabulary elsewhere was checked and deliberately left: the "single parent FK" in the MCP column tool is a board-name lookup, "hierarchical read" in the store adapter is column/card containment, and the "two-level hierarchy" in `card.rs` is branch-prefix resolution. None concerns `spawns`. CHANGELOG entries were left as an append-only historical record.

CLAUDE.md does not mention `spawns` at all, so there is no collision with the KAN-1384 rework.

The premise was verified against the code before documenting it, rather than taken from the card.