### PR TITLE
KAN-1467 feat(domain,view,tui): return a ModelChanged receipt from Model mutators

### DIFF
--- a/.changeset/kan-1467-model-changed-receipt.md
+++ b/.changeset/kan-1467-model-changed-receipt.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+kanban-domain, kanban-view, kanban-tui: `Model::apply_resolved`, `Model::mark_failed` and `Model::load_from_snapshot` now return a `#[must_use]` `ModelChanged` receipt instead of `()`. A new one-method `DerivedProjections` trait consumes that receipt, with a `NoProjections` no-op implementor for callers with nothing to derive. `kanban-view`'s inherent `Controller::sync` is replaced by `impl DerivedProjections for Controller`, so forgetting to recompute derived state after a `Model` mutation is now a compile-time lint rather than a doc-comment plea.

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -71,9 +71,9 @@ pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use invalidation::{invalidation_from_inverse, EntityIds, Invalidation};
 pub use load_state::LoadState;
-pub use model::{DerivedProjections, Model, ModelChanged, NoProjections};
 #[cfg(any(test, feature = "test-helpers"))]
 pub use model::ModelLoadStates;
+pub use model::{DerivedProjections, Model, ModelChanged, NoProjections};
 pub use operations::KanbanOperations;
 pub use prefix::{
     allocate_card_number, allocate_sprint_number, effective_card_prefix, effective_prefixes,

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -71,7 +71,7 @@ pub use filter::CardFilters;
 pub use graph_operations::GraphOperations;
 pub use invalidation::{invalidation_from_inverse, EntityIds, Invalidation};
 pub use load_state::LoadState;
-pub use model::Model;
+pub use model::{DerivedProjections, Model, ModelChanged, NoProjections};
 #[cfg(any(test, feature = "test-helpers"))]
 pub use model::ModelLoadStates;
 pub use operations::KanbanOperations;

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -54,9 +54,10 @@ impl Model {
     /// `NotLoaded`/empty is untouched; the flat and scoped tiers never merge
     /// into each other or into the per-id tier.
     ///
-    /// Maintains the id indexes only. A caller must follow with
-    /// `Controller::sync` so the view layer's derived partitions do not lag.
-    pub fn apply_resolved(&mut self, resolved: Resolved) {
+    /// Maintains the id indexes only. Returns a [`ModelChanged`] receipt:
+    /// whatever derives from this `Model` is stale until a
+    /// [`DerivedProjections`] implementor consumes it.
+    pub fn apply_resolved(&mut self, resolved: Resolved) -> ModelChanged {
         let boards_touched = !resolved.boards.is_untouched();
         let cards_touched = !resolved.cards.is_untouched();
 
@@ -131,6 +132,8 @@ impl Model {
         if boards_touched {
             self.rebuild_board_index();
         }
+
+        ModelChanged::new()
     }
 
     /// Marks the flat collection, the per-id entries and the parent scopes
@@ -138,9 +141,10 @@ impl Model {
     /// of them. An empty `EntityIds` changes nothing. `ids.prefixes` has no
     /// corresponding `Model` field.
     ///
-    /// Maintains the id indexes only. A caller must follow with
-    /// `Controller::sync` so the view layer's derived partitions do not lag.
-    pub fn mark_failed(&mut self, ids: EntityIds, err: Arc<KanbanError>) {
+    /// Maintains the id indexes only. Returns a [`ModelChanged`] receipt:
+    /// whatever derives from this `Model` is stale until a
+    /// [`DerivedProjections`] implementor consumes it.
+    pub fn mark_failed(&mut self, ids: EntityIds, err: Arc<KanbanError>) -> ModelChanged {
         if !ids.boards.is_empty() {
             self.boards = LoadState::Failed(Arc::clone(&err));
             self.rebuild_board_index();
@@ -179,6 +183,8 @@ impl Model {
         if ids.graph {
             self.graph = LoadState::Failed(err);
         }
+
+        ModelChanged::new()
     }
 }
 
@@ -232,7 +238,7 @@ mod tests {
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let card_a = seed_card(&board, column.id);
         let card_b = seed_card(&board, column.id);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board.clone()],
             columns: vec![column.clone()],
             sprints: vec![sprint.clone()],
@@ -248,7 +254,7 @@ mod tests {
         let (mut m, board, column, sprint, _card_a, _card_b) = seed_full_model();
         let new_card = seed_card(&board, column.id);
 
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::Loaded(vec![new_card.clone()]),
                 ..Default::default()
@@ -273,7 +279,7 @@ mod tests {
         let board = Board::new("B", None::<String>);
         let a = Column::new(board.id, "A", 0);
         let b = Column::new(board.id, "B", 1);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             archived_boards: Vec::new(),
             ..Default::default()
@@ -281,7 +287,7 @@ mod tests {
 
         let mut by_id = HashMap::new();
         by_id.insert(b.id, LoadState::Missing);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             columns: Collection {
                 all: LoadState::Loaded(vec![a.clone(), b]),
                 by_id,
@@ -301,7 +307,7 @@ mod tests {
 
         let mut by_id = HashMap::new();
         by_id.insert(card_a.id, LoadState::Loaded(a_edited.clone()));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::NotLoaded,
                 by_id,
@@ -332,7 +338,7 @@ mod tests {
         let (mut m, board, column, sprint, card_a, card_b) = seed_full_model();
         let err = Arc::new(KanbanError::unsupported("boom"));
 
-        m.mark_failed(EntityIds::cards([card_a.id]), Arc::clone(&err));
+        let _ = m.mark_failed(EntityIds::cards([card_a.id]), Arc::clone(&err));
 
         match m.cards_state() {
             LoadState::Failed(e) => assert!(Arc::ptr_eq(e, &err)),
@@ -353,7 +359,7 @@ mod tests {
         let (mut m, board, _column, sprint, card_a, card_b) = seed_full_model();
         let mut by_id = HashMap::new();
         by_id.insert(card_b.id, LoadState::Missing);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::NotLoaded,
                 by_id,
@@ -364,7 +370,7 @@ mod tests {
         assert!(m.card_by_id_state(card_b.id).is_missing());
 
         let new_sprint = Sprint::new(board.id, 2, None, None::<String>);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             sprints: Collection {
                 all: LoadState::Loaded(vec![sprint, new_sprint]),
                 ..Default::default()
@@ -384,7 +390,7 @@ mod tests {
         let d = seed_card(&board, column.id);
         let e = seed_card(&board, column.id);
 
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::Loaded(vec![c.clone(), d.clone(), e.clone()]),
                 ..Default::default()
@@ -411,7 +417,7 @@ mod tests {
         let a = seed_card(&board, column.id);
         let b = seed_card(&board, column.id);
         let c = seed_card(&board, column.id);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             columns: vec![column],
             cards: vec![a.clone(), b.clone(), c.clone()],
@@ -421,7 +427,7 @@ mod tests {
 
         let mut by_id = HashMap::new();
         by_id.insert(b.id, LoadState::Missing);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::NotLoaded,
                 by_id,
@@ -446,7 +452,7 @@ mod tests {
         let archived_card = seed_card(&board_live, column.id);
         let archived_card_id = archived_card.id;
         let sprint = Sprint::new(board_live.id, 1, None, None::<String>);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board_live.clone(), board_archived.clone()],
             columns: vec![column.clone()],
             cards: vec![live_card, archived_card],
@@ -460,7 +466,7 @@ mod tests {
         let board_index_before = m.board_index.clone();
 
         let new_sprint = Sprint::new(board_live.id, 2, None, None::<String>);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             sprints: Collection {
                 all: LoadState::Loaded(vec![sprint, new_sprint]),
                 ..Default::default()
@@ -479,7 +485,7 @@ mod tests {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Col", 0);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             columns: vec![column],
             archived_boards: Vec::new(),
@@ -487,7 +493,7 @@ mod tests {
         });
 
         let err = Arc::new(KanbanError::unsupported("boom"));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             columns: Collection {
                 all: LoadState::Failed(Arc::clone(&err)),
                 ..Default::default()
@@ -510,7 +516,7 @@ mod tests {
 
         let mut by_id = HashMap::new();
         by_id.insert(x_id, LoadState::Loaded(x));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::NotLoaded,
                 by_id,
@@ -530,7 +536,7 @@ mod tests {
         let (mut m, board, column, sprint, card_a, card_b) = seed_full_model();
         let err = Arc::new(KanbanError::unsupported("boom"));
 
-        m.mark_failed(EntityIds::default(), err);
+        let _ = m.mark_failed(EntityIds::default(), err);
 
         assert!(m.boards_state().is_loaded());
         assert_eq!(m.boards_state().loaded().unwrap(), &vec![board]);
@@ -551,13 +557,13 @@ mod tests {
         let mut m = Model::default();
         assert!(m.graph_state().is_not_loaded());
 
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             graph: LoadState::Loaded(DependencyGraph::default()),
             ..Default::default()
         });
         assert!(m.graph_state().is_loaded());
 
-        m.apply_resolved(Resolved::default());
+        let _ = m.apply_resolved(Resolved::default());
         assert!(m.graph_state().is_loaded());
     }
 
@@ -571,7 +577,7 @@ mod tests {
 
         let mut by_parent = HashMap::new();
         by_parent.insert(column.id, LoadState::Loaded(vec![a.clone(), b.clone()]));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_parent,
                 ..Default::default()
@@ -594,7 +600,7 @@ mod tests {
         let ghost = Uuid::new_v4();
         let mut by_id = HashMap::new();
         by_id.insert(ghost, LoadState::Missing);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_id,
                 ..Default::default()
@@ -616,7 +622,7 @@ mod tests {
         let x_id = x.id;
         let mut by_id = HashMap::new();
         by_id.insert(x_id, LoadState::Loaded(x.clone()));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_id,
                 ..Default::default()
@@ -634,7 +640,7 @@ mod tests {
         let ghost = Uuid::new_v4();
         let mut by_id = HashMap::new();
         by_id.insert(ghost, LoadState::Missing);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_id,
                 ..Default::default()
@@ -644,7 +650,7 @@ mod tests {
 
         let mut by_id2 = HashMap::new();
         by_id2.insert(ghost, LoadState::NotLoaded);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_id: by_id2,
                 ..Default::default()
@@ -662,7 +668,7 @@ mod tests {
 
         let mut by_parent = HashMap::new();
         by_parent.insert(column.id, LoadState::Loaded(vec![third.clone()]));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_parent,
                 ..Default::default()
@@ -689,7 +695,7 @@ mod tests {
         let other_col = Uuid::new_v4();
         let mut by_parent = HashMap::new();
         by_parent.insert(col, LoadState::Loaded(Vec::<Card>::new()));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_parent,
                 ..Default::default()
@@ -709,7 +715,7 @@ mod tests {
         let err = Arc::new(KanbanError::unsupported("boom"));
         let mut by_parent = HashMap::new();
         by_parent.insert(col, LoadState::Failed(Arc::clone(&err)));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_parent,
                 ..Default::default()
@@ -733,7 +739,7 @@ mod tests {
 
         let mut by_parent = HashMap::new();
         by_parent.insert(column.id, LoadState::Loaded(vec![a.clone()]));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_parent,
                 ..Default::default()
@@ -743,7 +749,7 @@ mod tests {
 
         let mut by_parent2 = HashMap::new();
         by_parent2.insert(column.id, LoadState::NotLoaded);
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_parent: by_parent2,
                 ..Default::default()
@@ -771,7 +777,7 @@ mod tests {
         let mut sprints_by_parent = HashMap::new();
         sprints_by_parent.insert(board.id, LoadState::Loaded(vec![sprint.clone()]));
 
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             columns: Collection {
                 by_parent: columns_by_parent,
                 ..Default::default()
@@ -826,7 +832,7 @@ mod tests {
 
         let mut by_parent = HashMap::new();
         by_parent.insert(column.id, LoadState::Loaded(vec![y.clone()]));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::Loaded(vec![x.clone()]),
                 by_parent,
@@ -853,7 +859,7 @@ mod tests {
 
         let mut by_id = HashMap::new();
         by_id.insert(x_v1.id, LoadState::Loaded(x_v2));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_id,
                 ..Default::default()
@@ -861,7 +867,7 @@ mod tests {
             ..Default::default()
         });
 
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::Loaded(vec![x_v1]),
                 ..Default::default()
@@ -892,7 +898,7 @@ mod tests {
             column_x.id,
             LoadState::Loaded(vec![card_a.clone(), card_b.clone()]),
         );
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_parent,
                 ..Default::default()
@@ -923,7 +929,7 @@ mod tests {
             column_x.id,
             LoadState::Loaded(vec![card_a.clone(), card_b.clone()]),
         );
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_parent,
                 ..Default::default()
@@ -975,7 +981,7 @@ mod tests {
         let mut sprints_by_parent = HashMap::new();
         sprints_by_parent.insert(board.id, LoadState::Loaded(vec![sprint.clone()]));
 
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             columns: Collection {
                 by_id: columns_by_id,
                 by_parent: columns_by_parent,
@@ -994,7 +1000,7 @@ mod tests {
             ..Default::default()
         });
 
-        m.load_from_snapshot(Snapshot::default());
+        let _ = m.load_from_snapshot(Snapshot::default());
 
         assert!(m.board_columns_state(board.id).is_not_loaded());
         assert!(m.column_cards_state(column.id).is_not_loaded());
@@ -1017,7 +1023,7 @@ mod tests {
         cards_by_id.insert(card.id, LoadState::Loaded(card.clone()));
         let mut sprints_by_parent = HashMap::new();
         sprints_by_parent.insert(board.id, LoadState::Loaded(vec![sprint.clone()]));
-        m.apply_resolved(Resolved {
+        let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_id: cards_by_id,
                 ..Default::default()
@@ -1030,7 +1036,7 @@ mod tests {
         });
 
         let err = Arc::new(KanbanError::unsupported("boom"));
-        m.mark_failed(EntityIds::cards([card.id]), Arc::clone(&err));
+        let _ = m.mark_failed(EntityIds::cards([card.id]), Arc::clone(&err));
 
         match m.column_cards_state(column.id) {
             LoadState::Failed(e) => assert!(Arc::ptr_eq(&e, &err)),
@@ -1052,7 +1058,7 @@ mod tests {
 
         m.set_cards_of_column(column.id, LoadState::Loaded(vec![a.clone()]));
         let err = Arc::new(KanbanError::unsupported("boom"));
-        m.mark_failed(EntityIds::cards([a.id]), err);
+        let _ = m.mark_failed(EntityIds::cards([a.id]), err);
 
         assert!(!m.card_by_id_state(a.id).is_loaded());
     }

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -186,8 +186,40 @@ impl Model {
 mod tests {
     use super::super::*;
     use crate::resolved::Collection;
-    use crate::{ArchivedCard, EntityIds, KanbanError, Resolved};
+    use crate::{ArchivedCard, EntityIds, KanbanError, NoProjections, Resolved};
     use std::sync::Arc;
+
+    #[test]
+    fn test_apply_resolved_returns_a_model_changed_receipt() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let card = Card::new(board.id, column.id, "task", 0);
+        let resolved = Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![card]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let changed: ModelChanged = m.apply_resolved(resolved);
+        assert_eq!(m.cards_state().loaded_or_empty().len(), 1);
+        NoProjections.resync(&m, changed);
+    }
+
+    #[test]
+    fn test_mark_failed_returns_a_model_changed_receipt() {
+        let mut m = Model::default();
+        let card_id = Uuid::new_v4();
+        let ids = EntityIds {
+            cards: [card_id].into_iter().collect(),
+            ..Default::default()
+        };
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        let changed: ModelChanged = m.mark_failed(ids, err);
+        assert!(m.cards_state().is_failed());
+        NoProjections.resync(&m, changed);
+    }
 
     fn seed_card(board: &Board, column_id: Uuid) -> Card {
         Card::new(board.id, column_id, "task", 0)

--- a/crates/kanban-domain/src/model/boards.rs
+++ b/crates/kanban-domain/src/model/boards.rs
@@ -73,7 +73,7 @@ mod tests {
         let archived = Board::new("Archived", None::<String>);
         let live_id = live.id;
         let archived_id = archived.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             // snapshot.boards carries BOTH heads; the marker names the archived one.
             boards: vec![live.clone(), archived.clone()],
             archived_boards: vec![Archived::now(archived_id)],
@@ -112,7 +112,7 @@ mod tests {
         let archived = Board::new("Archived", None::<String>);
         let live_id = live.id;
         let archived_id = archived.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![live.clone(), archived.clone()],
             archived_boards: vec![Archived::now(archived_id)],
             ..Default::default()
@@ -139,7 +139,7 @@ mod tests {
         let archived = Board::new("Archived", None::<String>);
         let live_id = live.id;
         let archived_id = archived.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![live.clone(), archived.clone()],
             archived_boards: vec![Archived::now(archived_id)],
             ..Default::default()
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn test_board_by_id_missing_id_returns_none() {
         let mut m = Model::default();
-        m.load_from_snapshot(Snapshot::default());
+        let _ = m.load_from_snapshot(Snapshot::default());
         assert!(m
             .board_by_id_state(Uuid::new_v4())
             .loaded()
@@ -176,7 +176,7 @@ mod tests {
     #[test]
     fn test_boards_state_is_loaded_and_empty_after_an_empty_snapshot() {
         let mut m = Model::default();
-        m.load_from_snapshot(Snapshot::default());
+        let _ = m.load_from_snapshot(Snapshot::default());
         assert!(m.boards_state().is_loaded());
         assert!(m.boards_state().loaded().unwrap().is_empty());
         assert!(m.boards_state().loaded_or_empty().is_empty());
@@ -194,7 +194,7 @@ mod tests {
     fn test_board_by_id_state_is_missing_for_an_absent_board_after_load() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             ..Default::default()
         });
@@ -209,7 +209,7 @@ mod tests {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let board_id = board.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             ..Default::default()
         });
@@ -225,7 +225,7 @@ mod tests {
         let live = Board::new("Live", None::<String>);
         let archived = Board::new("Archived", None::<String>);
         let archived_id = archived.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![live, archived],
             archived_boards: vec![Archived::now(archived_id)],
             ..Default::default()

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -101,7 +101,7 @@ mod tests {
         let card_a = make_card(&board, col_id);
         let card_b = make_card(&board, col_id);
         let card_b_id = card_b.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             cards: vec![card_a, card_b],
             ..Default::default()
@@ -122,7 +122,7 @@ mod tests {
         let archived = make_card(&board, col_id);
         let live_id = live.id;
         let archived_id = archived.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             cards: vec![live, archived],
             archived_cards: vec![ArchivedCard::new(archived_id, uuid::Uuid::nil())],
@@ -161,7 +161,7 @@ mod tests {
         let live = make_card(&board, col_id);
         let archived = make_card(&board, col_id);
         let archived_id = archived.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             cards: vec![live, archived],
             archived_cards: vec![ArchivedCard::new(archived_id, uuid::Uuid::nil())],
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn test_cards_state_is_loaded_and_empty_after_an_empty_snapshot() {
         let mut m = Model::default();
-        m.load_from_snapshot(Snapshot::default());
+        let _ = m.load_from_snapshot(Snapshot::default());
         assert!(m.cards_state().is_loaded());
         assert!(m.cards_state().loaded().unwrap().is_empty());
         assert!(m.cards_state().loaded_or_empty().is_empty());
@@ -217,7 +217,7 @@ mod tests {
         let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
         let card = make_card(&board, col_id);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             cards: vec![card],
             ..Default::default()
@@ -236,7 +236,7 @@ mod tests {
         let first = make_card(&board, col_id);
         let second = make_card(&board, col_id);
         let second_id = second.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             cards: vec![first, second],
             ..Default::default()
@@ -254,7 +254,7 @@ mod tests {
         let live = make_card(&board, col_id);
         let archived = make_card(&board, col_id);
         let archived_id = archived.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             cards: vec![live, archived],
             archived_cards: vec![ArchivedCard::new(archived_id, uuid::Uuid::nil())],

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -1,7 +1,35 @@
+use super::Model;
+
+#[derive(Debug)]
+#[must_use = "derived projections are stale until resync consumes this"]
+pub struct ModelChanged(());
+
+#[allow(clippy::new_without_default)]
+impl ModelChanged {
+    pub(crate) fn new() -> Self {
+        Self(())
+    }
+
+    pub fn merge(self, _other: Self) -> Self {
+        self
+    }
+}
+
+pub trait DerivedProjections {
+    fn resync(&mut self, model: &Model, changed: ModelChanged);
+}
+
+#[derive(Debug, Default)]
+pub struct NoProjections;
+
+impl DerivedProjections for NoProjections {
+    fn resync(&mut self, _model: &Model, _changed: ModelChanged) {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::Model;
-    use crate::{DerivedProjections, ModelChanged, NoProjections, Snapshot};
+    use crate::{DerivedProjections, NoProjections, Snapshot};
 
     #[test]
     fn test_merge_folds_two_receipts_into_one() {

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -42,7 +42,10 @@ mod tests {
 
     #[test]
     fn test_model_changed_keeps_its_must_use_attribute_and_private_field() {
-        let prod = include_str!("changed.rs").split("#[cfg(test)]").next().unwrap();
+        let prod = include_str!("changed.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .unwrap();
         assert!(prod.contains(
             "#[must_use = \"derived projections are stale until resync consumes this\"]"
         ));

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -1,5 +1,8 @@
 use super::Model;
 
+/// Proof that a `Model` mutation happened and that whatever derives from it has
+/// not been recomputed yet. Minted only by the `Model` mutators, since the field
+/// is private, and consumed by a `DerivedProjections` implementor.
 #[derive(Debug)]
 #[must_use = "derived projections are stale until resync consumes this"]
 pub struct ModelChanged(());
@@ -9,15 +12,27 @@ impl ModelChanged {
         Self(())
     }
 
+    /// Folds two receipts into one so a caller performing several mutations
+    /// resyncs once instead of discarding the extras.
     pub fn merge(self, _other: Self) -> Self {
         self
     }
 }
 
+/// State an application derives from a `Model` and must recompute whenever the
+/// `Model` changes. Implemented where the derived state actually lives, so no
+/// layer below it has to name the implementor.
 pub trait DerivedProjections {
+    /// Recompute everything derived from `model`. Consumes the receipt, so this
+    /// cannot be called without a mutation having produced one.
     fn resync(&mut self, model: &Model, changed: ModelChanged);
 }
 
+/// For a path that derives nothing from the `Model`, so nothing can go stale:
+/// a one-shot command that renders straight from the `Model` and keeps nothing,
+/// or a test fixture. Recomputing nothing is the complete behaviour there, not
+/// a stub. Most applications hold real derived state and implement the trait
+/// over their own projection type instead.
 #[derive(Debug, Default)]
 pub struct NoProjections;
 

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -4,7 +4,6 @@ use super::Model;
 #[must_use = "derived projections are stale until resync consumes this"]
 pub struct ModelChanged(());
 
-#[allow(clippy::new_without_default)]
 impl ModelChanged {
     pub(crate) fn new() -> Self {
         Self(())

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -1,0 +1,49 @@
+#[cfg(test)]
+mod tests {
+    use super::super::Model;
+    use crate::{DerivedProjections, ModelChanged, NoProjections, Snapshot};
+
+    #[test]
+    fn test_merge_folds_two_receipts_into_one() {
+        let mut m = Model::default();
+        let a = m.load_from_snapshot(Snapshot::default());
+        let b = m.load_from_snapshot(Snapshot::default());
+        let merged = a.merge(b);
+        NoProjections.resync(&m, merged);
+    }
+
+    #[test]
+    fn test_model_changed_keeps_its_must_use_attribute_and_private_field() {
+        let prod = include_str!("changed.rs").split("#[cfg(test)]").next().unwrap();
+        assert!(prod.contains(
+            "#[must_use = \"derived projections are stale until resync consumes this\"]"
+        ));
+        assert!(prod.contains("pub struct ModelChanged(());"));
+    }
+
+    #[test]
+    fn test_no_projections_is_a_usable_derived_projections_substitute() {
+        use crate::{Board, Card, Column};
+
+        fn drive(p: &mut impl DerivedProjections, m: &mut Model) {
+            let board = Board::new("B", None::<String>);
+            let col = Column::new(board.id, "Col", 0);
+            let card = Card::new(board.id, col.id, "task", 0);
+            let changed = m.load_from_snapshot(Snapshot {
+                boards: vec![board],
+                columns: vec![col],
+                cards: vec![card],
+                archived_boards: Vec::new(),
+                ..Default::default()
+            });
+            p.resync(m, changed);
+        }
+
+        let mut m = Model::default();
+        let mut p = NoProjections;
+        drive(&mut p, &mut m);
+
+        assert!(m.cards_state().is_loaded());
+        assert_eq!(m.cards_state().loaded_or_empty().len(), 1);
+    }
+}

--- a/crates/kanban-domain/src/model/collections.rs
+++ b/crates/kanban-domain/src/model/collections.rs
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn test_columns_state_is_loaded_and_empty_after_an_empty_snapshot() {
         let mut m = Model::default();
-        m.load_from_snapshot(Snapshot::default());
+        let _ = m.load_from_snapshot(Snapshot::default());
         assert!(m.columns_state().is_loaded());
         assert!(m.columns_state().loaded().unwrap().is_empty());
         assert!(m.columns().is_empty());
@@ -110,7 +110,7 @@ mod tests {
         let board = Board::new("B", None::<String>);
         let col = Column::new(board.id, "Col", 0);
         let col_id = col.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             columns: vec![col],
             ..Default::default()
@@ -132,7 +132,7 @@ mod tests {
         let board = Board::new("B", None::<String>);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let sprint_id = sprint.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             sprints: vec![sprint],
             ..Default::default()

--- a/crates/kanban-domain/src/model/graph.rs
+++ b/crates/kanban-domain/src/model/graph.rs
@@ -25,7 +25,7 @@ mod tests {
     #[test]
     fn test_graph_state_is_loaded_after_load_from_snapshot() {
         let mut m = Model::default();
-        m.load_from_snapshot(Snapshot::default());
+        let _ = m.load_from_snapshot(Snapshot::default());
         assert!(m.graph_state().is_loaded());
     }
 

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -71,7 +71,10 @@ fn scoped_state<T>(map: &HashMap<Uuid, LoadState<Vec<T>>>, parent: Uuid) -> Load
 }
 
 impl Model {
-    pub fn load_from_snapshot(&mut self, snapshot: Snapshot) {
+    /// Returns a [`ModelChanged`] receipt: whatever derives from this
+    /// `Model` is stale until a [`DerivedProjections`] implementor consumes
+    /// it.
+    pub fn load_from_snapshot(&mut self, snapshot: Snapshot) -> ModelChanged {
         // Reference-marker model: `snapshot.cards`/`snapshot.boards` each carry
         // EVERY row — live AND archived — with archival recorded by markers
         // keyed by `entity_id`. One collection holds all rows and an id set
@@ -99,6 +102,8 @@ impl Model {
 
         self.rebuild_card_index();
         self.rebuild_board_index();
+
+        ModelChanged::new()
     }
 
     fn absorb_archival_markers(
@@ -172,7 +177,7 @@ mod tests {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let col = Column::new(board.id, "Col", 0);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             boards: vec![board.clone()],
             columns: vec![col.clone()],
@@ -188,7 +193,7 @@ mod tests {
     fn test_load_from_snapshot_overwrites_previous_state() {
         let mut m = Model::default();
         let board_a = Board::new("A", None::<String>);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             boards: vec![board_a],
             ..Default::default()
@@ -197,7 +202,7 @@ mod tests {
 
         let board_b = Board::new("B", None::<String>);
         let board_c = Board::new("C", None::<String>);
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             boards: vec![board_b, board_c],
             ..Default::default()
@@ -213,7 +218,7 @@ mod tests {
         let col_id = Uuid::new_v4();
         let card = make_card(&board, col_id);
         let old_id = card.id;
-        m.load_from_snapshot(Snapshot {
+        let _ = m.load_from_snapshot(Snapshot {
             archived_boards: Vec::new(),
             cards: vec![card],
             ..Default::default()
@@ -221,7 +226,7 @@ mod tests {
         assert!(m.card_by_id_state(old_id).loaded().copied().is_some());
 
         // Reload with no cards — stale index entry must be gone
-        m.load_from_snapshot(Snapshot::default());
+        let _ = m.load_from_snapshot(Snapshot::default());
         assert!(m.card_by_id_state(old_id).loaded().copied().is_none());
     }
 

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -3,6 +3,16 @@ use crate::{
 };
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
+
+/// The unified, per-Model view of every entity kind's flat, per-id and
+/// parent-scoped tiers, chained by precedence in accessors like
+/// `card_by_id_state`. This differs from [`crate::resolved::Collection`],
+/// whose three tiers stay mutually independent so that a resolve pass can
+/// touch one tier without silently inferring another: a `Model` accessor
+/// answers "what do we know about this id, from any source", while a
+/// `Collection` answers "what did this specific resolve pass say about this
+/// tier", and conflating the two would let an archived-excluding tier
+/// silently mark an id `Missing` that another tier still holds.
 pub struct Model {
     boards: LoadState<Vec<Board>>,
     columns: LoadState<Vec<Column>>,

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -136,8 +136,11 @@ impl Model {
 mod apply;
 mod boards;
 mod cards;
+mod changed;
 mod collections;
 mod graph;
+
+pub use changed::{DerivedProjections, ModelChanged, NoProjections};
 
 #[cfg(any(test, feature = "test-helpers"))]
 mod test_helpers;
@@ -220,6 +223,14 @@ mod tests {
         // Reload with no cards — stale index entry must be gone
         m.load_from_snapshot(Snapshot::default());
         assert!(m.card_by_id_state(old_id).loaded().copied().is_none());
+    }
+
+    #[test]
+    fn test_load_from_snapshot_returns_a_model_changed_receipt() {
+        let mut m = Model::default();
+        let changed: ModelChanged = m.load_from_snapshot(Snapshot::default());
+        assert!(m.cards_state().is_loaded());
+        NoProjections.resync(&m, changed);
     }
 
     #[test]

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -1,6 +1,9 @@
 use super::{App, AppMode};
 use crate::view_strategy::UnifiedViewStrategy;
-use kanban_domain::{filter_and_sort_boards, Board, BoardListFilter, Card, KanbanResult, Snapshot};
+use kanban_domain::{
+    filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, KanbanResult,
+    Snapshot,
+};
 use kanban_view::view_strategy::{ViewRefreshContext, ViewStrategy};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -76,8 +79,8 @@ impl App {
     /// partitions. Every snapshot load in this crate goes through here so the
     /// partitions can never lag the model.
     pub fn load_snapshot(&mut self, snapshot: Snapshot) {
-        self.model.load_from_snapshot(snapshot);
-        self.controller.sync(&self.model);
+        let changed = self.model.load_from_snapshot(snapshot);
+        self.controller.resync(&self.model, changed);
     }
 
     /// Reload the whole view model from the store. I/O. Call after a mutation,

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -43,7 +43,7 @@ fn test_load_from_snapshot_populates_all_fields() {
         prefixes: Vec::new(),
     };
 
-    model.load_from_snapshot(snapshot);
+    let _ = model.load_from_snapshot(snapshot);
 
     assert_eq!(model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(model.boards_state().loaded_or_empty()[0].name, "Board1");
@@ -66,7 +66,7 @@ fn test_card_lookup_by_id() {
     let id1 = card1.id;
     let id2 = card2.id;
 
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card1, card2],
         ..Default::default()
@@ -88,7 +88,7 @@ fn test_card_lookup_missing_id_returns_none() {
 
     let board = Board::new("B", None::<String>);
     let card = make_card(&board, Uuid::new_v4(), "Exists", 0);
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card],
         ..Default::default()
@@ -110,7 +110,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
     let card_a = make_card(&board, column_id, "A", 0);
     let id_a = card_a.id;
 
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card_a],
         ..Default::default()
@@ -119,7 +119,7 @@ fn test_load_from_snapshot_rebuilds_card_index() {
 
     let card_b = make_card(&board, column_id, "B", 0);
     let id_b = card_b.id;
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card_b],
         ..Default::default()
@@ -165,7 +165,7 @@ fn test_archived_cards_resolve_from_unified_collection() {
     let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
     let ac2 = ArchivedCard::new(card2.id, uuid::Uuid::nil());
 
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card1, card2],
         archived_cards: vec![ac1, ac2],
@@ -184,7 +184,7 @@ fn test_archived_id_set_rebuilds_on_reload() {
 
     let card1 = make_card(&board, column_id, "First", 0);
     let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card1],
         archived_cards: vec![ac1],
@@ -196,7 +196,7 @@ fn test_archived_id_set_rebuilds_on_reload() {
     let card3 = make_card(&board, column_id, "Third", 1);
     let ac2 = ArchivedCard::new(card2.id, uuid::Uuid::nil());
     let ac3 = ArchivedCard::new(card3.id, uuid::Uuid::nil());
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card2, card3],
         archived_cards: vec![ac2, ac3],
@@ -223,7 +223,7 @@ fn test_card_by_id_resolves_archived_card() {
     let ac1 = ArchivedCard::new(card1.id, uuid::Uuid::nil());
     let ac2 = ArchivedCard::new(card2.id, uuid::Uuid::nil());
 
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card1, card2],
         archived_cards: vec![ac1, ac2],
@@ -251,7 +251,7 @@ fn test_card_by_id_missing_returns_none() {
     let card = make_card(&board, column_id, "Archived", 0);
     let ac = ArchivedCard::new(card.id, uuid::Uuid::nil());
 
-    model.load_from_snapshot(Snapshot {
+    let _ = model.load_from_snapshot(Snapshot {
         archived_boards: Vec::new(),
         cards: vec![card],
         archived_cards: vec![ac],

--- a/crates/kanban-view/src/controller/board_sort.rs
+++ b/crates/kanban-view/src/controller/board_sort.rs
@@ -71,7 +71,7 @@ impl Controller {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kanban_domain::{Archived, Board, Model, Snapshot};
+    use kanban_domain::{Archived, Board, DerivedProjections, Model, Snapshot};
     use uuid::Uuid;
 
     fn seed_two_archived_boards(m: &mut Model, c: &mut Controller) -> (Uuid, Uuid) {
@@ -90,7 +90,7 @@ mod tests {
         let t_new = chrono::DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        m.load_from_snapshot(Snapshot {
+        let changed = m.load_from_snapshot(Snapshot {
             boards: vec![first, second],
             archived_boards: vec![
                 Archived::at(first_id, t_old),
@@ -98,7 +98,7 @@ mod tests {
             ],
             ..Default::default()
         });
-        c.sync(m);
+        c.resync(m, changed);
         (first_id, second_id)
     }
 
@@ -152,12 +152,12 @@ mod tests {
         second.position = 1;
         let first_id = first.id;
         let second_id = second.id;
-        m.load_from_snapshot(Snapshot {
+        let changed = m.load_from_snapshot(Snapshot {
             boards: vec![second, first],
             archived_boards: vec![],
             ..Default::default()
         });
-        c.sync(&m);
+        c.resync(&m, changed);
         let live: Vec<Uuid> = c.displayed_boards(false).iter().map(|b| b.id).collect();
         assert_eq!(
             live,
@@ -226,12 +226,12 @@ mod tests {
         alpha.position = 1;
         let zed_id = zed.id;
         let alpha_id = alpha.id;
-        m.load_from_snapshot(Snapshot {
+        let changed = m.load_from_snapshot(Snapshot {
             boards: vec![zed, alpha],
             archived_boards: vec![],
             ..Default::default()
         });
-        c.sync(&m);
+        c.resync(&m, changed);
 
         c.set_board_sort(false, BoardSortField::Name, SortOrder::Ascending);
         let live: Vec<Uuid> = c.displayed_boards(false).iter().map(|b| b.id).collect();

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -257,6 +257,70 @@ mod tests {
     }
 
     #[test]
+    fn test_a_projections_implementor_cannot_mint_a_receipt() {
+        let src = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../kanban-domain/src/model/changed.rs"
+        ))
+        .expect("kanban-domain changed.rs must be readable");
+        let prod = src.split("#[cfg(test)]").next().unwrap();
+        assert!(prod.contains("pub(crate) fn new()"));
+        assert!(!prod.contains("pub fn new("));
+        assert!(!prod.contains("derive(Debug, Default)"));
+    }
+
+    #[test]
+    fn test_resync_consumes_the_receipt_from_apply_resolved() {
+        let board = seed_board("B", 0);
+        let column = Column::new(board.id, "Col", 0);
+        let live = Card::new(board.id, column.id, "live", 0);
+        let archived = Card::new(board.id, column.id, "archived", 1);
+        let live_id = live.id;
+        let archived_id = archived.id;
+        let mut model = Model::default();
+        let changed = model.load_from_snapshot(Snapshot {
+            boards: vec![board.clone()],
+            columns: vec![column.clone()],
+            cards: vec![live, archived],
+            archived_cards: vec![ArchivedCard::new(archived_id, Uuid::nil())],
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model, changed);
+        assert_eq!(controller.displayed_cards(false).len(), 1);
+
+        let mut live_edited = Card::new(board.id, column.id, "live edited", 0);
+        live_edited.id = live_id;
+        let mut archived_edited = Card::new(board.id, column.id, "archived edited", 1);
+        archived_edited.id = archived_id;
+        let extra = Card::new(board.id, column.id, "extra", 2);
+        let extra_id = extra.id;
+
+        let changed = model.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![live_edited, archived_edited, extra]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        controller.resync(&model, changed);
+
+        let live_ids: Vec<Uuid> = controller
+            .displayed_cards(false)
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        let archived_ids: Vec<Uuid> = controller
+            .displayed_cards(true)
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(live_ids, vec![live_id, extra_id]);
+        assert_eq!(archived_ids, vec![archived_id]);
+    }
+
+    #[test]
     fn test_a_controller_that_was_never_synced_has_empty_partitions() {
         let board = seed_board("B", 0);
         let column = Column::new(board.id, "Col", 0);

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use kanban_domain::{
-    Board, BoardSortField, Card, Model, SortOrder, DEFAULT_ARCHIVED_BOARD_SORT,
-    DEFAULT_BOARD_SORT_LIVE,
+    Board, BoardSortField, Card, DerivedProjections, Model, ModelChanged, SortOrder,
+    DEFAULT_ARCHIVED_BOARD_SORT, DEFAULT_BOARD_SORT_LIVE,
 };
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -15,7 +15,7 @@ mod partitions;
 #[derive(Debug)]
 pub struct Controller {
     // Live/archived partitions of the Model's unified `cards`/`boards`
-    // collections, computed ONCE in `sync` and served as a borrow by
+    // collections, computed ONCE in `resync` and served as a borrow by
     // `displayed_cards`/`displayed_boards`. This is the concrete
     // no-per-frame-recompute fix: the projects/tasks panels borrow the cached
     // subset every redraw instead of re-filtering+cloning per frame.
@@ -24,7 +24,7 @@ pub struct Controller {
     displayed_boards_live: Vec<Board>,
     displayed_boards_archived: Vec<Board>,
     // archived_at timestamps keyed by board id, REBUILT from the Model's
-    // archival markers on every `sync`. The board head does NOT carry
+    // archival markers on every `resync`. The board head does NOT carry
     // archived_at (it stays live under the reference-marker model), so recency
     // sorting needs this side map.
     archived_board_at: HashMap<Uuid, DateTime<Utc>>,
@@ -56,12 +56,8 @@ impl Default for Controller {
     }
 }
 
-impl Controller {
-    /// Recompute every derived partition and the archived-at map from `model`.
-    /// Call after anything that changes the Model's boards, cards or archival
-    /// markers; the partitions are borrowed every redraw, so they are rebuilt
-    /// here and never per frame.
-    pub fn sync(&mut self, model: &Model) {
+impl DerivedProjections for Controller {
+    fn resync(&mut self, model: &Model, _changed: ModelChanged) {
         self.archived_board_at = model
             .archived_boards()
             .iter()
@@ -70,11 +66,14 @@ impl Controller {
         self.rebuild_card_partitions(model);
         self.rebuild_board_partitions(model);
     }
+}
 
+impl Controller {
     /// The cards the tasks panel should display, selected by `want_archived`:
     /// the archived subset when a confirm dialog / the archived-cards view is
     /// active, the live subset otherwise. Returns a BORROW of the partition
-    /// cached on the last [`sync`](Self::sync) — no per-frame filter or clone.
+    /// cached on the last [`resync`](kanban_domain::DerivedProjections::resync)
+    /// — no per-frame filter or clone.
     pub fn displayed_cards(&self, want_archived: bool) -> &[Card] {
         if want_archived {
             &self.displayed_cards_archived
@@ -85,7 +84,7 @@ impl Controller {
 
     /// The boards the projects panel should display, selected by
     /// `want_archived`. Borrow of the partition cached on
-    /// [`sync`](Self::sync); the mode decision (live vs archived) lives at the
+    /// [`resync`](kanban_domain::DerivedProjections::resync); the mode decision (live vs archived) lives at the
     /// `App` accessor, which passes the stack-aware base mode in.
     pub fn displayed_boards(&self, want_archived: bool) -> &[Board] {
         if want_archived {
@@ -151,7 +150,7 @@ mod tests {
         let archived = Card::new(board.id, column.id, "archived", 1);
         let (live_id, archived_id) = (live.id, archived.id);
         let mut model = Model::default();
-        model.load_from_snapshot(Snapshot {
+        let changed = model.load_from_snapshot(Snapshot {
             boards: vec![board],
             columns: vec![column],
             cards: vec![live, archived],
@@ -160,7 +159,7 @@ mod tests {
             ..Default::default()
         });
         let mut controller = Controller::default();
-        controller.sync(&model);
+        controller.resync(&model, changed);
 
         let live_ids: Vec<Uuid> = controller
             .displayed_cards(false)
@@ -182,13 +181,13 @@ mod tests {
         let archived = seed_board("Archived", 1);
         let (live_id, archived_id) = (live.id, archived.id);
         let mut model = Model::default();
-        model.load_from_snapshot(Snapshot {
+        let changed = model.load_from_snapshot(Snapshot {
             boards: vec![live, archived],
             archived_boards: vec![archived_board_marker(archived_id, "2026-01-01T00:00:00Z")],
             ..Default::default()
         });
         let mut controller = Controller::default();
-        controller.sync(&model);
+        controller.resync(&model, changed);
 
         let live_ids: Vec<Uuid> = controller
             .displayed_boards(false)
@@ -213,7 +212,7 @@ mod tests {
         let live_id = live.id;
         let archived_id = archived.id;
         let mut model = Model::default();
-        model.load_from_snapshot(Snapshot {
+        let changed = model.load_from_snapshot(Snapshot {
             boards: vec![board.clone()],
             columns: vec![column.clone()],
             cards: vec![live, archived],
@@ -222,7 +221,7 @@ mod tests {
             ..Default::default()
         });
         let mut controller = Controller::default();
-        controller.sync(&model);
+        controller.resync(&model, changed);
         assert_eq!(controller.displayed_cards(false).len(), 1);
 
         let mut live_edited = Card::new(board.id, column.id, "live edited", 0);
@@ -232,14 +231,14 @@ mod tests {
         let extra = Card::new(board.id, column.id, "extra", 2);
         let extra_id = extra.id;
 
-        model.apply_resolved(Resolved {
+        let changed = model.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::Loaded(vec![live_edited, archived_edited, extra]),
                 ..Default::default()
             },
             ..Default::default()
         });
-        controller.sync(&model);
+        controller.resync(&model, changed);
 
         let live_ids: Vec<Uuid> = controller
             .displayed_cards(false)
@@ -264,9 +263,10 @@ mod tests {
         ))
         .expect("kanban-domain changed.rs must be readable");
         let prod = src.split("#[cfg(test)]").next().unwrap();
+        let model_changed_block = prod.split("pub struct ModelChanged").next().unwrap();
         assert!(prod.contains("pub(crate) fn new()"));
         assert!(!prod.contains("pub fn new("));
-        assert!(!prod.contains("derive(Debug, Default)"));
+        assert!(!model_changed_block.contains("derive(Debug, Default)"));
     }
 
     #[test]
@@ -326,7 +326,7 @@ mod tests {
         let column = Column::new(board.id, "Col", 0);
         let card = Card::new(board.id, column.id, "live", 0);
         let mut model = Model::default();
-        model.load_from_snapshot(Snapshot {
+        let _ = model.load_from_snapshot(Snapshot {
             boards: vec![board],
             columns: vec![column],
             cards: vec![card],
@@ -345,7 +345,7 @@ mod tests {
         let card_a = Card::new(board.id, column.id, "a", 0);
         let card_b = Card::new(board.id, column.id, "b", 1);
         let mut model = Model::default();
-        model.load_from_snapshot(Snapshot {
+        let changed = model.load_from_snapshot(Snapshot {
             boards: vec![board.clone()],
             columns: vec![column.clone()],
             cards: vec![card_a.clone()],
@@ -353,17 +353,17 @@ mod tests {
             ..Default::default()
         });
         let mut controller = Controller::default();
-        controller.sync(&model);
+        controller.resync(&model, changed);
         assert_eq!(controller.displayed_cards(false).len(), 1);
 
-        model.load_from_snapshot(Snapshot {
+        let changed = model.load_from_snapshot(Snapshot {
             boards: vec![board],
             columns: vec![column],
             cards: vec![card_a, card_b],
             archived_boards: Vec::new(),
             ..Default::default()
         });
-        controller.sync(&model);
+        controller.resync(&model, changed);
         assert_eq!(controller.displayed_cards(false).len(), 2);
     }
 
@@ -373,7 +373,7 @@ mod tests {
         let second = seed_board("Second", 1);
         let (first_id, second_id) = (first.id, second.id);
         let mut model = Model::default();
-        model.load_from_snapshot(Snapshot {
+        let changed = model.load_from_snapshot(Snapshot {
             boards: vec![first, second],
             archived_boards: vec![
                 archived_board_marker(first_id, "2026-01-01T00:00:00Z"),
@@ -382,7 +382,7 @@ mod tests {
             ..Default::default()
         });
         let mut controller = Controller::default();
-        controller.sync(&model);
+        controller.resync(&model, changed);
 
         let order: Vec<Uuid> = controller.archived_boards_view().map(|b| b.id).collect();
         assert_eq!(order, vec![second_id, first_id]);

--- a/crates/kanban-view/src/panel_titles.rs
+++ b/crates/kanban-view/src/panel_titles.rs
@@ -120,7 +120,7 @@ mod tests {
             .collect();
 
         let mut model = Model::default();
-        model.load_from_snapshot(Snapshot::from_data(
+        let _ = model.load_from_snapshot(Snapshot::from_data(
             vec![board.clone()],
             vec![],
             vec![],


### PR DESCRIPTION
## Summary

- Adds a zero-sized, `#[must_use]`, privately-constructed `ModelChanged` receipt in `kanban-domain`, returned by `Model::apply_resolved`, `Model::mark_failed` and `Model::load_from_snapshot` instead of `()`.
- Adds a one-method `DerivedProjections` trait (`fn resync(&mut self, model: &Model, changed: ModelChanged)`) and a `NoProjections` no-op implementor for callers with nothing to derive.
- Replaces `kanban-view`'s inherent `Controller::sync` with `impl DerivedProjections for Controller`, body unchanged.
- Sweeps every call site: bound and handed to `resync` where a `sync` call followed, discarded with `let _ =` elsewhere.
- Adds the D5 doc comment on `Model` explaining why it chains its tiers by precedence while `Collection<T>` keeps them mutually independent.

Forgetting to recompute derived state after a `Model` mutation is now a lint error rather than a doc-comment plea.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p kanban-domain -p kanban-view -p kanban-tui --all-targets --all-features -- -D warnings`
- [x] `cargo test -p kanban-domain --all-features`
- [x] `cargo test -p kanban-view --all-features` (including `dependency_lock_tests`)
- [x] `cargo test -p kanban-tui --all-features`
- [x] Mutation check: removing the `#[must_use]` attribute on `ModelChanged` fails `test_model_changed_keeps_its_must_use_attribute_and_private_field`; reverted.
- [x] `git diff origin/develop...HEAD -- 'crates/*/Cargo.toml' 'Cargo.toml'` is empty
