### PR TITLE
test(service): a fault-injecting, read-recording backend wrapper

### DIFF
--- a/.changeset/kan-1425-fault-injecting.md
+++ b/.changeset/kan-1425-fault-injecting.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 service: add `FaultInjectingBackend` under the `test-helpers` feature, a wrapper over any `Arc<dyn KanbanBackend>` that makes named `DataStore` reads fail on demand and records every intercepted read in call order. It lets the cross-backend contract suite prove that a store error resolves to `Failed` rather than `Missing` on JSON and SQLite, not just in-memory, and lets downstream tests assert that a read did not happen at all. Every trait method delegates to the wrapped backend, including the defaulted ones that real backends override, so the wrapper stays transparent.

--- a/.changeset/kan-1425-fault-injecting.md
+++ b/.changeset/kan-1425-fault-injecting.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: add `FaultInjectingBackend` under the `test-helpers` feature, a wrapper over any `Arc<dyn KanbanBackend>` that makes named `DataStore` reads fail on demand and records every intercepted read in call order. It lets the cross-backend contract suite prove that a store error resolves to `Failed` rather than `Missing` on JSON and SQLite, not just in-memory, and lets downstream tests assert that a read did not happen at all. Every trait method delegates to the wrapped backend, including the defaulted ones that real backends override, so the wrapper stays transparent.

