### PR TITLE
KAN-1455 fix(domain,service): resolve each card's own board on unscoped search

### DIFF
--- a/.changeset/kan-1455-unscoped-card-search-must-match.md
+++ b/.changeset/kan-1455-unscoped-card-search-must-match.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain,service: an unscoped `CardListFilter` search (no `board_id`) now filters cards by their own board instead of silently admitting every card. `filter_and_sort_cards` and `count_filtered_cards` gain a `boards: &[Board]` lookup slice, positioned after `board: Option<&Board>`, that each card's own board is resolved from when the search predicate runs; a card whose board is not present in the slice is excluded rather than admitted. The service tier gathers that boards slice, plus the cross-board sprint set, on the unscoped search path. Because this changes the signature of two public functions re-exported from `kanban-domain`, it takes a `minor` bump under the pre-1.0 policy.

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -514,4 +514,122 @@ mod tests {
         let out = filter_and_sort_boards(&boards, &filter, &HashMap::new(), None);
         assert_eq!(names(&out), vec!["Zeta Archive", "Zeta Project"]);
     }
+
+    fn two_boards_with_prefixes(prefix_a: &str, prefix_b: &str) -> (Board, Board) {
+        (
+            Board::new("Board A", Some(prefix_a)),
+            Board::new("Board B", Some(prefix_b)),
+        )
+    }
+
+    #[test]
+    fn test_unscoped_search_excludes_a_non_matching_card() {
+        let (board_a, board_b) = two_boards_with_prefixes("AAA", "BBB");
+        let col_a = Column::new(board_a.id, "Todo".to_string(), 0);
+        let col_b = Column::new(board_b.id, "Todo".to_string(), 0);
+        let card_a = Card::new(board_a.id, col_a.id, "alpha", 0);
+        let card_b = Card::new(board_b.id, col_b.id, "beta", 0);
+        let cards = vec![card_a.clone(), card_b];
+        let columns = vec![col_a, col_b];
+        let boards = vec![board_a, board_b];
+        let filter = CardListFilter {
+            search: Some("alpha".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort_cards(&cards, &columns, &[], None, &boards, &filter);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, card_a.id);
+    }
+
+    #[test]
+    fn test_a_card_whose_board_is_absent_is_excluded() {
+        let (board_a, board_b) = two_boards_with_prefixes("AAA", "BBB");
+        let col_b = Column::new(board_b.id, "Todo".to_string(), 0);
+        let card_b = Card::new(board_b.id, col_b.id, "beta", 0);
+        let cards = vec![card_b];
+        let columns = vec![col_b];
+        let boards = vec![board_a];
+        let filter = CardListFilter {
+            search: Some("beta".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort_cards(&cards, &columns, &[], None, &boards, &filter);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_unscoped_search_resolves_the_card_identifier_on_the_cards_own_board() {
+        let (board_a, board_b) = two_boards_with_prefixes("AAA", "ZZZ");
+        let col_a = Column::new(board_a.id, "Todo".to_string(), 0);
+        let col_b = Column::new(board_b.id, "Todo".to_string(), 0);
+        let mut card_a = Card::new(board_a.id, col_a.id, "one", 0);
+        card_a.card_number = 7;
+        let mut card_b = Card::new(board_b.id, col_b.id, "two", 0);
+        card_b.card_number = 7;
+        let cards = vec![card_a, card_b.clone()];
+        let columns = vec![col_a, col_b];
+        let boards = vec![board_a, board_b];
+        let filter = CardListFilter {
+            search: Some("ZZZ-7".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort_cards(&cards, &columns, &[], None, &boards, &filter);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, card_b.id);
+    }
+
+    #[test]
+    fn test_scoped_search_is_unchanged_by_the_boards_slice() {
+        let (board_a, board_b) = two_boards_with_prefixes("AAA", "BBB");
+        let col_a = Column::new(board_a.id, "Todo".to_string(), 0);
+        let col_b = Column::new(board_b.id, "Todo".to_string(), 0);
+        let card_a = Card::new(board_a.id, col_a.id, "alpha", 0);
+        let card_a2 = Card::new(board_a.id, col_a.id, "beta-on-a", 1);
+        let card_b = Card::new(board_b.id, col_b.id, "beta", 0);
+        let cards = vec![card_a.clone(), card_a2, card_b];
+        let columns = vec![col_a, col_b];
+        let boards = vec![board_a.clone(), board_b];
+        let filter = CardListFilter {
+            board_id: Some(board_a.id),
+            search: Some("alpha".to_string()),
+            ..Default::default()
+        };
+        let out = filter_and_sort_cards(&cards, &columns, &[], Some(&board_a), &boards, &filter);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, card_a.id);
+    }
+
+    #[test]
+    fn test_count_filtered_cards_agrees_with_filter_on_the_unscoped_search_path() {
+        let (board_a, board_b) = two_boards_with_prefixes("AAA", "BBB");
+        let col_a = Column::new(board_a.id, "Todo".to_string(), 0);
+        let col_b = Column::new(board_b.id, "Todo".to_string(), 0);
+        let card_a = Card::new(board_a.id, col_a.id, "alpha", 0);
+        let card_b = Card::new(board_b.id, col_b.id, "beta", 0);
+        let cards = vec![card_a, card_b];
+        let columns = vec![col_a, col_b];
+        let boards = vec![board_a, board_b];
+        let filter = CardListFilter {
+            search: Some("alpha".to_string()),
+            ..Default::default()
+        };
+        let count = count_filtered_cards(&cards, &columns, &[], None, &boards, &filter);
+        let list = filter_and_sort_cards(&cards, &columns, &[], None, &boards, &filter);
+        assert_eq!(count, 1);
+        assert_eq!(count, list.len());
+    }
+
+    #[test]
+    fn test_unscoped_read_without_a_search_returns_every_card() {
+        let (board_a, board_b) = two_boards_with_prefixes("AAA", "BBB");
+        let col_a = Column::new(board_a.id, "Todo".to_string(), 0);
+        let col_b = Column::new(board_b.id, "Todo".to_string(), 0);
+        let card_a = Card::new(board_a.id, col_a.id, "alpha", 0);
+        let card_b = Card::new(board_b.id, col_b.id, "beta", 0);
+        let cards = vec![card_a, card_b];
+        let columns = vec![col_a, col_b];
+        let filter = CardListFilter::default();
+        let out = filter_and_sort_cards(&cards, &columns, &[], None, &[], &filter);
+        assert_eq!(out.len(), 2);
+    }
 }

--- a/crates/kanban-domain/src/query/filter_sort.rs
+++ b/crates/kanban-domain/src/query/filter_sort.rs
@@ -95,11 +95,21 @@ fn build_searcher(filter: &CardListFilter) -> Option<CompositeSearcher> {
         .map(|q| CompositeSearcher::all(q.to_string()))
 }
 
+fn board_for<'a>(card: &Card, board: Option<&'a Board>, boards: &'a [Board]) -> Option<&'a Board> {
+    if let Some(b) = board {
+        if b.id == card.board_id {
+            return Some(b);
+        }
+    }
+    boards.iter().find(|b| b.id == card.board_id)
+}
+
 fn passes_filter(
     card: &Card,
     allowed_columns: Option<&HashSet<Uuid>>,
     searcher: Option<&CompositeSearcher>,
     board: Option<&Board>,
+    boards: &[Board],
     sprints: &[Sprint],
     filter: &CardListFilter,
 ) -> bool {
@@ -130,7 +140,9 @@ fn passes_filter(
         }
     }
     if let Some(searcher) = searcher {
-        let Some(board) = board else { return true };
+        let Some(board) = board_for(card, board, boards) else {
+            return false;
+        };
         if !searcher.matches(card, board, sprints) {
             return false;
         }
@@ -146,6 +158,7 @@ pub fn filter_and_sort_cards<T: Borrow<Card> + Clone>(
     columns: &[Column],
     sprints: &[Sprint],
     board: Option<&Board>,
+    boards: &[Board],
     filter: &CardListFilter,
 ) -> Vec<T> {
     let allowed = allowed_column_ids(columns, filter.board_id);
@@ -158,6 +171,7 @@ pub fn filter_and_sort_cards<T: Borrow<Card> + Clone>(
                 allowed.as_ref(),
                 searcher.as_ref(),
                 board,
+                boards,
                 sprints,
                 filter,
             )
@@ -177,6 +191,7 @@ pub fn count_filtered_cards<T: Borrow<Card>>(
     columns: &[Column],
     sprints: &[Sprint],
     board: Option<&Board>,
+    boards: &[Board],
     filter: &CardListFilter,
 ) -> usize {
     let allowed = allowed_column_ids(columns, filter.board_id);
@@ -189,6 +204,7 @@ pub fn count_filtered_cards<T: Borrow<Card>>(
                 allowed.as_ref(),
                 searcher.as_ref(),
                 board,
+                boards,
                 sprints,
                 filter,
             )

--- a/crates/kanban-domain/src/query/mod.rs
+++ b/crates/kanban-domain/src/query/mod.rs
@@ -97,6 +97,7 @@ impl<'a> CardQueryBuilder<'a> {
             self.columns,
             self.sprints,
             Some(self.board),
+            std::slice::from_ref(self.board),
             &filter,
         )
         .into_iter()

--- a/crates/kanban-service/src/context/filters.rs
+++ b/crates/kanban-service/src/context/filters.rs
@@ -49,9 +49,11 @@ impl KanbanContext {
                 None,
             ),
         };
-        let sprints = match (board.as_ref(), filter.search.as_deref()) {
-            (Some(b), Some(q)) if !q.is_empty() => self.backend.list_sprints_by_board(b.id)?,
-            _ => Vec::new(),
+        let searching = filter.search.as_deref().is_some_and(|q| !q.is_empty());
+        let (boards, sprints) = match (&board, searching) {
+            (Some(b), true) => (vec![b.clone()], self.backend.list_sprints_by_board(b.id)?),
+            (None, true) => (self.list_boards_impl()?, self.list_live_sprints_impl()?),
+            _ => (Vec::new(), Vec::new()),
         };
         // For ArchivedOnly and Include with a board scope, the cards are already
         // pre-scoped by marker board_id (see gather_board_cards_for_selector, which
@@ -74,6 +76,7 @@ impl KanbanContext {
             &columns,
             &sprints,
             board.as_ref(),
+            &boards,
             filter_ref,
         ))
     }

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -2,7 +2,9 @@ use super::super::BackendFactory;
 use crate::KanbanContext;
 use kanban_core::AppConfig;
 use kanban_domain::card::{CardPriority, CardStatus};
-use kanban_domain::{BoardUpdate, CardUpdate, CreateCardOptions, FieldUpdate, KanbanOperations};
+use kanban_domain::{
+    BoardUpdate, CardListFilter, CardUpdate, CreateCardOptions, FieldUpdate, KanbanOperations,
+};
 use tempfile::TempDir;
 
 pub async fn test_card_all_fields_roundtrip(factory: &BackendFactory) {
@@ -591,4 +593,102 @@ pub async fn test_existing_card_prefix_is_unchanged_by_a_board_rename(factory: &
         "the card keeps the prefix it was minted under; the rename affects only \
          cards created afterwards"
     );
+}
+
+pub async fn test_unscoped_list_cards_with_a_search_filters_across_boards(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board_a = ctx.create_board("Board A".into(), Some("AAA".into())).unwrap();
+    let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
+    let alpha = ctx
+        .create_card(board_a.id, col_a.id, "alpha".into(), CreateCardOptions::default())
+        .unwrap();
+
+    let board_b = ctx.create_board("Board B".into(), Some("BBB".into())).unwrap();
+    let col_b = ctx.create_column(board_b.id, "Todo".into(), None).unwrap();
+    ctx.create_card(board_b.id, col_b.id, "beta".into(), CreateCardOptions::default())
+        .unwrap();
+
+    let out = ctx
+        .list_cards(CardListFilter {
+            search: Some("alpha".into()),
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(out.len(), 1, "expected only the alpha card, got {out:?}");
+    assert_eq!(out[0].id, alpha.id);
+}
+
+pub async fn test_unscoped_search_resolves_each_cards_own_prefix(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board_a = ctx.create_board("Board A".into(), Some("AAA".into())).unwrap();
+    let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
+    ctx.create_card(board_a.id, col_a.id, "one".into(), CreateCardOptions::default())
+        .unwrap();
+
+    let board_b = ctx.create_board("Board B".into(), Some("ZZZ".into())).unwrap();
+    let col_b = ctx.create_column(board_b.id, "Todo".into(), None).unwrap();
+    let two = ctx
+        .create_card(board_b.id, col_b.id, "two".into(), CreateCardOptions::default())
+        .unwrap();
+
+    let query = format!("{}-{}", two.prefix, two.card_number);
+    let out = ctx
+        .list_cards(CardListFilter {
+            search: Some(query),
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(out.len(), 1, "expected only the second board's card, got {out:?}");
+    assert_eq!(out[0].id, two.id);
+}
+
+pub async fn test_unscoped_search_does_not_return_archived_board_descendants(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board_a = ctx.create_board("Board A".into(), Some("AAA".into())).unwrap();
+    let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
+    let alpha = ctx
+        .create_card(board_a.id, col_a.id, "alpha".into(), CreateCardOptions::default())
+        .unwrap();
+    ctx.create_card(board_a.id, col_a.id, "beta".into(), CreateCardOptions::default())
+        .unwrap();
+
+    let board_c = ctx.create_board("Board C".into(), Some("CCC".into())).unwrap();
+    let col_c = ctx.create_column(board_c.id, "Todo".into(), None).unwrap();
+    ctx.create_card(
+        board_c.id,
+        col_c.id,
+        "alpha-archived".into(),
+        CreateCardOptions::default(),
+    )
+    .unwrap();
+    ctx.archive_board(board_c.id).unwrap();
+
+    let out = ctx
+        .list_cards(CardListFilter {
+            search: Some("alpha".into()),
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(out.len(), 1, "expected only the live alpha card, got {out:?}");
+    assert_eq!(out[0].id, alpha.id);
 }

--- a/crates/kanban-service/src/test_helpers/contract/card.rs
+++ b/crates/kanban-service/src/test_helpers/contract/card.rs
@@ -595,23 +595,39 @@ pub async fn test_existing_card_prefix_is_unchanged_by_a_board_rename(factory: &
     );
 }
 
-pub async fn test_unscoped_list_cards_with_a_search_filters_across_boards(factory: &BackendFactory) {
+pub async fn test_unscoped_list_cards_with_a_search_filters_across_boards(
+    factory: &BackendFactory,
+) {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.store");
     let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
         .await
         .unwrap();
 
-    let board_a = ctx.create_board("Board A".into(), Some("AAA".into())).unwrap();
+    let board_a = ctx
+        .create_board("Board A".into(), Some("AAA".into()))
+        .unwrap();
     let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
     let alpha = ctx
-        .create_card(board_a.id, col_a.id, "alpha".into(), CreateCardOptions::default())
+        .create_card(
+            board_a.id,
+            col_a.id,
+            "alpha".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
 
-    let board_b = ctx.create_board("Board B".into(), Some("BBB".into())).unwrap();
-    let col_b = ctx.create_column(board_b.id, "Todo".into(), None).unwrap();
-    ctx.create_card(board_b.id, col_b.id, "beta".into(), CreateCardOptions::default())
+    let board_b = ctx
+        .create_board("Board B".into(), Some("BBB".into()))
         .unwrap();
+    let col_b = ctx.create_column(board_b.id, "Todo".into(), None).unwrap();
+    ctx.create_card(
+        board_b.id,
+        col_b.id,
+        "beta".into(),
+        CreateCardOptions::default(),
+    )
+    .unwrap();
 
     let out = ctx
         .list_cards(CardListFilter {
@@ -631,15 +647,29 @@ pub async fn test_unscoped_search_resolves_each_cards_own_prefix(factory: &Backe
         .await
         .unwrap();
 
-    let board_a = ctx.create_board("Board A".into(), Some("AAA".into())).unwrap();
-    let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
-    ctx.create_card(board_a.id, col_a.id, "one".into(), CreateCardOptions::default())
+    let board_a = ctx
+        .create_board("Board A".into(), Some("AAA".into()))
         .unwrap();
+    let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
+    ctx.create_card(
+        board_a.id,
+        col_a.id,
+        "one".into(),
+        CreateCardOptions::default(),
+    )
+    .unwrap();
 
-    let board_b = ctx.create_board("Board B".into(), Some("ZZZ".into())).unwrap();
+    let board_b = ctx
+        .create_board("Board B".into(), Some("ZZZ".into()))
+        .unwrap();
     let col_b = ctx.create_column(board_b.id, "Todo".into(), None).unwrap();
     let two = ctx
-        .create_card(board_b.id, col_b.id, "two".into(), CreateCardOptions::default())
+        .create_card(
+            board_b.id,
+            col_b.id,
+            "two".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
 
     let query = format!("{}-{}", two.prefix, two.card_number);
@@ -650,7 +680,11 @@ pub async fn test_unscoped_search_resolves_each_cards_own_prefix(factory: &Backe
         })
         .unwrap();
 
-    assert_eq!(out.len(), 1, "expected only the second board's card, got {out:?}");
+    assert_eq!(
+        out.len(),
+        1,
+        "expected only the second board's card, got {out:?}"
+    );
     assert_eq!(out[0].id, two.id);
 }
 
@@ -663,15 +697,29 @@ pub async fn test_unscoped_search_does_not_return_archived_board_descendants(
         .await
         .unwrap();
 
-    let board_a = ctx.create_board("Board A".into(), Some("AAA".into())).unwrap();
+    let board_a = ctx
+        .create_board("Board A".into(), Some("AAA".into()))
+        .unwrap();
     let col_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
     let alpha = ctx
-        .create_card(board_a.id, col_a.id, "alpha".into(), CreateCardOptions::default())
+        .create_card(
+            board_a.id,
+            col_a.id,
+            "alpha".into(),
+            CreateCardOptions::default(),
+        )
         .unwrap();
-    ctx.create_card(board_a.id, col_a.id, "beta".into(), CreateCardOptions::default())
-        .unwrap();
+    ctx.create_card(
+        board_a.id,
+        col_a.id,
+        "beta".into(),
+        CreateCardOptions::default(),
+    )
+    .unwrap();
 
-    let board_c = ctx.create_board("Board C".into(), Some("CCC".into())).unwrap();
+    let board_c = ctx
+        .create_board("Board C".into(), Some("CCC".into()))
+        .unwrap();
     let col_c = ctx.create_column(board_c.id, "Todo".into(), None).unwrap();
     ctx.create_card(
         board_c.id,
@@ -689,6 +737,10 @@ pub async fn test_unscoped_search_does_not_return_archived_board_descendants(
         })
         .unwrap();
 
-    assert_eq!(out.len(), 1, "expected only the live alpha card, got {out:?}");
+    assert_eq!(
+        out.len(),
+        1,
+        "expected only the live alpha card, got {out:?}"
+    );
     assert_eq!(out[0].id, alpha.id);
 }

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -204,6 +204,18 @@ macro_rules! context_contract_tests {
         async fn test_get_card_by_sprint_and_number_returns_none_for_missing_number() {
             $crate::test_helpers::contract::card::test_get_card_by_sprint_and_number_returns_none_for_missing_number(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_unscoped_list_cards_with_a_search_filters_across_boards() {
+            $crate::test_helpers::contract::card::test_unscoped_list_cards_with_a_search_filters_across_boards(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_unscoped_search_resolves_each_cards_own_prefix() {
+            $crate::test_helpers::contract::card::test_unscoped_search_resolves_each_cards_own_prefix(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_unscoped_search_does_not_return_archived_board_descendants() {
+            $crate::test_helpers::contract::card::test_unscoped_search_does_not_return_archived_board_descendants(&$factory_fn()).await;
+        }
 
         // Sprint log tests
         #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/list_cards_filters.rs
+++ b/crates/kanban-service/tests/list_cards_filters.rs
@@ -206,6 +206,7 @@ async fn test_count_filtered_cards_matches_list_cards_len() -> KanbanResult<()> 
     let all_cards = store.list_all_cards()?;
     let all_columns = store.list_all_columns()?;
     let all_sprints = store.list_all_sprints()?;
+    let all_boards = store.list_boards()?;
 
     for (label, filter) in cases {
         let board = match filter.board_id {
@@ -218,6 +219,7 @@ async fn test_count_filtered_cards_matches_list_cards_len() -> KanbanResult<()> 
             &all_columns,
             &all_sprints,
             board.as_ref(),
+            &all_boards,
             &filter,
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

An unscoped `CardListFilter` (`board_id: None`) with a non-empty `search` silently admitted every card instead of filtering: `passes_filter` hit `let Some(board) = board else { return true }` because the unscoped path never has a `board`, so the search predicate never ran.

- `filter_and_sort_cards` and `count_filtered_cards` (`kanban-domain`) now take a `boards: &[Board]` lookup slice, positioned after `board: Option<&Board>`.
- A private `board_for` helper resolves each card's own board, preferring the already-resolved `board` when it matches `card.board_id`, then falling back to a scan of `boards`.
- The search predicate excludes a card whose board cannot be resolved, matching the polarity already used by `find_sprints_by_query_global`.
- The scoped path is unaffected: `CardQueryBuilder::execute` passes a single-board slice via `std::slice::from_ref`, and the service tier's scoped branch passes `vec![board.clone()]`.
- The service tier (`filter_cards`) now gathers the full live board list plus the live sprint set on the unscoped search path, and the single board plus its own sprints on the scoped search path; no gather happens when there is no search.
- Test-only caller in `list_cards_filters.rs` updated to thread the real board list instead of an empty slice.

## Tests

- Domain: 6 new tests in `crates/kanban-domain/src/query/filter_sort.rs`, covering exclusion of a non-matching card, an unresolvable board, cross-board identifier resolution, scoped-search regression, `count_filtered_cards`/`filter_and_sort_cards` parity, and the no-search no-op case.
- Service: 3 new contract tests in `crates/kanban-service/src/test_helpers/contract/card.rs`, registered in the `context_contract_tests!` macro so they run against in-memory, JSON, and SQLite backends (9 test runs total).
- Mutation check performed: added the `boards` parameter as unused while leaving the old `return true` branch in place, confirmed the four load-bearing domain tests failed for the right reason, then applied the fix and confirmed all pass.

## Verification

- `cargo test -p kanban-domain` green
- `cargo test -p kanban-service --features test-helpers` green (all 9 new backend-parity runs pass)
- `cargo clippy -p kanban-domain -p kanban-service --features kanban-service/test-helpers -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo check --workspace --all-features` compiles

## Notes for the reviewer

- Used `self.list_boards_impl()` for the unscoped board gather; the card's handoff named a non-existent `list_live_boards_impl`. `list_boards_impl` delegates to `backend.list_boards()`, which is already live-only because archiving removes the head from that set.
- Service tests were added to the existing contract suite (`test_helpers/contract/card.rs`) rather than a new integration test file, to get in-memory/JSON/SQLite parity for free from the existing macro plumbing.
- Added a `count_filtered_cards`/`filter_and_sort_cards` parity test that isn't in the original handoff, since `count_filtered_cards` is a second, independent call site of the same predicate and could otherwise be threaded incorrectly while staying green.

