### PR TITLE
feat(ci): preflight checks and per-leg release jobs with resume mode

### DIFF
--- a/.changeset/release-ci-preflight-atomic.md
+++ b/.changeset/release-ci-preflight-atomic.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Restructure the release workflow into fail-fast, per-leg re-runnable jobs. A new mutation-free preflight job classifies each run as release, resume, or noop and probes every release credential (deploy key, crates.io token, AUR key, Homebrew tap key, winget token, Chocolatey key) in its own step before anything is pushed, so a dead credential now fails the run before the version bump instead of after it. The monolithic release job is split into prepare, publish-crates, tag-release, publish-aur, publish-homebrew, and sync-develop, each idempotent and re-runnable on its own, and resume mode lets a full re-run finish a release that died after the master push (previously a silent no-op once the changesets were consumed). build-windows now depends on tag-release instead of racing it, and resolve-version keeps the workflow_dispatch recovery path for the Windows legs unchanged.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,49 +18,145 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Release to crates.io
+  preflight:
+    name: Preflight checks
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     if: github.event.pull_request.merged == true
     outputs:
-      new: ${{ steps.release.outputs.new }}
-      has_changesets: ${{ steps.check.outputs.has_changesets }}
+      mode: ${{ steps.mode.outputs.mode }}
+      version: ${{ steps.mode.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      # Dry mirror of scripts/bump-version.sh's version computation; keep the
+      # two in sync.
+      - name: Determine release mode and version
+        id: mode
+        run: |
+          set -euo pipefail
+          CURRENT_VERSION=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)
+          CHANGESETS=$(find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" 2>/dev/null || true)
+          if [ -n "$CHANGESETS" ]; then
+            BUMP_TYPE="patch"
+            for changeset in $CHANGESETS; do
+              bump=$(sed -n '/^---$/,/^---$/{ /^bump:/{ s/^bump: *//; p; } }' "$changeset" | tr -d '\r\n')
+              if [ "$bump" = "major" ]; then
+                BUMP_TYPE="major"
+              elif [ "$bump" = "minor" ] && [ "$BUMP_TYPE" != "major" ]; then
+                BUMP_TYPE="minor"
+              fi
+            done
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+            case "$BUMP_TYPE" in
+              major) VERSION="$((MAJOR + 1)).0.0" ;;
+              minor) VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+              patch) VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            esac
+            MODE="release"
+            echo "Found changesets; next version: $VERSION (bump: $BUMP_TYPE)"
+          elif ! git ls-remote --exit-code --tags origin "v${CURRENT_VERSION}" >/dev/null 2>&1; then
+            VERSION="$CURRENT_VERSION"
+            MODE="resume"
+            echo "No changesets but v${CURRENT_VERSION} has no tag; resuming that release"
+          else
+            VERSION=""
+            MODE="noop"
+            echo "No changesets and v${CURRENT_VERSION} is already tagged; nothing to release"
+          fi
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Setup SSH deploy key
+        if: steps.mode.outputs.mode != 'noop'
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Probe DEPLOY_KEY
+        if: steps.mode.outputs.mode != 'noop'
+        run: |
+          set -euo pipefail
+          GREETING=$(ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no git@github.com 2>&1 || true)
+          echo "$GREETING"
+          echo "$GREETING" | grep -q "successfully authenticated"
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no" \
+            git ls-remote git@github.com:kanban-rs/kanban.git HEAD > /dev/null
+          echo "DEPLOY_KEY authenticates and can read kanban-rs/kanban"
+
+      - name: Probe CARGO_REGISTRY_TOKEN
+        if: steps.mode.outputs.mode != 'noop'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -fsS -H "Authorization: $CARGO_REGISTRY_TOKEN" https://crates.io/api/v1/me > /dev/null
+          echo "CARGO_REGISTRY_TOKEN is accepted by crates.io"
+
+      - name: Probe AUR_SSH_KEY
+        if: steps.mode.outputs.mode != 'noop'
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.AUR_SSH_KEY }}" > ~/.ssh/aur_key
+          chmod 600 ~/.ssh/aur_key
+          GREETING=$(ssh -i ~/.ssh/aur_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no aur@aur.archlinux.org 2>&1 || true)
+          echo "$GREETING"
+          echo "$GREETING" | grep -q "Welcome to AUR"
+          echo "AUR_SSH_KEY is accepted by aur.archlinux.org"
+
+      - name: Probe HOMEBREW_TAP_DEPLOY_KEY
+        if: steps.mode.outputs.mode != 'noop'
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}" > ~/.ssh/homebrew_tap_key
+          chmod 600 ~/.ssh/homebrew_tap_key
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/homebrew_tap_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no" \
+            git ls-remote git@github.com:fulsomenko/homebrew-tap.git HEAD > /dev/null
+          echo "HOMEBREW_TAP_DEPLOY_KEY can read fulsomenko/homebrew-tap"
+
+      - name: Probe WINGET_TOKEN
+        if: steps.mode.outputs.mode != 'noop'
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -fsS -H "Authorization: token $WINGET_TOKEN" https://api.github.com/user > /dev/null
+          echo "WINGET_TOKEN is accepted by the GitHub API"
+
+      - name: Probe CHOCO_API_KEY
+        if: steps.mode.outputs.mode != 'noop'
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+        run: |
+          set -euo pipefail
+          [ -n "$CHOCO_API_KEY" ]
+          echo "CHOCO_API_KEY is set"
+
+  prepare:
+    name: Prepare release commit
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.preflight.outputs.mode == 'release'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: master
 
