### PR TITLE
KAN-1420 feat(service): resolve becomes a stateless free function

### DIFF
--- a/.changeset/kan-1420-resolve-becomes-stateless-free-function.md
+++ b/.changeset/kan-1420-resolve-becomes-stateless-free-function.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: adds `kanban_service::resolve(plan, loaded, store) -> Resolved`, a new public free function that runs `FetchPlan` rounds against a `DataStore` without owning any state between calls. It reads whole-collection, per-id and the three parent-scoped tiers, deduping within a call and composing the caller's `LoadedEntities` with the in-flight `Resolved` so a scope discovered mid-call resolves in the same call. `resolve` returns `Resolved` directly rather than a `Result`, since backend failures already surface per-entity as `LoadState::Failed`.

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -21,6 +21,7 @@ pub mod fetch_plan;
 mod path;
 #[cfg(test)]
 mod read_recorder;
+pub mod resolve;
 mod sprint_name;
 mod store_adapter;
 mod store_manager;

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -38,6 +38,7 @@ pub use kanban_backend::KanbanBackend;
 pub use kanban_backend::RemoteWrites;
 pub use kanban_backend::TransactionFn;
 pub use path::validate_path;
+pub use resolve::resolve;
 pub use sprint_name::{resolve_sprint_name, resolve_sprint_names};
 pub use store_manager::StoreManager;
 

--- a/crates/kanban-service/src/read_recorder.rs
+++ b/crates/kanban-service/src/read_recorder.rs
@@ -133,6 +133,7 @@ impl DataStore for RecordingStore {
     }
     fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
         self.record("list_columns_by_board", vec![board_id]);
+        self.check("list_columns_by_board")?;
         self.inner.list_columns_by_board(board_id)
     }
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
@@ -163,6 +164,7 @@ impl DataStore for RecordingStore {
     }
     fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
         self.record("list_cards_by_column", vec![column_id]);
+        self.check("list_cards_by_column")?;
         self.inner.list_cards_by_column(column_id)
     }
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
@@ -236,6 +238,7 @@ impl DataStore for RecordingStore {
     }
     fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
         self.record("list_sprints_by_board", vec![board_id]);
