### PR TITLE
KAN-1466 feat(service): implement LoadedState and LoadedEntities for Model

### DIFF
--- a/.changeset/kan-1466-model-loaded-state.md
+++ b/.changeset/kan-1466-model-loaded-state.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: `Model` now implements `LoadedState` and `LoadedEntities` from `kanban_service::fetch_plan`, so a `resolve` call can read fetch status and loaded columns directly off the domain `Model` instead of only off the `resolve`-internal `Overlay`.

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -18,6 +18,7 @@ mod cascade;
 pub mod config;
 mod context;
 pub mod fetch_plan;
+mod model_loaded;
 mod path;
 #[cfg(test)]
 mod read_recorder;

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -5,7 +5,7 @@ use kanban_domain::{Column, Model};
 use crate::fetch_plan::{FetchStatus, LoadedEntities, LoadedState};
 
 /// `column`/`card`/`sprint` read the per-id tier alone, never the composed
-/// `*_by_id_state` accessors: a composed read falls through to the flat
+/// three-tier accessors: a composed read falls through to the flat
 /// collection, whose `Loaded` arm answers `Missing` for any id it does not
 /// name, which would make a live-only card list's absence terminal to a
 /// fetch plan instead of leaving the id `NotLoaded`.

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -1,0 +1,108 @@
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use kanban_domain::resolved::Collection;
+    use kanban_domain::{Card, Column, KanbanError, LoadState, Model, Resolved};
+    use uuid::Uuid;
+
+    use crate::fetch_plan::{requestable, FetchStatus, LoadedEntities, LoadedState};
+
+    fn card_in(column_id: Uuid) -> Card {
+        Card::new(Uuid::new_v4(), column_id, "task", 0)
+    }
+
+    #[test]
+    fn test_the_fetch_status_of_a_card_absent_from_a_loaded_list_is_not_loaded() {
+        let column_id = Uuid::new_v4();
+        let card_a = card_in(column_id);
+        let b_id = Uuid::new_v4();
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![card_a]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(LoadedState::card(&model, b_id), FetchStatus::NotLoaded);
+    }
+
+    #[test]
+    fn test_a_missing_per_id_entry_reports_missing_to_a_plan() {
+        let b_id = Uuid::new_v4();
+        let mut model = Model::default();
+        let mut cards = Collection::<Card>::default();
+        cards.by_id.insert(b_id, LoadState::Missing);
+        let _ = model.apply_resolved(Resolved {
+            cards,
+            ..Default::default()
+        });
+
+        assert_eq!(LoadedState::card(&model, b_id), FetchStatus::Missing);
+        assert!(!requestable(LoadedState::card(&model, b_id)));
+    }
+
+    #[test]
+    fn test_the_list_status_and_the_scope_status_are_independent() {
+        let column_id = Uuid::new_v4();
+        let card = card_in(column_id);
+        let mut model = Model::default();
+        model.set_cards_of_column(column_id, LoadState::Loaded(vec![card]));
+
+        assert_eq!(LoadedState::card_list(&model), FetchStatus::NotLoaded);
+        assert_eq!(
+            LoadedState::cards_of_column(&model, column_id),
+            FetchStatus::Loaded
+        );
+    }
+
+    #[test]
+    fn test_loaded_columns_of_board_is_none_for_an_unfetched_scope_and_some_for_an_empty_one() {
+        let empty_board = Uuid::new_v4();
+        let unread_board = Uuid::new_v4();
+        let mut model = Model::default();
+        let mut columns = Collection::<Column>::default();
+        columns
+            .by_parent
+            .insert(empty_board, LoadState::Loaded(Vec::new()));
+        let _ = model.apply_resolved(Resolved {
+            columns,
+            ..Default::default()
+        });
+
+        assert!(matches!(
+            model.loaded_columns_of_board(empty_board),
+            Some(s) if s.is_empty()
+        ));
+        assert!(model.loaded_columns_of_board(unread_board).is_none());
+    }
+
+    #[test]
+    fn test_loaded_columns_of_board_is_none_for_a_failed_scope() {
+        let board_id = Uuid::new_v4();
+        let mut model = Model::default();
+        let mut columns = Collection::<Column>::default();
+        columns.by_parent.insert(
+            board_id,
+            LoadState::Failed(Arc::new(KanbanError::unsupported("boom"))),
+        );
+        let _ = model.apply_resolved(Resolved {
+            columns,
+            ..Default::default()
+        });
+
+        assert_eq!(
+            LoadedState::columns_of_board(&model, board_id),
+            FetchStatus::Failed
+        );
+        assert!(model.loaded_columns_of_board(board_id).is_none());
+    }
+
+    #[test]
+    fn test_a_model_is_usable_as_a_dyn_loaded_entities() {
+        fn takes(_: &dyn LoadedEntities) {}
+        takes(&Model::default());
+    }
+}

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -1,3 +1,66 @@
+use uuid::Uuid;
+
+use kanban_domain::{Column, Model};
+
+use crate::fetch_plan::{FetchStatus, LoadedEntities, LoadedState};
+
+/// `column`/`card`/`sprint` read the per-id tier alone, never the composed
+/// `*_by_id_state` accessors: a composed read falls through to the flat
+/// collection, whose `Loaded` arm answers `Missing` for any id it does not
+/// name, which would make a live-only card list's absence terminal to a
+/// fetch plan instead of leaving the id `NotLoaded`.
+impl LoadedState for Model {
+    fn board_list(&self) -> FetchStatus {
+        self.boards_state().into()
+    }
+
+    fn column_list(&self) -> FetchStatus {
+        self.columns_state().into()
+    }
+
+    fn card_list(&self) -> FetchStatus {
+        self.cards_state().into()
+    }
+
+    fn sprint_list(&self) -> FetchStatus {
+        self.sprints_state().into()
+    }
+
+    fn graph(&self) -> FetchStatus {
+        self.graph_state().into()
+    }
+
+    fn column(&self, id: Uuid) -> FetchStatus {
+        (&self.column_id_status(id)).into()
+    }
+
+    fn card(&self, id: Uuid) -> FetchStatus {
+        (&self.card_id_status(id)).into()
+    }
+
+    fn sprint(&self, id: Uuid) -> FetchStatus {
+        (&self.sprint_id_status(id)).into()
+    }
+
+    fn columns_of_board(&self, board_id: Uuid) -> FetchStatus {
+        (&self.board_columns_state(board_id)).into()
+    }
+
+    fn cards_of_column(&self, column_id: Uuid) -> FetchStatus {
+        (&self.column_cards_state(column_id)).into()
+    }
+
+    fn sprints_of_board(&self, board_id: Uuid) -> FetchStatus {
+        (&self.board_sprints_state(board_id)).into()
+    }
+}
+
+impl LoadedEntities for Model {
+    fn loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[Column]> {
+        self.board_columns_state(board_id).loaded().copied()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;


### PR DESCRIPTION
Adds `impl LoadedState for Model` (all eleven methods) and `impl LoadedEntities for Model` (one method) in a new `crates/kanban-service/src/model_loaded.rs`, wired in with a single `mod model_loaded;` line in `lib.rs`.

The three per-id methods (`column`, `card`, `sprint`) read the Model's per-id tier only via `column_id_status`/`card_id_status`/`sprint_id_status`, never the composed `*_by_id_state` accessors. This matters because the composed accessors fall through to the flat collection whose `Loaded` arm answers `Missing` for any id it does not name, which would make an archived card absent from a live-only flat list report a terminal `Missing` instead of `NotLoaded`.

The five whole-collection methods delegate to the existing `&LoadState<_>`-returning accessors without an extra borrow; the six by-id/scoped methods take a `&` on the by-value `LoadState<..>` temporary since the `From<&LoadState<T>> for FetchStatus` conversion is generic over a reference.

Mutation check on the central pin (`test_the_fetch_status_of_a_card_absent_from_a_loaded_list_is_not_loaded`): temporarily swapping `card_id_status` for `card_by_id_state` produced

```
assertion `left == right` failed
  left: Missing
 right: NotLoaded
```

confirming the test actually distinguishes the two accessor tiers. The swap was reverted before committing.

KAN-1420 (the file-overlap concern the card originally flagged) has already merged, so this card was executed standalone with no batching conflict.

Changes:
- `crates/kanban-service/src/model_loaded.rs`: new file, `impl LoadedState for Model`, `impl LoadedEntities for Model`, and six unit tests
- `crates/kanban-service/src/lib.rs`: add `mod model_loaded;`
- `.changeset/kan-1466-model-loaded-state.md`: minor bump, new public API

Verification:
- `cargo fmt --all -- --check` clean
- `cargo clippy -p kanban-service --all-targets --all-features -- -D warnings` clean
- `cargo test -p kanban-service --all-features` green (all suites passing, 6 new tests in `model_loaded`)
- `cargo check --workspace --all-targets` green