-      - name: Check for changesets
-        id: check
-        run: |
-          if [ ! -d ".changeset" ]; then
-            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-            echo "No .changeset directory, skipping release"
-            exit 0
-          fi
-
-          CHANGESETS=$(find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" 2>/dev/null || true)
-          if [ -z "$CHANGESETS" ]; then
-            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-            echo "No changesets found, skipping release"
-          else
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-            echo "Found changesets:"
-            echo "$CHANGESETS"
-          fi
-
       - uses: cachix/install-nix-action@v27
-        if: steps.check.outputs.has_changesets == 'true'
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           extra_nix_config: |
             experimental-features = nix-command flakes
 
       - name: Setup SSH deploy key
-        if: steps.check.outputs.has_changesets == 'true'
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
@@ -68,7 +164,6 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
       - name: Configure Git
-        if: steps.check.outputs.has_changesets == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -77,53 +172,123 @@ jobs:
       # bump-version reads changesets, aggregate-changelog reads then deletes them.
       # These two steps must run in this order.
       - name: Bump version from changesets
-        if: steps.check.outputs.has_changesets == 'true'
         run: |
           nix develop --command bump-version
 
       - name: Aggregate changelog
-        if: steps.check.outputs.has_changesets == 'true'
         run: |
           nix develop --command aggregate-changelog "${{ github.event.pull_request.number }}"
 
       - name: Commit release changes
-        if: steps.check.outputs.has_changesets == 'true'
-        id: release
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
         run: |
+          set -euo pipefail
           NEW_VERSION=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)
-          echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$NEW_VERSION" != "$VERSION" ]; then
+            echo "::error::bump-version produced ${NEW_VERSION} but preflight computed ${VERSION}"
+            exit 1
+          fi
           echo "Release version: $NEW_VERSION"
           git add .
           git commit -m "chore: release v${NEW_VERSION}"
 
       - name: Validate release build
-        if: steps.check.outputs.has_changesets == 'true'
         run: |
           nix develop --command validate-release
 
       - name: Push release commit
-        if: steps.check.outputs.has_changesets == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+          VERSION: ${{ needs.preflight.outputs.version }}
         run: |
-          git push origin master
+          set -euo pipefail
+          git fetch origin master
+          REMOTE_VERSION=$(git show origin/master:Cargo.toml | grep -m1 'version = ' | cut -d'"' -f2)
+          if [ "$REMOTE_VERSION" = "$VERSION" ]; then
+            echo "origin/master already carries the v${VERSION} release commit, skipping push"
+          else
+            git push origin master
+          fi
+
+  publish-crates:
+    name: Publish to crates.io
+    needs: [preflight, prepare]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # `prepare` is legitimately skipped in resume mode; without !cancelled()
+    # here, GitHub Actions auto-skips this job whenever ANY needs job is
+    # skipped, regardless of this condition (a known runner quirk). The
+    # explicit result checks restore the gating that !cancelled() bypasses.
+    if: >-
+      !cancelled() &&
+      needs.preflight.result == 'success' &&
+      needs.preflight.outputs.mode != 'noop' &&
+      (needs.prepare.result == 'success' ||
+       (needs.prepare.result == 'skipped' && needs.preflight.outputs.mode == 'resume'))
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
       - name: Publish to crates.io
-        if: steps.check.outputs.has_changesets == 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ needs.preflight.outputs.version }}
         run: |
