### PR TITLE
KAN-1411 fix(core,domain): thread edge state through dependency-edge removal so undo can remove a tombstone

### DIFF
--- a/.changeset/kan-1411-undo-import-archived-edges.md
+++ b/.changeset/kan-1411-undo-import-archived-edges.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+core,domain: undoing an import no longer strands an archived dependency edge it added. The inverse-capture the import merge emits (`RemoveSpawns`/`RemoveBlocks`/`RemoveRelates`) now carries the edge's state, so undo removes the edge in whatever state the forward insert left it instead of silently no-opping against a tombstone. `EdgeStore` gains `remove_archived_directed_edge`/`remove_archived_undirected_edge` as archived-only mirrors of the existing active-only removers, which are unchanged.

--- a/crates/kanban-core/src/graph/core.rs
+++ b/crates/kanban-core/src/graph/core.rs
@@ -128,6 +128,32 @@ impl<E: Edge> EdgeStore<E> {
         self.edges.len() < before
     }
 
+    /// Remove the single **archived** edge whose `source == source` and
+    /// `target == target` exactly (directed-graph semantics). Active
+    /// edges with the same endpoints are preserved — this is the exact
+    /// mirror of `remove_directed_edge`, for callers undoing an
+    /// operation that inserted a tombstone. Returns `true` iff an
+    /// archived edge was removed.
+    pub fn remove_archived_directed_edge(&mut self, source: E::NodeId, target: E::NodeId) -> bool {
+        let before = self.edges.len();
+        self.edges
+            .retain(|e| !(!e.is_active() && e.source() == source && e.target() == target));
+        self.edges.len() < before
+    }
+
+    /// Remove any **archived** edge whose endpoints are `{a, b}`
+    /// regardless of ordering (undirected-graph semantics). Active edges
+    /// are preserved. Returns `true` iff at least one archived edge was
+    /// removed.
+    pub fn remove_archived_undirected_edge(&mut self, a: E::NodeId, b: E::NodeId) -> bool {
+        let before = self.edges.len();
+        self.edges.retain(|e| {
+            !(!e.is_active()
+                && ((e.source() == a && e.target() == b) || (e.source() == b && e.target() == a)))
+        });
+        self.edges.len() < before
+    }
+
     /// Iterate every outgoing edge from `node` (source == node).
     pub fn outgoing(&self, node_id: E::NodeId) -> impl Iterator<Item = &E> {
         self.edges.iter().filter(move |e| e.source() == node_id)

--- a/crates/kanban-core/src/graph/dag.rs
+++ b/crates/kanban-core/src/graph/dag.rs
@@ -133,6 +133,21 @@ impl<E: Edge> DagGraph<E> {
         }
         out
     }
+
+    /// Remove the archived `from -> to` edge. Mirror of
+    /// `Graph::remove_edge` for tombstones. `GraphError::EdgeNotFound`
+    /// when no archived edge with those endpoints exists.
+    pub fn remove_archived_edge(
+        &mut self,
+        from: E::NodeId,
+        to: E::NodeId,
+    ) -> Result<(), GraphError> {
+        if self.store.remove_archived_directed_edge(from, to) {
+            Ok(())
+        } else {
+            Err(GraphError::EdgeNotFound)
+        }
+    }
 }
 
 impl<E: Edge> Cascadable for DagGraph<E> {

--- a/crates/kanban-core/src/graph/undirected.rs
+++ b/crates/kanban-core/src/graph/undirected.rs
@@ -83,6 +83,17 @@ impl<E: Edge> UndirectedGraph<E> {
         self.store.add_edge(edge);
         Ok(())
     }
+
+    /// Remove the archived edge whose endpoints are `{a, b}` regardless
+    /// of ordering. Mirror of `Graph::remove_edge` for tombstones.
+    /// `GraphError::EdgeNotFound` when no archived edge exists there.
+    pub fn remove_archived_edge(&mut self, a: E::NodeId, b: E::NodeId) -> Result<(), GraphError> {
+        if self.store.remove_archived_undirected_edge(a, b) {
+            Ok(())
+        } else {
+            Err(GraphError::EdgeNotFound)
+        }
+    }
 }
 
 impl<E: Edge> Cascadable for UndirectedGraph<E> {

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -619,6 +619,7 @@ fn new_edge_removals(imported: &DependencyGraph, existing: &DependencyGraph) -> 
                     source: parent,
                     target: child,
                     tolerate_missing: true,
+                    as_archived: !edge.is_active(),
                 }),
             ));
         }
