### PR TITLE
KAN-1418 feat(domain): add a parent-keyed third tier to Collection

### DIFF
--- a/.changeset/kan-1418-parent-scoped-third-tier-resolved.md
+++ b/.changeset/kan-1418-parent-scoped-third-tier-resolved.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain: `Collection<T>` in `resolved.rs` gains a third, parent-keyed tier, `by_parent: HashMap<Uuid, LoadState<Vec<T>>>`, alongside the existing `all` and `by_id`. It lets a resolve pass describe the whole child set of one parent (columns of a board, cards of a column, sprints of a board) without loading the entire collection, which is what makes lazy loading actually lazy. `Default` and `is_untouched` account for the new tier and the hand-written `Default` still works for a `T` that is not `Default`. The change is purely additive: nothing fetches into the tier and nothing consumes it yet. It is a `minor` bump because adding a public field to a public struct that is not `#[non_exhaustive]` is both new public API and breaking for any exhaustive struct literal.

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -161,6 +161,7 @@ mod tests {
             columns: Collection {
                 all: LoadState::Loaded(vec![a.clone(), b]),
                 by_id,
+                ..Default::default()
             },
             ..Default::default()
         });
@@ -180,6 +181,7 @@ mod tests {
             cards: Collection {
                 all: LoadState::NotLoaded,
                 by_id,
+                ..Default::default()
             },
             ..Default::default()
         });
@@ -231,6 +233,7 @@ mod tests {
             cards: Collection {
                 all: LoadState::NotLoaded,
                 by_id,
+                ..Default::default()
             },
             ..Default::default()
         });
@@ -298,6 +301,7 @@ mod tests {
             cards: Collection {
                 all: LoadState::NotLoaded,
                 by_id,
+                ..Default::default()
             },
             ..Default::default()
         });
@@ -386,6 +390,7 @@ mod tests {
             cards: Collection {
                 all: LoadState::NotLoaded,
                 by_id,
+                ..Default::default()
             },
             ..Default::default()
         });

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -177,6 +177,88 @@ mod tests {
     }
 
     #[test]