+          set -euo pipefail
+          CHECKED_OUT=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)
+          if [ "$CHECKED_OUT" != "$VERSION" ]; then
+            echo "::error::master is at ${CHECKED_OUT} but this run releases ${VERSION}; refusing to publish"
+            exit 1
+          fi
           echo "Publishing to crates.io..."
           nix run .#publish-crates
           echo "Published successfully"
 
+  tag-release:
+    name: Tag and create GitHub Release
+    needs: [preflight, publish-crates]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Setup SSH deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin git@github.com:kanban-rs/kanban.git
+
       - name: Tag version
-        if: steps.check.outputs.has_changesets == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
-          TAG: v${{ steps.release.outputs.new }}
+          TAG: v${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
+          HEAD_VERSION=$(grep -m1 'version = ' Cargo.toml | cut -d'"' -f2)
+          if [ "v${HEAD_VERSION}" != "$TAG" ]; then
+            echo "::error::master is at v${HEAD_VERSION} but this run releases ${TAG}; refusing to tag"
+            exit 1
+          fi
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists locally, skipping git tag"
           else
@@ -136,16 +301,45 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        if: steps.check.outputs.has_changesets == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.release.outputs.new }}
+          tag_name: v${{ needs.preflight.outputs.version }}
           generate_release_notes: true
 
+  publish-aur:
+    name: Publish to AUR
+    needs: [preflight, tag-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Setup SSH deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin git@github.com:kanban-rs/kanban.git
+
       - name: Update PKGBUILD version and sha256
-        if: steps.check.outputs.has_changesets == 'true'
         env:
-          VERSION: ${{ steps.release.outputs.new }}
+          VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
           URL="https://github.com/kanban-rs/kanban/archive/v${VERSION}.tar.gz"
@@ -155,7 +349,6 @@ jobs:
           sed -i "s|sha256sums=.*|sha256sums=(\"${SHA256}\")|" ./packaging/aur/PKGBUILD
 
       - name: Generate .SRCINFO
-        if: steps.check.outputs.has_changesets == 'true'
         run: |
           # Single quotes are required: the expansions run in the inner pacman
           # shell where makepkg is on PATH, not the runner shell.
@@ -167,7 +360,6 @@ jobs:
           '
 
       - name: Commit and push AUR files
-        if: steps.check.outputs.has_changesets == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: |
@@ -175,28 +367,33 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: update AUR package to v${{ steps.release.outputs.new }}"
+            git commit -m "chore: update AUR package to v${{ needs.preflight.outputs.version }}"
             git push origin master
           fi
 
       - name: Deploy to AUR
-        if: steps.check.outputs.has_changesets == 'true'
         uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7
         with:
           pkgname: kanban
           pkgbuild: ./packaging/aur/PKGBUILD
           commit_username: github-actions[bot]
           commit_email: 41898282+github-actions[bot]@users.noreply.github.com
-          commit_message: "Update to v${{ steps.release.outputs.new }}"
+          commit_message: "Update to v${{ needs.preflight.outputs.version }}"
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
           updpkgsums: false
           allow_empty_commits: false
 
+  publish-homebrew:
+    name: Publish to Homebrew tap
+    needs: [preflight, tag-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
       - name: Compute upstream tarball SHA256 for Homebrew
-        if: steps.check.outputs.has_changesets == 'true'
         id: brew-sha
         env:
-          VERSION: ${{ steps.release.outputs.new }}
+          VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
           URL="https://github.com/kanban-rs/kanban/archive/refs/tags/v${VERSION}.tar.gz"
@@ -205,7 +402,6 @@ jobs:
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Homebrew tap SSH key
-        if: steps.check.outputs.has_changesets == 'true'
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}" > ~/.ssh/homebrew_tap_key
@@ -213,10 +409,9 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
       - name: Bump formula in homebrew-tap
-        if: steps.check.outputs.has_changesets == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/homebrew_tap_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
-          VERSION: ${{ steps.release.outputs.new }}
+          VERSION: ${{ needs.preflight.outputs.version }}
           SHA: ${{ steps.brew-sha.outputs.sha256 }}
           URL: ${{ steps.brew-sha.outputs.url }}
         run: |
@@ -235,8 +430,32 @@ jobs:
             git push origin master
           fi
 
+  sync-develop:
+    name: Sync develop with master
+    needs: [tag-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Setup SSH deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin git@github.com:kanban-rs/kanban.git
+
       - name: Sync develop with master
-        if: steps.check.outputs.has_changesets == 'true'
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: |
@@ -251,7 +470,7 @@ jobs:
 
   resolve-version:
     name: Resolve release version
-    needs: [release]
+    needs: [preflight]
     if: always()
     runs-on: ubuntu-latest
     outputs:
@@ -263,18 +482,27 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.preflight.result }}" = "success" ] && [ "${{ needs.preflight.outputs.mode }}" != "noop" ]; then
+            echo "version=${{ needs.preflight.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${{ needs.release.outputs.new }}" >> "$GITHUB_OUTPUT"
-            echo "should_run=${{ needs.release.outputs.has_changesets }}" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
   build-windows:
     name: Build Windows release archive