@@ -636,6 +637,7 @@ fn new_edge_removals(imported: &DependencyGraph, existing: &DependencyGraph) -> 
                     source: blocker,
                     target: blocked,
                     tolerate_missing: true,
+                    as_archived: !edge.is_active(),
                 }),
             ));
         }
@@ -653,6 +655,7 @@ fn new_edge_removals(imported: &DependencyGraph, existing: &DependencyGraph) -> 
                     source: a,
                     target: b,
                     tolerate_missing: true,
+                    as_archived: !edge.is_active(),
                 }),
             ));
         }

--- a/crates/kanban-domain/src/commands/dependency_commands.rs
+++ b/crates/kanban-domain/src/commands/dependency_commands.rs
@@ -135,6 +135,7 @@ impl AddSpawns {
                 source: self.source,
                 target: self.target,
                 tolerate_missing: true,
+                as_archived: self.as_archived,
             },
         ))])
     }
@@ -184,6 +185,7 @@ impl AddBlocks {
                 source: self.source,
                 target: self.target,
                 tolerate_missing: true,
+                as_archived: self.as_archived,
             },
         ))])
     }
@@ -233,6 +235,7 @@ impl AddRelates {
                 source: self.source,
                 target: self.target,
                 tolerate_missing: true,
+                as_archived: self.as_archived,
             },
         ))])
     }
