### PR TITLE
KAN-1465 feat(domain): Model gains per-id and parent-scoped tiers

### DIFF
--- a/.changeset/kan-1465-model-per-id-and-scoped-tiers.md
+++ b/.changeset/kan-1465-model-per-id-and-scoped-tiers.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain: `Model` gains a per-id tier and a parent-scoped tier for boards, columns, cards and sprints, alongside the flat collections it already held. `apply_resolved` applies all three independently, `load_from_snapshot` clears the new tiers so a whole-store load supersedes every tier, and `mark_failed` marks the flat collection, the per-id entries and the parent scopes without removing any of them. New public accessors expose each tier's `LoadState` so a caller can tell a scope that was never read from one that resolved empty. A `scoped_card_index` maps a card id to the column scope holding it, which keeps the per-id lookup chain from scanning every scope.

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -902,4 +902,54 @@ mod tests {
         assert!(m.card_by_id_state(b.id).is_loaded());
         assert!(m.card_by_id_state(a.id).is_not_loaded());
     }
+
+    #[test]
+    fn test_load_from_snapshot_clears_every_new_tier() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
+        let card = seed_card(&board, column.id);
+
+        let mut cards_by_id = HashMap::new();
+        cards_by_id.insert(card.id, LoadState::Loaded(card.clone()));
+        let mut columns_by_id = HashMap::new();
+        columns_by_id.insert(column.id, LoadState::Loaded(column.clone()));
+        let mut sprints_by_id = HashMap::new();
+        sprints_by_id.insert(sprint.id, LoadState::Loaded(sprint.clone()));
+        let mut columns_by_parent = HashMap::new();
+        columns_by_parent.insert(board.id, LoadState::Loaded(vec![column.clone()]));
+        let mut cards_by_parent = HashMap::new();
+        cards_by_parent.insert(column.id, LoadState::Loaded(vec![card.clone()]));
+        let mut sprints_by_parent = HashMap::new();
+        sprints_by_parent.insert(board.id, LoadState::Loaded(vec![sprint.clone()]));
+
+        m.apply_resolved(Resolved {
+            columns: Collection {
+                by_id: columns_by_id,
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_id: cards_by_id,
+                by_parent: cards_by_parent,
+                ..Default::default()
+            },
+            sprints: Collection {
+                by_id: sprints_by_id,
+                by_parent: sprints_by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        m.load_from_snapshot(Snapshot::default());
+
+        assert!(m.board_columns_state(board.id).is_not_loaded());
+        assert!(m.column_cards_state(column.id).is_not_loaded());
+        assert!(m.board_sprints_state(board.id).is_not_loaded());
+        assert!(m.card_id_status(card.id).is_not_loaded());
+        assert!(m.column_id_status(column.id).is_not_loaded());
+        assert!(m.sprint_id_status(sprint.id).is_not_loaded());
+    }
 }

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -146,16 +146,37 @@ impl Model {
         if !ids.boards.is_empty() {
             self.boards = LoadState::Failed(Arc::clone(&err));
             self.rebuild_board_index();
+            for state in self.boards_by_id.values_mut() {
+                *state = LoadState::Failed(Arc::clone(&err));
+            }
         }
         if !ids.columns.is_empty() {
             self.columns = LoadState::Failed(Arc::clone(&err));
+            for state in self.columns_by_board.values_mut() {
+                *state = LoadState::Failed(Arc::clone(&err));
+            }
+            for state in self.columns_by_id.values_mut() {
+                *state = LoadState::Failed(Arc::clone(&err));
+            }
         }
         if !ids.cards.is_empty() {
             self.cards = LoadState::Failed(Arc::clone(&err));
             self.rebuild_card_index();
+            for state in self.cards_by_column.values_mut() {
+                *state = LoadState::Failed(Arc::clone(&err));
+            }
+            for state in self.cards_by_id.values_mut() {
+                *state = LoadState::Failed(Arc::clone(&err));
+            }
         }
         if !ids.sprints.is_empty() {
             self.sprints = LoadState::Failed(Arc::clone(&err));
+            for state in self.sprints_by_board.values_mut() {
+                *state = LoadState::Failed(Arc::clone(&err));
+            }
+            for state in self.sprints_by_id.values_mut() {
+                *state = LoadState::Failed(Arc::clone(&err));
+            }
         }
         if ids.graph {
             self.graph = LoadState::Failed(err);

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -952,4 +952,57 @@ mod tests {
         assert!(m.column_id_status(column.id).is_not_loaded());
         assert!(m.sprint_id_status(sprint.id).is_not_loaded());
     }
+
+    #[test]
+    fn test_mark_failed_marks_the_matching_scopes_and_ids_failed() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
+        let card = seed_card(&board, column.id);
+
+        m.set_cards_of_column(column.id, LoadState::Loaded(vec![card.clone()]));
+        let mut cards_by_id = HashMap::new();
+        cards_by_id.insert(card.id, LoadState::Loaded(card.clone()));
+        let mut sprints_by_parent = HashMap::new();
+        sprints_by_parent.insert(board.id, LoadState::Loaded(vec![sprint.clone()]));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_id: cards_by_id,
+                ..Default::default()
+            },
+            sprints: Collection {
+                by_parent: sprints_by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        m.mark_failed(EntityIds::cards([card.id]), Arc::clone(&err));
+
+        match m.column_cards_state(column.id) {
+            LoadState::Failed(e) => assert!(Arc::ptr_eq(&e, &err)),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        match m.card_id_status(card.id) {
+            LoadState::Failed(e) => assert!(Arc::ptr_eq(&e, &err)),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        assert!(m.board_sprints_state(board.id).is_loaded());
+    }
+
+    #[test]
+    fn test_a_failed_card_scope_does_not_serve_a_card_through_the_scoped_index() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let a = seed_card(&board, column.id);
+
+        m.set_cards_of_column(column.id, LoadState::Loaded(vec![a.clone()]));
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        m.mark_failed(EntityIds::cards([a.id]), err);
+
+        assert!(!m.card_by_id_state(a.id).is_loaded());
+    }
 }

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -49,13 +49,10 @@ fn apply_scopes<T>(
 }
 
 impl Model {
-    /// Applies one resolve pass. Each tier is left exactly as it was when its
-    /// `Collection` is untouched (`all` is `NotLoaded` and `by_id` is empty).
-    /// Otherwise `all` replaces the whole tier first (any of `Loaded`,
-    /// `Missing`, `Failed`), then every `by_id` entry is applied on top; a
-    /// `by_id` entry onto a tier that is not `Loaded` is dropped rather than
-    /// promoted, since promoting it would report every other entity in that
-    /// tier as `Missing`. `graph` follows the same not-`NotLoaded` rule.
+    /// Applies one resolve pass across the three independent tiers per
+    /// entity kind: `all`, then `by_id`, then `by_parent`. A tier left
+    /// `NotLoaded`/empty is untouched; the flat and scoped tiers never merge
+    /// into each other or into the per-id tier.
     ///
     /// Maintains the id indexes only. A caller must follow with
     /// `Controller::sync` so the view layer's derived partitions do not lag.
@@ -136,9 +133,10 @@ impl Model {
         }
     }
 
-    /// Marks every collection named in `ids` as `Failed(err)`, the finest
-    /// granularity `Model` represents. An empty `EntityIds` changes nothing.
-    /// `ids.prefixes` has no corresponding `Model` field.
+    /// Marks the flat collection, the per-id entries and the parent scopes
+    /// of every kind named in `ids` as `Failed(err)`, without removing any
+    /// of them. An empty `EntityIds` changes nothing. `ids.prefixes` has no
+    /// corresponding `Model` field.
     ///
     /// Maintains the id indexes only. A caller must follow with
     /// `Controller::sync` so the view layer's derived partitions do not lag.

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -396,7 +396,7 @@ mod tests {
         });
 
         assert!(m.cards_state().is_not_loaded());
-        assert!(m.card_by_id_state(x_id).is_not_loaded());
+        assert!(m.card_by_id_state(x_id).is_loaded());
         assert!(m.card_by_id_state(other_id).is_not_loaded());
         assert!(!m.card_by_id_state(other_id).is_missing());
     }
