### PR TITLE
fix(ci): repoint the release pipeline at kanban-rs after the org move

### DIFF
--- a/.changeset/release-ci-kanban-rs.md
+++ b/.changeset/release-ci-kanban-rs.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Repoint the release pipeline at the kanban-rs org after the repo move: the release workflow's push remote, the tarball SHA URLs for the AUR and Homebrew bumps, the aur-publish repository guard and tarball URL, the AUR PKGBUILD/.SRCINFO source URLs, and the Chocolatey install URL and nuspec project URLs now reference kanban-rs/kanban. The Homebrew tap repo and the winget identifier and fork-user deliberately stay under fulsomenko. The "Sync develop with master" step now fails loudly (exit 1) on a merge conflict instead of warning and exiting 0, so a conflicted develop can no longer pass silently.

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -13,7 +13,7 @@ jobs:
     name: Update AUR package
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.repository == 'fulsomenko/kanban'
+    if: github.repository == 'kanban-rs/kanban'
     permissions:
       contents: write
     steps:
@@ -28,7 +28,7 @@ jobs:
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9]+)?$ ]]; then
             echo "Invalid version: $VERSION" >&2; exit 1
           fi
-          URL="https://github.com/fulsomenko/kanban/archive/v${VERSION}.tar.gz"
+          URL="https://github.com/kanban-rs/kanban/archive/v${VERSION}.tar.gz"
           SHA256=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
           sed -i "s|^pkgver=.*|pkgver=${VERSION}|" ./packaging/aur/PKGBUILD
           sed -i "s|^pkgrel=.*|pkgrel=1|" ./packaging/aur/PKGBUILD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin git@github.com:fulsomenko/kanban.git
+          git remote set-url origin git@github.com:kanban-rs/kanban.git
 
       # bump-version reads changesets, aggregate-changelog reads then deletes them.
       # These two steps must run in this order.
@@ -148,7 +148,7 @@ jobs:
           VERSION: ${{ steps.release.outputs.new }}
         run: |
           set -euo pipefail
-          URL="https://github.com/fulsomenko/kanban/archive/v${VERSION}.tar.gz"
+          URL="https://github.com/kanban-rs/kanban/archive/v${VERSION}.tar.gz"
           SHA256=$(curl -fsL "$URL" | sha256sum | cut -d' ' -f1)
           sed -i "s|^pkgver=.*|pkgver=${VERSION}|" ./packaging/aur/PKGBUILD
           sed -i "s|^pkgrel=.*|pkgrel=1|" ./packaging/aur/PKGBUILD
@@ -199,7 +199,7 @@ jobs:
           VERSION: ${{ steps.release.outputs.new }}
         run: |
           set -euo pipefail
-          URL="https://github.com/fulsomenko/kanban/archive/refs/tags/v${VERSION}.tar.gz"
+          URL="https://github.com/kanban-rs/kanban/archive/refs/tags/v${VERSION}.tar.gz"
           SHA256=$(curl -fsL "$URL" | sha256sum | cut -d' ' -f1)
           echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
@@ -243,9 +243,9 @@ jobs:
           git checkout develop
           git pull origin develop
           if ! git merge origin/master --no-edit; then
-            echo "::warning::Failed to auto-merge master into develop. Manual merge required."
+            echo "::error::Failed to auto-merge master into develop. Manual merge required."
             git merge --abort
-            exit 0
+            exit 1
           fi
           git push origin develop
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -741,7 +741,7 @@ To enable automated publishing and releases, configure these secrets in GitHub r
 - Build validation
 - Changeset validation (only on PRs to develop)
 
-**release.yml** - Runs on push to master
+**release.yml** - Runs when a pull request into master is closed (and only proceeds if it was merged)
 - Checks for changesets (skips if none found)
 - Bumps version based on changesets
 - Updates CHANGELOG.md

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -2,13 +2,13 @@ pkgbase = kanban
 	pkgdesc = Terminal-based kanban board with MCP server integration
 	pkgver = 0.8.1
 	pkgrel = 1
-	url = https://github.com/fulsomenko/kanban
+	url = https://github.com/kanban-rs/kanban
 	arch = x86_64
 	arch = aarch64
 	license = Apache-2.0
 	makedepends = rust
 	makedepends = cargo
-	source = kanban-0.8.1.tar.gz::https://github.com/fulsomenko/kanban/archive/v0.8.1.tar.gz
+	source = kanban-0.8.1.tar.gz::https://github.com/kanban-rs/kanban/archive/v0.8.1.tar.gz
 	sha256sums = 77118655d62b59bb7b82144802045a3b55238ae4a254cb35816a757c5622e5d2
 
 pkgname = kanban

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -4,10 +4,10 @@ pkgver=0.8.1
 pkgrel=1
 pkgdesc="Terminal-based kanban board with MCP server integration"
 arch=("x86_64" "aarch64")
-url="https://github.com/fulsomenko/kanban"
+url="https://github.com/kanban-rs/kanban"
 license=("Apache-2.0")
 makedepends=("rust" "cargo")