-    needs: [release, resolve-version]
-    # `release` is legitimately skipped on a workflow_dispatch trigger; without
-    # always() here, GitHub Actions auto-skips this job whenever ANY needs job
-    # is skipped, regardless of this condition (a known runner quirk).
-    if: always() && needs.resolve-version.outputs.should_run == 'true'
+    needs: [resolve-version, tag-release]
+    # `tag-release` is legitimately skipped on a workflow_dispatch trigger;
+    # without !cancelled() here, GitHub Actions auto-skips this job whenever
+    # ANY needs job is skipped, regardless of this condition (a known runner
+    # quirk). The explicit result checks restore the gating that !cancelled()
+    # bypasses: on the normal path the tag must exist before building.
+    if: >-
+      !cancelled() &&
+      needs.resolve-version.outputs.should_run == 'true' &&
+      (needs.tag-release.result == 'success' ||
+       (needs.tag-release.result == 'skipped' && github.event_name == 'workflow_dispatch'))
     runs-on: windows-latest
     permissions:
       contents: write
@@ -339,9 +567,9 @@ jobs:
 
   publish-chocolatey:
     name: Publish to Chocolatey
-    needs: [release, resolve-version, build-windows]
+    needs: [resolve-version, build-windows]
     # See build-windows: needs-skip-propagation requires always() even though
-    # `release` being skipped is expected on a workflow_dispatch trigger.
+    # `tag-release` being skipped is expected on a workflow_dispatch trigger.
     # Guard build-windows explicitly since always() also bypasses the default
     # success() check against it.
     if: always() && needs.resolve-version.outputs.should_run == 'true' && needs.build-windows.result == 'success'
@@ -497,9 +725,9 @@ jobs:
 
   publish-winget:
     name: Submit to winget
-    needs: [release, resolve-version, build-windows]
+    needs: [resolve-version, build-windows]
     # See build-windows: needs-skip-propagation requires always() even though
-    # `release` being skipped is expected on a workflow_dispatch trigger.
+    # `tag-release` being skipped is expected on a workflow_dispatch trigger.
     # Guard build-windows explicitly since always() also bypasses the default
     # success() check against it.
     if: always() && needs.resolve-version.outputs.should_run == 'true' && needs.build-windows.result == 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,7 +432,7 @@ jobs:
 
   sync-develop:
     name: Sync develop with master
-    needs: [tag-release]
+    needs: [tag-release, publish-aur]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -742,11 +742,10 @@ To enable automated publishing and releases, configure these secrets in GitHub r
 - Changeset validation (only on PRs to develop)
 
 **release.yml** - Runs when a pull request into master is closed (and only proceeds if it was merged)
-- Checks for changesets (skips if none found)
-- Bumps version based on changesets
-- Updates CHANGELOG.md
-- Publishes to crates.io
-- Creates GitHub release with tag
+- `preflight` (mutation-free) classifies the run as release, resume, or noop and probes every release credential in its own step, so a broken secret fails the run before anything is pushed or published
+- `prepare` bumps the version from changesets, updates CHANGELOG.md, and pushes the release commit to master (release mode only; resume mode skips it because the commit is already on master)
+- `publish-crates` publishes to crates.io, `tag-release` pushes the tag and creates the GitHub release, then `publish-aur`, `publish-homebrew`, and `sync-develop` run as independent legs
+- Each leg is its own idempotent job, so "Re-run failed jobs" retries only the leg that broke; see `docs/release-recovery.md`
 
 **ci.yml**'s `release-validation` job also runs two drift guards after
 `validate-release`, both defined in `scripts/`:
@@ -760,7 +759,7 @@ managers once `build-windows`/the crates.io release succeed. The
 `packaging/` directory holds the source or reference files each of
 these jobs consumes:
 