@@ -435,5 +435,388 @@ mod tests {
 
         m.apply_resolved(Resolved::default());
         assert!(m.graph_state().is_loaded());
+    }
+
+    #[test]
+    fn test_applying_a_scoped_cards_result_is_readable_back() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let a = seed_card(&board, column.id);
+        let b = seed_card(&board, column.id);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(column.id, LoadState::Loaded(vec![a.clone(), b.clone()]));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let scoped = m.column_cards_state(column.id).loaded().unwrap();
+        assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![a.id, b.id]);
+        assert!(m.cards_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_a_missing_by_id_result_is_recorded_on_a_not_loaded_collection() {
+        let mut m = Model::default();
+        let ghost = Uuid::new_v4();
+        let mut by_id = HashMap::new();
+        by_id.insert(ghost, LoadState::Missing);
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(m.card_by_id_state(ghost).is_missing());
+        assert!(m.card_id_status(ghost).is_missing());
+        assert!(m.cards_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_a_loaded_by_id_result_lands_on_a_not_loaded_collection() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let x = seed_card(&board, column.id);
+        let x_id = x.id;
+        let mut by_id = HashMap::new();
+        by_id.insert(x_id, LoadState::Loaded(x.clone()));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(m.card_by_id_state(x_id).loaded().copied().unwrap(), &x);
+        assert!(m.cards_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_a_not_loaded_by_id_entry_does_not_erase_a_recorded_missing() {
+        let mut m = Model::default();
+        let ghost = Uuid::new_v4();
+        let mut by_id = HashMap::new();
+        by_id.insert(ghost, LoadState::Missing);
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut by_id2 = HashMap::new();
+        by_id2.insert(ghost, LoadState::NotLoaded);
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_id: by_id2,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(m.card_id_status(ghost).is_missing());
+    }
+
+    #[test]
+    fn test_a_scoped_result_never_touches_the_flat_collection() {
+        let (mut m, board, column, _sprint, card_a, card_b) = seed_full_model();
+        let third = seed_card(&board, column.id);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(column.id, LoadState::Loaded(vec![third.clone()]));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            m.cards_state().loaded().unwrap(),
+            &vec![card_a.clone(), card_b.clone()]
+        );
+        let scoped = m.column_cards_state(column.id).loaded().unwrap();
+        assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![third.id]);
+    }
+
+    #[test]
+    fn test_a_loaded_empty_scope_is_not_a_not_loaded_scope() {
+        let mut m = Model::default();
+        let col = Uuid::new_v4();
+        let other_col = Uuid::new_v4();
+        let mut by_parent = HashMap::new();
+        by_parent.insert(col, LoadState::Loaded(Vec::<Card>::new()));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(m.column_cards_state(col).is_loaded());
+        assert!(m.column_cards_state(col).loaded().unwrap().is_empty());
+        assert!(m.column_cards_state(other_col).is_not_loaded());
+    }
+
+    #[test]
+    fn test_a_failed_scope_is_applied_as_failed() {
+        let mut m = Model::default();
+        let col = Uuid::new_v4();
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        let mut by_parent = HashMap::new();
+        by_parent.insert(col, LoadState::Failed(Arc::clone(&err)));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        match m.column_cards_state(col) {
+            LoadState::Failed(e) => assert!(Arc::ptr_eq(&e, &err)),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        assert!(!m.column_cards_state(col).is_missing());
+    }
+
+    #[test]
+    fn test_a_not_loaded_scope_entry_leaves_an_existing_scope_alone() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let a = seed_card(&board, column.id);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(column.id, LoadState::Loaded(vec![a.clone()]));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut by_parent2 = HashMap::new();
+        by_parent2.insert(column.id, LoadState::NotLoaded);
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent: by_parent2,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let scoped = m.column_cards_state(column.id).loaded().unwrap();
+        assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![a.id]);
+    }
+
+    #[test]
+    fn test_every_scoped_kind_is_applied() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
+        let card = seed_card(&board, column.id);
+
+        let mut columns_by_parent = HashMap::new();
+        columns_by_parent.insert(board.id, LoadState::Loaded(vec![column.clone()]));
+        let mut cards_by_parent = HashMap::new();
+        cards_by_parent.insert(column.id, LoadState::Loaded(vec![card.clone()]));
+        let mut sprints_by_parent = HashMap::new();
+        sprints_by_parent.insert(board.id, LoadState::Loaded(vec![sprint.clone()]));
+
+        m.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_parent: cards_by_parent,
+                ..Default::default()
+            },
+            sprints: Collection {
+                by_parent: sprints_by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            m.board_columns_state(board.id)
+                .loaded()
+                .unwrap()
+                .iter()
+                .map(|c| c.id)
+                .collect::<Vec<_>>(),
+            vec![column.id]
+        );
+        assert_eq!(
+            m.column_cards_state(column.id)
+                .loaded()
+                .unwrap()
+                .iter()
+                .map(|c| c.id)
+                .collect::<Vec<_>>(),
+            vec![card.id]
+        );
+        assert_eq!(
+            m.board_sprints_state(board.id)
+                .loaded()
+                .unwrap()
+                .iter()
+                .map(|s| s.id)
+                .collect::<Vec<_>>(),
+            vec![sprint.id]
+        );
+    }
+
+    #[test]
+    fn test_applying_all_and_by_parent_in_one_pass_keeps_them_independent() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let x = seed_card(&board, column.id);
+        let y = seed_card(&board, column.id);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(column.id, LoadState::Loaded(vec![y.clone()]));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![x.clone()]),
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(m.cards_state().loaded().unwrap(), &vec![x]);
+        let scoped = m.column_cards_state(column.id).loaded().unwrap();
+        assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![y.id]);
+    }
+
+    #[test]
+    fn test_a_by_id_result_wins_over_the_flat_collection() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let mut x_v1 = seed_card(&board, column.id);
+        x_v1.title = "v1".to_string();
+        let mut x_v2 = x_v1.clone();
+        x_v2.title = "v2".to_string();
+
+        let mut by_id = HashMap::new();
+        by_id.insert(x_v1.id, LoadState::Loaded(x_v2));
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![x_v1]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            m.card_by_id_state(m.cards_state().loaded().unwrap()[0].id)
+                .loaded()
+                .unwrap()
+                .title,
+            "v2"
+        );
+        assert_eq!(m.cards_state().loaded().unwrap()[0].title, "v1");
+    }
+
+    #[test]
+    fn test_a_scope_loaded_card_is_readable_by_id() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column_x = Column::new(board.id, "X", 0);
+        let card_a = seed_card(&board, column_x.id);
+        let card_b = seed_card(&board, column_x.id);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(
+            column_x.id,
+            LoadState::Loaded(vec![card_a.clone(), card_b.clone()]),
+        );
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            m.card_by_id_state(card_a.id).loaded().copied(),
+            Some(&card_a)
+        );
+        assert_eq!(
+            m.card_by_id_state(card_b.id).loaded().copied(),
+            Some(&card_b)
+        );
+    }
+
+    #[test]
+    fn test_a_scope_loaded_card_list_renders_every_row() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column_x = Column::new(board.id, "X", 0);
+        let card_a = seed_card(&board, column_x.id);
+        let card_b = seed_card(&board, column_x.id);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(
+            column_x.id,
+            LoadState::Loaded(vec![card_a.clone(), card_b.clone()]),
+        );
+        m.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let ids = vec![card_a.id, card_b.id];
+        let rows: Vec<_> = ids
+            .iter()
+            .filter_map(|id| m.card_by_id_state(*id).loaded().copied())
+            .collect();
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn test_replacing_a_columns_cards_drops_the_old_ids_from_the_scoped_index() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let a = seed_card(&board, column.id);
+        let b = seed_card(&board, column.id);
+
+        m.set_cards_of_column(column.id, LoadState::Loaded(vec![a.clone()]));
+        m.set_cards_of_column(column.id, LoadState::Loaded(vec![b.clone()]));
+
+        assert!(m.card_by_id_state(b.id).is_loaded());
+        assert!(m.card_by_id_state(a.id).is_not_loaded());
     }
 }

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -3,23 +3,29 @@ use crate::resolved::Collection;
 use crate::{EntityIds, KanbanError, Resolved};
 use std::sync::Arc;
 