@@ -265,13 +268,32 @@ pub struct RemoveSpawns {
     pub target: Uuid,
     #[serde(default)]
     pub tolerate_missing: bool,
+    /// Target the **archived** edge with these endpoints rather than the
+    /// active one. Mirrors [`AddSpawns::as_archived`]: an inverse must
+    /// remove the edge in the state the forward inserted it, and the two
+    /// states coexist independently between the same pair of cards.
+    ///
+    /// `#[serde(default)]` keeps legacy command-log entries deserialising
+    /// as `false`, matching their original active-only semantics.
+    #[serde(default)]
+    pub as_archived: bool,
 }
 
 impl RemoveSpawns {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
-        let (source, target, tolerate) = (self.source, self.target, self.tolerate_missing);
+        let (source, target, tolerate, as_archived) = (
+            self.source,
+            self.target,
+            self.tolerate_missing,
+            self.as_archived,
+        );
         context.store.modify_graph(Box::new(move |graph| {
-            match graph.remove_parent(target, source) {
+            let result = if as_archived {
+                graph.remove_archived_spawns(source, target)
+            } else {
+                graph.remove_parent(target, source)
+            };
+            match result {
                 Ok(()) => Ok(()),
                 Err(e) if tolerate && e.is_edge_not_found() => Ok(()),
                 Err(e) => Err(e),
@@ -290,15 +312,14 @@ impl RemoveSpawns {
         Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
     }
 
-    /// Inverse: re-add the parent edge (as active — user-initiated
-    /// removes only fire against active edges, so the original state
-    /// was active).
+    /// Inverse: re-add the parent edge in the same state it was removed
+    /// from, so redo does not resurrect a tombstone as active.
     pub fn capture_inverse(&self, _store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         Ok(vec![Command::Dependency(DependencyCommand::AddSpawns(
             AddSpawns {
                 source: self.source,
                 target: self.target,
-                as_archived: false,
+                as_archived: self.as_archived,
             },
         ))])
     }
@@ -312,18 +333,31 @@ pub struct RemoveBlocks {
     pub target: Uuid,
     #[serde(default)]
     pub tolerate_missing: bool,
+    /// See [`RemoveSpawns::as_archived`] for the rationale.
+    #[serde(default)]
+    pub as_archived: bool,
 }
 
 impl RemoveBlocks {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
-        let (source, target, tolerate) = (self.source, self.target, self.tolerate_missing);
-        context
-            .store
-            .modify_graph(Box::new(move |graph| match graph.unblock(source, target) {
+        let (source, target, tolerate, as_archived) = (
+            self.source,
+            self.target,
+            self.tolerate_missing,
+            self.as_archived,
+        );
+        context.store.modify_graph(Box::new(move |graph| {
+            let result = if as_archived {
+                graph.remove_archived_blocks(source, target)
+            } else {
+                graph.unblock(source, target)
+            };
+            match result {
                 Ok(()) => Ok(()),
                 Err(e) if tolerate && e.is_edge_not_found() => Ok(()),
                 Err(e) => Err(e),
-            }))
+            }
+        }))
     }
 
     pub fn description(&self) -> String {
@@ -337,9 +371,9 @@ impl RemoveBlocks {
         Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
     }
 
-    /// Inverse: re-add the blocks edge. We don't know the original
-    /// severity at remove time; the capture function walks the
-    /// pre-remove graph to record it.
+    /// Inverse: re-add the blocks edge in the same state it was removed
+    /// from. We don't know the original severity at remove time; the
+    /// capture function walks the pre-remove graph to record it.
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let graph = store.get_graph()?;
         let severity = graph
@@ -353,7 +387,7 @@ impl RemoveBlocks {
                 source: self.source,
                 target: self.target,
                 severity,
-                as_archived: false,
+                as_archived: self.as_archived,
             },
         ))])
     }
@@ -367,13 +401,26 @@ pub struct RemoveRelates {
     pub target: Uuid,
     #[serde(default)]
     pub tolerate_missing: bool,
+    /// See [`RemoveSpawns::as_archived`] for the rationale.
+    #[serde(default)]
+    pub as_archived: bool,
 }
 
 impl RemoveRelates {
     pub fn execute(&self, context: &CommandContext) -> KanbanResult<()> {
-        let (source, target, tolerate) = (self.source, self.target, self.tolerate_missing);
+        let (source, target, tolerate, as_archived) = (
+            self.source,
+            self.target,
+            self.tolerate_missing,
+            self.as_archived,
+        );
         context.store.modify_graph(Box::new(move |graph| {
-            match graph.dissociate(source, target) {
+            let result = if as_archived {
+                graph.remove_archived_relates(source, target)
+            } else {
+                graph.dissociate(source, target)
+            };
+            match result {
                 Ok(()) => Ok(()),
                 Err(e) if tolerate && e.is_edge_not_found() => Ok(()),
                 Err(e) => Err(e),
@@ -392,8 +439,9 @@ impl RemoveRelates {
         Some(crate::EntityIds::cards([self.source, self.target]).with_graph())
     }
 
-    /// Inverse: re-add the relates edge. Same as RemoveBlocks: we
-    /// capture the kind from the pre-remove graph.
+    /// Inverse: re-add the relates edge in the same state it was removed
+    /// from. Same as RemoveBlocks: we capture the kind from the
+    /// pre-remove graph.
     pub fn capture_inverse(&self, store: &dyn DataStore) -> KanbanResult<Vec<Command>> {
         let graph = store.get_graph()?;
         let (a, b) = (self.source, self.target);
@@ -408,7 +456,7 @@ impl RemoveRelates {
                 source: self.source,
                 target: self.target,
                 kind,
-                as_archived: false,
+                as_archived: self.as_archived,
             },
         ))])
     }

--- a/crates/kanban-domain/src/dependencies/dependency_graph.rs
+++ b/crates/kanban-domain/src/dependencies/dependency_graph.rs
@@ -118,6 +118,12 @@ impl DependencyGraph {
         self.spawns.remove_edge(parent, child).map_err(dep_err)
     }
 
+    pub fn remove_archived_spawns(&mut self, parent: CardId, child: CardId) -> KanbanResult<()> {
+        self.spawns
+            .remove_archived_edge(parent, child)
+            .map_err(dep_err)
+    }
+
     pub fn children(&self, parent: CardId) -> Vec<CardId> {
         self.spawns.outgoing(parent)
     }
@@ -178,6 +184,12 @@ impl DependencyGraph {
         self.blocks.remove_edge(blocker, blocked).map_err(dep_err)
     }
 
+    pub fn remove_archived_blocks(&mut self, blocker: CardId, blocked: CardId) -> KanbanResult<()> {
+        self.blocks
+            .remove_archived_edge(blocker, blocked)
+            .map_err(dep_err)
+    }
+
     pub fn blocked(&self, card: CardId) -> Vec<CardId> {
         self.blocks.outgoing(card)
     }
@@ -232,6 +244,10 @@ impl DependencyGraph {
     pub fn dissociate(&mut self, a: CardId, b: CardId) -> KanbanResult<()> {
         use kanban_core::Graph as _;
         self.relates.remove_edge(a, b).map_err(dep_err)
+    }
+
+    pub fn remove_archived_relates(&mut self, a: CardId, b: CardId) -> KanbanResult<()> {
+        self.relates.remove_archived_edge(a, b).map_err(dep_err)
     }
 
     pub fn related(&self, card: CardId) -> Vec<CardId> {

--- a/crates/kanban-domain/tests/commands_mod.rs
+++ b/crates/kanban-domain/tests/commands_mod.rs
@@ -196,6 +196,7 @@ fn test_command_serde_roundtrip_all_domains() {
             source: Uuid::new_v4(),
             target: Uuid::new_v4(),
             tolerate_missing: false,
+            as_archived: false,
         })),
     ];
     for cmd in commands {

--- a/crates/kanban-domain/tests/dependency_commands.rs
+++ b/crates/kanban-domain/tests/dependency_commands.rs
@@ -97,6 +97,7 @@ fn test_remove_spawns_executes() {
         source: parent_id,
         target: child_id,
         tolerate_missing: false,
+        as_archived: false,
     }
     .execute(&context)
     .is_ok());
@@ -120,6 +121,7 @@ fn test_remove_blocks_inverse_captures_severity_from_pre_remove_graph() {
         source: blocker,
         target: blocked,
         tolerate_missing: false,
+        as_archived: false,
     };
     let inverse = cmd.capture_inverse(&tc.store).unwrap();
     match &inverse[0] {
@@ -146,6 +148,7 @@ fn test_remove_relates_inverse_captures_kind_from_pre_remove_graph() {
         source: a,
         target: b,
         tolerate_missing: false,
+        as_archived: false,
     };
     let inverse = cmd.capture_inverse(&tc.store).unwrap();
     match &inverse[0] {
@@ -183,6 +186,7 @@ fn test_remove_blocks_inverse_preserves_severity_across_all_variants() {
             source: blocker,
             target: blocked,
             tolerate_missing: false,
+            as_archived: false,
         };
         let inverse = cmd.capture_inverse(&tc.store).unwrap();
         match &inverse[0] {
@@ -219,6 +223,7 @@ fn test_remove_relates_inverse_preserves_kind_across_all_variants() {
             source: a,
             target: b,
             tolerate_missing: false,
+            as_archived: false,
         };
         let inverse = cmd.capture_inverse(&tc.store).unwrap();
         match &inverse[0] {
@@ -364,6 +369,7 @@ fn test_remove_relates_inverse_finds_edge_in_reversed_orientation() {
         source: b,
         target: a,
         tolerate_missing: false,
+        as_archived: false,
     };
     let inverse = cmd.capture_inverse(&tc.store).unwrap();
     match &inverse[0] {
@@ -450,6 +456,7 @@ fn test_remove_spawns_tolerant_succeeds_on_missing_edge() {
         source: Uuid::new_v4(),
         target: Uuid::new_v4(),
         tolerate_missing: true,
+        as_archived: false,
     }
     .execute(&context);
     assert!(result.is_ok(), "tolerant remove must swallow EdgeNotFound");
@@ -463,6 +470,7 @@ fn test_remove_spawns_strict_errors_on_missing_edge() {
         source: Uuid::new_v4(),
         target: Uuid::new_v4(),
         tolerate_missing: false,
+        as_archived: false,
     }
     .execute(&context);
     assert!(
@@ -479,6 +487,7 @@ fn test_remove_blocks_tolerant_succeeds_on_missing_edge() {
         source: Uuid::new_v4(),
         target: Uuid::new_v4(),
         tolerate_missing: true,
+        as_archived: false,
     }
     .execute(&context);
     assert!(result.is_ok());
@@ -492,6 +501,7 @@ fn test_remove_relates_tolerant_succeeds_on_missing_edge() {
         source: Uuid::new_v4(),
         target: Uuid::new_v4(),
         tolerate_missing: true,
+        as_archived: false,
     }
     .execute(&context);
     assert!(result.is_ok());
@@ -541,6 +551,7 @@ fn test_dependency_command_serialization_shape_is_stable() {
         source,
         target,
         tolerate_missing: false,
+        as_archived: false,
     });
     let json = serde_json::to_value(&remove_blocks).unwrap();
     assert_eq!(json["action"], "remove_blocks");

--- a/crates/kanban-service/src/context/graph.rs
+++ b/crates/kanban-service/src/context/graph.rs
@@ -131,6 +131,7 @@ impl GraphOperations for KanbanContext {
                     source: parent,
                     target: child,
                     tolerate_missing: false,
+                    as_archived: false,
                 }))
             })
             .collect();
@@ -169,6 +170,7 @@ impl GraphOperations for KanbanContext {
                 source: blocker,
                 target: blocked,
                 tolerate_missing: false,
+                as_archived: false,
             },
         ))])
     }