-source=("$pkgname-$pkgver.tar.gz::https://github.com/fulsomenko/kanban/archive/v$pkgver.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::https://github.com/kanban-rs/kanban/archive/v$pkgver.tar.gz")
 sha256sums=("77118655d62b59bb7b82144802045a3b55238ae4a254cb35816a757c5622e5d2")
 
 prepare() {

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -16,7 +16,7 @@ and pushes to the AUR via
 [`KSXGitHub/github-actions-deploy-aur`](https://github.com/KSXGitHub/github-actions-deploy-aur):
 
     VERSION='0.7.2'                                         # the version being released
-    URL="https://github.com/fulsomenko/kanban/archive/v$VERSION.tar.gz"
+    URL="https://github.com/kanban-rs/kanban/archive/v$VERSION.tar.gz"
     SHA256=$(curl -fsL "$URL" | sha256sum | cut -d' ' -f1)
 
     sed -i "s|^pkgver=.*|pkgver=$VERSION|" ./PKGBUILD

--- a/packaging/chocolatey/kanban.nuspec
+++ b/packaging/chocolatey/kanban.nuspec
@@ -6,15 +6,15 @@
     <version>$version$</version>
     <authors>Max Emil Yoon Blomstervall</authors>
     <owners>fulsomenko</owners>
-    <licenseUrl>https://github.com/fulsomenko/kanban/blob/master/LICENSE.md</licenseUrl>
+    <licenseUrl>https://github.com/kanban-rs/kanban/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>https://kanban.rs</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/fulsomenko/kanban/master/assets/icon-bold-transparent-black.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/kanban-rs/kanban/master/assets/icon-bold-transparent-black.png</iconUrl>
     <copyright>2025 Max Emil Yoon Blomstervall</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/fulsomenko/kanban</projectSourceUrl>
-    <packageSourceUrl>https://github.com/fulsomenko/kanban/tree/master/packaging/chocolatey</packageSourceUrl>
-    <docsUrl>https://github.com/fulsomenko/kanban#readme</docsUrl>
-    <bugTrackerUrl>https://github.com/fulsomenko/kanban/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/kanban-rs/kanban</projectSourceUrl>
+    <packageSourceUrl>https://github.com/kanban-rs/kanban/tree/master/packaging/chocolatey</packageSourceUrl>
+    <docsUrl>https://github.com/kanban-rs/kanban#readme</docsUrl>
+    <bugTrackerUrl>https://github.com/kanban-rs/kanban/issues</bugTrackerUrl>
     <tags>kanban tui terminal productivity rust mcp</tags>
     <summary>Fast, keyboard-driven terminal kanban board (with MCP server)</summary>
     <description><![CDATA[
@@ -33,7 +33,7 @@ This package installs two binaries:
 
 Run `kanban --help` to get started.
     ]]></description>
-    <releaseNotes>https://github.com/fulsomenko/kanban/releases/tag/v$version$</releaseNotes>
+    <releaseNotes>https://github.com/kanban-rs/kanban/releases/tag/v$version$</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $version  = '$version$'
-$url64    = "https://github.com/fulsomenko/kanban/releases/download/v$version/kanban-v$version-x86_64-pc-windows-msvc.zip"
+$url64    = "https://github.com/kanban-rs/kanban/releases/download/v$version/kanban-v$version-x86_64-pc-windows-msvc.zip"
 
 $packageArgs = @{
   packageName    = 'kanban'


### PR DESCRIPTION
## Summary

A release-pipeline audit ahead of v0.9.0 found that the release workflow still targets the old fulsomenko namespace after the move to the kanban-rs org. The old URLs only work through GitHub's redirect, and one guard is permanently dead. This PR repoints everything that should follow the repo, keeps everything that deliberately should not, and makes one silent failure loud.

## Changes

- release.yml: the push remote is now kanban-rs/kanban (previously every push in the release job, including the release commit, tag, AUR files, and develop sync, went to the old namespace). Both tarball SHA fetch URLs updated. The develop-sync merge-conflict path now fails the step with an error instead of warning and exiting 0, since a silently unsynced develop keeps consumed changesets and can trigger a phantom follow-up release.
- aur-publish.yml: the repository guard checked for fulsomenko/kanban and was therefore always false, making the only automated AUR recovery path a permanent no-op. Now checks kanban-rs/kanban. Its tarball SHA URL had the same stale-org defect as release.yml and is fixed too.
- packaging: AUR PKGBUILD url/source and .SRCINFO now point at kanban-rs (sha256 unchanged; the tarball content is identical). Chocolatey install script download URL and all seven nuspec repo URLs updated, which matters because Chocolatey moderation flags packages whose URLs redirect.
- CONTRIBUTING.md: the release trigger was documented as running on push to master; it actually runs when a PR into master is closed and only proceeds if merged.

## Deliberately unchanged

- The homebrew tap clone stays fulsomenko/homebrew-tap: the tap repo never moved (verified via the GitHub API; kanban-rs/homebrew-tap does not exist).
- The winget identifier fulsomenko.kanban and fork-user stay: renaming a winget identifier is a manual winget-pkgs migration and should be its own decision.
- The chocolatey nuspec owners field is a Chocolatey.org account name, not a repo URL.

All six release secrets (DEPLOY_KEY, CARGO_REGISTRY_TOKEN, AUR_SSH_KEY, HOMEBREW_TAP_DEPLOY_KEY, CHOCO_API_KEY, WINGET_TOKEN) and a writable deploy key were verified present on kanban-rs/kanban, so no secret migration is needed.

Changeset included (bump: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)