### PR TITLE
KAN-1390 feat(api,server,backend-http): expose prefixes read-only over the REST API

### DIFF
--- a/.changeset/kan-1390-prefixes-rest-readonly.md
+++ b/.changeset/kan-1390-prefixes-rest-readonly.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-api,server,backend-http: expose prefixes read-only over the REST API (`GET /v1/prefixes`, `GET /v1/prefixes/{name}`), backed by a new `PrefixResponse` DTO. `HttpBackend::list_prefixes`/`get_prefix` now call these routes instead of failing with `Unsupported`; `upsert_prefix` stays `Unsupported` since no create/rename/delete route exists.
+api,server,backend-http: expose prefixes read-only over the REST API (`GET /v1/prefixes` for the list, `GET /v1/prefixes?name=<value>` for a single row), backed by a new `PrefixResponse` DTO with high-water-mark-named fields (`last_card_number`/`last_sprint_number`). `HttpBackend::list_prefixes`/`get_prefix` now call these routes instead of failing with `Unsupported`; `upsert_prefix` stays `Unsupported` since no create/rename/delete route exists. The lookup takes `name` as a query parameter rather than a path segment so a value containing `/`, `#`, `?` or a space round-trips correctly, and so the empty prefix (a valid namespace) stays addressable.

--- a/.changeset/kan-1390-prefixes-rest-readonly.md
+++ b/.changeset/kan-1390-prefixes-rest-readonly.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+api,server,backend-http: expose prefixes read-only over the REST API (`GET /v1/prefixes`, `GET /v1/prefixes/{name}`), backed by a new `PrefixResponse` DTO. `HttpBackend::list_prefixes`/`get_prefix` now call these routes instead of failing with `Unsupported`; `upsert_prefix` stays `Unsupported` since no create/rename/delete route exists.

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -8,7 +8,7 @@ pub use v1::{
     ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
     CardStatusDto, ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest,
     CreateCardRequest, CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType,
-    ErrorCode, Page, PageParams, Patch, ReorderColumnRequest, ReplaceBoardRequest,
+    ErrorCode, Page, PageParams, Patch, PrefixResponse, ReorderColumnRequest, ReplaceBoardRequest,
     ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto,
     SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest,
     UpdateColumnRequest, UpdateSprintRequest,

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -8,6 +8,7 @@ mod events;
 mod graph;
 mod pagination;
 mod patch;
+mod prefixes;
 mod sprints;
 pub use boards::{BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
 pub use cards::{CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
@@ -24,6 +25,7 @@ pub use events::{ChangeEventFrame, ChangeKind, EntityType};
 pub use graph::CardGraphResponse;
 pub use pagination::{Page, PageParams};
 pub use patch::Patch;
+pub use prefixes::PrefixResponse;
 pub use sprints::{
     CreateSprintParts, CreateSprintRequest, ReplaceSprintRequest, SprintResponse,
     UpdateSprintRequest,

--- a/crates/kanban-api/src/v1/prefixes.rs
+++ b/crates/kanban-api/src/v1/prefixes.rs
@@ -1,0 +1,59 @@
+use kanban_domain::Prefix;
+use serde::{Deserialize, Serialize};
+
+/// Response body for prefix reads. Mirrors the domain row: `name` is the
+/// namespace's identity (already normalised), and the two counters are the
+/// last card/sprint number minted from it. Read-only -- there is no write
+/// route, so `Deserialize` is derived only for round-trip tests / client use.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PrefixResponse {
+    pub name: String,
+    pub card_counter: u32,
+    pub sprint_counter: u32,
+}
+
+impl From<&Prefix> for PrefixResponse {
+    fn from(p: &Prefix) -> Self {
+        let Prefix {
+            name,
+            card_counter,
+            sprint_counter,
+        } = p;
+        Self {
+            name: name.clone(),
+            card_counter: *card_counter,
+            sprint_counter: *sprint_counter,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prefix_response_from_prefix_carries_name_and_counters() {
+        let mut prefix = Prefix::new("kan");
+        prefix.card_counter = 42;
+        prefix.sprint_counter = 3;
+
+        let resp = PrefixResponse::from(&prefix);
+
+        assert_eq!(resp.name, "kan");
+        assert_eq!(resp.card_counter, 42);
+        assert_eq!(resp.sprint_counter, 3);
+    }
+
+    #[test]
+    fn test_prefix_response_round_trips_through_json() {
+        let mut prefix = Prefix::new("feat");
+        prefix.card_counter = 7;
+        prefix.sprint_counter = 1;
+        let resp = PrefixResponse::from(&prefix);
+
+        let json = serde_json::to_string(&resp).unwrap();
+        let decoded: PrefixResponse = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, resp);
+    }
+}

--- a/crates/kanban-api/src/v1/prefixes.rs
+++ b/crates/kanban-api/src/v1/prefixes.rs
@@ -2,14 +2,17 @@ use kanban_domain::Prefix;
 use serde::{Deserialize, Serialize};
 
 /// Response body for prefix reads. Mirrors the domain row: `name` is the
-/// namespace's identity (already normalised), and the two counters are the
-/// last card/sprint number minted from it. Read-only -- there is no write
-/// route, so `Deserialize` is derived only for round-trip tests / client use.
+/// namespace's identity (already normalised). `last_card_number` and
+/// `last_sprint_number` are HIGH-WATER MARKS (the last number handed out,
+/// not a count) -- named to say so on the wire, since the domain fields they
+/// come from (`Prefix::card_counter`/`sprint_counter`) read as counts and are
+/// not. Read-only -- there is no write route, so `Deserialize` is derived
+/// only for round-trip tests / client use.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PrefixResponse {
     pub name: String,
-    pub card_counter: u32,
-    pub sprint_counter: u32,
+    pub last_card_number: u32,
+    pub last_sprint_number: u32,
 }
 
 impl From<&Prefix> for PrefixResponse {
@@ -21,8 +24,8 @@ impl From<&Prefix> for PrefixResponse {
         } = p;
         Self {
             name: name.clone(),
-            card_counter: *card_counter,
-            sprint_counter: *sprint_counter,
+            last_card_number: *card_counter,
+            last_sprint_number: *sprint_counter,
         }
     }
 }
@@ -40,8 +43,8 @@ mod tests {
         let resp = PrefixResponse::from(&prefix);
 
         assert_eq!(resp.name, "kan");
-        assert_eq!(resp.card_counter, 42);
-        assert_eq!(resp.sprint_counter, 3);
+        assert_eq!(resp.last_card_number, 42);
+        assert_eq!(resp.last_sprint_number, 3);
     }
 
     #[test]
@@ -55,5 +58,18 @@ mod tests {
         let decoded: PrefixResponse = serde_json::from_str(&json).unwrap();
 
         assert_eq!(decoded, resp);
+    }
+
+    #[test]
+    fn test_prefix_response_wire_fields_are_high_water_mark_named() {
+        let prefix = Prefix::new("kan");
+        let resp = PrefixResponse::from(&prefix);
+
+        let json = serde_json::to_string(&resp).unwrap();
+
+        assert!(json.contains("\"last_card_number\""), "json: {json}");
+        assert!(json.contains("\"last_sprint_number\""), "json: {json}");
+        assert!(!json.contains("card_counter"), "json: {json}");
+        assert!(!json.contains("sprint_counter"), "json: {json}");
     }
 }

--- a/crates/kanban-backend-http/src/conversions.rs
+++ b/crates/kanban-backend-http/src/conversions.rs
@@ -3,8 +3,8 @@ use kanban_domain::{Board, Card, Column, Prefix, Sprint};
 
 pub(crate) fn prefix_from_response(resp: &PrefixResponse) -> Prefix {
     let mut prefix = Prefix::new(&resp.name);
-    prefix.card_counter = resp.card_counter;
-    prefix.sprint_counter = resp.sprint_counter;
+    prefix.card_counter = resp.last_card_number;
+    prefix.sprint_counter = resp.last_sprint_number;
     prefix
 }
 

--- a/crates/kanban-backend-http/src/conversions.rs
+++ b/crates/kanban-backend-http/src/conversions.rs
@@ -1,5 +1,12 @@
-use kanban_api::{BoardResponse, CardResponse, ColumnResponse, SprintResponse};
-use kanban_domain::{Board, Card, Column, Sprint};
+use kanban_api::{BoardResponse, CardResponse, ColumnResponse, PrefixResponse, SprintResponse};
+use kanban_domain::{Board, Card, Column, Prefix, Sprint};
+
+pub(crate) fn prefix_from_response(resp: &PrefixResponse) -> Prefix {
+    let mut prefix = Prefix::new(&resp.name);
+    prefix.card_counter = resp.card_counter;
+    prefix.sprint_counter = resp.sprint_counter;
+    prefix
+}
 
 /// `BoardResponse` omits `sprint_names`, `sprint_name_used_count` and
 /// `next_sprint_number`; they are defaulted here to empty/zero/one. A board

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -1,8 +1,9 @@
 use crate::conversions::{
-    board_from_response, card_from_response, column_from_response, sprint_from_response,
+    board_from_response, card_from_response, column_from_response, prefix_from_response,
+    sprint_from_response,
 };
 use crate::HttpBackend;
-use kanban_api::{BoardResponse, CardResponse, ColumnResponse, SprintResponse};
+use kanban_api::{BoardResponse, CardResponse, ColumnResponse, PrefixResponse, SprintResponse};
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
     KanbanResult, Prefix, Snapshot, Sprint,
@@ -10,12 +11,19 @@ use kanban_domain::{
 use uuid::Uuid;
 
 impl DataStore for HttpBackend {
-    fn get_prefix(&self, _name: &str) -> KanbanResult<Option<Prefix>> {
-        Err(KanbanError::unsupported("get_prefix"))
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<Prefix>> {
+        self.block_on(async {
+            let resp: Option<PrefixResponse> =
+                self.get_json(&format!("/v1/prefixes/{name}")).await?;
+            Ok(resp.as_ref().map(prefix_from_response))
+        })
     }
 
     fn list_prefixes(&self) -> KanbanResult<Vec<Prefix>> {
-        Err(KanbanError::unsupported("list_prefixes"))
+        self.block_on(async {
+            let resp: Vec<PrefixResponse> = self.get_json_list("/v1/prefixes").await?;
+            Ok(resp.iter().map(prefix_from_response).collect())
+        })
     }
 
     fn upsert_prefix(&self, _prefix: Prefix) -> KanbanResult<()> {

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -13,8 +13,9 @@ use uuid::Uuid;
 impl DataStore for HttpBackend {
     fn get_prefix(&self, name: &str) -> KanbanResult<Option<Prefix>> {
         self.block_on(async {
-            let resp: Option<PrefixResponse> =
-                self.get_json(&format!("/v1/prefixes/{name}")).await?;
+            let resp: Option<PrefixResponse> = self
+                .get_json_with_query("/v1/prefixes", &[("name", name)])
+                .await?;
             Ok(resp.as_ref().map(prefix_from_response))
         })
     }

--- a/crates/kanban-backend-http/src/http.rs
+++ b/crates/kanban-backend-http/src/http.rs
@@ -15,10 +15,22 @@ impl HttpBackend {
         &self,
         path: &str,
     ) -> KanbanResult<Option<T>> {
+        self.get_json_with_query(path, &[]).await
+    }
+
+    /// Like [`Self::get_json`], but attaches `query` via reqwest's own query
+    /// builder rather than string interpolation, so a value is percent-encoded
+    /// (and an empty value stays addressable) instead of corrupting the path.
+    pub(crate) async fn get_json_with_query<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> KanbanResult<Option<T>> {
         let url = format!("{}{}", self.base_url(), path);
         let resp = self
             .client()
             .get(&url)
+            .query(query)
             .send()
             .await
             .map_err(|e| KanbanError::Transport(e.to_string()))?;

--- a/crates/kanban-backend-http/tests/decline_rulings.rs
+++ b/crates/kanban-backend-http/tests/decline_rulings.rs
@@ -1,5 +1,5 @@
 use kanban_backend_http::HttpBackend;
-use kanban_domain::{DataStore, KanbanError};
+use kanban_domain::{DataStore, KanbanError, Prefix};
 use uuid::Uuid;
 
 fn unreachable_backend() -> HttpBackend {
@@ -35,6 +35,13 @@ fn test_list_cards_by_prefix_and_number_declines_under_its_own_name() {
     let backend = unreachable_backend();
     let result = backend.list_cards_by_prefix_and_number("kan", 1);
     assert_declines_under_its_own_name(result, "list_cards_by_prefix_and_number");
+}
+
+#[test]
+fn test_upsert_prefix_declines_under_its_own_name() {
+    let backend = unreachable_backend();
+    let result = backend.upsert_prefix(Prefix::new("kan"));
+    assert_declines_under_its_own_name(result, "upsert_prefix");
 }
 
 #[test]

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -3,7 +3,7 @@ use kanban_api::{
     SortOrderDto, TaskListViewDto,
 };
 use kanban_backend_http::HttpBackend;
-use kanban_domain::{Board, Card, Column, DataStore, Sprint};
+use kanban_domain::{Board, Card, Column, DataStore, Prefix, Sprint};
 use kanban_server::test_helpers::TestServer;
 use uuid::Uuid;
 
@@ -444,6 +444,87 @@ async fn test_list_cards_by_columns_returns_cards_from_every_requested_column() 
     let titles: Vec<&str> = cards.iter().map(|c| c.title.as_str()).collect();
     assert!(titles.contains(&"A1"));
     assert!(titles.contains(&"B1"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_prefixes_returns_the_namespace_minted_by_a_card_create() {
+    let server = TestServer::start().await;
+    let req = CreateBoardRequest {
+        id: None,
+        name: "Prefix Board".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: Some("PFX".to_string()),
+        task_sort_field: Some(SortFieldDto::Default),
+        task_sort_order: Some(SortOrderDto::Ascending),
+        sprint_duration_days: None,
+        task_list_view: Some(TaskListViewDto::Flat),
+    };
+    let resp = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    let board: kanban_api::BoardResponse = resp.json().await.unwrap();
+    let column_id = seed_column(&server, board.id, "Col", None, None).await;
+    seed_card(&server, column_id, "First card", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefixes: Vec<Prefix> = blocking(move || backend.list_prefixes().unwrap()).await;
+
+    let names: Vec<&str> = prefixes.iter().map(|p| p.name.as_str()).collect();
+    assert!(names.contains(&"pfx"), "expected pfx in {names:?}");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_returns_the_row_minted_by_a_card_create() {
+    let server = TestServer::start().await;
+    let req = CreateBoardRequest {
+        id: None,
+        name: "Prefix Board".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: Some("GET".to_string()),
+        task_sort_field: Some(SortFieldDto::Default),
+        task_sort_order: Some(SortOrderDto::Ascending),
+        sprint_duration_days: None,
+        task_list_view: Some(TaskListViewDto::Flat),
+    };
+    let resp = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    let board: kanban_api::BoardResponse = resp.json().await.unwrap();
+    let column_id = seed_column(&server, board.id, "Col", None, None).await;
+    seed_card(&server, column_id, "First card", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefix: Option<Prefix> = blocking(move || backend.get_prefix("get").unwrap()).await;
+
+    let prefix = prefix.expect("get_prefix should find the minted row");
+    assert_eq!(prefix.name, "get");
+    assert_eq!(prefix.card_counter, 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_unknown_name_returns_none() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefix: Option<Prefix> = blocking(move || backend.get_prefix("missing").unwrap()).await;
+
+    assert!(prefix.is_none());
 
     server.shutdown().await;
 }

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -529,6 +529,133 @@ async fn test_get_prefix_unknown_name_returns_none() {
     server.shutdown().await;
 }
 
+async fn seed_board_with_card_prefix(server: &TestServer, card_prefix: &str) -> Uuid {
+    let req = CreateBoardRequest {
+        id: None,
+        name: "Prefix Board".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: Some(card_prefix.to_string()),
+        task_sort_field: Some(SortFieldDto::Default),
+        task_sort_order: Some(SortOrderDto::Ascending),
+        sprint_duration_days: None,
+        task_list_view: Some(TaskListViewDto::Flat),
+    };
+    let resp = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    let board: kanban_api::BoardResponse = resp.json().await.unwrap();
+    board.id
+}
+
+async fn mint_prefix_via_card(server: &TestServer, card_prefix: &str) {
+    let board_id = seed_board_with_card_prefix(server, card_prefix).await;
+    let column_id = seed_column(server, board_id, "Col", None, None).await;
+    seed_card(server, column_id, "First card", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_round_trips_a_name_containing_a_hash() {
+    let server = TestServer::start().await;
+    mint_prefix_via_card(&server, "a#b").await;
+    mint_prefix_via_card(&server, "a").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefix: Option<Prefix> = blocking(move || backend.get_prefix("a#b").unwrap()).await;
+
+    let prefix = prefix.expect("get_prefix should find the a#b row, not the a row");
+    assert_eq!(prefix.name, "a#b");
+    assert_eq!(prefix.card_counter, 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_round_trips_a_name_containing_a_slash() {
+    let server = TestServer::start().await;
+    mint_prefix_via_card(&server, "a/b").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefix: Option<Prefix> = blocking(move || backend.get_prefix("a/b").unwrap()).await;
+
+    let prefix = prefix.expect("get_prefix should find the a/b row");
+    assert_eq!(prefix.name, "a/b");
+    assert_eq!(prefix.card_counter, 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_round_trips_a_name_containing_a_question_mark() {
+    let server = TestServer::start().await;
+    mint_prefix_via_card(&server, "a?b").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefix: Option<Prefix> = blocking(move || backend.get_prefix("a?b").unwrap()).await;
+
+    let prefix = prefix.expect("get_prefix should find the a?b row");
+    assert_eq!(prefix.name, "a?b");
+    assert_eq!(prefix.card_counter, 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_round_trips_a_name_containing_a_space() {
+    let server = TestServer::start().await;
+    mint_prefix_via_card(&server, "a b").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefix: Option<Prefix> = blocking(move || backend.get_prefix("a b").unwrap()).await;
+
+    let prefix = prefix.expect("get_prefix should find the 'a b' row");
+    assert_eq!(prefix.name, "a b");
+    assert_eq!(prefix.card_counter, 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_round_trips_the_empty_name() {
+    let server = TestServer::start().await;
+    mint_prefix_via_card(&server, "").await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefix: Option<Prefix> = blocking(move || backend.get_prefix("").unwrap()).await;
+
+    let prefix = prefix.expect("get_prefix should find the empty-name row, not report absent");
+    assert_eq!(prefix.name, "");
+    assert_eq!(prefix.card_counter, 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_prefixes_follows_pagination_past_the_first_page() {
+    let server = TestServer::start().await;
+    for i in 0..75 {
+        mint_prefix_via_card(&server, &format!("p{i}")).await;
+    }
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let prefixes: Vec<Prefix> = blocking(move || backend.list_prefixes().unwrap()).await;
+
+    let unique: std::collections::HashSet<String> =
+        prefixes.iter().map(|p| p.name.clone()).collect();
+    assert_eq!(
+        unique.len(),
+        75,
+        "expected all 75 prefixes, got {}",
+        prefixes.len()
+    );
+
+    server.shutdown().await;
+}
+
 #[test]
 fn test_a_read_against_an_unreachable_server_maps_to_a_transport_error() {
     let backend = HttpBackend::new("http://127.0.0.1:1").unwrap();

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -33,6 +33,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::columns::flat_read_router())
         .merge(crate::routes::columns::flat_write_router())
         .merge(crate::routes::graph::read_router())
+        .merge(crate::routes::prefixes::read_router())
         .merge(crate::routes::sprints::read_router())
         .merge(crate::routes::sprints::write_router())
         .merge(crate::routes::sprints::flat_read_router())

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -18,6 +18,7 @@ pub mod routes {
     pub mod columns;
     pub mod events;
     pub mod graph;
+    pub mod prefixes;
     pub mod sprints;
 }
 

--- a/crates/kanban-server/src/routes/prefixes.rs
+++ b/crates/kanban-server/src/routes/prefixes.rs
@@ -1,0 +1,46 @@
+use crate::error::AppError;
+use crate::pagination::paginate_response;
+use crate::state::AppState;
+use axum::extract::{Path, Query, State};
+use axum::routing::get;
+use axum::{Json, Router};
+use kanban_domain::{KanbanError, Prefix};
+use kanban_service::api::{Page, PageParams, PrefixResponse};
+
+async fn list_prefixes(
+    State(state): State<AppState>,
+    Query(params): Query<PageParams>,
+) -> Result<Json<Page<PrefixResponse>>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let prefixes = ctx
+        .data_store()
+        .list_prefixes()
+        .map_err(|e| AppError::from(&e))?;
+    paginate_response(prefixes.iter().map(PrefixResponse::from).collect(), &params)
+}
+
+async fn get_prefix(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<PrefixResponse>, AppError> {
+    let ctx = state.ctx.lock().await;
+    let normalized = Prefix::normalize(&name);
+    let prefix = ctx
+        .data_store()
+        .get_prefix(&normalized)
+        .map_err(|e| AppError::from(&e))?
+        .ok_or_else(|| {
+            AppError::from(&KanbanError::not_found_by_name(
+                "Prefix",
+                &normalized,
+                Vec::new(),
+            ))
+        })?;
+    Ok(Json(PrefixResponse::from(&prefix)))
+}
+
+pub fn read_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/prefixes", get(list_prefixes))
+        .route("/v1/prefixes/{name}", get(get_prefix))
+}

--- a/crates/kanban-server/src/routes/prefixes.rs
+++ b/crates/kanban-server/src/routes/prefixes.rs
@@ -1,46 +1,66 @@
 use crate::error::AppError;
 use crate::pagination::paginate_response;
 use crate::state::AppState;
-use axum::extract::{Path, Query, State};
+use axum::extract::{Query, State};
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use kanban_domain::{KanbanError, Prefix};
-use kanban_service::api::{Page, PageParams, PrefixResponse};
+use kanban_service::api::{PageParams, PrefixResponse};
+use serde::Deserialize;
 
-async fn list_prefixes(
-    State(state): State<AppState>,
-    Query(params): Query<PageParams>,
-) -> Result<Json<Page<PrefixResponse>>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let prefixes = ctx
-        .data_store()
-        .list_prefixes()
-        .map_err(|e| AppError::from(&e))?;
-    paginate_response(prefixes.iter().map(PrefixResponse::from).collect(), &params)
+#[derive(Debug, Deserialize)]
+struct PrefixesQuery {
+    name: Option<String>,
+    page: Option<u32>,
+    page_size: Option<u32>,
 }
 
-async fn get_prefix(
+async fn prefixes_route(
     State(state): State<AppState>,
-    Path(name): Path<String>,
-) -> Result<Json<PrefixResponse>, AppError> {
+    Query(query): Query<PrefixesQuery>,
+) -> Result<Response, AppError> {
     let ctx = state.ctx.lock().await;
-    let normalized = Prefix::normalize(&name);
-    let prefix = ctx
-        .data_store()
-        .get_prefix(&normalized)
-        .map_err(|e| AppError::from(&e))?
-        .ok_or_else(|| {
-            AppError::from(&KanbanError::not_found_by_name(
-                "Prefix",
-                &normalized,
-                Vec::new(),
-            ))
-        })?;
-    Ok(Json(PrefixResponse::from(&prefix)))
+    match query.name {
+        Some(name) => {
+            let normalized = Prefix::normalize(&name);
+            let prefix = ctx
+                .data_store()
+                .get_prefix(&normalized)
+                .map_err(|e| AppError::from(&e))?;
+            match prefix {
+                Some(prefix) => Ok(Json(PrefixResponse::from(&prefix)).into_response()),
+                None => {
+                    let available = ctx
+                        .data_store()
+                        .list_prefixes()
+                        .map(|rows| rows.into_iter().map(|p| p.name).collect())
+                        .unwrap_or_default();
+                    Err(AppError::from(&KanbanError::not_found_by_name(
+                        "Prefix",
+                        &normalized,
+                        available,
+                    )))
+                }
+            }
+        }
+        None => {
+            let prefixes = ctx
+                .data_store()
+                .list_prefixes()
+                .map_err(|e| AppError::from(&e))?;
+            let params = PageParams {
+                page: query.page,
+                page_size: query.page_size,
+            };
+            Ok(
+                paginate_response(prefixes.iter().map(PrefixResponse::from).collect(), &params)?
+                    .into_response(),
+            )
+        }
+    }
 }
 
 pub fn read_router() -> Router<AppState> {
-    Router::new()
-        .route("/v1/prefixes", get(list_prefixes))
-        .route("/v1/prefixes/{name}", get(get_prefix))
+    Router::new().route("/v1/prefixes", get(prefixes_route))
 }

--- a/crates/kanban-server/tests/prefixes_read.rs
+++ b/crates/kanban-server/tests/prefixes_read.rs
@@ -57,13 +57,13 @@ async fn test_get_prefix_returns_row_for_existing_name() {
         ctx.data_store().upsert_prefix(kan).unwrap();
     }
 
-    let response = send(&state, "GET", "/v1/prefixes/kan", None).await;
+    let response = send(&state, "GET", "/v1/prefixes?name=kan", None).await;
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
     assert_eq!(json["name"], "kan");
-    assert_eq!(json["card_counter"], 7);
-    assert_eq!(json["sprint_counter"], 3);
+    assert_eq!(json["last_card_number"], 7);
+    assert_eq!(json["last_sprint_number"], 3);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -76,7 +76,7 @@ async fn test_get_prefix_normalizes_name_before_lookup() {
         ctx.data_store().upsert_prefix(Prefix::new("kan")).unwrap();
     }
 
-    let response = send(&state, "GET", "/v1/prefixes/KAN", None).await;
+    let response = send(&state, "GET", "/v1/prefixes?name=KAN", None).await;
 
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_of(response).await;
@@ -88,9 +88,86 @@ async fn test_get_prefix_unknown_name_returns_404_not_found() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
-    let response = send(&state, "GET", "/v1/prefixes/missing", None).await;
+    let response = send(&state, "GET", "/v1/prefixes?name=missing", None).await;
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let json = json_of(response).await;
     assert_eq!(json["code"], "NOT_FOUND_BY_NAME");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_unknown_name_populates_available_from_the_workspace() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let ctx = state.ctx.lock().await;
+        ctx.data_store().upsert_prefix(Prefix::new("kan")).unwrap();
+        ctx.data_store().upsert_prefix(Prefix::new("feat")).unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/prefixes?name=missing", None).await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    let available: std::collections::HashSet<_> = json["message"]
+        .as_str()
+        .unwrap()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|s| *s == "kan" || *s == "feat")
+        .collect();
+    assert_eq!(
+        available,
+        std::collections::HashSet::from(["kan", "feat"]),
+        "the 404 message should name the available prefixes, got: {}",
+        json["message"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_empty_name_is_addressable() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let ctx = state.ctx.lock().await;
+        let mut empty = Prefix::new("");
+        empty.card_counter = 4;
+        ctx.data_store().upsert_prefix(empty).unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/prefixes?name=", None).await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "the empty-name row must be addressable, not silently 404"
+    );
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "");
+    assert_eq!(json["last_card_number"], 4);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_prefixes_follows_pagination_past_the_first_page() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let ctx = state.ctx.lock().await;
+        for i in 0..75 {
+            ctx.data_store()
+                .upsert_prefix(Prefix::new(&format!("p{i}")))
+                .unwrap();
+        }
+    }
+
+    let page1 = send(&state, "GET", "/v1/prefixes?page=1&page_size=50", None).await;
+    let page1 = json_of(page1).await;
+    assert_eq!(page1["items"].as_array().unwrap().len(), 50);
+    assert_eq!(page1["total_pages"], 2);
+
+    let page2 = send(&state, "GET", "/v1/prefixes?page=2&page_size=50", None).await;
+    let page2 = json_of(page2).await;
+    assert_eq!(page2["items"].as_array().unwrap().len(), 25);
 }

--- a/crates/kanban-server/tests/prefixes_read.rs
+++ b/crates/kanban-server/tests/prefixes_read.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::http::StatusCode;
+use kanban_domain::Prefix;
+use kanban_server::test_helpers::{json_of, make_state, send};
+use tempfile::tempdir;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_prefixes_empty_returns_200_empty_page() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = send(&state, "GET", "/v1/prefixes", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["items"], serde_json::json!([]));
+    assert_eq!(json["total"], 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_prefixes_returns_seeded_rows() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let ctx = state.ctx.lock().await;
+        let mut kan = Prefix::new("kan");
+        kan.card_counter = 5;
+        ctx.data_store().upsert_prefix(kan).unwrap();
+        let mut feat = Prefix::new("feat");
+        feat.sprint_counter = 2;
+        ctx.data_store().upsert_prefix(feat).unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/prefixes", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json["items"].as_array().expect("items should be an array");
+    assert_eq!(arr.len(), 2);
+    let names: std::collections::HashSet<_> =
+        arr.iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert_eq!(names, std::collections::HashSet::from(["kan", "feat"]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_returns_row_for_existing_name() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let ctx = state.ctx.lock().await;
+        let mut kan = Prefix::new("kan");
+        kan.card_counter = 7;
+        kan.sprint_counter = 3;
+        ctx.data_store().upsert_prefix(kan).unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/prefixes/kan", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "kan");
+    assert_eq!(json["card_counter"], 7);
+    assert_eq!(json["sprint_counter"], 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_normalizes_name_before_lookup() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let ctx = state.ctx.lock().await;
+        ctx.data_store().upsert_prefix(Prefix::new("kan")).unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/prefixes/KAN", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "kan");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_prefix_unknown_name_returns_404_not_found() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = send(&state, "GET", "/v1/prefixes/missing", None).await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND_BY_NAME");
+}


### PR DESCRIPTION
The `Prefix` entity had no REST exposure at all. `HttpBackend::get_prefix`, `list_prefixes` and `upsert_prefix` all hard-failed with `Unsupported`, so a remote client created cards carrying a prefix that had to be backed by a row it could neither see nor validate against.

Closes KAN-1390, part of KAN-1388.

`GET /v1/prefixes` lists namespaces paginated; `GET /v1/prefixes?name=<value>` looks one up. `HttpBackend` implements both.

## The lookup is a query parameter, not a path segment, for two reasons

Review caught both on the first revision, and a query parameter fixes them together.

**A path segment returned the wrong namespace's data.** The client built the URL with `format!("/v1/prefixes/{name}")` and nothing encoded it. `Board::card_prefix` has no charset validation and `Prefix::normalize` only lowercases, so a board with `card_prefix: "a#b"` mints a row that `list_prefixes()` returns, while `get_prefix("a#b")` requested `/v1/prefixes/a` and came back with a different namespace's counters. Silently wrong data rather than an error. The test for it seeds a sibling `"a"` prefix so a truncating request returns the wrong row rather than nothing.

**The empty prefix was unaddressable.** It is first-class here: the FK exempts it and `allocate_card_number` will mint and advance it. But axum does not match an empty path segment, and `get_json` turns any 404 into `Ok(None)`, so `list_prefixes()` showed the row while `get_prefix("")` reported absent and all three local backends reported `Some`. That is a backend-substitutability break, the same class KAN-1391 fixes one layer down.

Encoding now goes through reqwest's `.query()`, the idiom `get_json_list` already uses for pagination, rather than string interpolation. Tests cover `#`, `/`, `?`, space and the empty name, each through a real `TestServer` over actual HTTP.

## Wire field names say what they are

`card_counter` and `sprint_counter` are high-water marks, not counts, and the domain notes a previous representation stored the NEXT number instead. `{"card_counter": 5}` invites a client to read five cards. On the wire they are `last_card_number` and `last_sprint_number`; the domain fields are unchanged. A test asserts the old names never appear on the wire. Field names freeze on release, so this is free now and breaking later.

## Read-only, deliberately

No create, rename or delete. `ON UPDATE RESTRICT` and `ON DELETE RESTRICT` refuse either while a card references the prefix, which is the only case worth using them for, so such an endpoint must either fail for its own use case or migrate data behind an HTTP call. `upsert_prefix` still returns `Unsupported`, with a test pinning that it declines.

## Notes for review

Pagination reuses `paginate_response`/`PaginatedList` with no hand-rolled slicing, and a multi-page test now exercises `get_json_list` following `total_pages` across 75 rows.

This is the first `kanban-server` route to reach `ctx.data_store()` rather than a `KanbanOperations` method. Checked for observable effect: `data_store()` returns the same backend instance those methods use, with no separate lock or bypassed validation, and prefixes are simply the first entity with no `KanbanOperations` surface at all. The TUI, CLI and MCP already call it directly.

One pre-existing issue noted and not touched here: `get_json` converts any 404 to `Ok(None)`, so a missing row and a server too old to have the route are indistinguishable to the caller. Shared by every `get_*` on `HttpBackend`; carded separately.