+    fn test_collection_default_has_an_empty_by_parent() {
+        let c = Collection::<Card>::default();
+        assert!(c.by_parent.is_empty());
+        assert!(c.is_untouched());
+    }
+
+    #[test]
+    fn test_a_collection_with_a_populated_by_parent_is_not_untouched() {
+        let mut c = Collection::<Card>::default();
+        c.by_parent
+            .insert(Uuid::new_v4(), LoadState::Loaded(Vec::new()));
+
+        assert!(c.all.is_not_loaded());
+        assert!(c.by_id.is_empty());
+        assert!(!c.is_untouched());
+    }
+
+    #[test]
+    fn test_resolved_carries_a_scoped_tier_for_every_scopable_kind() {
+        let board_id = Uuid::new_v4();
+        let column = Column::new(board_id, "todo", 0);
+        let column_id = column.id;
+        let card = Card::new(board_id, column_id, "a", 0);
+        let card_id = card.id;
+        let sprint = Sprint::new(board_id, 1, None, None::<String>);
+        let sprint_id = sprint.id;
+
+        let mut r = Resolved::default();
+        r.columns
+            .by_parent
+            .insert(board_id, LoadState::Loaded(vec![column]));
+        r.cards
+            .by_parent
+            .insert(column_id, LoadState::Loaded(vec![card]));
+        r.sprints
+            .by_parent
+            .insert(board_id, LoadState::Loaded(vec![sprint]));
+
+        assert_eq!(
+            r.columns.by_parent[&board_id].loaded().unwrap()[0].id,
+            column_id
+        );
+        assert_eq!(r.cards.by_parent[&column_id].loaded().unwrap()[0].id, card_id);
+        assert_eq!(
+            r.sprints.by_parent[&board_id].loaded().unwrap()[0].id,
+            sprint_id
+        );
+        assert!(r.boards.by_parent.is_empty());
+        assert!(r.graph.is_not_loaded());
+    }
+
+    #[test]
+    fn test_the_three_tiers_of_a_collection_are_independent() {
+        let missing_id = Uuid::new_v4();
+        let column_id = Uuid::new_v4();
+        let card = Card::new(Uuid::new_v4(), column_id, "a", 0);
+        let card_id = card.id;
+
+        let mut c = Collection::<Card>::default();
+        c.by_id.insert(missing_id, LoadState::Missing);
+        c.by_parent.insert(column_id, LoadState::Loaded(vec![card]));
+
+        assert!(c.all.is_not_loaded());
+        assert!(c.by_id[&missing_id].is_missing());
+        assert!(!c.by_parent.contains_key(&card_id));
+        assert_eq!(c.by_parent[&column_id].loaded().unwrap()[0].id, card_id);
+    }
+
+    #[test]
+    fn test_a_loaded_empty_scope_is_distinguishable_from_an_unmentioned_one() {
+        let known = Uuid::new_v4();
+        let unmentioned = Uuid::new_v4();
+
+        let mut c = Collection::<Column>::default();
+        c.by_parent.insert(known, LoadState::Loaded(Vec::new()));
+
+        assert!(c.by_parent[&known].is_loaded());
+        assert!(c.by_parent[&known].loaded().unwrap().is_empty());
+        assert!(c.by_parent.get(&unmentioned).is_none());
+    }
+
+    #[test]
     fn test_collection_default_works_for_a_non_default_type() {
         let c = Collection::<NoDefault>::default();
         assert!(c.is_untouched());

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -281,7 +281,8 @@ mod tests {
 
         assert!(c.by_parent[&known].is_loaded());
         assert!(c.by_parent[&known].loaded().unwrap().is_empty());
-        assert!(c.by_parent.get(&unmentioned).is_none());
+        let unmentioned_scope = c.by_parent.get(&unmentioned);
+        assert!(unmentioned_scope.is_none());
     }
 
     #[test]

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -9,11 +9,32 @@ use crate::dependencies::DependencyGraph;
 use crate::load_state::LoadState;
 use crate::sprint::Sprint;
 
-/// One entity kind's slice of a resolve pass, in two independent tiers.
+/// One entity kind's slice of a resolve pass, in three independent tiers.
 ///
 /// `all` speaks about the whole collection; `by_id` speaks about individual
-/// entities. `NotLoaded` in `all` and an empty `by_id` each mean the pass did
-/// not touch that tier, so applying it leaves the target unchanged.
+/// entities; `by_parent` speaks about the whole child set of one parent id.
+/// `NotLoaded` in `all`, an empty `by_id` and an empty `by_parent` each mean
+/// the pass did not touch that tier, so applying it leaves the target
+/// unchanged.
+///
+/// The three tiers are mutually independent. No tier may ever be inferred from
+/// another, in either direction. Concretely for cards: `list_all_cards` and
+/// `list_cards_by_column` both exclude archived cards while `get_card` does
+/// not, so inferring `by_id` from either list tier would report an archived
+/// card as `Missing`; and because a pass reads each tier at its own moment,
+/// even two tiers that agree on archival semantics can disagree about content.
+///
+/// The parent key per entity kind is fixed:
+/// - `columns.by_parent` is keyed by board id (`list_columns_by_board`)
+/// - `cards.by_parent` is keyed by column id (`list_cards_by_column`)
+/// - `sprints.by_parent` is keyed by board id (`list_sprints_by_board`)
+/// - `boards.by_parent` is unused and stays permanently empty: a board has no
+///   parent.
+///
+/// `LoadState::Missing` is unrepresentable in `by_parent` by contract: the
+/// scoped `DataStore` reads return `Ok(Vec::new())` for an unknown parent,
+/// never `None`, so an empty scope is `Loaded(vec![])`. Only `NotLoaded`,
+/// `Loaded` and `Failed` may ever appear there.
 ///
 /// Appliers must, per entity kind: first, if `all` is `Loaded`, replace the
 /// whole target collection with it; second, apply every `by_id` entry on top.
@@ -27,6 +48,7 @@ use crate::sprint::Sprint;
 pub struct Collection<T> {
     pub all: LoadState<Vec<T>>,
     pub by_id: HashMap<Uuid, LoadState<T>>,
+    pub by_parent: HashMap<Uuid, LoadState<Vec<T>>>,
 }
 
 impl<T> Default for Collection<T> {
@@ -34,13 +56,14 @@ impl<T> Default for Collection<T> {
         Self {
             all: LoadState::NotLoaded,
             by_id: HashMap::new(),
+            by_parent: HashMap::new(),
         }
     }
 }
 
 impl<T> Collection<T> {
     pub fn is_untouched(&self) -> bool {
-        self.all.is_not_loaded() && self.by_id.is_empty()
+        self.all.is_not_loaded() && self.by_id.is_empty() && self.by_parent.is_empty()
     }
 }
 
@@ -219,7 +242,10 @@ mod tests {
             r.columns.by_parent[&board_id].loaded().unwrap()[0].id,
             column_id
         );
-        assert_eq!(r.cards.by_parent[&column_id].loaded().unwrap()[0].id, card_id);
+        assert_eq!(
+            r.cards.by_parent[&column_id].loaded().unwrap()[0].id,
+            card_id
+        );
         assert_eq!(
             r.sprints.by_parent[&board_id].loaded().unwrap()[0].id,
             sprint_id
@@ -266,6 +292,7 @@ mod tests {
         let loaded = Collection {
             all: LoadState::Loaded(vec![NoDefault]),
             by_id: HashMap::new(),
+            ..Default::default()
         };
         assert!(!loaded.is_untouched());
         let _ = loaded.clone();


### PR DESCRIPTION
## What

`Collection<T>` in `crates/kanban-domain/src/resolved.rs` gains a third tier:

```rust
pub struct Collection<T> {
    pub all: LoadState<Vec<T>>,
    pub by_id: HashMap<Uuid, LoadState<T>>,
    pub by_parent: HashMap<Uuid, LoadState<Vec<T>>>,
}
```

`Default` and `is_untouched` account for it. The hand-written `Default` is preserved, so `Collection::<T>::default()` still compiles for a `T` that is not `Default`. The doc comment states the fixed parent key per entity kind, the mutual-independence rule, and that `LoadState::Missing` is unrepresentable in `by_parent`.

Purely additive. Nothing fetches into the tier and nothing consumes it yet. `Resolved` is unchanged, since every kind already carries a `Collection`.

## Why

Without a scoped tier the lazy-loading epic degenerates into "load every list, but keep it around", which is `snapshot()` with extra steps. The scoped tier is what makes lazy loading lazy: it gives a resolve pass somewhere to put "the columns of board X" or "the cards of column Y". KAN-1419, KAN-1420, KAN-1421, KAN-1422/KAN-1465 and KAN-1423 all need that somewhere.

## Premise checks re-derived at pickup

The card claimed 14 exhaustive `Collection {` literals across 2 files. Re-derived against `origin/develop` at `6daeab3b`:

```
$ git grep -n 'Collection {' origin/develop -- crates/
crates/kanban-domain/src/model/apply.rs:128,161,180,231,241,261,298,336,363,386
crates/kanban-domain/src/resolved.rs:82,148,184
crates/kanban-view/src/controller/mod.rs:236
```

14 literals, but across **3** files, not 2. The card missed `crates/kanban-view/src/controller/mod.rs`. It turned out not to matter: only **6** of the 14 are actually exhaustive, and all 6 are in `kanban-domain` (`apply.rs:161,180,231,298,386` and `resolved.rs:184`). The other 8, including the `kanban-view` one, already spell `..Default::default()` and needed no edit. The diff therefore touches `kanban-domain` only, as the card's last acceptance criterion requires.

`EntityCache` is already fully gone; the card said a `pub use` re-export survived:

```
$ git grep -n EntityCache origin/develop -- crates/
(no output)
```

`Collection` carries no `#[non_exhaustive]`, so adding a public field is both new public API and breaking for exhaustive literals. Per `.changeset/README.md` pre-1.0 that is `minor`.

## Verification

- `cargo test -p kanban-domain`: green, all 5 new tests passing.
- `cargo test --workspace`: green, 229 `test result: ok` lines, 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.

The only executable assertion this card adds is `test_a_collection_with_a_populated_by_parent_is_not_untouched`, which pins that `is_untouched()` accounts for a scoped-only pass. The other four are type-level round-trips that document the shape and the parent-key mapping; they cannot fail once the crate compiles.