--- a/crates/kanban-service/src/test_helpers/fault.rs
+++ b/crates/kanban-service/src/test_helpers/fault.rs
@@ -1,0 +1,419 @@
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use kanban_domain::command_batch::CommandBatch;
+use kanban_domain::command_store::CommandStore;
+use kanban_domain::data_store::{DataStore, GraphMutFn};
+use kanban_domain::{
+    ArchivedBoard, ArchivedCard, ArchivedFilter, Board, Card, Column, DependencyGraph, KanbanError,
+    KanbanResult, Prefix, Snapshot, Sprint,
+};
+use uuid::Uuid;
+
+use super::BackendFactory;
+use crate::KanbanBackend;
+
+/// One intercepted read: the `DataStore` method name and the ids it was called
+/// with (empty for whole-collection reads, the scope key for scoped reads).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadOp {
+    pub method: &'static str,
+    pub ids: Vec<Uuid>,
+}
+
+/// The read methods this wrapper intercepts: these are the ones `fail()` can
+/// fault AND the ones that appear in `ops()`. A `fail()` call naming anything
+/// outside this list panics rather than silently doing nothing - a test that
+/// thinks it injected a fault and did not is a test that asserts nothing.
+/// A later card that needs to fault a read not listed here must WIDEN this
+/// const; it cannot fault it by name alone.
+pub const FAULTABLE_READS: &[&str] = &[
+    "list_boards",
+    "get_board",
+    "list_all_columns",
+    "list_columns_by_board",
+    "get_column",
+    "list_all_cards",
+    "list_cards_by_column",
+    "get_card",
+    "list_all_sprints",
+    "list_sprints_by_board",
+    "get_sprint",
+    "get_graph",
+    "list_archived_cards",
+    "list_archived_cards_by_board",
+    "list_prefixes",
+];
+
+/// Wraps a real backend and (a) makes named `DataStore` reads return an error
+/// on demand, and (b) records every intercepted read in order, so a test can
+/// prove a read *failure* is distinguished from a read that legitimately found
+/// nothing, AND that a read it expected NOT to happen did not happen - on every
+/// backend, not just in-memory.
+///
+/// Every method delegates to `inner`. Only the reads named in
+/// `FAULTABLE_READS` are intercepted; writes are never faulted and never
+/// recorded, because a half-applied write would leave the wrapped backend in a
+/// state the test did not ask for.
+pub struct FaultInjectingBackend {
+    inner: Arc<dyn KanbanBackend>,
+    failing: Mutex<HashSet<&'static str>>,
+    ops: Mutex<Vec<ReadOp>>,
+}
+
+impl FaultInjectingBackend {
+    pub fn new(inner: Arc<dyn KanbanBackend>) -> Self {
+        Self {
+            inner,
+            failing: Mutex::new(HashSet::new()),
+            ops: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The wrapped backend, for assertions about real state.
+    pub fn inner(&self) -> &Arc<dyn KanbanBackend> {
+        &self.inner
+    }
+
+    /// Make `method` return an error until cleared. `method` must be one of the
+    /// names in [`FAULTABLE_READS`]; anything else panics.
+    pub fn fail(&self, method: &'static str) {
+        assert!(
+            FAULTABLE_READS.contains(&method),
+            "{method} is not a faultable read; widen FAULTABLE_READS to fault it"
+        );
+        self.failing.lock().unwrap().insert(method);
+    }
+
+    pub fn clear_faults(&self) {
+        self.failing.lock().unwrap().clear();
+    }
+
+    /// Every intercepted read since construction or the last `clear_ops`, in
+    /// call order. Returns a clone so the caller holds no lock while asserting.
+    ///
+    /// A read is recorded whether it succeeded OR was faulted: the log answers
+    /// "was this method called", not "did it return data". A test asserting a
+    /// read did not happen wants the call to be absent, not merely failed.
+    pub fn ops(&self) -> Vec<ReadOp> {
+        self.ops.lock().unwrap().clone()
+    }
+
+    /// Reset the log. Tests that resolve once to warm the `Model` and then
+    /// assert on a SECOND resolve call this in between; without it every
+    /// assertion has to skip a prefix, which is how an off-by-one in an op
+    /// assertion hides.
+    pub fn clear_ops(&self) {
+        self.ops.lock().unwrap().clear();
+    }
+
+    pub fn op_count(&self, method: &str) -> usize {
+        self.ops
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|o| o.method == method)
+            .count()
+    }
+
+    /// Records first, then faults, so a faulted read still appears in the log.
+    fn check(&self, method: &'static str, ids: Vec<Uuid>) -> KanbanResult<()> {
+        self.ops.lock().unwrap().push(ReadOp { method, ids });
+        if self.failing.lock().unwrap().contains(method) {
+            return Err(KanbanError::Database(format!("injected fault: {method}")));
+        }
+        Ok(())
+    }
+}
+
+/// Path -> the wrapper wrapping that path's backend.
+pub type FaultHandles = Arc<Mutex<HashMap<PathBuf, Arc<FaultInjectingBackend>>>>;
+
+/// Wrap a `BackendFactory` so every backend it produces is fault-injectable.
+/// The handles are keyed by path so a test can reach the same wrapper the
+/// context is using and flip a fault on it mid-test.
+pub fn faultable(inner: BackendFactory) -> (BackendFactory, FaultHandles) {
+    let handles: FaultHandles = Arc::new(Mutex::new(HashMap::new()));
+    let for_factory = Arc::clone(&handles);
+    let factory: BackendFactory = Box::new(move |path: &std::path::Path| {
+        let mut map = for_factory.lock().unwrap();
+        let wrapper = map
+            .entry(path.to_path_buf())
+            .or_insert_with(|| Arc::new(FaultInjectingBackend::new(inner(path))))
+            .clone();
+        wrapper as Arc<dyn KanbanBackend>
+    });
+    (factory, handles)
+}
+
+impl DataStore for FaultInjectingBackend {
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        self.check("get_board", vec![id])?;
+        self.inner.get_board(id)
+    }
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        self.check("list_boards", vec![])?;
+        self.inner.list_boards()
+    }
+    fn upsert_board(&self, board: Board) -> KanbanResult<()> {
+        self.inner.upsert_board(board)
+    }
+    fn delete_board(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_board(id)
+    }
+
+    fn get_prefix(&self, name: &str) -> KanbanResult<Option<Prefix>> {
+        self.inner.get_prefix(name)
+    }
+    fn list_prefixes(&self) -> KanbanResult<Vec<Prefix>> {
+        self.check("list_prefixes", vec![])?;
+        self.inner.list_prefixes()
+    }
+    fn upsert_prefix(&self, prefix: Prefix) -> KanbanResult<()> {
+        self.inner.upsert_prefix(prefix)
+    }
+
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        self.check("get_column", vec![id])?;
+        self.inner.get_column(id)
+    }
+    fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        self.check("list_columns_by_board", vec![board_id])?;
+        self.inner.list_columns_by_board(board_id)
+    }
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.check("list_all_columns", vec![])?;
+        self.inner.list_all_columns()
+    }
+    fn upsert_column(&self, column: Column) -> KanbanResult<()> {
+        self.inner.upsert_column(column)
+    }
+    fn delete_column(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_column(id)
+    }
+    fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_columns_by_board(board_id)
+    }
+
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        self.check("get_card", vec![id])?;
+        self.inner.get_card(id)
+    }
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.check("list_all_cards", vec![])?;
+        self.inner.list_all_cards()
+    }
+    fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.check("list_cards_by_column", vec![column_id])?;
+        self.inner.list_cards_by_column(column_id)
+    }
+    fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_sprint(sprint_id)
+    }
+    fn count_cards_in_column(&self, column_id: Uuid) -> KanbanResult<usize> {
+        self.inner.count_cards_in_column(column_id)
+    }
+    fn list_cards_by_prefix_and_number(
+        &self,
+        prefix: &str,
+        card_number: u32,
+    ) -> KanbanResult<Vec<Card>> {
+        self.inner
+            .list_cards_by_prefix_and_number(prefix, card_number)
+    }
+    fn list_cards_by_number(&self, card_number: u32) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_number(card_number)
+    }
+    fn get_card_by_board_and_number(
+        &self,
+        board_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        self.inner
+            .get_card_by_board_and_number(board_id, card_number)
+    }
+    fn get_card_by_sprint_and_number(
+        &self,
+        sprint_id: Uuid,
+        card_number: u32,
+    ) -> KanbanResult<Option<Card>> {
+        self.inner
+            .get_card_by_sprint_and_number(sprint_id, card_number)
+    }
+    fn count_cards_in_column_excluding(
+        &self,
+        column_id: Uuid,
+        exclude: &[Uuid],
+    ) -> KanbanResult<usize> {
+        self.inner
+            .count_cards_in_column_excluding(column_id, exclude)
+    }
+    fn upsert_card(&self, card: Card) -> KanbanResult<()> {
+        self.inner.upsert_card(card)
+    }
+    fn delete_card(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_card(id)
+    }
+    fn delete_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<()> {
+        self.inner.delete_cards_by_columns(column_ids)
+    }
+    fn list_cards_by_columns(&self, column_ids: &[Uuid]) -> KanbanResult<Vec<Card>> {
+        self.inner.list_cards_by_columns(column_ids)
+    }
+    fn list_cards_by_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        self.inner
+            .list_cards_by_column_filtered(column_id, archived)
+    }
+    fn count_cards_in_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        self.inner
+            .count_cards_in_column_filtered(column_id, archived)
+    }
+    fn clear_sprint_from_cards(
+        &self,
+        sprint_id: Uuid,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner.clear_sprint_from_cards(sprint_id, timestamp)
+    }
+
+    fn get_archived_card(&self, card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
+        self.inner.get_archived_card(card_id)
+    }
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        self.check("list_archived_cards", vec![])?;
+        self.inner.list_archived_cards()
+    }
+    fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
+        self.inner.insert_archived_card(ac)
+    }
+    fn delete_archived_card(&self, card_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_card(card_id)
+    }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.check("list_archived_cards_by_board", vec![board_id])?;
+        self.inner.list_archived_cards_by_board(board_id)
+    }
+    fn clear_sprint_from_archived_cards(
+        &self,
+        sprint_id: Uuid,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        self.inner
+            .clear_sprint_from_archived_cards(sprint_id, timestamp)
+    }
+
+    fn get_archived_board(&self, board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
+        self.inner.get_archived_board(board_id)
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.inner.list_archived_boards()
+    }
+    fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
+        self.inner.insert_archived_board(ab)
+    }
+    fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_archived_board(board_id)
+    }
+    fn unarchive_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.unarchive_board(board_id)
+    }
+
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        self.check("get_sprint", vec![id])?;
+        self.inner.get_sprint(id)
+    }
+    fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        self.check("list_sprints_by_board", vec![board_id])?;
+        self.inner.list_sprints_by_board(board_id)
+    }
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.check("list_all_sprints", vec![])?;
+        self.inner.list_all_sprints()
+    }
+    fn upsert_sprint(&self, sprint: Sprint) -> KanbanResult<()> {
+        self.inner.upsert_sprint(sprint)
+    }
+    fn delete_sprint(&self, id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprint(id)
+    }
+    fn delete_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<()> {
+        self.inner.delete_sprints_by_board(board_id)
+    }
+
+    fn get_graph(&self) -> KanbanResult<DependencyGraph> {
+        self.check("get_graph", vec![])?;
+        self.inner.get_graph()
+    }
+    fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
+        self.inner.set_graph(graph)
+    }
+    fn modify_graph(&self, f: GraphMutFn) -> KanbanResult<()> {
+        self.inner.modify_graph(f)
+    }
+
+    fn snapshot(&self) -> KanbanResult<Snapshot> {
+        self.inner.snapshot()
+    }
+    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
+        self.inner.apply_snapshot(snapshot)
+    }
+}
+
+impl CommandStore for FaultInjectingBackend {
+    fn append_batch(&self, batch: &CommandBatch) -> KanbanResult<u64> {
+        self.inner.append_batch(batch)
+    }
+    fn batch_count(&self) -> KanbanResult<u64> {
+        self.inner.batch_count()
+    }
+    fn load_batches(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
+        self.inner.load_batches(from, to)
+    }
+    fn load_all_batches(&self) -> KanbanResult<(Vec<CommandBatch>, u64)> {
+        self.inner.load_all_batches()
+    }
+}
+
+#[async_trait]
+impl KanbanBackend for FaultInjectingBackend {
+    fn as_data_store(&self) -> &dyn DataStore {
+        self
+    }
+    async fn flush(&self) -> KanbanResult<()> {
+        self.inner.flush().await
+    }
+    async fn reload(&self) -> KanbanResult<()> {
+        self.inner.reload().await
+    }
+    fn needs_flush(&self) -> bool {
+        self.inner.needs_flush()
+    }
+    fn needs_save_worker(&self) -> bool {
+        self.inner.needs_save_worker()
+    }
+    fn instance_id(&self) -> Uuid {
+        self.inner.instance_id()
+    }
+    fn local_persistence(&self) -> Option<&dyn kanban_backend::LocalPersistence> {
+        self.inner.local_persistence()
+    }
+    fn health_checker(&self) -> Option<Box<dyn kanban_core::HealthChecker>> {
+        self.inner.health_checker()
+    }
+    fn remote_writes(&self) -> Option<&dyn kanban_backend::RemoteWrites> {
+        self.inner.remote_writes()
+    }
+    fn with_transaction(&self, f: kanban_backend::TransactionFn<'_>) -> KanbanResult<()> {
+        self.inner.with_transaction(f)
+    }
+}