-- `packaging/aur/` — AUR `PKGBUILD`, updated and pushed by the `release` job
+- `packaging/aur/` — AUR `PKGBUILD`, updated and pushed by the `publish-aur` job
 - `packaging/chocolatey/` — Chocolatey nuspec/tools, packed and pushed by `publish-chocolatey`
 - `packaging/winget/` — a reference/fallback copy of the winget manifest (for `winget validate` and manual submission); the real per-version manifest is generated and submitted to `microsoft/winget-pkgs` by the `publish-winget` job via `winget-releaser`, using the `WINGET_TOKEN` secret and the `fulsomenko/winget-pkgs` fork (see [Required Secrets](#required-secrets))
 

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -11,9 +11,8 @@ The workflow is split into per-leg jobs so a failure in one leg never
 forces you to redo (or hand-finish) the others:
 
 ```
-preflight -> prepare -> publish-crates -> tag-release -+-> publish-aur
+preflight -> prepare -> publish-crates -> tag-release -+-> publish-aur -> sync-develop
                                                        +-> publish-homebrew
-                                                       +-> sync-develop
                                                        +-> build-windows -> publish-chocolatey
                                                                          -> publish-winget
 ```
@@ -180,11 +179,10 @@ git merge origin/master   # resolve conflicts
 git push origin develop
 ```
 
-Note: `publish-aur` pushes its own bump commit to `master` in parallel
-with this job. If `sync-develop` merged before that commit landed,
-`develop` trails `master` by the AUR bump until the next sync; merging
-`master` into `develop` by hand (or waiting for the next release)
-resolves it.
+Note: this job runs after `publish-aur` so the AUR bump commit on
+`master` is included in the sync. If `publish-aur` failed and was
+skipped past, develop trails `master` by that commit until the AUR
+job is re-run or the merge is done by hand.
 
 ## Job: build-windows
 

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -1,60 +1,99 @@
 # Release recovery runbook
 
 When `.github/workflows/release.yml` fails partway through, this runbook
-tells you how to finish the release by hand. Each section is keyed to
-the step that failed.
+tells you how to finish the release. Since the per-job restructure, the
+first move is almost always a re-run from the GitHub Actions UI; the
+manual fallbacks at the bottom of each section are the last resort.
 
-The workflow is designed to be re-runnable: most steps either skip
-cleanly when the work is already done or carry their own idempotency
-guard. Re-running the failed job from the GitHub Actions UI is almost
-always the right first move. The sections below are for the cases where
-a re-run does not converge or where you need to finish the release
-without GitHub Actions.
+## Pipeline shape
 
-## Important: re-run is a no-op after `Push to master`
+The workflow is split into per-leg jobs so a failure in one leg never
+forces you to redo (or hand-finish) the others:
 
-The `Check for changesets` step at the top of the `release` job exits
-the whole job cleanly when `.changeset/` contains no entries. Once the
-release commit is pushed to master, the changesets are gone from
-origin, so a fresh runner started by "Re-run failed jobs" sees zero
-changesets and **silently skips every downstream step**. This is
-correct behaviour for an unrelated PR merge, but it means a re-run
-after a failure in `Publish to crates.io` (or any later step) does
-not retry the failing step — it returns a green workflow with nothing
-recovered. For those cases, follow the manual fallback in the relevant
-section below. A `workflow_dispatch` recovery trigger is tracked in a
-follow-up card.
+```
+preflight -> prepare -> publish-crates -> tag-release -+-> publish-aur
+                                                       +-> publish-homebrew
+                                                       +-> sync-develop
+                                                       +-> build-windows -> publish-chocolatey
+                                                                         -> publish-winget
+```
 
-## Step: Push to master
+- **preflight** is mutation-free. It determines the run mode and probes
+  every credential the pipeline will need (`DEPLOY_KEY`,
+  `CARGO_REGISTRY_TOKEN`, `AUR_SSH_KEY`, `HOMEBREW_TAP_DEPLOY_KEY`,
+  `WINGET_TOKEN`, `CHOCO_API_KEY`), each in its own step so a failure
+  names the broken credential. If preflight fails, nothing has been
+  pushed, published, or tagged; fix the credential and re-run.
+- **prepare** is the only job that builds the release commit
+  (version bump, changelog aggregation, changeset deletion) and pushes
+  it to `master`.
+- Every downstream leg checks out `master` fresh and consumes
+  `needs.preflight.outputs.version`, so each leg can re-run on its own.
 
-**Symptom:** the workflow finished `Bump version`, `Aggregate changelog`,
-and `Commit release` but the push to `master` failed (auth glitch,
-branch protection, force-push race).
+## Run modes
 
-**State on origin:** no release commit, no tag, nothing published.
+Preflight classifies the run and exposes it as `mode`:
 
-**Recovery:**
-1. Re-run the failed job from the GitHub Actions UI. The runner starts
-   from a fresh checkout, but the changesets in `.changeset/` are still
-   present on origin, so bump-version, aggregate-changelog, and commit
-   re-produce the same release commit; the push retries.
-2. If the re-run still fails, the release is not partially shipped, so
-   it is safe to revert the merged PR, fix the underlying issue, and
-   re-merge.
+- **release**: changesets exist on `master`. The normal path; `prepare`
+  runs and the pipeline proceeds end to end.
+- **resume**: no changesets, but the version in `master`'s `Cargo.toml`
+  has no corresponding `v{X}` tag. This is the signature of a run that
+  died after `prepare` pushed the release commit. `prepare` is skipped
+  and the pipeline resumes at `publish-crates`.
+- **noop**: no changesets and the tag exists. Every downstream job
+  skips. This keeps non-release merges to `master` (and full re-runs of
+  an already-tagged release) green without side effects.
 
-## Step: Publish to crates.io
+## Recovery, in order of preference
 
-**Symptom:** the workflow tagged the release commit on master but
-`nix run .#publish-crates` exited non-zero partway through the crate
-list.
+1. **"Re-run failed jobs"** from the workflow run page. Each leg is its
+   own job, so only the failed leg (and anything downstream of it)
+   re-runs; outputs of the successful jobs are preserved. Every leg is
+   idempotent: crates.io publishing skips already-published crates, the
+   tag step skips an existing tag, the GitHub Release action updates in
+   place, and the AUR/Homebrew bumps skip when there is no diff.
+2. **"Re-run all jobs"** when the run died between `prepare`'s push to
+   `master` and the tag push. Preflight detects resume mode (consumed
+   changesets, untagged version) and completes every remaining leg.
+3. **`workflow_dispatch` with the `version` input** re-runs only the
+   Windows legs (`build-windows`, `publish-chocolatey`,
+   `publish-winget`) for an already-tagged version, e.g. when the
+   original run is too old to re-run.
+4. **Manual fallbacks** below, when a re-run does not converge.
 
-**State on origin:** release commit pushed; tag not yet created; one or
-more crates may have been pushed to crates.io already.
+**Caveat:** once the tag exists, a full "Re-run all jobs" is a noop by
+design (preflight sees the tag and classifies the run as noop). For a
+failure in any job after `tag-release`, use "Re-run failed jobs" on the
+original run, or the `workflow_dispatch` path for the Windows legs.
 
-**Recovery:** the workflow re-run is a no-op here (see top caveat); use
-the manual fallback below. `scripts/publish-crates.sh` is itself
-idempotent — it checks each crate against crates.io and skips the ones
-already at the target version — so re-invoking it locally converges.
+## Job: prepare (release commit and push to master)
+
+**Symptom:** version bump, changelog, commit, validation, or the push
+to `master` failed.
+
+**State on origin:** no release commit, no tag, nothing published
+(preflight already proved the credentials work, so a push failure here
+is something new, e.g. branch protection or a force-push race).
+
+**Recovery:** re-run failed jobs. The changesets are still on origin,
+so `prepare` re-produces the same release commit and retries the push.
+If `master` already carries the release commit (a re-run race), the
+push step detects the version match and skips instead of failing.
+If it still fails, nothing is partially shipped; it is safe to revert
+the merged PR, fix the underlying issue, and re-merge.
+
+## Job: publish-crates
+
+**Symptom:** `nix run .#publish-crates` exited non-zero partway
+through the crate list.
+
+**State on origin:** release commit pushed; no tag; some crates may be
+on crates.io already.
+
+**Recovery:** re-run failed jobs. `scripts/publish-crates.sh` is
+idempotent per crate: `cargo publish` failures whose output contains
+"already exists" are skipped, so a re-run converges after a partial
+publish.
 
 If you must finish by hand:
 ```bash
@@ -63,60 +102,38 @@ git fetch origin && git checkout master && git pull --ff-only
 nix run .#publish-crates
 ```
 
-## Step: Tag version
+## Job: tag-release (tag and GitHub Release)
 
-**Symptom:** crates.io publishes succeeded but the `git tag` /
-`git push origin <tag>` step failed (network, permissions).
+**Symptom:** the tag push or the GitHub Release creation failed.
 
 **State on origin:** release commit and crates.io are at the new
-version; tag may or may not be on origin.
+version; tag and Release object may or may not exist.
 
-**Recovery:** the tag step guards both the local tag creation and the
-push against an existing tag, so it is safe to re-execute whether the
-tag was created locally only, pushed to origin, or both. Note the
-re-run caveat above — in practice you will need the manual fallback
-below.
+**Recovery:** re-run failed jobs. The tag step guards both the local
+tag creation and the push against an existing tag, and
+`softprops/action-gh-release@v2` creates the Release if missing and
+updates it if present.
 
 If you must finish by hand:
 ```bash
-git fetch origin
-git checkout master
-git pull --ff-only
+git fetch origin && git checkout master && git pull --ff-only
 git tag "v<VERSION>"
 git push origin "v<VERSION>"
-```
-
-## Step: Create GitHub Release
-
-**Symptom:** tag exists on origin but the GitHub Release object was
-not created.
-
-**State on origin:** crates.io and the git tag are at the new version;
-no Release object; downstream jobs (`build-windows`,
-`publish-chocolatey`) cannot start because they checkout the tag and
-upload to the Release.
-
-**Recovery:** the workflow re-run is a no-op here (see top caveat); use
-the manual fallback below. `softprops/action-gh-release@v2` is
-idempotent — it creates the release if missing and updates it if
-present — so triggering the same operation by hand is safe.
-
-If you must finish by hand:
-```bash
 gh release create "v<VERSION>" --generate-notes
 ```
 
-## Step: AUR (PKGBUILD, .SRCINFO, deploy)
+## Job: publish-aur
 
-**Symptom:** the AUR commit or push failed.
+**Symptom:** the PKGBUILD bump, the commit to `master`, or the AUR
+deploy failed.
 
 **State on origin:** crates.io, tag, and GitHub Release are at the new
 version; AUR may have a stale `pkgver`.
 
-**Recovery:** the workflow re-run is a no-op here (see top caveat); use
-the manual fallback below. The AUR commit step is idempotent against
-the local working copy (empty-commit skip + `allow_empty_commits: false`
-on deploy), so the same operation by hand converges.
+**Recovery:** re-run failed jobs. The job re-checks out `master`; if a
+previous attempt already committed the PKGBUILD bump, the sed produces
+no diff and the commit step skips, then the deploy action re-runs
+(`allow_empty_commits: false` keeps that safe).
 
 If you must finish by hand:
 ```bash
@@ -129,18 +146,16 @@ git commit -m "Update to <VERSION>"
 git push
 ```
 
-## Step: Homebrew tap formula bump
+## Job: publish-homebrew
 
-**Symptom:** the Homebrew formula bump or push to
-`fulsomenko/homebrew-tap` failed.
+**Symptom:** the formula bump or push to `fulsomenko/homebrew-tap`
+failed.
 
-**State on origin:** crates.io, tag, GitHub Release, and AUR are at
-the new version; the tap formula may be stale.
+**State on origin:** everything upstream of this leg is at the new
+version; the tap formula may be stale.
 
-**Recovery:** the workflow re-run is a no-op here (see top caveat); use
-the manual fallback below. The bump step is idempotent (empty-commit
-skip), so the same operation by hand is safe when the formula already
-matches the target.
+**Recovery:** re-run failed jobs. The bump step skips the commit when
+the formula already matches the target (no diff), so a re-run is safe.
 
 If you must finish by hand:
 ```bash
@@ -152,33 +167,46 @@ git commit -m "Bump kanban to <VERSION>"
 git push
 ```
 
+## Job: sync-develop
+
+**Symptom:** the merge of `master` into `develop` failed (the job
+fails loudly instead of force-resolving).
+
+**Recovery:** merge by hand and push:
+```bash
+git fetch origin
+git checkout develop && git pull origin develop
+git merge origin/master   # resolve conflicts
+git push origin develop
+```
+
+Note: `publish-aur` pushes its own bump commit to `master` in parallel
+with this job. If `sync-develop` merged before that commit landed,
+`develop` trails `master` by the AUR bump until the next sync; merging
+`master` into `develop` by hand (or waiting for the next release)
+resolves it.
+
 ## Job: build-windows
 
 **Symptom:** the Windows build, archive, or asset upload failed.
 
-**State on origin:** crates.io, tag, GitHub Release, AUR, and Homebrew
-are at the new version; the Windows ZIP and SHA256SUMS may be missing
-from the GitHub Release.
+**State on origin:** the tag and Release exist (the job depends on
+`tag-release`); the Windows ZIP and SHA256SUMS may be missing from the
+Release.
 
-**Recovery:** re-run the `build-windows` job from the GitHub Actions
-UI. It re-checks out at the tag, rebuilds, and re-uploads to the same
-Release. `softprops/action-gh-release@v2` updates assets in place, so
-a re-run is safe.
+**Recovery:** re-run the `build-windows` job from the UI. It re-checks
+out the tag, rebuilds, and re-uploads; `softprops/action-gh-release@v2`
+updates assets in place. If the original run is gone, use
+`workflow_dispatch` with the released version.
 
 ## Job: publish-chocolatey
 
 **Symptom:** the Chocolatey push failed or was held in the moderation
 queue.
 
-**State on origin:** every other surface is at the new version; the
-Chocolatey package may or may not be published.
-
 The job is marked `continue-on-error: true`, so this failure surfaces
-as a warning rather than blocking the workflow. To keep the failure
-visible despite that, the job ends with a `Surface chocolatey failure`
-step that fires `if: failure()` and writes a `::warning::` annotation
-plus a `$GITHUB_STEP_SUMMARY` block linking back to this runbook. Look
-for the yellow warning banner at the top of the workflow run page.
+as a warning rather than blocking the workflow. Look for the yellow
+warning banner and the step-summary block on the workflow run page.
 
 **Recovery:** see [`packaging/chocolatey/RECOVERY.md`](../packaging/chocolatey/RECOVERY.md)
 for the full Chocolatey-specific flowchart. The short version:
@@ -187,3 +215,13 @@ for the full Chocolatey-specific flowchart. The short version:
 2. If `choco push` itself failed with a hard error, follow the
    chocolatey runbook to either retry, contact moderation, or
    ship the next patch with a corrected nupkg.
+
+## Job: publish-winget
+
+**Symptom:** the winget submission failed. Also
+`continue-on-error: true`, surfaced as a warning.
+
+**Recovery:** the most common cause is that the first-ever submission
+of a new identifier must be made manually; see
+[`packaging/winget/README.md`](../packaging/winget/README.md).
+Otherwise re-run the job or use `workflow_dispatch`.


### PR DESCRIPTION
## Summary

Restructures the release workflow from one monolithic job into a fail-fast, per-leg re-runnable pipeline. Motivated by the v0.9.0 release, where a disabled deploy key was discovered only after the version bump and changelog were already built, and by the audit finding that a mid-run failure after the master push made every UI re-run a silent no-op.

## Changes

- New preflight job runs before any mutation: computes the release version and mode, then probes every credential in its own step (DEPLOY_KEY ssh auth and ls-remote, CARGO_REGISTRY_TOKEN against the crates.io me endpoint, AUR_SSH_KEY greeting, HOMEBREW_TAP_DEPLOY_KEY ls-remote, WINGET_TOKEN user probe, CHOCO_API_KEY presence). A dead credential now fails the run in under a minute with the credential named, before anything is touched.
- The monolithic release job becomes separate jobs: prepare (bump, changelog, master push), publish-crates, tag-release, publish-aur, publish-homebrew, sync-develop. GitHub's re-run failed jobs now recovers a single failed leg without re-running the rest.
- Resume mode replaces the silent no-op trap: when a run dies after the master push (changesets consumed), a full re-run detects the bumped version with no matching tag, skips prepare, and completes only the missing legs. Each leg guards itself (crates publish already skips published versions, tag and release steps keep their existing guards, AUR and Homebrew tolerate no-change).
- build-windows now depends on tag-release, fixing a race where it could check out a tag that did not exist yet. The workflow_dispatch recovery path for the Windows legs is unchanged.
- sync-develop runs after publish-aur so the AUR bump commit on master is included in the sync.
- docs/release-recovery.md rewritten around per-job re-runs and resume mode, with manual fallbacks kept as last resort; CONTRIBUTING.md release section updated.

## Verification

actionlint clean, bash -n clean on all authored script blocks, and the job graph hand-traced through six scenarios: happy path, non-release merge (green no-op, zero mutations), credential failure (nothing mutated), death after master push plus full re-run (resumes and completes), single-leg failure plus re-run failed jobs (re-runs only that leg), and workflow_dispatch recovery (unchanged). The preflight mode computation was executed against the real repo state and reproduced v0.9.0 from 0.8.1 plus the pending changesets.

Changeset included (bump: patch).