@@ -205,6 +207,7 @@ impl GraphOperations for KanbanContext {
                 source: a,
                 target: b,
                 tolerate_missing: false,
+                as_archived: false,
             },
         ))])
     }

--- a/crates/kanban-service/tests/import_merges_dependency_graph.rs
+++ b/crates/kanban-service/tests/import_merges_dependency_graph.rs
@@ -497,8 +497,18 @@ async fn test_sqlite_undoing_an_import_removes_an_archived_edge_it_added() {
 /// those SAME endpoints (the shape produced by re-importing an export of the
 /// destination itself). `merge_from` skips the endpoint pair because an edge
 /// already exists there, so `new_edge_removals` must not emit a removal for
-/// it — a fix that keys the removal on the imported edge's state alone, or
-/// drops the existence guard, would destroy the destination's tombstone.
+/// it.
+///
+/// This does not catch every over-correction: a fix that keys the emitted
+/// `as_archived` on the imported edge's state alone (dropping the existence
+/// guard) would still emit `RemoveSpawns { as_archived: false }` here, since
+/// the imported edge is active — that targets a `dest_d -> dest_e` active
+/// edge that never existed, `tolerate_missing: true` swallows the miss, and
+/// the tombstone survives untouched, so this test alone would still pass.
+/// What it does catch is that same existence-guard removal COMBINED with a
+/// state-blind remover (e.g. relaxing `remove_directed_edge` to match any
+/// state) — the highest-value over-correction, since it is the shape that
+/// would actually delete the tombstone.
 async fn assert_undoing_an_import_leaves_a_pre_existing_archived_edge_alone(
     mut other: KanbanContext,
     mut dest: KanbanContext,

--- a/crates/kanban-service/tests/import_merges_dependency_graph.rs
+++ b/crates/kanban-service/tests/import_merges_dependency_graph.rs
@@ -347,6 +347,277 @@ async fn assert_merge_and_undo_survive_reload(backend_kind: BackendKind) {
     );
 }
 
+/// Seeds `seed_board_with_all_three_kinds`, then additionally records one
+/// ARCHIVED edge of each kind among the same three cards, via a direct
+/// dependency command rather than card archival. No card is archived, so no
+/// `archived_cards` marker is produced for these edges: the fixture that
+/// would let `DeleteCard`'s node-level cascade mask the bug this test pins.
+fn seed_board_with_all_three_kinds_plus_archived_edges(
+    ctx: &mut KanbanContext,
+) -> (Uuid, Uuid, Uuid, Uuid) {
+    use kanban_domain::commands::{AddBlocks, AddRelates, AddSpawns, Command, DependencyCommand};
+
+    let (board_id, a, b, c) = seed_board_with_all_three_kinds(ctx);
+    ctx.execute(vec![
+        Command::Dependency(DependencyCommand::AddSpawns(AddSpawns {
+            source: a,
+            target: c,
+            as_archived: true,
+        })),
+        Command::Dependency(DependencyCommand::AddBlocks(AddBlocks {
+            source: b,
+            target: c,
+            severity: Severity::Medium,
+            as_archived: true,
+        })),
+        Command::Dependency(DependencyCommand::AddRelates(AddRelates {
+            source: a,
+            target: b,
+            kind: RelatesKind::General,
+            as_archived: true,
+        })),
+    ])
+    .unwrap();
+    (board_id, a, b, c)
+}
+
+/// Undoing an import must remove an ARCHIVED edge the import added, not just
+/// an active one. `new_edge_removals` used to emit a `RemoveSpawns`/
+/// `RemoveBlocks`/`RemoveRelates` with no state selector, which can only ever
+/// match an active edge, so the removal silently no-opped
+/// (`tolerate_missing: true` swallowed `EdgeNotFound`) and the archived edge
+/// was stranded in the destination forever.
+async fn assert_undoing_an_import_removes_an_archived_edge_it_added(
+    mut src: KanbanContext,
+    mut dest: KanbanContext,
+) {
+    use kanban_domain::commands::{BoardCommand, Command, ImportEntities};
+
+    let (_src_board, src_a, src_b, src_c) =
+        seed_board_with_all_three_kinds_plus_archived_edges(&mut src);
+    let exported = src.export_board(Some(_src_board)).unwrap();
+    let imported: kanban_domain::Snapshot = serde_json::from_str(&exported).unwrap();
+    assert!(
+        imported.archived_cards.is_empty(),
+        "fixture must carry no archived-card markers, or DeleteCard's node-level \
+         cascade would sweep the archived edges away and mask the bug"
+    );
+
+    let (dest_board_id, dest_a, dest_b, dest_c) = seed_board_with_all_three_kinds(&mut dest);
+
+    dest.execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
+        boards: imported.boards,
+        columns: imported.columns,
+        cards: imported.cards,
+        archived_cards: imported.archived_cards,
+        archived_boards: imported.archived_boards,
+        sprints: imported.sprints,
+        graph: Some(imported.graph),
+        prefixes: imported.prefixes,
+        default_sprint_prefix: None,
+    }))])
+    .unwrap();
+    dest.undo().unwrap();
+
+    let dest_relations = dest.list_relations_for_board(dest_board_id).unwrap();
+    assert!(
+        dest_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_b),
+        "undo must leave the destination's own spawns edge in place"
+    );
+    assert!(
+        dest_relations
+            .blocks
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_c),
+        "undo must leave the destination's own blocks edge in place"
+    );
+    assert!(
+        dest_relations
+            .relates
+            .iter()
+            .any(|e| (e.source() == dest_b && e.target() == dest_c)
+                || (e.source() == dest_c && e.target() == dest_b)),
+        "undo must leave the destination's own relates edge in place"
+    );
+
+    // Active-scoped reads (`list_relations_for_board`, `contains`) would
+    // report a stranded archived edge as absent, giving a false green. Assert
+    // on the raw graph, which surfaces archived edges too.
+    let graph = dest.backend().get_graph().unwrap();
+    assert!(
+        !graph
+            .spawns_edges()
+            .iter()
+            .any(|e| e.source() == src_a && e.target() == src_c),
+        "undo must remove the imported ARCHIVED spawns edge"
+    );
+    assert!(
+        !graph
+            .blocks_edges()
+            .iter()
+            .any(|e| e.source() == src_b && e.target() == src_c),
+        "undo must remove the imported ARCHIVED blocks edge"
+    );
+    assert!(
+        !graph
+            .relates_edges()
+            .iter()
+            .any(|e| (e.source() == src_a && e.target() == src_b)
+                || (e.source() == src_b && e.target() == src_a)),
+        "undo must remove the imported ARCHIVED relates edge"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_undoing_an_import_removes_an_archived_edge_it_added() {
+    let dir = tempdir().unwrap();
+    let src = open_json(&dir.path().join("src.json")).await;
+    let dest = open_json(&dir.path().join("dest.json")).await;
+    assert_undoing_an_import_removes_an_archived_edge_it_added(src, dest).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_undoing_an_import_removes_an_archived_edge_it_added() {
+    let dir = tempdir().unwrap();
+    let src = open_sqlite(&dir.path().join("src.db")).await;
+    let dest = open_sqlite(&dir.path().join("dest.db")).await;
+    assert_undoing_an_import_removes_an_archived_edge_it_added(src, dest).await;
+}
+
+/// A destination tombstone on unrelated endpoints is never targeted by
+/// `new_edge_removals`, so that fixture would pass trivially even against a
+/// broken fix. This pins the shape that actually exercises the guard: the
+/// destination already has an ARCHIVED `dest_d -> dest_e` spawns edge (its
+/// only edge on that pair — a SQLite `spawns_edges` row is keyed on
+/// `(source_id, target_id)` alone, so active and archived cannot coexist on
+/// the same pair there), and the import separately carries an ACTIVE edge on
+/// those SAME endpoints (the shape produced by re-importing an export of the
+/// destination itself). `merge_from` skips the endpoint pair because an edge
+/// already exists there, so `new_edge_removals` must not emit a removal for
+/// it — a fix that keys the removal on the imported edge's state alone, or
+/// drops the existence guard, would destroy the destination's tombstone.
+async fn assert_undoing_an_import_leaves_a_pre_existing_archived_edge_alone(
+    mut other: KanbanContext,
+    mut dest: KanbanContext,
+) {
+    use kanban_domain::commands::{
+        AddSpawns, BoardCommand, Command, DependencyCommand, ImportEntities,
+    };
+    use kanban_domain::DependencyGraph;
+
+    let (dest_board_id, dest_a, dest_b, dest_c) = seed_board_with_all_three_kinds(&mut dest);
+    let column = dest.list_columns(dest_board_id).unwrap()[0].id;
+    let dest_d = dest
+        .create_card(
+            dest_board_id,
+            column,
+            "d".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap()
+        .id;
+    let dest_e = dest
+        .create_card(
+            dest_board_id,
+            column,
+            "e".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap()
+        .id;
+
+    dest.execute(vec![Command::Dependency(DependencyCommand::AddSpawns(
+        AddSpawns {
+            source: dest_d,
+            target: dest_e,
+            as_archived: true,
+        },
+    ))])
+    .unwrap();
+
+    // An independently-seeded board/card set (fresh ids, no collision with
+    // `dest`) so the import's boards/columns/cards are valid to merge, but a
+    // hand-built graph carrying an ACTIVE edge on `dest`'s own endpoints —
+    // the shape a re-import of the destination's own export would carry.
+    let (_other_board, _other_a, _other_b, _other_c, exported) = seed_and_export(&mut other);
+    let imported: kanban_domain::Snapshot = serde_json::from_str(&exported).unwrap();
+
+    let mut hand_built_graph = DependencyGraph::new();
+    hand_built_graph.set_parent(dest_e, dest_d).unwrap();
+
+    dest.execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
+        boards: imported.boards,
+        columns: imported.columns,
+        cards: imported.cards,
+        archived_cards: imported.archived_cards,
+        archived_boards: imported.archived_boards,
+        sprints: imported.sprints,
+        graph: Some(hand_built_graph),
+        prefixes: imported.prefixes,
+        default_sprint_prefix: None,
+    }))])
+    .unwrap();
+    dest.undo().unwrap();
+
+    let graph = dest.backend().get_graph().unwrap();
+    assert!(
+        graph
+            .spawns_edges()
+            .iter()
+            .any(|e| e.source() == dest_d && e.target() == dest_e && !e.is_active()),
+        "undo must leave the destination's pre-existing ARCHIVED edge in place"
+    );
+    assert!(
+        !graph
+            .spawns_edges()
+            .iter()
+            .any(|e| e.source() == dest_d && e.target() == dest_e && e.is_active()),
+        "the tombstone must not have been resurrected as active"
+    );
+    let dest_relations = dest.list_relations_for_board(dest_board_id).unwrap();
+    assert!(
+        dest_relations
+            .spawns
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_b),
+        "undo must leave the destination's own active spawns edge in place"
+    );
+    assert!(
+        dest_relations
+            .blocks
+            .iter()
+            .any(|e| e.source() == dest_a && e.target() == dest_c),
+        "undo must leave the destination's own blocks edge in place"
+    );
+    assert!(
+        dest_relations
+            .relates
+            .iter()
+            .any(|e| (e.source() == dest_b && e.target() == dest_c)
+                || (e.source() == dest_c && e.target() == dest_b)),
+        "undo must leave the destination's own relates edge in place"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_undoing_an_import_leaves_a_pre_existing_archived_edge_alone() {
+    let dir = tempdir().unwrap();
+    let other = open_json(&dir.path().join("other.json")).await;
+    let dest = open_json(&dir.path().join("dest.json")).await;
+    assert_undoing_an_import_leaves_a_pre_existing_archived_edge_alone(other, dest).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_undoing_an_import_leaves_a_pre_existing_archived_edge_alone() {
+    let dir = tempdir().unwrap();
+    let other = open_sqlite(&dir.path().join("other.db")).await;
+    let dest = open_sqlite(&dir.path().join("dest.db")).await;
+    assert_undoing_an_import_leaves_a_pre_existing_archived_edge_alone(other, dest).await;
+}
+
 enum BackendKind {
     Json,
     Sqlite,

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -390,6 +390,7 @@ async fn test_inverse_remove_parent_reestablishes_relation() -> KanbanResult<()>
             source: parent.id,
             target: child.id,
             tolerate_missing: false,
+            as_archived: false,
         },
     ))])?;
     assert!(
@@ -942,6 +943,7 @@ async fn test_inverse_remove_blocks_restores_blocks_edge() -> KanbanResult<()> {
             source: a.id,
             target: b.id,
             tolerate_missing: false,
+            as_archived: false,
         },
     ))])?;
     assert!(!ctx.graph()?.contains(a.id, b.id));