+        self.check("list_sprints_by_board")?;
         self.inner.list_sprints_by_board(board_id)
     }
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod tests;

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -1,2 +1,284 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use kanban_domain::{DataStore, LoadState, Resolved};
+use uuid::Uuid;
+
+use crate::fetch_plan::{FetchPlan, FetchRound, FetchStatus, LoadedEntities, LoadedState};
+
+pub(crate) struct Overlay<'a> {
+    pub(crate) base: &'a dyn LoadedEntities,
+    pub(crate) pass: &'a Resolved,
+}
+
+fn overlay_status<T>(pass: &LoadState<T>, base: FetchStatus) -> FetchStatus {
+    match pass {
+        LoadState::NotLoaded => base,
+        other => other.into(),
+    }
+}
+
+impl LoadedState for Overlay<'_> {
+    fn board_list(&self) -> FetchStatus {
+        overlay_status(&self.pass.boards.all, self.base.board_list())
+    }
+    fn column_list(&self) -> FetchStatus {
+        overlay_status(&self.pass.columns.all, self.base.column_list())
+    }
+    fn card_list(&self) -> FetchStatus {
+        overlay_status(&self.pass.cards.all, self.base.card_list())
+    }
+    fn sprint_list(&self) -> FetchStatus {
+        overlay_status(&self.pass.sprints.all, self.base.sprint_list())
+    }
+    fn graph(&self) -> FetchStatus {
+        overlay_status(&self.pass.graph, self.base.graph())
+    }
+    fn column(&self, id: Uuid) -> FetchStatus {
+        match self.pass.columns.by_id.get(&id) {
+            Some(state) => state.into(),
+            None => self.base.column(id),
+        }
+    }
+    fn card(&self, id: Uuid) -> FetchStatus {
+        match self.pass.cards.by_id.get(&id) {
+            Some(state) => state.into(),
+            None => self.base.card(id),
+        }
+    }
+    fn sprint(&self, id: Uuid) -> FetchStatus {
+        match self.pass.sprints.by_id.get(&id) {
+            Some(state) => state.into(),
+            None => self.base.sprint(id),
+        }
+    }
+    fn columns_of_board(&self, board_id: Uuid) -> FetchStatus {
+        match self.pass.columns.by_parent.get(&board_id) {
+            Some(state) => state.into(),
+            None => self.base.columns_of_board(board_id),
+        }
+    }
+    fn cards_of_column(&self, column_id: Uuid) -> FetchStatus {
+        match self.pass.cards.by_parent.get(&column_id) {
+            Some(state) => state.into(),
+            None => self.base.cards_of_column(column_id),
+        }
+    }
+    fn sprints_of_board(&self, board_id: Uuid) -> FetchStatus {
+        match self.pass.sprints.by_parent.get(&board_id) {
+            Some(state) => state.into(),
+            None => self.base.sprints_of_board(board_id),
+        }
+    }
+}
+
+impl LoadedEntities for Overlay<'_> {
+    fn loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[kanban_domain::Column]> {
+        match self.pass.columns.by_parent.get(&board_id) {
+            Some(LoadState::Loaded(v)) => Some(v.as_slice()),
+            Some(_) => None,
+            None => self.base.loaded_columns_of_board(board_id),
+        }
+    }
+}
+
+#[derive(Default)]
+struct Fetched {
+    board_list: bool,
+    column_list: bool,
+    card_list: bool,
+    sprint_list: bool,
+    graph: bool,
+    columns: HashSet<Uuid>,
+    cards: HashSet<Uuid>,
+    sprints: HashSet<Uuid>,
+    columns_by_board: HashSet<Uuid>,
+    cards_by_column: HashSet<Uuid>,
+    sprints_by_board: HashSet<Uuid>,
+}
+
+impl Fetched {
+    fn record(&mut self, round: &FetchRound) {
+        self.board_list |= round.board_list;
+        self.column_list |= round.column_list;
+        self.card_list |= round.card_list;
+        self.sprint_list |= round.sprint_list;
+        self.graph |= round.graph;
+        self.columns.extend(round.columns.iter().copied());
+        self.cards.extend(round.cards.iter().copied());
+        self.sprints.extend(round.sprints.iter().copied());
+        self.columns_by_board
+            .extend(round.columns_by_board.iter().copied());
+        self.cards_by_column
+            .extend(round.cards_by_column.iter().copied());
+        self.sprints_by_board
+            .extend(round.sprints_by_board.iter().copied());
+    }
+}
+
+fn outstanding(
+    ids: Vec<Uuid>,
+    fetched: &HashSet<Uuid>,
+    status: impl Fn(Uuid) -> FetchStatus,
+) -> Vec<Uuid> {
+    ids.into_iter()
+        .filter(|&id| !fetched.contains(&id) && status(id) != FetchStatus::Missing)
+        .collect()
+}
+
+fn outstanding_scoped(parents: Vec<Uuid>, fetched: &HashSet<Uuid>) -> Vec<Uuid> {
+    parents
+        .into_iter()
+        .filter(|id| !fetched.contains(id))
+        .collect()
+}
+
+fn narrow_to_outstanding(
+    round: FetchRound,
+    fetched: &Fetched,
+    loaded: &dyn LoadedState,
+) -> FetchRound {
+    FetchRound {
+        board_list: round.board_list && !fetched.board_list,
+        column_list: round.column_list && !fetched.column_list,
+        card_list: round.card_list && !fetched.card_list,
+        sprint_list: round.sprint_list && !fetched.sprint_list,
+        graph: round.graph && !fetched.graph,
+        columns: outstanding(round.columns, &fetched.columns, |id| loaded.column(id)),
+        cards: outstanding(round.cards, &fetched.cards, |id| loaded.card(id)),
+        sprints: outstanding(round.sprints, &fetched.sprints, |id| loaded.sprint(id)),
+        columns_by_board: outstanding_scoped(round.columns_by_board, &fetched.columns_by_board),
+        cards_by_column: outstanding_scoped(round.cards_by_column, &fetched.cards_by_column),
+        sprints_by_board: outstanding_scoped(round.sprints_by_board, &fetched.sprints_by_board),
+    }
+}
+
+fn fetch_round(round: &FetchRound, store: &dyn DataStore, resolved: &mut Resolved) {
+    if round.board_list {
+        resolved.boards.all = match store.list_boards() {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+    }
+    if round.column_list {
+        resolved.columns.all = match store.list_all_columns() {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+    }
+    if round.card_list {
+        resolved.cards.all = match store.list_all_cards() {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+    }
+    if round.sprint_list {
+        resolved.sprints.all = match store.list_all_sprints() {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+    }
+    if round.graph {
+        resolved.graph = match store.get_graph() {
+            Ok(g) => LoadState::Loaded(g),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+    }
+
+    for &id in &round.columns {
+        let state = match store.get_column(id) {
+            Ok(Some(v)) => LoadState::Loaded(v),
+            Ok(None) => LoadState::Missing,
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+        resolved.columns.by_id.insert(id, state);
+    }
+    for &id in &round.cards {
+        let state = match store.get_card(id) {
+            Ok(Some(v)) => LoadState::Loaded(v),
+            Ok(None) => LoadState::Missing,
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+        resolved.cards.by_id.insert(id, state);
+    }
+    for &id in &round.sprints {
+        let state = match store.get_sprint(id) {
+            Ok(Some(v)) => LoadState::Loaded(v),
+            Ok(None) => LoadState::Missing,
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+        resolved.sprints.by_id.insert(id, state);
+    }
+
+    for &board_id in &round.columns_by_board {
+        let state = match store.list_columns_by_board(board_id) {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+        resolved.columns.by_parent.insert(board_id, state);
+    }
+    for &column_id in &round.cards_by_column {
+        let state = match store.list_cards_by_column(column_id) {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+        resolved.cards.by_parent.insert(column_id, state);
+    }
+    for &board_id in &round.sprints_by_board {
+        let state = match store.list_sprints_by_board(board_id) {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+        resolved.sprints.by_parent.insert(board_id, state);
+    }
+}
+
+/// Loops until the plan has nothing left to ask for: each round is
+/// narrowed to what this call has not already fetched, and every fetch
+/// writes a terminal state, so the requestable set strictly shrinks and
+/// the loop halts structurally rather than on a round cap. A plan that
+/// keeps naming an entity it already received in this call is therefore
+/// harmless, and a need whose ids only become knowable after an earlier
+/// round resolves in the same call, because the plan is consulted through
+/// an `Overlay` of the caller's `loaded` and the in-flight `Resolved`.
+///
+/// Each entity reflects the backend as of its own individual fetch, not as
+/// of the resolve pass as a whole: two entities in the same `Resolved` may
+/// have been read moments apart. `resolve` deliberately does not wrap the
+/// rounds in one transaction, because that would hold a connection open
+/// across render-adjacent I/O today and across an unbounded number of
+/// rounds. The consequence of a torn read is a stale entity, never a
+/// fabricated one: every value returned came from a real backend
+/// response.
+///
+/// A parent-scoped fetch has no terminal-`Missing` shortcut: the scoped
+/// `DataStore` reads answer an unknown parent with an empty vector, so
+/// [`outstanding_scoped`] narrows only against what this call has already
+/// fetched, never against `loaded`, which keeps a scope refetchable by a
+/// later call the same way the whole-list tier already is.
+pub fn resolve(
+    plan: &dyn FetchPlan,
+    loaded: &dyn LoadedEntities,
+    store: &dyn DataStore,
+) -> Resolved {
+    let mut resolved = Resolved::default();
+    let mut fetched = Fetched::default();
+    loop {
+        let round = {
+            let overlay = Overlay {
+                base: loaded,
+                pass: &resolved,
+            };
+            narrow_to_outstanding(plan.next_round(&overlay), &fetched, &overlay)
+        };
+        if round.is_empty() {
+            break;
+        }
+        fetch_round(&round, store, &mut resolved);
+        fetched.record(&round);
+    }
+    resolved
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/kanban-service/src/resolve/tests/mod.rs
+++ b/crates/kanban-service/src/resolve/tests/mod.rs
@@ -1,0 +1,449 @@
+#![allow(dead_code)]
+
+use std::cell::{Cell, RefCell};
+
+use kanban_domain::resolved::Collection;
+use kanban_domain::{Board, Card, Column, DataStore, DependencyGraph, LoadState, Sprint};
+use uuid::Uuid;
+
+use crate::fetch_plan::{
+    requestable, FetchPlan, FetchRound, FetchStatus, LoadedEntities,
+    LoadedState as LoadedStateTrait,
+};
+use crate::read_recorder::RecordingStore;
+
+mod multi_round;
+mod overlay;
+mod resolve;
+mod result_mapping;
+mod retry;
+mod scoped;
+
+#[derive(Default)]
+pub(super) struct StubLoaded {
+    boards: Collection<Board>,
+    columns: Collection<Column>,
+    cards: Collection<Card>,
+    sprints: Collection<Sprint>,
+    graph: LoadState<DependencyGraph>,
+}
+
+impl LoadedStateTrait for StubLoaded {
+    fn board_list(&self) -> FetchStatus {
+        (&self.boards.all).into()
+    }
+    fn column_list(&self) -> FetchStatus {
+        (&self.columns.all).into()
+    }
+    fn card_list(&self) -> FetchStatus {
+        (&self.cards.all).into()
+    }
+    fn sprint_list(&self) -> FetchStatus {
+        (&self.sprints.all).into()
+    }
+    fn graph(&self) -> FetchStatus {
+        (&self.graph).into()
+    }
+    fn column(&self, id: Uuid) -> FetchStatus {
+        self.columns
+            .by_id
+            .get(&id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn card(&self, id: Uuid) -> FetchStatus {
+        self.cards
+            .by_id
+            .get(&id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn sprint(&self, id: Uuid) -> FetchStatus {
+        self.sprints
+            .by_id
+            .get(&id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn columns_of_board(&self, board_id: Uuid) -> FetchStatus {
+        self.columns
+            .by_parent
+            .get(&board_id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn cards_of_column(&self, column_id: Uuid) -> FetchStatus {
+        self.cards
+            .by_parent
+            .get(&column_id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn sprints_of_board(&self, board_id: Uuid) -> FetchStatus {
+        self.sprints
+            .by_parent
+            .get(&board_id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+}
+
+impl LoadedEntities for StubLoaded {
+    fn loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[Column]> {
+        self.columns
+            .by_parent
+            .get(&board_id)
+            .and_then(LoadState::loaded)
+            .map(Vec::as_slice)
+    }
+}
+
+fn apply_collection<T: Clone>(target: &mut Collection<T>, incoming: Collection<T>) {
+    if !matches!(incoming.all, LoadState::NotLoaded) {
+        target.all = incoming.all;
+    }
+    for (id, state) in incoming.by_id {
+        target.by_id.insert(id, state);
+    }
+    for (key, state) in incoming.by_parent {
+        target.by_parent.insert(key, state);
+    }
+}
+
+impl StubLoaded {
+    pub(super) fn apply(&mut self, resolved: kanban_domain::Resolved) {
+        apply_collection(&mut self.boards, resolved.boards);
+        apply_collection(&mut self.columns, resolved.columns);
+        apply_collection(&mut self.cards, resolved.cards);
+        apply_collection(&mut self.sprints, resolved.sprints);
+        if !matches!(resolved.graph, LoadState::NotLoaded) {
+            self.graph = resolved.graph;
+        }
+    }
+
+    pub(super) fn forget_card(&mut self, id: Uuid) {
+        self.cards.by_id.remove(&id);
+    }
+
+    pub(super) fn board_list_state(&self) -> LoadState<&Vec<Board>> {
+        self.boards.all.as_ref()
+    }
+
+    pub(super) fn column_list_state(&self) -> LoadState<&Vec<Column>> {
+        self.columns.all.as_ref()
+    }
+
+    pub(super) fn card_list_state(&self) -> LoadState<&Vec<Card>> {
+        self.cards.all.as_ref()
+    }
+
+    pub(super) fn sprint_list_state(&self) -> LoadState<&Vec<Sprint>> {
+        self.sprints.all.as_ref()
+    }
+
+    pub(super) fn graph_state(&self) -> LoadState<&DependencyGraph> {
+        self.graph.as_ref()
+    }
+
+    pub(super) fn column_state(&self, id: Uuid) -> LoadState<&Column> {
+        self.columns
+            .by_id
+            .get(&id)
+            .map(LoadState::as_ref)
+            .unwrap_or(LoadState::NotLoaded)
+    }
+
+    pub(super) fn card_state(&self, id: Uuid) -> LoadState<&Card> {
+        self.cards
+            .by_id
+            .get(&id)
+            .map(LoadState::as_ref)
+            .unwrap_or(LoadState::NotLoaded)
+    }
+
+    pub(super) fn sprint_state(&self, id: Uuid) -> LoadState<&Sprint> {
+        self.sprints
+            .by_id
+            .get(&id)
+            .map(LoadState::as_ref)
+            .unwrap_or(LoadState::NotLoaded)
+    }
+}
+
+pub(super) fn store() -> RecordingStore {
+    RecordingStore::new()
+}
+
+pub(super) fn seed_board(store: &RecordingStore, name: &str) -> Board {
+    let board = Board::new(name, None::<String>);
+    store.upsert_board(board.clone()).unwrap();
+    board
+}
+
+pub(super) fn seed_column(store: &RecordingStore, board: &Board, name: &str) -> Column {
+    let column = Column::new(board.id, name, 0);
+    store.upsert_column(column.clone()).unwrap();
+    column
+}
+
+pub(super) fn seed_card(
+    store: &RecordingStore,
+    board: &Board,
+    column: &Column,
+    title: &str,
+) -> Card {
+    let card = Card::new(board.id, column.id, title, 0);
+    store.upsert_card(card.clone()).unwrap();
+    card
+}
+
+pub(super) fn seed_sprint(store: &RecordingStore, board: &Board) -> Sprint {
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+    store.upsert_sprint(sprint.clone()).unwrap();
+    sprint
+}
+
+pub(super) fn seed_board_with_column(store: &RecordingStore) -> (Board, Column) {
+    let board = seed_board(store, "b");
+    let column = seed_column(store, &board, "c");
+    (board, column)
+}
+
+pub(super) struct FixedPlan(pub FetchRound);
+
+impl FetchPlan for FixedPlan {
+    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+        self.0.clone()
+    }
+}
+
+pub(super) struct OneShotPlan(pub FetchRound, pub Cell<bool>);
+
+impl OneShotPlan {
+    pub(super) fn new(round: FetchRound) -> Self {
+        Self(round, Cell::new(false))
+    }
+}
+
+impl FetchPlan for OneShotPlan {
+    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+        if self.1.get() {
+            FetchRound::default()
+        } else {
+            self.1.set(true);
+            self.0.clone()
+        }
+    }
+}
+
+pub(super) struct BoardListPlan;
+
+impl FetchPlan for BoardListPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            board_list: requestable(loaded.board_list()),
+            ..Default::default()
+        }
+    }
+}
+
+pub(super) struct GraphThenCardPlan {
+    pub card_id: Uuid,
+}
+
+impl FetchPlan for GraphThenCardPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        if requestable(loaded.graph()) {
+            FetchRound {
+                graph: true,
+                ..Default::default()
+            }
+        } else if requestable(loaded.card(self.card_id)) {
+            FetchRound {
+                cards: vec![self.card_id],
+                ..Default::default()
+            }
+        } else {
+            FetchRound::default()
+        }
+    }
+}
+
+pub(super) struct ChainPlan {
+    pub ids: Vec<Uuid>,
+}
+
+impl FetchPlan for ChainPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        match self
+            .ids
+            .iter()
+            .find(|&&id| loaded.card(id) != FetchStatus::Loaded)
+        {
+            Some(&id) => FetchRound {
+                cards: vec![id],
+                ..Default::default()
+            },
+            None => FetchRound::default(),
+        }
+    }
+}
+
+pub(super) struct StickyThenNextPlan {
+    pub first: Uuid,
+    pub second: Uuid,
+}
+
+impl FetchPlan for StickyThenNextPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        let mut cards = vec![self.first];
+        if loaded.card(self.first) == FetchStatus::Loaded && requestable(loaded.card(self.second)) {
+            cards.push(self.second);
+        }
+        FetchRound {
+            cards,
+            ..Default::default()
+        }
+    }
+}
+
+pub(super) struct CardListThenCardPlan {
+    pub card_id: Uuid,
+}
+
+impl FetchPlan for CardListThenCardPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        if requestable(loaded.card_list()) {
+            FetchRound {
+                card_list: true,
+                ..Default::default()
+            }
+        } else if requestable(loaded.card(self.card_id)) {
+            FetchRound {
+                cards: vec![self.card_id],
+                ..Default::default()
+            }
+        } else {
+            FetchRound::default()
+        }
+    }
+}
+
+pub(super) struct HierarchyPlan {
+    pub board_id: Uuid,
+}
+
+impl FetchPlan for HierarchyPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        if requestable(loaded.board_list()) {
+            return FetchRound {
+                board_list: true,
+                ..Default::default()
+            };
+        }
+        if requestable(loaded.columns_of_board(self.board_id)) {
+            return FetchRound {
+                columns_by_board: vec![self.board_id],
+                ..Default::default()
+            };
+        }
+        match loaded.loaded_columns_of_board(self.board_id) {
+            Some(columns) => {
+                let ids: Vec<Uuid> = columns
+                    .iter()
+                    .map(|c| c.id)
+                    .filter(|&id| requestable(loaded.cards_of_column(id)))
+                    .collect();
+                FetchRound {
+                    cards_by_column: ids,
+                    ..Default::default()
+                }
+            }
+            None => FetchRound::default(),
+        }
+    }
+}
+
+pub(super) struct CardsByIdPlan {
+    pub ids: Vec<Uuid>,
+}
+
+impl FetchPlan for CardsByIdPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            cards: self
+                .ids
+                .iter()
+                .copied()
+                .filter(|&id| requestable(loaded.card(id)))
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Observed {
+    pub board_list: FetchStatus,
+    pub column_list: FetchStatus,
+    pub card_list: FetchStatus,
+    pub sprint_list: FetchStatus,
+    pub graph: FetchStatus,
+    pub column: FetchStatus,
+    pub card: FetchStatus,
+    pub sprint: FetchStatus,
+    pub columns_of_board: FetchStatus,
+    pub cards_of_column: FetchStatus,
+    pub sprints_of_board: FetchStatus,
+}
+
+pub(super) struct ProbePlan {
+    pub round: FetchRound,
+    pub board_id: Uuid,
+    pub column_id: Uuid,
+    pub card_id: Uuid,
+    pub sprint_id: Uuid,
+    pub seen: RefCell<Vec<Observed>>,
+}
+
+impl ProbePlan {
+    pub(super) fn new(
+        round: FetchRound,
+        board_id: Uuid,
+        column_id: Uuid,
+        card_id: Uuid,
+        sprint_id: Uuid,
+    ) -> Self {
+        Self {
+            round,
+            board_id,
+            column_id,
+            card_id,
+            sprint_id,
+            seen: RefCell::new(Vec::new()),
+        }
+    }
+
+    pub(super) fn last(&self) -> Observed {
+        *self.seen.borrow().last().expect("plan was never consulted")
+    }
+}
+
+impl FetchPlan for ProbePlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        self.seen.borrow_mut().push(Observed {
+            board_list: loaded.board_list(),
+            column_list: loaded.column_list(),
+            card_list: loaded.card_list(),
+            sprint_list: loaded.sprint_list(),
+            graph: loaded.graph(),
+            column: loaded.column(self.column_id),
+            card: loaded.card(self.card_id),
+            sprint: loaded.sprint(self.sprint_id),
+            columns_of_board: loaded.columns_of_board(self.board_id),
+            cards_of_column: loaded.cards_of_column(self.column_id),
+            sprints_of_board: loaded.sprints_of_board(self.board_id),
+        });
+        self.round.clone()
+    }
+}

--- a/crates/kanban-service/src/resolve/tests/multi_round.rs
+++ b/crates/kanban-service/src/resolve/tests/multi_round.rs
@@ -1,0 +1,259 @@
+use crate::fetch_plan::FetchRound;
+use uuid::Uuid;
+
+use super::{
+    seed_board_with_column, seed_card, store, CardListThenCardPlan, CardsByIdPlan, ChainPlan,
+    FixedPlan, GraphThenCardPlan, StickyThenNextPlan, StubLoaded,
+};
+use crate::read_recorder::{assert_ops, ReadOp};
+use crate::resolve::resolve;
+
+#[test]
+fn test_resolve_serves_a_need_whose_ids_depend_on_an_earlier_round() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let loaded = StubLoaded::default();
+    let plan = GraphThenCardPlan { card_id: card.id };
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_graph",
+                ids: vec![],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![card.id],
+            },
+        ],
+    );
+    assert!(resolved.graph.is_loaded());
+    assert_eq!(
+        resolved.cards.by_id[&card.id].loaded().map(|c| c.id),
+        Some(card.id)
+    );
+}
+
+#[test]
+fn test_resolve_walks_a_chain_of_twelve_dependent_links() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let ids: Vec<Uuid> = (0..12)
+        .map(|i| seed_card(&store, &board, &column, &format!("c{i}")).id)
+        .collect();
+    let loaded = StubLoaded::default();
+    let plan = ChainPlan { ids: ids.clone() };
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    for id in &ids {
+        assert!(resolved.cards.by_id[id].is_loaded());
+    }
+    assert_eq!(store.ops().lock().unwrap().len(), 12);
+    assert_eq!(resolved.cards.by_id.len(), 12);
+}
+
+#[test]
+fn test_a_permanently_missing_id_costs_exactly_one_read_across_repeated_resolves() {
+    let store = store();
+    let absent = Uuid::new_v4();
+    let mut loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![absent],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![absent],
+        }],
+    );
+    assert!(loaded.card_state(absent).is_missing());
+}
+
+#[test]
+fn test_a_missing_id_is_read_once_across_calls_while_a_loaded_sibling_is_refetched() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let present = seed_card(&store, &board, &column, "present");
+    let absent = Uuid::new_v4();
+    let mut loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![absent, present.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_card",
+                ids: vec![absent],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![present.id],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![present.id],
+            },
+        ],
+    );
+    assert!(loaded.card_state(absent).is_missing());
+    assert!(loaded.card_state(present.id).is_loaded());
+}
+
+#[test]
+fn test_a_plan_that_keeps_naming_a_loaded_card_fetches_it_once_and_still_serves_the_dependent_need()
+{
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let first = seed_card(&store, &board, &column, "first");
+    let second = seed_card(&store, &board, &column, "second");
+    let loaded = StubLoaded::default();
+    let plan = StickyThenNextPlan {
+        first: first.id,
+        second: second.id,
+    };
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_card",
+                ids: vec![first.id],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![second.id],
+            },
+        ],
+    );
+    assert!(resolved.cards.by_id[&first.id].is_loaded());
+    assert!(resolved.cards.by_id[&second.id].is_loaded());
+}
+
+#[test]
+fn test_resolve_returns_entities_from_every_round_not_only_the_last() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let loaded = StubLoaded::default();
+    let plan = GraphThenCardPlan { card_id: card.id };
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.graph.is_loaded());
+    assert!(resolved
+        .cards
+        .by_id
+        .get(&card.id)
+        .is_some_and(|s| s.is_loaded()));
+}
+
+#[test]
+fn test_a_later_round_does_not_clobber_a_collection_loaded_by_an_earlier_round() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let loaded = StubLoaded::default();
+    let plan = CardListThenCardPlan { card_id: card.id };
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "list_all_cards",
+                ids: vec![],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![card.id],
+            },
+        ],
+    );
+    assert!(resolved.cards.all.is_loaded());
+    assert_eq!(resolved.cards.all.loaded().unwrap().len(), 1);
+    assert!(resolved.cards.by_id[&card.id].is_loaded());
+}
+
+#[test]
+fn test_narrowing_does_not_drop_a_not_loaded_id() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![card.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![card.id],
+        }],
+    );
+    assert!(resolved.cards.by_id[&card.id].is_loaded());
+}
+
+#[test]
+fn test_an_empty_first_round_performs_zero_reads() {
+    let store = store();
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound::default());
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(store.ops().lock().unwrap().is_empty());
+    assert!(resolved.boards.is_untouched());
+    assert!(resolved.columns.is_untouched());
+    assert!(resolved.cards.is_untouched());
+    assert!(resolved.sprints.is_untouched());
+    assert!(resolved.graph.is_not_loaded());
+}
+
+#[test]
+fn test_a_failed_entity_is_not_refetched_within_a_single_resolve() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    store.fail_card(card.id);
+    let loaded = StubLoaded::default();
+    let plan = CardsByIdPlan { ids: vec![card.id] };
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![card.id],
+        }],
+    );
+    assert!(resolved.cards.by_id[&card.id].is_failed());
+}