--- a/crates/kanban-service/src/test_helpers/fault.rs
+++ b/crates/kanban-service/src/test_helpers/fault.rs
@@ -128,21 +128,33 @@ impl FaultInjectingBackend {
     }
 }
 
-/// Path -> the wrapper wrapping that path's backend.
-pub type FaultHandles = Arc<Mutex<HashMap<PathBuf, Arc<FaultInjectingBackend>>>>;
+/// Path -> every wrapper produced for that path, in construction order.
+///
+/// A durable backend is expected to hand back a *fresh* store on each open of
+/// the same path, sharing on-disk state; the reload assertions in the contract
+/// suite depend on it. So this records one entry per call rather than one per
+/// path, and the wrapper the context is currently using is the LAST element.
+pub type FaultHandles = Arc<Mutex<HashMap<PathBuf, Vec<Arc<FaultInjectingBackend>>>>>;
 
 /// Wrap a `BackendFactory` so every backend it produces is fault-injectable.
-/// The handles are keyed by path so a test can reach the same wrapper the
-/// context is using and flip a fault on it mid-test.
+/// The handles are keyed by path so a test can reach the wrapper the context is
+/// using and flip a fault on it mid-test.
+///
+/// This calls `inner` on EVERY invocation and never reuses a previously built
+/// backend. Caching by path would turn "reopen and re-read from disk" into
+/// "hand back the same in-memory instance", silently defeating the reload
+/// assertions this helper exists to serve.
 pub fn faultable(inner: BackendFactory) -> (BackendFactory, FaultHandles) {
     let handles: FaultHandles = Arc::new(Mutex::new(HashMap::new()));
     let for_factory = Arc::clone(&handles);
     let factory: BackendFactory = Box::new(move |path: &std::path::Path| {
-        let mut map = for_factory.lock().unwrap();
-        let wrapper = map
+        let wrapper = Arc::new(FaultInjectingBackend::new(inner(path)));
+        for_factory
+            .lock()
+            .unwrap()
             .entry(path.to_path_buf())
-            .or_insert_with(|| Arc::new(FaultInjectingBackend::new(inner(path))))
-            .clone();
+            .or_default()
+            .push(Arc::clone(&wrapper));
         wrapper as Arc<dyn KanbanBackend>
     });
     (factory, handles)

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -1,5 +1,8 @@
 pub mod contract;
+pub mod fault;
 pub mod helpers;
+
+pub use fault::{faultable, FaultHandles, FaultInjectingBackend, ReadOp, FAULTABLE_READS};
 
 pub type BackendFactory =
     Box<dyn Fn(&std::path::Path) -> std::sync::Arc<dyn crate::KanbanBackend> + Send + Sync>;

--- a/crates/kanban-service/tests/fault_injection.rs
+++ b/crates/kanban-service/tests/fault_injection.rs
@@ -1,0 +1,175 @@
+//! Requires the `test-helpers` feature; run with
+//! `cargo test -p kanban-service --features test-helpers`.
+#![cfg(feature = "test-helpers")]
+
+use std::sync::Arc;
+
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{Board, Card, Column};
+use kanban_persistence_sqlite::SqliteBackend;
+use kanban_service::test_helpers::{FaultInjectingBackend, ReadOp};
+use kanban_service::KanbanBackend;
+
+fn wrapped_in_memory() -> (FaultInjectingBackend, Board) {
+    let inner = InMemoryStore::new();
+    let board = Board::new("Seeded", None::<String>);
+    inner.upsert_board(board.clone()).unwrap();
+    (
+        FaultInjectingBackend::new(Arc::new(inner) as Arc<dyn KanbanBackend>),
+        board,
+    )
+}
+
+#[test]
+fn test_a_faulted_read_returns_an_error_from_the_wrapper() {
+    let (backend, _board) = wrapped_in_memory();
+    backend.fail("list_boards");
+    assert!(backend.list_boards().is_err());
+}
+
+#[test]
+fn test_an_unfaulted_read_delegates_to_the_wrapped_backend() {
+    let (backend, board) = wrapped_in_memory();
+    let boards = backend.list_boards().unwrap();
+    assert_eq!(boards.len(), 1);
+    assert_eq!(boards[0].id, board.id);
+    assert_eq!(boards[0].name, "Seeded");
+}
+
+#[test]
+fn test_a_fault_on_one_method_does_not_affect_another() {
+    let (backend, _board) = wrapped_in_memory();
+    backend.fail("get_card");
+    assert!(backend.get_card(uuid::Uuid::new_v4()).is_err());
+    assert!(backend.list_boards().is_ok());
+}
+
+#[test]
+fn test_clearing_a_fault_restores_the_read() {
+    let (backend, _board) = wrapped_in_memory();
+    backend.fail("list_boards");
+    assert!(backend.list_boards().is_err());
+    backend.clear_faults();
+    assert_eq!(backend.list_boards().unwrap().len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "not a faultable read")]
+fn test_faulting_an_unknown_method_name_panics() {
+    let (backend, _board) = wrapped_in_memory();
+    backend.fail("list_bords");
+}
+
+#[test]
+fn test_writes_are_never_faulted() {
+    let (backend, _board) = wrapped_in_memory();
+    for method in kanban_service::test_helpers::FAULTABLE_READS {
+        backend.fail(method);
+    }
+    assert!(backend
+        .upsert_board(Board::new("Written anyway", None::<String>))
+        .is_ok());
+}
+
+/// The pinning test. A wrapper that omits a delegation for a *defaulted*
+/// `DataStore` method silently resolves to the domain default instead of the
+/// backend's override, which would make every downstream parity assertion test
+/// the wrapper rather than the backend. SQLite is the backend with real
+/// index-backed overrides of defaulted methods.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_the_wrapper_delegates_a_backend_overridden_default_method() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pin.sqlite3");
+    let inner: Arc<dyn KanbanBackend> = Arc::new(
+        SqliteBackend::open(path.to_str().unwrap())
+            .await
+            .expect("open sqlite backend"),
+    );
+
+    let board = Board::new("Pinned", Some("PIN"));
+    let column = Column::new(board.id, "Todo", 0);
+    let mut card = Card::new(board.id, column.id, "Pinned card", 0);
+    card.card_number = 7;
+    card.prefix = "PIN".to_string();
+    inner
+        .upsert_prefix(kanban_domain::Prefix::new("PIN"))
+        .unwrap();
+    inner.upsert_board(board.clone()).unwrap();
+    inner.upsert_column(column).unwrap();
+    inner.upsert_card(card.clone()).unwrap();
+
+    let backend = FaultInjectingBackend::new(inner.clone());
+
+    let through_wrapper = backend.get_card_by_board_and_number(board.id, 7).unwrap();
+    let direct = inner.get_card_by_board_and_number(board.id, 7).unwrap();
+
+    assert_eq!(through_wrapper.as_ref().map(|c| c.id), Some(card.id));
+    assert_eq!(
+        through_wrapper.as_ref().map(|c| c.id),
+        direct.as_ref().map(|c| c.id),
+        "the wrapper must answer from the backend's override, not the trait default"
+    );
+}
+
+#[test]
+fn test_an_intercepted_read_is_recorded_in_call_order() {
+    let (backend, _board) = wrapped_in_memory();
+    let card_id = uuid::Uuid::new_v4();
+    backend.list_boards().unwrap();
+    backend.get_card(card_id).unwrap();
+    assert_eq!(
+        backend.ops(),
+        vec![
+            ReadOp {
+                method: "list_boards",
+                ids: vec![],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![card_id],
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_a_faulted_read_is_still_recorded() {
+    let (backend, _board) = wrapped_in_memory();
+    let card_id = uuid::Uuid::new_v4();
+    backend.fail("get_card");
+    assert!(backend.get_card(card_id).is_err());
+    assert_eq!(
+        backend.ops(),
+        vec![ReadOp {
+            method: "get_card",
+            ids: vec![card_id],
+        }]
+    );
+}
+
+#[test]
+fn test_a_write_is_not_recorded() {
+    let (backend, _board) = wrapped_in_memory();
+    backend
+        .upsert_board(Board::new("Unlogged", None::<String>))
+        .unwrap();
+    assert_eq!(backend.ops(), vec![]);
+}
+
+#[test]
+fn test_clear_ops_empties_the_log() {
+    let (backend, _board) = wrapped_in_memory();
+    backend.list_boards().unwrap();
+    assert_eq!(backend.ops().len(), 1);
+    backend.clear_ops();
+    assert_eq!(backend.ops(), vec![]);
+}
+
+#[test]
+fn test_an_unread_method_is_absent_from_the_log() {
+    let (backend, _board) = wrapped_in_memory();
+    backend.list_boards().unwrap();
+    assert_eq!(backend.op_count("list_boards"), 1);
+    assert_eq!(backend.op_count("get_card"), 0);
+}

--- a/crates/kanban-service/tests/fault_injection.rs
+++ b/crates/kanban-service/tests/fault_injection.rs
@@ -8,7 +8,7 @@ use kanban_backend_memory::InMemoryStore;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{Board, Card, Column};
 use kanban_persistence_sqlite::SqliteBackend;
-use kanban_service::test_helpers::{FaultInjectingBackend, ReadOp};
+use kanban_service::test_helpers::{faultable, BackendFactory, FaultInjectingBackend, ReadOp};
 use kanban_service::KanbanBackend;
 
 fn wrapped_in_memory() -> (FaultInjectingBackend, Board) {
@@ -110,6 +110,18 @@ async fn test_the_wrapper_delegates_a_backend_overridden_default_method() {
         direct.as_ref().map(|c| c.id),
         "the wrapper must answer from the backend's override, not the trait default"
     );
+
+    // The equality above cannot fail on its own: the trait default is
+    // `self.list_all_cards().find(..)`, which routes back through the
+    // wrapper's own delegated `list_all_cards` and returns the same answer.
+    // The side channel is what discriminates. `list_all_cards` is recorded, so
+    // a missing delegation shows up as a non-zero count here.
+    assert_eq!(
+        backend.op_count("list_all_cards"),
+        0,
+        "a missing delegation would have fallen back to the trait default, \
+         which reaches the backend via list_all_cards"
+    );
 }
 
 #[test]
@@ -172,4 +184,44 @@ fn test_an_unread_method_is_absent_from_the_log() {
     backend.list_boards().unwrap();
     assert_eq!(backend.op_count("list_boards"), 1);
     assert_eq!(backend.op_count("get_card"), 0);
+}
+
+/// `faultable` must not cache by path. A durable backend hands back a fresh
+/// store on each open of the same path, sharing on-disk state, and every reload
+/// assertion in the contract suite depends on that. Caching would turn a reopen
+/// into "the same in-memory instance" and silently defeat them.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_faultable_preserves_reload_semantics_for_a_durable_backend() {
+    use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("reload.json");
+
+    let json: BackendFactory = Box::new(|p: &std::path::Path| {
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(p)))) as Arc<dyn KanbanBackend>
+    });
+    let (factory, handles) = faultable(json);
+
+    let first = factory(&path);
+    let board = Board::new("Persisted", None::<String>);
+    first.upsert_board(board.clone()).unwrap();
+    first.flush().await.unwrap();
+
+    let second = factory(&path);
+    assert!(
+        !Arc::ptr_eq(&first, &second),
+        "a reopen must build a fresh backend, not return the cached one"
+    );
+    assert_eq!(
+        second.get_board(board.id).unwrap().map(|b| b.id),
+        Some(board.id),
+        "the second open must read the state the first one flushed to disk"
+    );
+
+    let recorded = handles.lock().unwrap();
+    assert_eq!(
+        recorded.get(&path).map(|v| v.len()),
+        Some(2),
+        "both wrappers must be reachable, in construction order"
+    );
 }


