### PR TITLE
KAN-1419 feat(domain): add parent-scoped tiers and LoadedEntities to the fetch vocabulary

### DIFF
--- a/.changeset/kan-1419-scoped-tiers-loadedentities-in-fetch.md
+++ b/.changeset/kan-1419-scoped-tiers-loadedentities-in-fetch.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain: `FetchRound` gains three parent-scoped request vectors, `columns_by_board`, `cards_by_column` and `sprints_by_board`, accounted for in `is_empty()` so a scoped-only round is not mistaken for a halt signal. `LoadedState` gains three matching no-default status accessors, `columns_of_board`, `cards_of_column` and `sprints_of_board`, each returning `FetchStatus` and never `Missing`, since the scoped `DataStore` reads that serve them answer an unknown parent with an empty vector rather than an error. A new `LoadedEntities: LoadedState` trait adds the single payload projection `loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[Column]>`, distinguishing a column-less board (`Some(&[])`) from a board whose columns were never read (`None`). `FetchPlan::next_round` now takes `&dyn LoadedEntities` instead of `&dyn LoadedState`. This is a `minor` bump: it adds public fields to a struct that is not `#[non_exhaustive]`, adds trait methods with no default body which breaks every out-of-tree implementor, and changes a public trait method's signature.

--- a/crates/kanban-domain/src/fetch_plan.rs
+++ b/crates/kanban-domain/src/fetch_plan.rs
@@ -76,6 +76,7 @@ pub trait FetchPlan {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use super::*;
@@ -85,6 +86,20 @@ mod tests {
         board_list: FetchStatus,
         card_list: FetchStatus,
         card: FetchStatus,
+        cards_of_column: FetchStatus,
+        columns_by_board: HashMap<Uuid, Vec<Column>>,
+    }
+
+    impl Default for StubLoaded {
+        fn default() -> Self {
+            StubLoaded {
+                board_list: FetchStatus::NotLoaded,
+                card_list: FetchStatus::NotLoaded,
+                card: FetchStatus::NotLoaded,
+                cards_of_column: FetchStatus::NotLoaded,
+                columns_by_board: HashMap::new(),
+            }
+        }
     }
 
     impl LoadedState for StubLoaded {
@@ -111,6 +126,25 @@ mod tests {
         }
         fn sprint(&self, _id: Uuid) -> FetchStatus {
             FetchStatus::NotLoaded
+        }
+        fn columns_of_board(&self, board_id: Uuid) -> FetchStatus {
+            if self.columns_by_board.contains_key(&board_id) {
+                FetchStatus::Loaded
+            } else {
+                FetchStatus::NotLoaded
+            }
+        }
+        fn cards_of_column(&self, _column_id: Uuid) -> FetchStatus {
+            self.cards_of_column
+        }
+        fn sprints_of_board(&self, _board_id: Uuid) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+    }
+
+    impl LoadedEntities for StubLoaded {
+        fn loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[Column]> {
+            self.columns_by_board.get(&board_id).map(Vec::as_slice)
         }
     }
 
@@ -208,14 +242,80 @@ mod tests {
             ..Default::default()
         }
         .is_empty());