--- a/crates/kanban-service/src/resolve/tests/overlay.rs
+++ b/crates/kanban-service/src/resolve/tests/overlay.rs
@@ -1,0 +1,152 @@
+use kanban_domain::{LoadState, Resolved};
+
+use crate::fetch_plan::FetchRound;
+use uuid::Uuid;
+
+use super::{
+    seed_board, seed_board_with_column, seed_card, seed_column, store, CardsByIdPlan,
+    HierarchyPlan, ProbePlan, StubLoaded,
+};
+use crate::fetch_plan::{FetchStatus, LoadedEntities, LoadedState as LoadedStateTrait};
+use crate::read_recorder::assert_ops;
+use crate::resolve::{resolve, Overlay};
+
+#[test]
+fn test_a_scope_discovered_from_an_earlier_round_resolves_in_the_same_call() {
+    let store = store();
+    let board = seed_board(&store, "b");
+    let col_a = seed_column(&store, &board, "a");
+    let col_b = seed_column(&store, &board, "b");
+    seed_card(&store, &board, &col_a, "1");
+    seed_card(&store, &board, &col_b, "2");
+    let loaded = StubLoaded::default();
+    let plan = HierarchyPlan { board_id: board.id };
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.boards.all.is_loaded());
+    assert!(resolved.columns.by_parent[&board.id].is_loaded());
+    assert_eq!(
+        resolved.columns.by_parent[&board.id]
+            .loaded()
+            .unwrap()
+            .len(),
+        2
+    );
+    assert!(resolved.cards.by_parent[&col_a.id].is_loaded());
+    assert!(resolved.cards.by_parent[&col_b.id].is_loaded());
+
+    assert_ops(
+        &store.ops(),
+        &[
+            crate::read_recorder::ReadOp {
+                method: "list_boards",
+                ids: vec![],
+            },
+            crate::read_recorder::ReadOp {
+                method: "list_columns_by_board",
+                ids: vec![board.id],
+            },
+            crate::read_recorder::ReadOp {
+                method: "list_cards_by_column",
+                ids: vec![col_a.id],
+            },
+            crate::read_recorder::ReadOp {
+                method: "list_cards_by_column",
+                ids: vec![col_b.id],
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_the_overlay_reports_the_pass_over_the_base() {
+    let base = StubLoaded::default();
+    let mut resolved = Resolved::default();
+    resolved.cards.all = LoadState::Loaded(vec![]);
+    let overlay = Overlay {
+        base: &base,
+        pass: &resolved,
+    };
+
+    assert_eq!(overlay.card_list(), FetchStatus::Loaded);
+}
+
+#[test]
+fn test_the_overlay_falls_through_to_the_base_for_an_untouched_tier() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let plan = CardsByIdPlan { ids: vec![card.id] };
+    let mut base = StubLoaded::default();
+    base.forget_card(card.id);
+    base.cards.by_id.insert(card.id, LoadState::Missing);
+
+    let resolved = Resolved::default();
+    let overlay = Overlay {
+        base: &base,
+        pass: &resolved,
+    };
+    assert_eq!(overlay.card(card.id), FetchStatus::Missing);
+
+    store.clear_log();
+    resolve(&plan, &base, &store);
+    assert!(store.ops().lock().unwrap().is_empty());
+}
+
+#[test]
+fn test_a_scope_the_pass_failed_does_not_fall_through_to_a_loaded_base() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let mut base = StubLoaded::default();
+    base.columns
+        .by_parent
+        .insert(board.id, LoadState::Loaded(vec![column.clone()]));
+
+    let mut resolved = Resolved::default();
+    resolved.columns.by_parent.insert(
+        board.id,
+        LoadState::Failed(std::sync::Arc::new(
+            kanban_domain::KanbanError::unsupported("x"),
+        )),
+    );
+    let overlay = Overlay {
+        base: &base,
+        pass: &resolved,
+    };
+
+    assert!(overlay.loaded_columns_of_board(board.id).is_none());
+    assert_eq!(overlay.columns_of_board(board.id), FetchStatus::Failed);
+}
+
+#[test]
+fn test_an_empty_base_and_empty_pass_project_every_dimension_as_not_loaded() {
+    let store = store();
+    let loaded = StubLoaded::default();
+    let board_id = Uuid::new_v4();
+    let column_id = Uuid::new_v4();
+    let card_id = Uuid::new_v4();
+    let sprint_id = Uuid::new_v4();
+    let plan = ProbePlan::new(
+        FetchRound::default(),
+        board_id,
+        column_id,
+        card_id,
+        sprint_id,
+    );
+
+    resolve(&plan, &loaded, &store);
+
+    let observed = plan.last();
+    assert_eq!(observed.board_list, FetchStatus::NotLoaded);
+    assert_eq!(observed.column_list, FetchStatus::NotLoaded);
+    assert_eq!(observed.card_list, FetchStatus::NotLoaded);
+    assert_eq!(observed.sprint_list, FetchStatus::NotLoaded);
+    assert_eq!(observed.graph, FetchStatus::NotLoaded);
+    assert_eq!(observed.column, FetchStatus::NotLoaded);
+    assert_eq!(observed.card, FetchStatus::NotLoaded);
+    assert_eq!(observed.sprint, FetchStatus::NotLoaded);
+    assert_eq!(observed.columns_of_board, FetchStatus::NotLoaded);
+    assert_eq!(observed.cards_of_column, FetchStatus::NotLoaded);
+    assert_eq!(observed.sprints_of_board, FetchStatus::NotLoaded);
+}

--- a/crates/kanban-service/src/resolve/tests/resolve.rs
+++ b/crates/kanban-service/src/resolve/tests/resolve.rs
@@ -1,0 +1,268 @@
+use crate::fetch_plan::FetchRound;
+use uuid::Uuid;
+
+use super::{
+    seed_board, seed_board_with_column, seed_card, seed_sprint, store, BoardListPlan, FixedPlan,
+    StubLoaded,
+};
+use crate::read_recorder::{assert_ops, ReadOp};
+use crate::resolve::resolve;
+
+#[test]
+fn test_resolve_for_a_board_list_need_issues_exactly_one_list_boards_read() {
+    let store = store();
+    seed_board(&store, "a");
+    seed_board(&store, "b");
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_boards",
+            ids: vec![],
+        }],
+    );
+    assert!(resolved.boards.all.is_loaded());
+    assert_eq!(resolved.boards.all.loaded().unwrap().len(), 2);
+}
+
+#[test]
+fn test_resolve_of_a_whole_collection_need_populates_all_not_just_by_id() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    seed_card(&store, &board, &column, "a");
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        card_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.cards.all.is_loaded());
+    assert_eq!(resolved.cards.all.loaded().unwrap().len(), 1);
+    assert!(resolved.cards.by_id.is_empty());
+}
+
+#[test]
+fn test_resolve_of_column_sprint_and_graph_list_needs_populates_the_returned_all_tier() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let sprint = seed_sprint(&store, &board);
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        column_list: true,
+        sprint_list: true,
+        graph: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_eq!(
+        resolved
+            .columns
+            .all
+            .loaded()
+            .map(|c| c.iter().map(|c| c.id).collect::<Vec<_>>()),
+        Some(vec![column.id])
+    );
+    assert_eq!(
+        resolved
+            .sprints
+            .all
+            .loaded()
+            .map(|s| s.iter().map(|s| s.id).collect::<Vec<_>>()),
+        Some(vec![sprint.id])
+    );
+    assert!(resolved.graph.is_loaded());
+}
+
+#[test]
+fn test_resolve_of_a_genuinely_empty_card_list_is_loaded_not_not_loaded() {
+    let store = store();
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        card_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.cards.all.is_loaded());
+    assert!(resolved.cards.all.loaded().unwrap().is_empty());
+    assert!(!resolved.cards.all.is_not_loaded());
+    assert!(!resolved.cards.is_untouched());
+}
+
+#[test]
+fn test_resolve_never_scans_a_collection_to_serve_a_single_id_need() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let a = seed_card(&store, &board, &column, "a");
+    seed_card(&store, &board, &column, "b");
+    seed_card(&store, &board, &column, "c");
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![a.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![a.id],
+        }],
+    );
+    assert!(resolved.cards.all.is_not_loaded());
+}
+
+#[test]
+fn test_resolve_of_column_and_sprint_id_needs_loads_each_into_its_own_by_id_tier() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let sprint = seed_sprint(&store, &board);
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        columns: vec![column.id],
+        sprints: vec![sprint.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_column",
+                ids: vec![column.id],
+            },
+            ReadOp {
+                method: "get_sprint",
+                ids: vec![sprint.id],
+            },
+        ],
+    );
+    assert_eq!(
+        resolved.columns.by_id[&column.id].loaded().map(|c| c.id),
+        Some(column.id)
+    );
+    assert_eq!(
+        resolved.sprints.by_id[&sprint.id].loaded().map(|s| s.id),
+        Some(sprint.id)
+    );
+    assert!(resolved.columns.all.is_not_loaded());
+    assert!(resolved.sprints.all.is_not_loaded());
+}
+
+#[test]
+fn test_resolve_maps_ok_none_to_missing() {
+    let store = store();
+    let id = Uuid::new_v4();
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    let state = &resolved.cards.by_id[&id];
+    assert!(state.is_missing());
+    assert!(!state.is_not_loaded());
+    assert!(!state.is_failed());
+    assert!(!state.is_loaded());
+}
+
+#[test]
+fn test_resolve_maps_a_backend_error_to_failed_without_starving_the_round() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let bad = seed_card(&store, &board, &column, "bad");
+    let good = seed_card(&store, &board, &column, "good");
+    store.fail_card(bad.id);
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards: vec![bad.id, good.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.cards.by_id[&bad.id].is_failed());
+    assert!(resolved.cards.by_id[&good.id].is_loaded());
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "get_card",
+                ids: vec![bad.id],
+            },
+            ReadOp {
+                method: "get_card",
+                ids: vec![good.id],
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_resolve_does_not_refetch_an_already_loaded_entity() {
+    let store = store();
+    seed_board(&store, "a");
+    let mut loaded = StubLoaded::default();
+    let plan = BoardListPlan;
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    assert_eq!(store.ops().lock().unwrap().len(), 1);
+}
+
+#[test]
+fn test_a_card_never_fetched_reads_as_not_loaded_and_a_missing_one_reads_as_missing() {
+    let store = store();
+    let id = Uuid::new_v4();
+    let mut loaded = StubLoaded::default();
+
+    assert!(loaded.card_state(id).is_not_loaded());
+
+    let plan = FixedPlan(FetchRound {
+        cards: vec![id],
+        ..Default::default()
+    });
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    assert!(loaded.card_state(id).is_missing());
+}
+
+#[test]
+fn test_a_loaded_card_collection_does_not_report_an_unfetched_card_id_as_loaded() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let a = seed_card(&store, &board, &column, "a");
+    let mut loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        card_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    assert!(loaded.card_list_state().is_loaded());
+    assert!(loaded.card_state(a.id).is_not_loaded());
+}