### PR DESCRIPTION
Adds `FaultInjectingBackend` to `kanban-service`'s `test_helpers`, a wrapper over any `Arc<dyn KanbanBackend>` that does two jobs at one seam.

**Job 1, inject faults.** `fail("get_card")` makes that read return `KanbanError::Database`. The `Model` distinguishes `Missing` (the store said no such row) from `Failed` (the store errored), and `Missing` deletes the row from the model while `Failed` leaves it alone. Proving that distinction holds identically on JSON and SQLite needs a real backend failing a named read on demand, which nothing in the workspace could do: `RecordingStore` in `read_recorder.rs` hard-codes `inner: InMemoryStore` and sits behind `#[cfg(test)]`, so it is invisible to the contract suite that other crates' integration tests invoke.

**Job 2, record reads.** Downstream cards assert that a read did *not* happen, which is unobservable from the `Model`, since the absence of a read looks exactly like a successful one. `ops()` returns every intercepted read in call order with its ids, `clear_ops()` resets, `op_count()` counts. `check()` records first and faults second, so a faulted read still appears in the log.

Writes are neither faulted nor recorded. That is what makes a "no read happened" assertion unambiguous, and it keeps a half-applied write from leaving the wrapped backend in a state the test did not ask for. Every write still delegates verbatim.

