### PR TITLE
fix(ci): run CI on master pushes so the badge tracks the default branch

### DIFF
--- a/.changeset/ci-badge-master-push.md
+++ b/.changeset/ci-badge-master-push.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Run CI on pushes to master so the README CI badge reflects the actual state of the default branch. The badge previously showed the latest run whose head branch was master, which was a failed develop-sync PR from the v0.8.0 era; with syncs now done by direct push, no newer run ever replaced it and the badge stayed red permanently. A concurrency group cancels the superseded run when the release pipeline pushes master twice in quick succession (release commit, then the AUR bump).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - develop
       - master
+
+concurrency:
+  group: ci-${{ github.ref }}-${{ github.event.pull_request.number || 'push' }}
+  cancel-in-progress: true
 
 jobs:
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check for changeset
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
           CHANGESETS=$(ls .changeset/*.md 2>/dev/null | grep -v "README.md" || true)
 
@@ -127,7 +129,6 @@ jobs:
             exit 1
           fi
 
-          BRANCH_NAME="${{ github.head_ref }}"
           TICKET_ID=$(echo "$BRANCH_NAME" | grep -oE '^[A-Z]+-[0-9]+' | tr '[:upper:]' '[:lower:]')
 
           if [ -n "$TICKET_ID" ]; then


### PR DESCRIPTION
## Summary

The README CI badge has been red since the v0.8.0 era. The badge (no branch param) shows the latest ci.yml run associated with the default branch, master, but ci.yml only triggers on pull_request. The only runs with master as head branch were the old sync-develop-with-master PRs, whose last run failed on 2026-08-02; syncs are now direct pushes, so nothing ever replaced that run and the badge froze on failing.

## Changes

- ci.yml gains a push trigger for master, so every push to master (the release commit and the AUR bump during a release) produces a real default-branch CI run and the badge tracks the actual state of master.
- A concurrency group cancels the superseded run when the release pipeline pushes master twice within a couple of minutes, keeping one meaningful run instead of two. PR runs group per PR number and are unaffected by each other.
- The changeset job's develop-PR-only guard already skips it on push events, so master pushes run only build/test/lint/format.

The badge turns green when this reaches master with the next release, whose pushes will trigger the first passing master run.

Changeset included (bump: patch).