--- a/crates/kanban-service/src/resolve/tests/result_mapping.rs
+++ b/crates/kanban-service/src/resolve/tests/result_mapping.rs
@@ -1,0 +1,103 @@
+use crate::fetch_plan::FetchRound;
+use uuid::Uuid;
+
+use super::{seed_board_with_column, seed_sprint, store, FixedPlan, StubLoaded};
+use crate::resolve::resolve;
+
+#[test]
+fn test_a_failing_list_read_is_failed_not_a_loaded_empty_collection() {
+    for (method, round) in [
+        (
+            "list_boards",
+            FetchRound {
+                board_list: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "list_all_columns",
+            FetchRound {
+                column_list: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "list_all_cards",
+            FetchRound {
+                card_list: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "list_all_sprints",
+            FetchRound {
+                sprint_list: true,
+                ..Default::default()
+            },
+        ),
+    ] {
+        let store = store();
+        seed_board_with_column(&store);
+        store.fail_method(method);
+        let loaded = StubLoaded::default();
+
+        let resolved = resolve(&FixedPlan(round), &loaded, &store);
+
+        let returned = match method {
+            "list_boards" => resolved.boards.all.is_failed(),
+            "list_all_columns" => resolved.columns.all.is_failed(),
+            "list_all_cards" => resolved.cards.all.is_failed(),
+            _ => resolved.sprints.all.is_failed(),
+        };
+
+        assert!(
+            returned,
+            "{method}: returned tier must be Failed, not Loaded(empty)"
+        );
+    }
+}
+
+#[test]
+fn test_a_failing_graph_read_is_failed_not_an_empty_graph() {
+    let store = store();
+    store.fail_method("get_graph");
+    let loaded = StubLoaded::default();
+
+    let resolved = resolve(
+        &FixedPlan(FetchRound {
+            graph: true,
+            ..Default::default()
+        }),
+        &loaded,
+        &store,
+    );
+
+    assert!(resolved.graph.is_failed());
+}
+
+#[test]
+fn test_an_absent_column_or_sprint_is_missing_and_a_failing_one_is_failed() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let sprint = seed_sprint(&store, &board);
+    let absent_column = Uuid::new_v4();
+    let absent_sprint = Uuid::new_v4();
+    store.fail_column(column.id);
+    store.fail_sprint(sprint.id);
+    let loaded = StubLoaded::default();
+
+    let resolved = resolve(
+        &FixedPlan(FetchRound {
+            columns: vec![absent_column, column.id],
+            sprints: vec![absent_sprint, sprint.id],
+            ..Default::default()
+        }),
+        &loaded,
+        &store,
+    );
+
+    assert!(resolved.columns.by_id[&absent_column].is_missing());
+    assert!(resolved.sprints.by_id[&absent_sprint].is_missing());
+    assert!(resolved.columns.by_id[&column.id].is_failed());
+    assert!(resolved.sprints.by_id[&sprint.id].is_failed());
+}

--- a/crates/kanban-service/src/resolve/tests/retry.rs
+++ b/crates/kanban-service/src/resolve/tests/retry.rs
@@ -1,0 +1,154 @@
+use crate::fetch_plan::FetchRound;
+
+use super::{
+    seed_board, seed_board_with_column, seed_card, store, BoardListPlan, CardsByIdPlan, FixedPlan,
+    StubLoaded,
+};
+use crate::read_recorder::{assert_ops, ReadOp};
+use crate::resolve::resolve;
+
+#[test]
+fn test_a_failed_card_is_refetched_and_recovers_once_the_backend_does() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    store.fail_card(card.id);
+    let mut loaded = StubLoaded::default();
+    let plan = CardsByIdPlan { ids: vec![card.id] };
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+    assert!(loaded.card_state(card.id).is_failed());
+
+    store.clear_failures();
+    store.clear_log();
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![card.id],
+        }],
+    );
+    assert_eq!(
+        loaded.card_state(card.id).loaded().map(|c| c.id),
+        Some(card.id)
+    );
+}
+
+#[test]
+fn test_a_failed_collection_is_refetched_and_recovers_once_the_backend_does() {
+    let store = store();
+    seed_board(&store, "a");
+    store.fail_method("list_boards");
+    let mut loaded = StubLoaded::default();
+
+    let resolved = resolve(&BoardListPlan, &loaded, &store);
+    loaded.apply(resolved);
+    assert!(loaded.board_list_state().is_failed());
+
+    store.clear_failures();
+    store.clear_log();
+
+    let resolved = resolve(&BoardListPlan, &loaded, &store);
+    loaded.apply(resolved);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_boards",
+            ids: vec![],
+        }],
+    );
+    assert_eq!(loaded.board_list_state().loaded().map(|b| b.len()), Some(1));
+}
+
+#[test]
+fn test_a_missing_card_is_not_refetched_while_a_failed_one_is() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let failing = seed_card(&store, &board, &column, "a");
+    let absent = uuid::Uuid::new_v4();
+    store.fail_card(failing.id);
+    let mut loaded = StubLoaded::default();
+    let plan = CardsByIdPlan {
+        ids: vec![absent, failing.id],
+    };
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+    assert!(loaded.card_state(absent).is_missing());
+    assert!(loaded.card_state(failing.id).is_failed());
+
+    store.clear_log();
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![failing.id],
+        }],
+    );
+    assert!(loaded.card_state(absent).is_missing());
+}
+
+#[test]
+fn test_an_invalidated_entity_is_refetched_while_an_untouched_sibling_is_not() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let a = seed_card(&store, &board, &column, "a");
+    let b = seed_card(&store, &board, &column, "b");
+    let mut loaded = StubLoaded::default();
+    let plan = CardsByIdPlan {
+        ids: vec![a.id, b.id],
+    };
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+    assert!(loaded.card_state(a.id).is_loaded());
+    assert!(loaded.card_state(b.id).is_loaded());
+
+    loaded.forget_card(a.id);
+    assert!(loaded.card_state(a.id).is_not_loaded());
+    assert!(loaded.card_state(b.id).is_loaded());
+
+    store.clear_log();
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "get_card",
+            ids: vec![a.id],
+        }],
+    );
+    assert_eq!(resolved.cards.by_id.len(), 1);
+    assert!(resolved.cards.by_id[&a.id].is_loaded());
+    loaded.apply(resolved);
+    assert_eq!(loaded.card_state(a.id).loaded().map(|c| c.id), Some(a.id));
+}
+
+#[test]
+fn test_a_refetched_collection_replaces_the_previously_cached_contents() {
+    let store = store();
+    seed_board(&store, "a");
+    let mut loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        ..Default::default()
+    });
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+    assert_eq!(loaded.board_list_state().loaded().map(|b| b.len()), Some(1));
+
+    seed_board(&store, "b");
+    let resolved = resolve(&plan, &loaded, &store);
+    assert_eq!(resolved.boards.all.loaded().map(|b| b.len()), Some(2));
+    loaded.apply(resolved);
+
+    assert_eq!(loaded.board_list_state().loaded().map(|b| b.len()), Some(2));
+}