### PR DESCRIPTION
Undoing an import that added an **archived** dependency edge silently failed to remove it. Undo reported success and the edge was stranded in the destination permanently.

`new_edge_removals` iterated `spawns_edges()`, which includes archived edges, and emitted state-blind `Remove*` commands. Those route to `remove_directed_edge`/`remove_undirected_edge`, which match only active edges by design, so `tolerate_missing: true` swallowed the miss as success.

Closes KAN-1411, part of KAN-1388. Introduced by KAN-1404's inverse capture in this same release.

## Why it is five files and atomic

The `Remove*` structs derive no `Default`, so adding `as_archived` breaks every literal at once. There is no purely additive intermediate: the core-layer siblings, the domain wrappers, the command threading and the literal fallout only compile together. 9 non-test and 14 test sites updated.

`remove_directed_edge` and `remove_undirected_edge` are **byte-identical** (the diff on `core.rs` has zero deletion lines). Their active-only contract is depended on by `Graph::remove_edge`, `contains_edge`, `outgoing_active` and the DAG duplicate check, so the new behaviour lives in siblings rather than relaxing them.

## The test that pins it would pass without care

`DeleteCard::execute` calls `graph.remove_node`, which is state-blind and strips archived edges. So an export carrying archived-card markers sweeps the edge away on undo and a naive fixture passes against the broken code. The fixture therefore drops the markers, and asserts that it did:

```rust
assert!(imported.archived_cards.is_empty(), "fixture must carry no archived-card markers...")
```

Assertions read `spawns_edges()`/`blocks_edges()`/`relates_edges()` from the backend graph rather than `list_relations_for_board` or `contains`, both of which are active-scoped and would report a stranded tombstone as absent.

## Scope note: Add\*::capture_inverse

Review endorsed one change beyond the card. `AddSpawns{as_archived: true}`, emitted by the cascade-undo path, previously produced `RemoveSpawns{as_archived: false}` — which either silently no-opped or **matched and destroyed a genuinely active edge on the same endpoints**. It now threads `self.as_archived`. Strictly confined to callers passing `true`; every `false` caller is bit-identical.

`#[serde(default)]` on all three new fields, so legacy command-log entries replay as `false`, the exact pre-change semantics.

## Known limits, stated rather than implied

The second test's doc comment was narrowed after review: it does **not** catch a fix that keys `as_archived` on the imported edge's state alone. It catches that combined with a state-blind remover, which is the shape that would actually delete a tombstone.

A pre-existing asymmetry is left alone and carded as KAN-1414: `attach_children` computes `edge_born_archived`, but `detach_children` hardcodes `as_archived: false`, so detaching an archived edge returns `EdgeNotFound`. This PR preserved that behaviour deliberately rather than changing it inside a fix for something else.

Tests run against JSON and SQLite. SQLite's `spawns_edges` has `PRIMARY KEY (source_id, target_id)`, so an active and archived edge cannot coexist on one pair; the fixtures work around that across edge kinds.