+        assert!(!FetchRound {
+            columns_by_board: vec![id],
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            cards_by_column: vec![id],
+            ..Default::default()
+        }
+        .is_empty());
+        assert!(!FetchRound {
+            sprints_by_board: vec![id],
+            ..Default::default()
+        }
+        .is_empty());
+    }
+
+    #[test]
+    fn test_a_scoped_only_round_is_not_empty() {
+        let round = FetchRound {
+            cards_by_column: vec![Uuid::new_v4()],
+            ..Default::default()
+        };
+
+        assert!(!round.is_empty());
+    }
+
+    #[test]
+    fn test_loaded_state_distinguishes_all_three_tiers() {
+        let column_id = Uuid::new_v4();
+        let card_id = Uuid::new_v4();
+        let loaded = StubLoaded {
+            card_list: FetchStatus::NotLoaded,
+            cards_of_column: FetchStatus::Loaded,
+            card: FetchStatus::Missing,
+            ..Default::default()
+        };
+
+        assert!(requestable(loaded.card_list()));
+        assert!(!requestable(loaded.cards_of_column(column_id)));
+        assert!(!requestable(loaded.card(card_id)));
+    }
+
+    #[test]
+    fn test_loaded_entities_projects_none_for_an_unfetched_scope() {
+        let board_id = Uuid::new_v4();
+        let loaded = StubLoaded::default();
+
+        assert!(loaded.loaded_columns_of_board(board_id).is_none());
+    }
+
+    #[test]
+    fn test_loaded_entities_distinguishes_an_empty_scope_from_an_unread_one() {
+        let board_with_no_columns = Uuid::new_v4();
+        let unread_board = Uuid::new_v4();
+        let mut columns_by_board = HashMap::new();
+        columns_by_board.insert(board_with_no_columns, Vec::new());
+        let loaded = StubLoaded {
+            columns_by_board,
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            loaded.loaded_columns_of_board(board_with_no_columns),
+            Some(s) if s.is_empty()
+        ));
+        assert!(loaded.loaded_columns_of_board(unread_board).is_none());
     }
 
     #[test]
     fn test_loaded_state_distinguishes_whole_collection_status_from_per_id_status() {
         let loaded = StubLoaded {
-            board_list: FetchStatus::NotLoaded,
-            card_list: FetchStatus::NotLoaded,
             card: FetchStatus::Loaded,
+            ..Default::default()
         };
 
         assert!(requestable(loaded.card_list()));
@@ -224,11 +324,7 @@ mod tests {
 
     #[test]
     fn test_next_round_on_stub_plan_requests_board_list_when_not_loaded() {
-        let loaded = StubLoaded {
-            board_list: FetchStatus::NotLoaded,
-            card_list: FetchStatus::NotLoaded,
-            card: FetchStatus::NotLoaded,
-        };
+        let loaded = StubLoaded::default();
         let plan = StubPlan;
 
         let round = plan.next_round(&loaded);
@@ -241,8 +337,7 @@ mod tests {
     fn test_next_round_on_stub_plan_returns_empty_round_once_board_list_loaded() {
         let loaded = StubLoaded {
             board_list: FetchStatus::Loaded,
-            card_list: FetchStatus::NotLoaded,
-            card: FetchStatus::NotLoaded,
+            ..Default::default()
         };
         let plan = StubPlan;
 

--- a/crates/kanban-domain/src/fetch_plan.rs
+++ b/crates/kanban-domain/src/fetch_plan.rs
@@ -1,5 +1,6 @@
 use uuid::Uuid;
 
+use crate::column::Column;
 use crate::load_state::LoadState;
 
 /// Payload-free mirror of `LoadState<T>`'s variants, usable across entity
@@ -29,9 +30,19 @@ pub fn requestable(status: FetchStatus) -> bool {
     matches!(status, FetchStatus::NotLoaded | FetchStatus::Failed)
 }
 
-/// Whole-collection accessors and per-id accessors are independent: a
-/// `card_list()` of `NotLoaded` alongside a `card(id)` of `Loaded` means one
-/// card was fetched by id and the collection as a whole has never been read.
+/// Whole-collection accessors, parent-scoped accessors, and per-id accessors
+/// are independent tiers: a `card_list()` of `NotLoaded` alongside a
+/// `cards_of_column(c)` of `Loaded` alongside a `card(id)` of `Missing` is a
+/// coherent state, not a contradiction.
+///
+/// Each parent-scoped accessor's parent kind is fixed and matches the
+/// `DataStore` read that serves it: `columns_of_board` is served by
+/// `list_columns_by_board`, `cards_of_column` by `list_cards_by_column`, and
+/// `sprints_of_board` by `list_sprints_by_board`.
+///
+/// A parent-scoped accessor never returns `FetchStatus::Missing`: the scoped
+/// reads answer an unknown parent with an empty vector, so implementors must
+/// not synthesise `Missing` for them.
 pub trait LoadedState {
     fn board_list(&self) -> FetchStatus;
     fn column_list(&self) -> FetchStatus;
@@ -41,9 +52,13 @@ pub trait LoadedState {
     fn column(&self, id: Uuid) -> FetchStatus;
     fn card(&self, id: Uuid) -> FetchStatus;
     fn sprint(&self, id: Uuid) -> FetchStatus;
+    fn columns_of_board(&self, board_id: Uuid) -> FetchStatus;
+    fn cards_of_column(&self, column_id: Uuid) -> FetchStatus;
+    fn sprints_of_board(&self, board_id: Uuid) -> FetchStatus;
 }
 
-/// The `*_list` flags request a whole collection, the id vectors request
+/// The `*_list` flags request a whole collection, the `*_by_*` vectors
+/// request every child of a named parent, the bare id vectors request
 /// individual entities, and an empty round is `resolve`'s halt signal.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FetchRound {
@@ -55,6 +70,12 @@ pub struct FetchRound {
     pub columns: Vec<Uuid>,
     pub cards: Vec<Uuid>,
     pub sprints: Vec<Uuid>,
+    /// Board ids whose columns are wanted.
+    pub columns_by_board: Vec<Uuid>,
+    /// Column ids whose cards are wanted.
+    pub cards_by_column: Vec<Uuid>,
+    /// Board ids whose sprints are wanted.
+    pub sprints_by_board: Vec<Uuid>,
 }
 
 impl FetchRound {
@@ -67,11 +88,23 @@ impl FetchRound {
             && self.columns.is_empty()
             && self.cards.is_empty()
             && self.sprints.is_empty()
+            && self.columns_by_board.is_empty()
+            && self.cards_by_column.is_empty()
+            && self.sprints_by_board.is_empty()
     }
 }
 
+/// Payload projection over [`LoadedState`]. `Some` exactly when the
+/// corresponding status accessor is `Loaded`. A genuinely column-less board
+/// is `Some(&[])`, not `None`; `None` means never read. Only columns are
+/// projected, because they are the only payload a plan needs in order to
+/// name a later round's ids.
+pub trait LoadedEntities: LoadedState {
+    fn loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[Column]>;
+}
+
 pub trait FetchPlan {
-    fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound;
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound;
 }
 
 #[cfg(test)]
@@ -151,7 +184,7 @@ mod tests {
     struct StubPlan;
 
     impl FetchPlan for StubPlan {
-        fn next_round(&self, loaded: &dyn LoadedState) -> FetchRound {
+        fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
             FetchRound {
                 board_list: requestable(loaded.board_list()),
                 ..Default::default()

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -67,7 +67,9 @@ pub use dependencies::{
 };
 pub use editable::{BoardSettingsDto, CardMetadataDto};
 pub use export::{AllBoardsExport, BoardExport, BoardExporter, BoardImporter, ImportedEntities};
-pub use fetch_plan::{requestable, FetchPlan, FetchRound, FetchStatus, LoadedEntities, LoadedState};
+pub use fetch_plan::{
+    requestable, FetchPlan, FetchRound, FetchStatus, LoadedEntities, LoadedState,
+};
 pub use field_update::FieldUpdate;
 pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -67,7 +67,7 @@ pub use dependencies::{
 };
 pub use editable::{BoardSettingsDto, CardMetadataDto};
 pub use export::{AllBoardsExport, BoardExport, BoardExporter, BoardImporter, ImportedEntities};
-pub use fetch_plan::{requestable, FetchPlan, FetchRound, FetchStatus, LoadedState};
+pub use fetch_plan::{requestable, FetchPlan, FetchRound, FetchStatus, LoadedEntities, LoadedState};
 pub use field_update::FieldUpdate;
 pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;


### PR DESCRIPTION
## Summary

- Add a third, parent-scoped request tier to `FetchRound`: `columns_by_board`, `cards_by_column`, `sprints_by_board`, all accounted for in `is_empty()`.
- Add three no-default `LoadedState` status accessors: `columns_of_board`, `cards_of_column`, `sprints_of_board`, each returning `FetchStatus`.
- Add a new `LoadedEntities: LoadedState` trait with exactly one method, `loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[Column]>`, distinguishing a column-less board (`Some(&[])`) from a board whose columns were never read (`None`).
- Change `FetchPlan::next_round` to take `&dyn LoadedEntities` instead of `&dyn LoadedState`.
- Re-export `LoadedEntities` from the crate root alongside its siblings.

The only implementors in the workspace are the file's own `StubLoaded`/`StubPlan`, so the blast radius is one source file plus one re-export line plus a changeset.

## Test plan

- [x] `cargo test -p kanban-domain` green, including five new/extended tests pinning the scoped tier, the tier independence, and the `LoadedEntities` projection
- [x] Mutation check: removing `cards_by_column` from `is_empty()`'s boolean chain fails the relevant tests, then restored
- [x] `cargo check --workspace --all-targets` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features --workspace` green
- [x] `cargo fmt --all --check` clean
