### PR TITLE
KAN-1410 fix(tui): probe the post-swap snapshot before installing the new backend

### DIFF
--- a/.changeset/kan-1410-preswap-snapshot-probe.md
+++ b/.changeset/kan-1410-preswap-snapshot-probe.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: probe the post-swap snapshot read before installing the new storage backend. A failed read after a storage-location swap used to leave the app with no save worker and a dead completion receiver, silently breaking persistence until restart.

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -266,7 +266,7 @@ impl App {
             Ok(s) => s,
             Err(e) => {
                 self.set_app_config(old_config);
-                self.set_error(format!("Store swap failed: reading it failed: {}", e));
+                self.set_error(format!("Storage swap aborted, reading it failed: {}", e));
                 return;
             }
         };

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -262,20 +262,21 @@ impl App {
             }
         };
 
+        let snapshot = match new_backend.snapshot() {
+            Ok(s) => s,
+            Err(e) => {
+                self.set_app_config(old_config);
+                self.set_error(format!("Store swap failed: reading it failed: {}", e));
+                return;
+            }
+        };
+
         self.ctx.replace_backend(new_backend);
         if let Some(watcher) = &self.persistence.file_watcher {
             watcher.set_own_instance_id(self.ctx.backend().instance_id());
         }
         let (save_rx, completion_rx) = self.ctx.save_coordinator.reset_save_channels();
         use crate::state::snapshot::TuiSnapshot;
-        let snapshot = match kanban_domain::Snapshot::from_app(self) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::error!("Failed to read snapshot after backend swap: {}", e);
-                self.set_error(format!("Storage swapped, but reading it failed: {}", e));
-                return;
-            }
-        };
         if let Err(e) = snapshot.apply_to_app(self) {
             tracing::error!("Failed to apply snapshot: {}", e);
         }

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -919,3 +919,14 @@ pub async fn setup_app_with_json_file(dir: &std::path::Path) -> App {
     app.load_initial_state().await;
     app
 }
+
+pub async fn setup_app_with_json_file_and_save_worker(dir: &std::path::Path) -> App {
+    let path = create_test_json_file(dir, "source.json", &["OriginalBoard"]).await;
+    let (mut app, save_rx) = App::new(Some(path)).await.unwrap();
+    app.load_initial_state().await;
+    app.spawn_save_worker(
+        save_rx.expect("App::new should hand back a save receiver"),
+        None,
+    );
+    app
+}