-fn apply_collection<T>(
+fn apply_collection<T: Clone>(
     target: &mut LoadState<Vec<T>>,
-    incoming: Collection<T>,
+    by_id_target: &mut HashMap<Uuid, LoadState<T>>,
+    all: LoadState<Vec<T>>,
+    by_id: HashMap<Uuid, LoadState<T>>,
     id_of: impl Fn(&T) -> Uuid,
 ) {
-    if !incoming.all.is_not_loaded() {
-        *target = incoming.all;
+    if !all.is_not_loaded() {
+        *target = all;
     }
-    if incoming.by_id.is_empty() {
+    if by_id.is_empty() {
         return;
     }
-    let LoadState::Loaded(items) = target else {
-        return;
-    };
-    let mut entries: Vec<(Uuid, LoadState<T>)> = incoming.by_id.into_iter().collect();
+    let mut entries: Vec<(Uuid, LoadState<T>)> = by_id.into_iter().collect();
     entries.sort_unstable_by_key(|(id, _)| *id);
     for (id, state) in entries {
+        if state.is_not_loaded() {
+            continue;
+        }
+        by_id_target.insert(id, state.clone());
+        let LoadState::Loaded(items) = &mut *target else {
+            continue;
+        };
         match state {
             LoadState::Loaded(entity) => match items.iter().position(|e| id_of(e) == id) {
                 Some(pos) => items[pos] = entity,
@@ -27,6 +33,17 @@ fn apply_collection<T>(
             },
             LoadState::Missing => items.retain(|e| id_of(e) != id),
             LoadState::NotLoaded | LoadState::Failed(_) => {}
+        }
+    }
+}
+
+fn apply_scopes<T>(
+    target: &mut HashMap<Uuid, LoadState<Vec<T>>>,
+    incoming: HashMap<Uuid, LoadState<Vec<T>>>,
+) {
+    for (parent, state) in incoming {
+        if !state.is_not_loaded() {
+            target.insert(parent, state);
         }
     }
 }
@@ -46,10 +63,66 @@ impl Model {
         let boards_touched = !resolved.boards.is_untouched();
         let cards_touched = !resolved.cards.is_untouched();
 
-        apply_collection(&mut self.boards, resolved.boards, |b| b.id);
-        apply_collection(&mut self.columns, resolved.columns, |c| c.id);
-        apply_collection(&mut self.cards, resolved.cards, |c| c.id);
-        apply_collection(&mut self.sprints, resolved.sprints, |s| s.id);
+        let Collection {
+            all: boards_all,
+            by_id: boards_by_id,
+            by_parent: boards_by_parent,
+        } = resolved.boards;
+        debug_assert!(boards_by_parent.is_empty(), "boards have no parent scope");
+        apply_collection(
+            &mut self.boards,
+            &mut self.boards_by_id,
+            boards_all,
+            boards_by_id,
+            |b| b.id,
+        );
+
+        let Collection {
+            all: columns_all,
+            by_id: columns_by_id,
+            by_parent: columns_by_parent,
+        } = resolved.columns;
+        apply_collection(
+            &mut self.columns,
+            &mut self.columns_by_id,
+            columns_all,
+            columns_by_id,
+            |c| c.id,
+        );
+        apply_scopes(&mut self.columns_by_board, columns_by_parent);
+
+        let Collection {
+            all: cards_all,
+            by_id: cards_by_id,
+            by_parent: cards_by_parent,
+        } = resolved.cards;
+        apply_collection(
+            &mut self.cards,
+            &mut self.cards_by_id,
+            cards_all,
+            cards_by_id,
+            |c| c.id,
+        );
+        for (column_id, state) in cards_by_parent {
+            if state.is_not_loaded() {
+                continue;
+            }
+            self.set_cards_of_column(column_id, state);
+        }
+
+        let Collection {
+            all: sprints_all,
+            by_id: sprints_by_id,
+            by_parent: sprints_by_parent,
+        } = resolved.sprints;
+        apply_collection(
+            &mut self.sprints,
+            &mut self.sprints_by_id,
+            sprints_all,
+            sprints_by_id,
+            |s| s.id,
+        );
+        apply_scopes(&mut self.sprints_by_board, sprints_by_parent);
 
         if !resolved.graph.is_not_loaded() {
             self.graph = resolved.graph;
@@ -455,8 +528,12 @@ mod tests {
             ..Default::default()
         });
 
-        let scoped = m.column_cards_state(column.id).loaded().unwrap();
-        assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![a.id, b.id]);
+        let state = m.column_cards_state(column.id);
+        let scoped = state.loaded().unwrap();
+        assert_eq!(
+            scoped.iter().map(|c| c.id).collect::<Vec<_>>(),
+            vec![a.id, b.id]
+        );
         assert!(m.cards_state().is_not_loaded());
     }
 
@@ -546,8 +623,12 @@ mod tests {
             m.cards_state().loaded().unwrap(),
             &vec![card_a.clone(), card_b.clone()]
         );
-        let scoped = m.column_cards_state(column.id).loaded().unwrap();
-        assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![third.id]);
+        let state = m.column_cards_state(column.id);
+        let scoped = state.loaded().unwrap();
+        assert_eq!(
+            scoped.iter().map(|c| c.id).collect::<Vec<_>>(),
+            vec![third.id]
+        );
     }
 
     #[test]
@@ -619,7 +700,8 @@ mod tests {
             ..Default::default()
         });
 