--- a/crates/kanban-service/src/resolve/tests/scoped.rs
+++ b/crates/kanban-service/src/resolve/tests/scoped.rs
@@ -1,6 +1,9 @@
 use crate::fetch_plan::FetchRound;
 
-use super::{seed_board_with_column, seed_card, store, FixedPlan, OneShotPlan, StubLoaded};
+use super::{
+    seed_board_with_column, seed_card, seed_column, seed_sprint, store, FixedPlan, OneShotPlan,
+    StubLoaded,
+};
 use crate::read_recorder::{assert_ops, ReadOp};
 use crate::resolve::resolve;
 
@@ -201,4 +204,103 @@ fn test_a_whole_list_fetch_leaves_the_scoped_tier_untouched() {
 
     assert!(resolved.cards.all.is_loaded());
     assert!(resolved.cards.by_parent.is_empty());
+}
+
+#[test]
+fn test_a_loaded_scope_is_refetched_by_a_later_resolve_call() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let mut loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards_by_column: vec![column.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    seed_card(&store, &board, &column, "a");
+    store.clear_log();
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_cards_by_column",
+            ids: vec![column.id],
+        }],
+    );
+    assert_eq!(
+        resolved.cards.by_parent[&column.id].loaded().unwrap().len(),
+        1
+    );
+}
+
+#[test]
+fn test_a_loaded_columns_by_board_scope_is_refetched_by_a_later_resolve_call() {
+    let store = store();
+    let (board, _column) = seed_board_with_column(&store);
+    let mut loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        columns_by_board: vec![board.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    seed_column(&store, &board, "another");
+    store.clear_log();
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_columns_by_board",
+            ids: vec![board.id],
+        }],
+    );
+    assert_eq!(
+        resolved.columns.by_parent[&board.id]
+            .loaded()
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn test_a_loaded_sprints_by_board_scope_is_refetched_by_a_later_resolve_call() {
+    let store = store();
+    let (board, _column) = seed_board_with_column(&store);
+    let mut loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        sprints_by_board: vec![board.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    seed_sprint(&store, &board);
+    store.clear_log();
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_sprints_by_board",
+            ids: vec![board.id],
+        }],
+    );
+    assert_eq!(
+        resolved.sprints.by_parent[&board.id]
+            .loaded()
+            .unwrap()
+            .len(),
+        1
+    );
 }