`faultable()` wraps a `BackendFactory` and hands back a path-keyed registry of the wrappers, so a test can reach the same wrapper its context is using and flip a fault mid-test.

## Transparency is the property that matters

Every `DataStore`, `CommandStore` and `KanbanBackend` method delegates to the wrapped backend, including the defaulted `DataStore` methods. A wrapper that omits one silently resolves to the domain default rather than the backend's override, which would make the whole parity suite test the wrapper instead of the backend. `test_the_wrapper_delegates_a_backend_overridden_default_method` pins this behaviourally against SQLite, whose `get_card_by_board_and_number` is an index-backed override.

## Trait census, re-derived on this branch

```
awk '/^pub trait DataStore/{t=1;next} /^\}$/{if(t)exit} t' crates/kanban-domain/src/data_store.rs \
 | awk '/^    fn /{buf=$0; while(buf !~ /;[ ]*$/ && buf !~ /\{[ ]*$/){getline l; buf=buf" "l}
        if(buf ~ /;[ ]*$/){r++} else {d++} }
     END{printf "total=%d required=%d defaulted=%d\n", r+d, r, d}'
```

prints `total=52 required=37 defaulted=15`, matching the figure the card recorded. All 52 are delegated, including the required `snapshot`/`apply_snapshot`, which have no default body and so cannot be omitted.

## mark_dirty

`KanbanBackend::mark_dirty` does not exist on `origin/develop` (`git show origin/develop:crates/kanban-backend/src/lib.rs | grep -n mark_dirty` returns nothing), so this branch does not delegate it. KAN-1438 introduces it as a defaulted method and must add the delegation here as part of its own change, or the wrapper will silently answer the no-op default instead of the wrapped backend.

## Tests

Twelve in `crates/kanban-service/tests/fault_injection.rs`, gated on `test-helpers`: seven for the fault switch and five for the read log. `read_recorder.rs` is byte-identical to its pre-branch state.

```
cargo test -p kanban-service --features test-helpers          # green, incl. 12 new
cargo clippy -p kanban-service --features test-helpers --all-targets -- -D warnings
cargo fmt --check
```

Changeset is `patch`: nothing public is removed, renamed or has a changed signature, so the pre-1.0 breaking-change rule in `.changeset/README.md` does not apply, and the added items sit behind the non-default `test-helpers` feature.