--- a/crates/kanban-tui/tests/settings_storage_tests.rs
+++ b/crates/kanban-tui/tests/settings_storage_tests.rs
@@ -257,6 +257,43 @@ async fn test_storage_swap_does_not_apply_an_empty_snapshot_when_the_read_fails(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_storage_swap_leaves_a_working_save_worker_when_the_post_swap_read_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut app = helpers::setup_app_with_json_file(dir.path()).await;
+
+    let (destination, _board_id, _column_id, _card_id) = seeded_destination_backend();
+    let locator = dir
+        .path()
+        .join("destination-that-fails-to-read-2.db")
+        .display()
+        .to_string();
+    let failing_destination = FailingSnapshotBackend::wrap(destination.clone());
+    app.store_manager = Arc::new(store_manager_with_fixed_backend(
+        locator.clone(),
+        failing_destination,
+    ));
+    app.app_config.storage_location = Some(locator);
+
+    let old_config = app.app_config.clone();
+    app.handle_migration_complete(old_config, Ok(true)).await;
+
+    app.ctx.save_coordinator.queue_flush();
+    let ack = app
+        .persistence
+        .save_completion_rx
+        .as_mut()
+        .expect("a save worker should still be wired up after a failed post-swap read")
+        .recv()
+        .await;
+
+    assert_eq!(
+        ack,
+        Some(()),
+        "a queued flush should be acknowledged by a live save worker"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_storage_swap_still_syncs_the_view_when_the_read_succeeds() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;

--- a/crates/kanban-tui/tests/settings_storage_tests.rs
+++ b/crates/kanban-tui/tests/settings_storage_tests.rs
@@ -259,7 +259,10 @@ async fn test_storage_swap_does_not_apply_an_empty_snapshot_when_the_read_fails(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_storage_swap_leaves_a_working_save_worker_when_the_post_swap_read_fails() {
     let dir = tempfile::tempdir().unwrap();
-    let mut app = helpers::setup_app_with_json_file(dir.path()).await;
+    let mut app = helpers::setup_app_with_json_file_and_save_worker(dir.path()).await;
+
+    let old_config = app.app_config.clone();
+    let old_save_file = app.persistence.save_file.clone();
 
     let (destination, _board_id, _column_id, _card_id) = seeded_destination_backend();
     let locator = dir
@@ -274,17 +277,42 @@ async fn test_storage_swap_leaves_a_working_save_worker_when_the_post_swap_read_
     ));
     app.app_config.storage_location = Some(locator);
 
-    let old_config = app.app_config.clone();
-    app.handle_migration_complete(old_config, Ok(true)).await;
+    app.handle_migration_complete(old_config.clone(), Ok(true))
+        .await;
+
+    assert_eq!(
+        app.app_config.effective_storage_location(),
+        old_config.effective_storage_location(),
+        "config should be reverted when the post-swap read fails"
+    );
+    assert_eq!(
+        app.persistence.save_file, old_save_file,
+        "save_file should not point at the unreadable destination"
+    );
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("should have an error banner when the post-swap read fails");
+    assert_eq!(banner.variant, kanban_tui::components::BannerVariant::Error);
+    assert!(
+        !banner.message.starts_with("Loaded from") && !banner.message.starts_with("Migrated to"),
+        "a success banner must not overwrite the swap-failure error: {}",
+        banner.message
+    );
 
     app.ctx.save_coordinator.queue_flush();
-    let ack = app
-        .persistence
-        .save_completion_rx
-        .as_mut()
-        .expect("a save worker should still be wired up after a failed post-swap read")
-        .recv()
-        .await;
+    let ack = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        app.persistence
+            .save_completion_rx
+            .as_mut()
+            .expect("a save worker should still be wired up after a failed post-swap read")
+            .recv(),
+    )
+    .await
+    .expect("save worker did not acknowledge the flush within the timeout");
 
     assert_eq!(
         ack,


### PR DESCRIPTION
When a storage-location swap succeeded but the post-swap snapshot read failed, the early return added by KAN-1379 dropped `save_rx` and `completion_rx` — which the success path consumes at the end of the function. `reset_save_channels()` had already replaced the senders, so the app was left with **no save worker and a dead completion receiver**. Edits stopped persisting until restart.

Closes KAN-1410. Introduced by KAN-1379 in this same release, in the fix for a different data-loss bug.

## The fix is a pre-swap probe

Read `new_backend.snapshot()` **before** installing it. On failure, restore `old_config` and return, exactly as the two sibling error arms above already do. Nothing is mutated on that path, so there is no half-swapped state to reason about.

The probed snapshot is the same value later passed to `apply_to_app` — one read, reused, not re-fetched after the swap. `lifecycle.rs` already reads an uninstalled backend this way.

## An earlier version of this fix was impossible

The first spec said to fall through and skip only the apply, letting `reload_model()` repair the stale view. That cannot work: `Snapshot::from_app` **is** `app.ctx.snapshot()`, so `reload_model` makes the identical call that just failed. Falling through also reaches `set_success(msg)`, which would clobber the very error banner the fix exists to raise.

## The first test hung rather than failed

Worth stating, because the shape recurs. `setup_app_with_json_file` drops `App::new`'s save receiver, so no worker existed in either arm — the round trip could not prove one survived. `queue_flush` hit a closed channel, and `recv()` pended forever because the completion sender was still alive. Two CI-length runs wedged before it was caught.

Now: a new `setup_app_with_json_file_and_save_worker` spawns a real worker before the swap, the `recv()` is wrapped in a five-second timeout so a regression fails instead of hanging, and the fixture captures `old_config`/`old_save_file` **before** the failing locator is set — without that ordering the config-restoration assertion could not have detected anything.

Observed red against develop's handler: `config should be reverted when the post-swap read fails`, in 0.07s. Green with the fix: 10 passed.

## Not in scope

`main_loop.rs:267` selects on the completion receiver with an unguarded `_ =` arm where its sibling at `:284` uses `Some(x) = ...`, so a closed channel spins the TUI at 100% CPU. Real, recorded on the card as a follow-up, deliberately untouched here.