--- a/crates/kanban-service/src/resolve/tests/scoped.rs
+++ b/crates/kanban-service/src/resolve/tests/scoped.rs
@@ -1,0 +1,204 @@
+use crate::fetch_plan::FetchRound;
+
+use super::{seed_board_with_column, seed_card, store, FixedPlan, OneShotPlan, StubLoaded};
+use crate::read_recorder::{assert_ops, ReadOp};
+use crate::resolve::resolve;
+
+#[test]
+fn test_a_scoped_round_fetches_the_children_of_the_named_parent() {
+    let store = store();
+    let (board, col_a) = seed_board_with_column(&store);
+    let col_b = super::seed_column(&store, &board, "other");
+    let card1 = seed_card(&store, &board, &col_a, "1");
+    let card2 = seed_card(&store, &board, &col_a, "2");
+    let _ = col_b;
+    let loaded = StubLoaded::default();
+    let plan = OneShotPlan::new(FetchRound {
+        cards_by_column: vec![col_a.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_cards_by_column",
+            ids: vec![col_a.id],
+        }],
+    );
+    let scoped = resolved.cards.by_parent[&col_a.id].loaded().unwrap();
+    let mut ids: Vec<_> = scoped.iter().map(|c| c.id).collect();
+    ids.sort();
+    let mut expected = vec![card1.id, card2.id];
+    expected.sort();
+    assert_eq!(ids, expected);
+    assert!(resolved.cards.all.is_not_loaded());
+    assert!(resolved.cards.by_id.is_empty());
+}
+
+#[test]
+fn test_a_scope_with_no_children_resolves_to_loaded_and_empty() {
+    let store = store();
+    let (_board, column) = seed_board_with_column(&store);
+    let loaded = StubLoaded::default();
+    let plan = OneShotPlan::new(FetchRound {
+        cards_by_column: vec![column.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    let state = &resolved.cards.by_parent[&column.id];
+    assert!(state.is_loaded());
+    assert!(state.loaded().unwrap().is_empty());
+    assert!(!state.is_missing());
+}
+
+#[test]
+fn test_every_scoped_tier_resolves_in_one_round() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let loaded = StubLoaded::default();
+    let plan = OneShotPlan::new(FetchRound {
+        columns_by_board: vec![board.id],
+        cards_by_column: vec![column.id],
+        sprints_by_board: vec![board.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.columns.by_parent[&board.id].is_loaded());
+    assert!(resolved.cards.by_parent[&column.id].is_loaded());
+    assert!(resolved.sprints.by_parent[&board.id].is_loaded());
+    assert!(resolved.boards.by_parent.is_empty());
+    assert_ops(
+        &store.ops(),
+        &[
+            ReadOp {
+                method: "list_columns_by_board",
+                ids: vec![board.id],
+            },
+            ReadOp {
+                method: "list_cards_by_column",
+                ids: vec![column.id],
+            },
+            ReadOp {
+                method: "list_sprints_by_board",
+                ids: vec![board.id],
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_a_plan_that_repeats_a_scope_fetches_it_once_and_halts() {
+    let store = store();
+    let (_board, column) = seed_board_with_column(&store);
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards_by_column: vec![column.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.cards.by_parent[&column.id].is_loaded());
+    let ops = store.ops();
+    let ops = ops.lock().unwrap();
+    assert_eq!(
+        ops.iter()
+            .filter(|op| op.method == "list_cards_by_column")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn test_a_failed_scoped_read_maps_to_failed_and_never_to_missing() {
+    let store = store();
+    let (board, _column) = seed_board_with_column(&store);
+    store.fail_method("list_columns_by_board");
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        columns_by_board: vec![board.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    let state = &resolved.columns.by_parent[&board.id];
+    assert!(state.is_failed());
+    assert!(!state.is_missing());
+    assert!(!state.is_loaded());
+}
+
+#[test]
+fn test_a_failed_scope_is_retried_by_a_later_resolve_call() {
+    let store = store();
+    let (_board, column) = seed_board_with_column(&store);
+    store.fail_method("list_cards_by_column");
+    let mut loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        cards_by_column: vec![column.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+    loaded.apply(resolved);
+
+    store.clear_failures();
+    store.clear_log();
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_cards_by_column",
+            ids: vec![column.id],
+        }],
+    );
+    assert!(resolved.cards.by_parent[&column.id].is_loaded());
+}
+
+#[test]
+fn test_a_scoped_fetch_leaves_the_list_and_id_tiers_untouched() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    seed_card(&store, &board, &column, "a");
+    seed_card(&store, &board, &column, "b");
+    let loaded = StubLoaded::default();
+    let plan = OneShotPlan::new(FetchRound {
+        cards_by_column: vec![column.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.cards.by_parent[&column.id].is_loaded());
+    assert_eq!(
+        resolved.cards.by_parent[&column.id].loaded().unwrap().len(),
+        2
+    );
+    assert!(resolved.cards.all.is_not_loaded());
+    assert!(resolved.cards.by_id.is_empty());
+}
+
+#[test]
+fn test_a_whole_list_fetch_leaves_the_scoped_tier_untouched() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    seed_card(&store, &board, &column, "a");
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        card_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.cards.all.is_loaded());
+    assert!(resolved.cards.by_parent.is_empty());
+}


### PR DESCRIPTION
Closes KAN-1420.

## What

Adds `kanban_service::resolve(plan, loaded, store) -> Resolved`, a stateless free function that runs `FetchPlan` rounds against a `DataStore` without owning any state between calls. It reads whole-collection, per-id and the three parent-scoped tiers, dedupes within a call, and composes the caller's `LoadedEntities` with the in-flight `Resolved` so a scope discovered mid-call resolves in the same call.

`resolve` returns `Resolved` directly rather than a `Result`, because backend failures already surface per-entity as `LoadState::Failed`. Collapsing them into a call-level error would discard which entity failed.

## Why this replaces EntityCache

`EntityCache` was deleted by KAN-1450 as an unadopted second owner of every entity. Its multi-round halting argument, per-call retry scoping and terminal-state rules were worth keeping, so they are recovered here as tests against the stateless function.

## Test recovery

The suites deleted with the cache are ported from `bded08f2^`:

- `multi_round.rs` the halting argument
- `retry.rs` per-call retry scoping
- `resolve.rs` and `result_mapping.rs` the terminal-state rules

plus two new suites for behaviour the cache never had: `scoped.rs` for the parent-keyed tier added by KAN-1418, and `overlay.rs` for composing the caller's `LoadedEntities` with the in-flight `Resolved`.

## Verification

- `cargo test --all-features --workspace`: 4477 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all --check`: clean

## Changeset

`minor`, since it adds new public API to `kanban-service`.