-        let scoped = m.column_cards_state(column.id).loaded().unwrap();
+        let state = m.column_cards_state(column.id);
+        let scoped = state.loaded().unwrap();
         assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![a.id]);
     }
 
@@ -703,7 +785,8 @@ mod tests {
         });
 
         assert_eq!(m.cards_state().loaded().unwrap(), &vec![x]);
-        let scoped = m.column_cards_state(column.id).loaded().unwrap();
+        let state = m.column_cards_state(column.id);
+        let scoped = state.loaded().unwrap();
         assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![y.id]);
     }
 
@@ -797,7 +880,7 @@ mod tests {
             ..Default::default()
         });
 
-        let ids = vec![card_a.id, card_b.id];
+        let ids = [card_a.id, card_b.id];
         let rows: Vec<_> = ids
             .iter()
             .filter_map(|id| m.card_by_id_state(*id).loaded().copied())

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -8,10 +8,22 @@ impl Model {
         &self.cards
     }
 
-    /// Resolve a card by id from the single unified collection (live AND
-    /// archived rows). One index lookup — no live/archived re-join. A card is
-    /// a card regardless of whether its head is archived.
+    /// Resolves a card by id in per-id, parent-scoped, then flat-collection
+    /// precedence order: a per-id result always wins, then a card found in a
+    /// loaded column scope, then the single unified collection (live AND
+    /// archived rows). A card is a card regardless of whether its head is
+    /// archived.
     pub fn card_by_id_state(&self, id: Uuid) -> LoadState<&Card> {
+        if let Some(state) = self.cards_by_id.get(&id) {
+            return state.as_ref();
+        }
+        if let Some(column_id) = self.scoped_card_index.get(&id) {
+            if let Some(LoadState::Loaded(cards)) = self.cards_by_column.get(column_id) {
+                if let Some(card) = cards.iter().find(|c| c.id == id) {
+                    return LoadState::Loaded(card);
+                }
+            }
+        }
         match self.cards.as_ref() {
             LoadState::Loaded(cards) => {
                 match self.card_index.get(&id).and_then(|&idx| cards.get(idx)) {
@@ -23,6 +35,36 @@ impl Model {
             LoadState::Missing => LoadState::Missing,
             LoadState::Failed(e) => LoadState::Failed(e),
         }
+    }
+
+    /// The parent-scoped card tier for one column. Independent of
+    /// `cards_state()`: a scoped result never touches the flat collection.
+    pub fn column_cards_state(&self, column_id: Uuid) -> LoadState<&[Card]> {
+        scoped_state(&self.cards_by_column, column_id)
+    }
+
+    /// The per-id tier only, with no composition against the flat
+    /// collection or the parent-scoped tier. Returns `NotLoaded` for an id
+    /// that was never named by a resolve pass.
+    pub fn card_id_status(&self, id: Uuid) -> LoadState<&Card> {
+        self.cards_by_id
+            .get(&id)
+            .map(|s| s.as_ref())
+            .unwrap_or(LoadState::NotLoaded)
+    }
+
+    /// Replaces the card set for one column's scoped tier. The only writer
+    /// of `cards_by_column`'s membership: `load_from_snapshot` clears the
+    /// map and index together, and `mark_failed` transitions state in place
+    /// without touching membership.
+    pub fn set_cards_of_column(&mut self, column_id: Uuid, state: LoadState<Vec<Card>>) {
+        self.scoped_card_index.retain(|_, col| *col != column_id);
+        if let LoadState::Loaded(cards) = &state {
+            for c in cards {
+                self.scoped_card_index.insert(c.id, column_id);
+            }
+        }
+        self.cards_by_column.insert(column_id, state);
     }
 
     /// The archived-card MARKER records (id + archived_at + restore context).

--- a/crates/kanban-domain/src/model/collections.rs
+++ b/crates/kanban-domain/src/model/collections.rs
@@ -16,6 +16,72 @@ impl Model {
     pub fn sprints_state(&self) -> &LoadState<Vec<Sprint>> {
         &self.sprints
     }
+
+    pub fn board_columns_state(&self, board_id: Uuid) -> LoadState<&[Column]> {
+        scoped_state(&self.columns_by_board, board_id)
+    }
+
+    pub fn board_sprints_state(&self, board_id: Uuid) -> LoadState<&[Sprint]> {
+        scoped_state(&self.sprints_by_board, board_id)
+    }
+
+    pub fn column_by_id_state(&self, id: Uuid) -> LoadState<&Column> {
+        if let Some(state) = self.columns_by_id.get(&id) {
+            return state.as_ref();
+        }
+        for state in self.columns_by_board.values() {
+            if let LoadState::Loaded(columns) = state {
+                if let Some(column) = columns.iter().find(|c| c.id == id) {
+                    return LoadState::Loaded(column);
+                }
+            }
+        }
+        match self.columns.as_ref() {
+            LoadState::Loaded(columns) => match columns.iter().find(|c| c.id == id) {
+                Some(column) => LoadState::Loaded(column),
+                None => LoadState::Missing,
+            },
+            LoadState::NotLoaded => LoadState::NotLoaded,
+            LoadState::Missing => LoadState::Missing,
+            LoadState::Failed(e) => LoadState::Failed(e),
+        }
+    }
+
+    pub fn sprint_by_id_state(&self, id: Uuid) -> LoadState<&Sprint> {
+        if let Some(state) = self.sprints_by_id.get(&id) {
+            return state.as_ref();
+        }
+        for state in self.sprints_by_board.values() {
+            if let LoadState::Loaded(sprints) = state {
+                if let Some(sprint) = sprints.iter().find(|s| s.id == id) {
+                    return LoadState::Loaded(sprint);
+                }
+            }
+        }
+        match self.sprints.as_ref() {
+            LoadState::Loaded(sprints) => match sprints.iter().find(|s| s.id == id) {
+                Some(sprint) => LoadState::Loaded(sprint),
+                None => LoadState::Missing,
+            },
+            LoadState::NotLoaded => LoadState::NotLoaded,
+            LoadState::Missing => LoadState::Missing,
+            LoadState::Failed(e) => LoadState::Failed(e),
+        }
+    }
+
+    pub fn column_id_status(&self, id: Uuid) -> LoadState<&Column> {
+        self.columns_by_id
+            .get(&id)
+            .map(|s| s.as_ref())
+            .unwrap_or(LoadState::NotLoaded)
+    }
+
+    pub fn sprint_id_status(&self, id: Uuid) -> LoadState<&Sprint> {
+        self.sprints_by_id
+            .get(&id)
+            .map(|s| s.as_ref())
+            .unwrap_or(LoadState::NotLoaded)
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -83,6 +83,15 @@ impl Model {
         self.cards = LoadState::Loaded(snapshot.cards);
         self.graph = LoadState::Loaded(snapshot.graph);
 
+        self.boards_by_id.clear();
+        self.columns_by_id.clear();
+        self.cards_by_id.clear();
+        self.sprints_by_id.clear();
+        self.columns_by_board.clear();
+        self.cards_by_column.clear();
+        self.scoped_card_index.clear();
+        self.sprints_by_board.clear();
+
         self.absorb_archival_markers(
             Some(snapshot.archived_cards),
             Some(snapshot.archived_boards),

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -15,6 +15,27 @@ pub struct Model {
     archived_boards: Option<Vec<ArchivedBoard>>,
     archived_board_ids: HashSet<Uuid>,
     graph: LoadState<DependencyGraph>,
+    /// The per-id tier beside each unified collection. Not a second row
+    /// store: a `Loaded` entry here can name an entity even while the
+    /// matching flat collection is `NotLoaded`, and it is the only tier that
+    /// can ever hold `LoadState::Missing` for a single id. Nothing writes
+    /// `boards_by_id` today; it exists for symmetry of the mutators.
+    boards_by_id: HashMap<Uuid, LoadState<Board>>,
+    columns_by_id: HashMap<Uuid, LoadState<Column>>,
+    cards_by_id: HashMap<Uuid, LoadState<Card>>,
+    sprints_by_id: HashMap<Uuid, LoadState<Sprint>>,
+    /// The parent-scoped tier, keyed by the fixed parent id per kind
+    /// (`columns_by_board`/`sprints_by_board` by board id,
+    /// `cards_by_column` by column id). A scoped result never mutates the
+    /// flat collection or the per-id tier, and vice versa.
+    columns_by_board: HashMap<Uuid, LoadState<Vec<Column>>>,
+    cards_by_column: HashMap<Uuid, LoadState<Vec<Card>>>,
+    sprints_by_board: HashMap<Uuid, LoadState<Vec<Sprint>>>,
+    /// Reverse index from card id to the column whose `cards_by_column`
+    /// entry currently holds it. Maintained only by `set_cards_of_column`;
+    /// without it, resolving a card by id through the scoped tier would scan
+    /// every column's bucket on every rendered row.
+    scoped_card_index: HashMap<Uuid, Uuid>,
 }
 
 impl Default for Model {
@@ -31,8 +52,22 @@ impl Default for Model {
             archived_boards: None,
             archived_board_ids: HashSet::new(),
             graph: LoadState::NotLoaded,
+            boards_by_id: HashMap::new(),
+            columns_by_id: HashMap::new(),
+            cards_by_id: HashMap::new(),
+            sprints_by_id: HashMap::new(),
+            columns_by_board: HashMap::new(),
+            cards_by_column: HashMap::new(),
+            sprints_by_board: HashMap::new(),
+            scoped_card_index: HashMap::new(),
         }
     }
+}
+
+fn scoped_state<T>(map: &HashMap<Uuid, LoadState<Vec<T>>>, parent: Uuid) -> LoadState<&[T]> {
+    map.get(&parent)
+        .map(|s| s.as_ref().map(|v| v.as_slice()))
+        .unwrap_or(LoadState::NotLoaded)
 }
 
 impl Model {


### PR DESCRIPTION
Closes KAN-1465.

## What

`Model` gains two tiers alongside the flat collections it already held:

- a **per-id** tier for boards, columns, cards and sprints
- a **parent-scoped** tier: columns by board, cards by column, sprints by board

plus `scoped_card_index`, mapping a card id to the column scope holding it so the per-id lookup chain does not scan every scope.

## Behaviour across the three tiers

- `apply_resolved` applies each tier independently. The flat and scoped tiers never merge into each other or into the per-id tier.
- `load_from_snapshot` clears the new tiers, so a whole-store load supersedes every tier rather than leaving stale scopes behind.
- `mark_failed` marks the flat collection, the per-id entries and the parent scopes, without removing any of them.

New public accessors expose each tier's `LoadState`, so a caller can distinguish a scope that was never read from one that resolved empty. That distinction is the point of the epic: nothing may report `NotLoaded` as empty.

## Scope

`crates/kanban-domain/src/model/**` only. No `kanban-service`, no `kanban-view`, no `Cargo.toml`. This card is the domain half of the old KAN-1422; the `impl LoadedState for Model` half is KAN-1466 and lives in `kanban-service`, because the dependency direction and the orphan rule both forbid it here.

## Verification

- `cargo test -p kanban-domain --all-features`: 841 passed, 0 failed
- `cargo clippy -p kanban-domain --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all --check`: clean

Six commits in Red/Green pairs: tiers, snapshot clearing, and `mark_failed`.

## Changeset

`minor`, since it adds new public API to a crate that publishes pre-1.0.
