### PR TITLE
chore(persistence-json): review follow-ups for the backup-retention change

### DIFF
--- a/crates/kanban-persistence-json/src/json_file_store.rs
+++ b/crates/kanban-persistence-json/src/json_file_store.rs
@@ -1107,7 +1107,7 @@ mod tests {
     }
 
     /// The V7->V8 migration writes a `.v7.backup` before the destructive
-    /// step and removes it on success.
+    /// step and keeps it on success.
     #[tokio::test]
     async fn test_load_v7_to_v8_keeps_v7_backup_on_success() {
         let dir = tempdir().unwrap();

--- a/crates/kanban-persistence-json/src/migration/migrator.rs
+++ b/crates/kanban-persistence-json/src/migration/migrator.rs
@@ -488,7 +488,6 @@ mod tests {
             1,
             "the original parent_child edge must survive"
         );
-        // Backup must be removed after a successful migration.
         assert!(
             path.with_extension("v6.backup").exists(),
             ".v6.backup must be kept after a successful migration as the rollback artifact"


### PR DESCRIPTION
Follow-ups from the self-review of the v0.9.0 pre-ship hotfix pass (commits ce10ae6..046846c on develop): two comments still described the old delete-on-success backup policy after the retention flip - the doc comment on `test_load_v7_to_v8_keeps_v7_backup_on_success` and a stray inline comment above the flipped v6 assertion in `migrator.rs`.

No behaviour change; `cargo test -p kanban-persistence-json` green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)