### PR TITLE
KAN-1424 feat(service): mutations return invalidation, add KanbanContext::resolve

### DIFF
--- a/.changeset/kan-1424-mutations-return-invalidation-kanbancontext-resolve.md
+++ b/.changeset/kan-1424-mutations-return-invalidation-kanbancontext-resolve.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: `KanbanContext::execute`, `execute_with`, `execute_with_extra`, `reload`, `replace_backend` and `migrate_sprint_logs` now return the `Invalidation` they computed instead of discarding it, and every mutating `*_impl` inherent method is now `pub` and returns its value paired with the `Invalidation`. `KanbanContext::resolve` is a new thin wrapper over the standalone `kanban_service::resolve` function, so a caller holding a `KanbanContext` can drive a resolve pass without threading the backend through separately.

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -97,7 +97,7 @@ impl CliContext {
         &mut self,
         commands: Vec<kanban_domain::commands::Command>,
     ) -> KanbanResult<()> {
-        self.inner.execute(commands)
+        self.inner.execute(commands).map(|_| ())
     }
 
     pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -34,7 +34,7 @@ impl McpContext {
     }
 
     pub async fn reload(&mut self) -> KanbanResult<()> {
-        self.inner.reload().await
+        self.inner.reload().await.map(|_| ())
     }
 
     /// The stable session id of the running context (per-process). Exposed so

--- a/crates/kanban-server/src/watch.rs
+++ b/crates/kanban-server/src/watch.rs
@@ -36,7 +36,7 @@ pub async fn watch_for_external_changes(
         while rx.recv().await.is_ok() {
             let mut ctx = state.ctx.lock().await;
             match ctx.reload().await {
-                Ok(()) => {
+                Ok(_) => {
                     drop(ctx);
                     state.broadcast_unscoped_change();
                     tracing::info!("Reloaded state from external file change");

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -89,11 +89,11 @@ each query the backend fresh and return an owned, `KanbanResult`-wrapped
 
 ```rust
 ctx.save() -> KanbanResult<()>                 // async; backend.flush().await
-ctx.reload() -> KanbanResult<()>               // async; backend.reload().await, clears undo_stack
-ctx.replace_backend(backend: Arc<dyn KanbanBackend>)  // clears undo_stack, marks clean
+ctx.reload() -> KanbanResult<Invalidation>     // async; backend.reload().await, clears undo_stack
+ctx.replace_backend(backend: Arc<dyn KanbanBackend>) -> Invalidation  // clears undo_stack, marks clean
 ctx.snapshot() -> KanbanResult<Snapshot>
 ctx.apply_snapshot(snapshot: Snapshot) -> KanbanResult<()>
-ctx.migrate_sprint_logs() -> KanbanResult<usize>  // one-time backfill utility, bypasses undo on purpose
+ctx.migrate_sprint_logs() -> KanbanResult<(usize, Option<Invalidation>)>  // one-time backfill utility, bypasses undo on purpose
 ```
 
 `save` and `reload` are `async` — `save` delegates to `backend.flush()`
@@ -104,9 +104,9 @@ entity ids from before the reload may no longer exist.
 ### Undo / Redo
 
 ```rust
-ctx.execute(commands: Vec<Command>) -> KanbanResult<()>
-ctx.execute_with(build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<()>
-ctx.execute_with_extra(extra: EntityIds, build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<()>
+ctx.execute(commands: Vec<Command>) -> KanbanResult<Invalidation>
+ctx.execute_with(build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<Invalidation>
+ctx.execute_with_extra(extra: EntityIds, build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<Invalidation>
 ctx.undo() -> KanbanResult<bool>   // Ok(false) if there was nothing to undo
 ctx.redo() -> KanbanResult<bool>   // Ok(false) if there was nothing to redo
 ctx.can_undo() -> bool

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -3,8 +3,8 @@ use chrono::{DateTime, Utc};
 use kanban_domain::commands::{ArchiveBoards, BoardCommand, Command, ImportEntities, RestoreBoard};
 use kanban_domain::{
     filter_and_sort_boards, resolve_board_sort, ArchivedBoard, ArchivedFilter, Board,
-    BoardListFilter, BoardSortField, BoardUpdate, FieldUpdate, KanbanError, KanbanResult, NewBoard,
-    SortOrder, DEFAULT_ARCHIVED_BOARD_SORT, DEFAULT_BOARD_SORT_LIVE,
+    BoardListFilter, BoardSortField, BoardUpdate, FieldUpdate, Invalidation, KanbanError,
+    KanbanResult, NewBoard, SortOrder, DEFAULT_ARCHIVED_BOARD_SORT, DEFAULT_BOARD_SORT_LIVE,
 };
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -33,6 +33,14 @@ impl KanbanContext {
         id: Option<Uuid>,
         spec: NewBoard,
     ) -> KanbanResult<Board> {
+        Ok(self.create_board_from_spec_returning(id, spec)?.0)
+    }
+
+    pub(super) fn create_board_from_spec_returning(
+        &mut self,
+        id: Option<Uuid>,
+        spec: NewBoard,
+    ) -> KanbanResult<(Board, Invalidation)> {
         let id = id.unwrap_or_else(Uuid::new_v4);
         if self.backend.get_board(id)?.is_some() {
             return Err(KanbanError::already_exists("Board", id));
@@ -47,10 +55,11 @@ impl KanbanContext {
             boards: vec![board],
             ..Default::default()
         }));
-        self.execute(vec![cmd])?;
-        self.get_board_impl(id)?.ok_or_else(|| {
+        let invalidation = self.execute(vec![cmd])?;
+        let board = self.get_board_impl(id)?.ok_or_else(|| {
             KanbanError::Internal("Board creation succeeded but board not found".into())
-        })
+        })?;
+        Ok((board, invalidation))
     }
 
     /// Idempotent PUT-create (create-or-replace) for a board keyed on a
@@ -73,7 +82,7 @@ impl KanbanContext {
                 created: true,
             });
         }
-        let board = self.update_board_impl(id, replace_update_from_spec(spec))?;
+        let (board, _inv) = self.update_board_impl(id, replace_update_from_spec(spec))?;
         Ok(BoardCreateOutcome {
             board,
             created: false,
@@ -83,11 +92,11 @@ impl KanbanContext {
     /// Thin shim over [`create_board_from_spec`](Self::create_board_from_spec)
     /// taking just `name`/`card_prefix`, so the existing trait callers do not
     /// churn. The service mints the id; the remaining create fields default.
-    pub(super) fn create_board_impl(
+    pub fn create_board_impl(
         &mut self,
         name: String,
         card_prefix: Option<String>,
-    ) -> KanbanResult<Board> {
+    ) -> KanbanResult<(Board, Invalidation)> {
         let spec = NewBoard {
             name,
             description: None,
@@ -98,7 +107,7 @@ impl KanbanContext {
             sprint_duration_days: None,
             task_list_view: None,
         };
-        self.create_board_from_spec(None, spec)
+        self.create_board_from_spec_returning(None, spec)
     }
 
     pub(super) fn list_boards_impl(&self) -> KanbanResult<Vec<Board>> {
@@ -208,29 +217,31 @@ impl KanbanContext {
         self.backend.get_board(id)
     }
 
-    pub(super) fn update_board_impl(
+    pub fn update_board_impl(
         &mut self,
         id: Uuid,
         updates: BoardUpdate,
-    ) -> KanbanResult<Board> {
+    ) -> KanbanResult<(Board, Invalidation)> {
         use kanban_domain::commands::UpdateBoard;
         let cmd = Command::Board(BoardCommand::Update(UpdateBoard {
             board_id: id,
             updates,
         }));
-        self.execute(vec![cmd])?;
-        self.get_board_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Board", id))
+        let invalidation = self.execute(vec![cmd])?;
+        let board = self
+            .get_board_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Board", id))?;
+        Ok((board, invalidation))
     }
 
-    pub(super) fn delete_board_impl(&mut self, id: Uuid) -> KanbanResult<()> {
+    pub fn delete_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
         let commands = crate::cascade::delete_board(self.backend.as_data_store(), id)?;
         self.execute(commands)
     }
 
     /// Archive a board (collection move). Undoable via the command's symmetric
     /// inverse. NotFound if the board is not live.
-    pub(super) fn archive_board_impl(&mut self, id: Uuid) -> KanbanResult<()> {
+    pub fn archive_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
         if self.backend.get_board(id)?.is_none() {
             return Err(KanbanError::not_found("Board", id));
         }
@@ -240,7 +251,7 @@ impl KanbanContext {
 
     /// Restore an archived board back into the live set. NotFound if the board
     /// is not in the archived collection.
-    pub(super) fn restore_board_impl(&mut self, id: Uuid) -> KanbanResult<()> {
+    pub fn restore_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
         if self.backend.get_archived_board(id)?.is_none() {
             return Err(KanbanError::not_found("archived board", id));
         }

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -2,7 +2,8 @@ use super::KanbanContext;
 use kanban_domain::commands::{CardCommand, Command};
 use kanban_domain::{
     ArchivedCard, ArchivedEntity, Card, CardListFilter, CardSummary, CardUpdate, Column,
-    CreateCardOptions, DomainError, FieldUpdate, KanbanError, KanbanResult, NewCard, Sprint,
+    CreateCardOptions, DomainError, FieldUpdate, Invalidation, KanbanError, KanbanResult, NewCard,
+    Sprint,
 };
 use uuid::Uuid;
 
@@ -103,6 +104,14 @@ impl KanbanContext {
         client_id: Option<Uuid>,
         spec: NewCard,
     ) -> KanbanResult<Card> {
+        Ok(self.create_card_from_spec_returning(client_id, spec)?.0)
+    }
+
+    pub(super) fn create_card_from_spec_returning(
+        &mut self,
+        client_id: Option<Uuid>,
+        spec: NewCard,
+    ) -> KanbanResult<(Card, Invalidation)> {
         // FK: column must exist; derive the owning board from it.
         let column = self.require_column(spec.column_id)?;
         let board_id = column.board_id;
@@ -155,7 +164,7 @@ impl KanbanContext {
             .app_config()
             .effective_default_card_prefix()
             .to_string();
-        self.execute_with_extra(
+        let invalidation = self.execute_with_extra(
             kanban_domain::EntityIds::default().with_prefixes(),
             |store| {
                 let (_prefix, card_number) = Self::allocate_card_number(
@@ -185,9 +194,10 @@ impl KanbanContext {
                 ))])
             },
         )?;
-        self.get_card_impl(id)?.ok_or_else(|| {
+        let card = self.get_card_impl(id)?.ok_or_else(|| {
             KanbanError::Internal("Card creation succeeded but card not found".into())
-        })
+        })?;
+        Ok((card, invalidation))
     }
 
     /// Idempotent PUT-create (create-or-replace) for a card keyed on a
@@ -215,7 +225,7 @@ impl KanbanContext {
         // update — a PUT-replace must not relocate a card to a non-existent
         // column. Routed through the canonical helper (KAN-248).
         self.require_column(spec.column_id)?;
-        let card = self.update_card_impl(id, replace_update_from_spec(spec))?;
+        let (card, _inv) = self.update_card_impl(id, replace_update_from_spec(spec))?;
         Ok(CardCreateOutcome {
             card,
             created: false,
@@ -225,13 +235,13 @@ impl KanbanContext {
     /// Thin shim over [`create_card_from_spec`](Self::create_card_from_spec)
     /// translating the legacy `CreateCardOptions` create path, so the existing
     /// trait callers do not churn. The service mints the id.
-    pub(super) fn create_card_impl(
+    pub fn create_card_impl(
         &mut self,
         _board_id: Uuid,
         column_id: Uuid,
         title: String,
         options: CreateCardOptions,
-    ) -> KanbanResult<Card> {
+    ) -> KanbanResult<(Card, Invalidation)> {
         let spec = NewCard {
             column_id,
             title,
@@ -243,7 +253,7 @@ impl KanbanContext {
             points: options.points,
             sprint_id: options.sprint_id,
         };
-        self.create_card_from_spec(None, spec)
+        self.create_card_from_spec_returning(None, spec)
     }
 
     pub(super) fn list_cards_impl(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
@@ -359,18 +369,24 @@ impl KanbanContext {
             .collect())
     }
 
-    pub(super) fn update_card_impl(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
-        self.update_cards_impl(vec![(id, updates)])?;
-        self.get_card_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Card", id))
+    pub fn update_card_impl(
+        &mut self,
+        id: Uuid,
+        updates: CardUpdate,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        let (_count, invalidation) = self.update_cards_impl(vec![(id, updates)])?;
+        let card = self
+            .get_card_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Card", id))?;
+        Ok((card, invalidation))
     }
 
-    pub(super) fn move_card_impl(
+    pub fn move_card_impl(
         &mut self,
         id: Uuid,
         column_id: Uuid,
         position: Option<i32>,
-    ) -> KanbanResult<Card> {
+    ) -> KanbanResult<(Card, Invalidation)> {
         use kanban_domain::commands::{MoveCard, UpdateCard};
         let position = match position {
             Some(p) => p,
@@ -399,26 +415,28 @@ impl KanbanContext {
             })));
         }
 
-        self.execute(batch)?;
-        self.get_card_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Card", id))
+        let invalidation = self.execute(batch)?;
+        let card = self
+            .get_card_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Card", id))?;
+        Ok((card, invalidation))
     }
 
-    pub(super) fn archive_card_impl(&mut self, id: Uuid) -> KanbanResult<()> {
+    pub fn archive_card_impl(&mut self, id: Uuid) -> KanbanResult<((), Invalidation)> {
         match self.archive_cards_impl(vec![id]) {
-            Ok(0) | Err(KanbanError::Domain(kanban_domain::DomainError::Validation(_))) => {
+            Ok((0, _)) | Err(KanbanError::Domain(kanban_domain::DomainError::Validation(_))) => {
                 Err(KanbanError::not_found("Card", id))
             }
-            Ok(_) => Ok(()),
+            Ok((_, invalidation)) => Ok(((), invalidation)),
             Err(e) => Err(e),
         }
     }
 
-    pub(super) fn restore_card_impl(
+    pub fn restore_card_impl(
         &mut self,
         id: Uuid,
         column_id: Option<Uuid>,
-    ) -> KanbanResult<Card> {
+    ) -> KanbanResult<(Card, Invalidation)> {
         use kanban_domain::commands::RestoreCard;
         if self.backend.get_archived_card(id)?.is_none() {
             return Err(KanbanError::not_found("archived card", id));
@@ -455,12 +473,14 @@ impl KanbanContext {
             position,
             timestamp: chrono::Utc::now(),
         }));
-        self.execute(vec![cmd])?;
-        self.get_card_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Card", id))
+        let invalidation = self.execute(vec![cmd])?;
+        let card = self
+            .get_card_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Card", id))?;
+        Ok((card, invalidation))
     }
 
-    pub(super) fn delete_card_impl(&mut self, id: Uuid) -> KanbanResult<()> {
+    pub fn delete_card_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
         use kanban_domain::commands::DeleteCard;
         let cmd = Command::Card(CardCommand::Delete(DeleteCard { card_id: id }));
         self.execute(vec![cmd])
@@ -477,25 +497,32 @@ impl KanbanContext {
         self.backend.list_archived_cards_by_board(board_id)
     }
 
-    pub(super) fn assign_card_to_sprint_impl(
+    pub fn assign_card_to_sprint_impl(
         &mut self,
         card_id: Uuid,
         sprint_id: Uuid,
-    ) -> KanbanResult<Card> {
-        self.assign_cards_to_sprint_impl(vec![card_id], sprint_id)?;
-        self.get_card_impl(card_id)?
-            .ok_or_else(|| KanbanError::not_found("Card", card_id))
+    ) -> KanbanResult<(Card, Invalidation)> {
+        let (_count, invalidation) = self.assign_cards_to_sprint_impl(vec![card_id], sprint_id)?;
+        let card = self
+            .get_card_impl(card_id)?
+            .ok_or_else(|| KanbanError::not_found("Card", card_id))?;
+        Ok((card, invalidation))
     }
 
-    pub(super) fn unassign_card_from_sprint_impl(&mut self, card_id: Uuid) -> KanbanResult<Card> {
+    pub fn unassign_card_from_sprint_impl(
+        &mut self,
+        card_id: Uuid,
+    ) -> KanbanResult<(Card, Invalidation)> {
         use kanban_domain::commands::UnassignCardFromSprint;
         let cmd = Command::Card(CardCommand::UnassignFromSprint(UnassignCardFromSprint {
             card_id,
             timestamp: chrono::Utc::now(),
         }));
-        self.execute(vec![cmd])?;
-        self.get_card_impl(card_id)?
-            .ok_or_else(|| KanbanError::not_found("Card", card_id))
+        let invalidation = self.execute(vec![cmd])?;
+        let card = self
+            .get_card_impl(card_id)?
+            .ok_or_else(|| KanbanError::not_found("Card", card_id))?;
+        Ok((card, invalidation))
     }
 
     pub(super) fn get_card_branch_name_impl(&self, id: Uuid) -> KanbanResult<String> {

--- a/crates/kanban-service/src/context/cards_batch.rs
+++ b/crates/kanban-service/src/context/cards_batch.rs
@@ -1,6 +1,6 @@
 use super::KanbanContext;
 use kanban_domain::commands::{CardCommand, Command};
-use kanban_domain::{CardStatus, CardUpdate, KanbanError, KanbanResult};
+use kanban_domain::{CardStatus, CardUpdate, Invalidation, KanbanError, KanbanResult};
 use uuid::Uuid;
 
 impl KanbanContext {
@@ -157,35 +157,37 @@ impl KanbanContext {
         )
     }
 
-    pub(super) fn archive_cards_impl(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
+    pub fn archive_cards_impl(&mut self, ids: Vec<Uuid>) -> KanbanResult<(usize, Invalidation)> {
         use kanban_domain::commands::ArchiveCards;
         let before = self.backend.list_archived_cards()?.len();
-        self.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards {
-            ids,
-        }))])?;
-        Ok(self.backend.list_archived_cards()?.len() - before)
+        let invalidation =
+            self.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards {
+                ids,
+            }))])?;
+        let count = self.backend.list_archived_cards()?.len() - before;
+        Ok((count, invalidation))
     }
 
-    pub(super) fn move_cards_impl(
+    pub fn move_cards_impl(
         &mut self,
         ids: Vec<Uuid>,
         column_id: Uuid,
-    ) -> KanbanResult<usize> {
+    ) -> KanbanResult<(usize, Invalidation)> {
         let ids = kanban_domain::card_lifecycle::dedup_preserving_order(&ids);
         let before = self.backend.list_cards_by_column(column_id)?.len();
 
         let chained_status_updates = self.chained_status_updates_for_batch_move(&ids, column_id)?;
         let batch = self.build_move_cards_batch(&ids, column_id, chained_status_updates)?;
 
-        self.execute(batch)?;
+        let invalidation = self.execute(batch)?;
         let after = self.backend.list_cards_by_column(column_id)?.len();
-        Ok(after - before)
+        Ok((after - before, invalidation))
     }
 
-    pub(super) fn update_cards_impl(
+    pub fn update_cards_impl(
         &mut self,
         updates: Vec<(Uuid, CardUpdate)>,
-    ) -> KanbanResult<usize> {
+    ) -> KanbanResult<(usize, Invalidation)> {
         use kanban_domain::commands::{MoveCard, UpdateCard};
         use kanban_domain::ArchivedFilter;
         use std::collections::HashMap;
@@ -278,21 +280,21 @@ impl KanbanContext {
             }
         }
 
-        self.execute(batch)?;
-        Ok(count)
+        let invalidation = self.execute(batch)?;
+        Ok((count, invalidation))
     }
 
-    pub(super) fn assign_cards_to_sprint_impl(
+    pub fn assign_cards_to_sprint_impl(
         &mut self,
         ids: Vec<Uuid>,
         sprint_id: Uuid,
-    ) -> KanbanResult<usize> {
+    ) -> KanbanResult<(usize, Invalidation)> {
         use kanban_domain::commands::AssignCardsToSprint;
         let before = self.backend.list_cards_by_sprint(sprint_id)?.len();
-        self.execute(vec![Command::Card(CardCommand::AssignToSprint(
+        let invalidation = self.execute(vec![Command::Card(CardCommand::AssignToSprint(
             AssignCardsToSprint { ids, sprint_id },
         ))])?;
         let after = self.backend.list_cards_by_sprint(sprint_id)?.len();
-        Ok(after - before)
+        Ok((after - before, invalidation))
     }
 }

--- a/crates/kanban-service/src/context/cards_batch_detailed.rs
+++ b/crates/kanban-service/src/context/cards_batch_detailed.rs
@@ -44,7 +44,7 @@ impl KanbanContext {
         match self.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards {
             ids: to_archive,
         }))]) {
-            Ok(()) => BatchOperationResult { succeeded, failed },
+            Ok(_) => BatchOperationResult { succeeded, failed },
             Err(e) => {
                 let err = e.to_string();
                 let mut all_failed = failed;
@@ -124,7 +124,7 @@ impl KanbanContext {
         };
 
         match self.execute(batch) {
-            Ok(()) => BatchOperationResult { succeeded, failed },
+            Ok(_) => BatchOperationResult { succeeded, failed },
             Err(e) => {
                 let err = e.to_string();
                 let mut all_failed = failed;
@@ -214,7 +214,7 @@ impl KanbanContext {
                 sprint_id,
             },
         ))]) {
-            Ok(()) => BatchOperationResult { succeeded, failed },
+            Ok(_) => BatchOperationResult { succeeded, failed },
             Err(e) => {
                 let err = e.to_string();
                 let mut all_failed = failed;

--- a/crates/kanban-service/src/context/columns.rs
+++ b/crates/kanban-service/src/context/columns.rs
@@ -1,7 +1,9 @@
 use super::KanbanContext;
 use chrono::Utc;
 use kanban_domain::commands::{BoardCommand, ColumnCommand, Command, ImportEntities};
-use kanban_domain::{Column, ColumnUpdate, FieldUpdate, KanbanError, KanbanResult, NewColumn};
+use kanban_domain::{
+    Column, ColumnUpdate, FieldUpdate, Invalidation, KanbanError, KanbanResult, NewColumn,
+};
 use uuid::Uuid;
 
 /// Result of an idempotent PUT-create ([`KanbanContext::create_or_replace_column`]):
@@ -28,6 +30,14 @@ impl KanbanContext {
         id: Option<Uuid>,
         spec: NewColumn,
     ) -> KanbanResult<Column> {
+        Ok(self.create_column_from_spec_returning(id, spec)?.0)
+    }
+
+    pub(super) fn create_column_from_spec_returning(
+        &mut self,
+        id: Option<Uuid>,
+        spec: NewColumn,
+    ) -> KanbanResult<(Column, Invalidation)> {
         self.require_board(spec.board_id)?;
         let id = id.unwrap_or_else(Uuid::new_v4);
         if self.backend.get_column(id)?.is_some() {
@@ -43,10 +53,11 @@ impl KanbanContext {
             columns: vec![column],
             ..Default::default()
         }));
-        self.execute(vec![cmd])?;
-        self.get_column_impl(id)?.ok_or_else(|| {
+        let invalidation = self.execute(vec![cmd])?;
+        let column = self.get_column_impl(id)?.ok_or_else(|| {
             KanbanError::Internal("Column creation succeeded but column not found".into())
-        })
+        })?;
+        Ok((column, invalidation))
     }
 
     /// Idempotent PUT-create (create-or-replace) for a column keyed on a
@@ -77,19 +88,20 @@ impl KanbanContext {
         // does not move a column across boards, but a board can be deleted
         // between reads, so the guard stays.
         self.require_board(spec.board_id)?;
-        let column = self.update_column_impl(id, replace_update_from_spec(spec, position))?;
+        let (column, _inv) =
+            self.update_column_impl(id, replace_update_from_spec(spec, position))?;
         Ok(ColumnCreateOutcome {
             column,
             created: false,
         })
     }
 
-    pub(super) fn create_column_impl(
+    pub fn create_column_impl(
         &mut self,
         board_id: Uuid,
         name: String,
         position: Option<i32>,
-    ) -> KanbanResult<Column> {
+    ) -> KanbanResult<(Column, Invalidation)> {
         // Explicit `position` callers (TUI/contract helpers seed columns at a
         // chosen index) keep the legacy command path; the `None` append case
         // routes through the rich spec funnel so it gains FK + id-uniqueness.
@@ -104,12 +116,13 @@ impl KanbanContext {
                     position,
                     default_status: None,
                 }));
-                self.execute(vec![cmd])?;
-                self.get_column_impl(id)?.ok_or_else(|| {
+                let invalidation = self.execute(vec![cmd])?;
+                let column = self.get_column_impl(id)?.ok_or_else(|| {
                     KanbanError::Internal("Column creation succeeded but column not found".into())
-                })
+                })?;
+                Ok((column, invalidation))
             }
-            None => self.create_column_from_spec(
+            None => self.create_column_from_spec_returning(
                 None,
                 NewColumn {
                     board_id,
@@ -129,32 +142,34 @@ impl KanbanContext {
         self.backend.get_column(id)
     }
 
-    pub(super) fn update_column_impl(
+    pub fn update_column_impl(
         &mut self,
         id: Uuid,
         updates: ColumnUpdate,
-    ) -> KanbanResult<Column> {
+    ) -> KanbanResult<(Column, Invalidation)> {
         use kanban_domain::commands::UpdateColumn;
         let cmd = Command::Column(ColumnCommand::Update(UpdateColumn {
             column_id: id,
             updates,
         }));
-        self.execute(vec![cmd])?;
-        self.get_column_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Column", id))
+        let invalidation = self.execute(vec![cmd])?;
+        let column = self
+            .get_column_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Column", id))?;
+        Ok((column, invalidation))
     }
 
-    pub(super) fn delete_column_impl(&mut self, id: Uuid) -> KanbanResult<()> {
+    pub fn delete_column_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
         use kanban_domain::commands::DeleteColumn;
         let cmd = Command::Column(ColumnCommand::Delete(DeleteColumn { column_id: id }));
         self.execute(vec![cmd])
     }
 
-    pub(super) fn reorder_column_impl(
+    pub fn reorder_column_impl(
         &mut self,
         id: Uuid,
         new_position: i32,
-    ) -> KanbanResult<Column> {
+    ) -> KanbanResult<(Column, Invalidation)> {
         let updates = ColumnUpdate {
             name: None,
             position: Some(new_position),

--- a/crates/kanban-service/src/context/core.rs
+++ b/crates/kanban-service/src/context/core.rs
@@ -1,8 +1,10 @@
 use super::KanbanContext;
 use crate::backend::KanbanBackend;
+use crate::fetch_plan::{FetchPlan, LoadedEntities};
 use kanban_core::{AppConfig, AppType};
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanResult, Snapshot, Sprint,
+    ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, Invalidation, KanbanResult,
+    Resolved, Snapshot, Sprint,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -63,6 +65,10 @@ impl KanbanContext {
         self.backend.as_data_store()
     }
 
+    pub fn resolve(&self, plan: &dyn FetchPlan, loaded: &dyn LoadedEntities) -> Resolved {
+        crate::resolve::resolve(plan, loaded, self.data_store())
+    }
+
     pub fn backend(&self) -> Arc<dyn KanbanBackend> {
         Arc::clone(&self.backend)
     }
@@ -76,11 +82,12 @@ impl KanbanContext {
     }
 
     /// Replace the active backend, discarding all undo/redo history.
-    pub fn replace_backend(&mut self, backend: Arc<dyn KanbanBackend>) {
+    pub fn replace_backend(&mut self, backend: Arc<dyn KanbanBackend>) -> Invalidation {
         tracing::info!("Replacing backend; undo/redo history discarded");
         self.backend = backend;
         self.undo_stack.clear();
         self.dirty = false;
+        Invalidation::All
     }
 
     pub fn boards(&self) -> KanbanResult<Vec<Board>> {

--- a/crates/kanban-service/src/context/graph.rs
+++ b/crates/kanban-service/src/context/graph.rs
@@ -116,7 +116,7 @@ impl GraphOperations for KanbanContext {
                 },
             )));
         }
-        self.execute(commands)
+        self.execute(commands).map(|_| ())
     }
 
     fn detach_children(&mut self, parent: Uuid, children: Vec<Uuid>) -> KanbanResult<()> {
@@ -135,7 +135,7 @@ impl GraphOperations for KanbanContext {
                 }))
             })
             .collect();
-        self.execute(commands)
+        self.execute(commands).map(|_| ())
     }
 
     fn list_children_of(&self, parent: Uuid) -> KanbanResult<Vec<Uuid>> {
@@ -160,6 +160,7 @@ impl GraphOperations for KanbanContext {
                 as_archived,
             },
         ))])
+        .map(|_| ())
     }
 
     fn unblock(&mut self, blocker: Uuid, blocked: Uuid) -> KanbanResult<()> {
@@ -173,6 +174,7 @@ impl GraphOperations for KanbanContext {
                 as_archived: false,
             },
         ))])
+        .map(|_| ())
     }
 
     fn list_blocked_by(&self, blocker: Uuid) -> KanbanResult<Vec<Uuid>> {
@@ -197,6 +199,7 @@ impl GraphOperations for KanbanContext {
                 as_archived,
             },
         ))])
+        .map(|_| ())
     }
 
     fn dissociate(&mut self, a: Uuid, b: Uuid) -> KanbanResult<()> {
@@ -210,6 +213,7 @@ impl GraphOperations for KanbanContext {
                 as_archived: false,
             },
         ))])
+        .map(|_| ())
     }
 
     fn list_related_to(&self, card: Uuid) -> KanbanResult<Vec<Uuid>> {

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -75,9 +75,13 @@ pub struct KanbanContext {
 // The `KanbanOperations` trait impl must live in a single block (Rust forbids
 // splitting a trait impl across files), so it forwards to the entity-focused
 // inherent methods in `boards`/`columns`/`cards`/`cards_batch`/`sprints`.
+/// Forwards to the entity-focused `*_impl` inherent methods, discarding the
+/// [`Invalidation`] each one now returns. A caller that wants the value calls
+/// the `*_impl` method directly rather than through this trait; see
+/// `KanbanContext::resolve` and the `*_impl` methods' `pub` visibility.
 impl KanbanOperations for KanbanContext {
     fn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {
-        KanbanContext::create_board_impl(self, name, card_prefix)
+        Ok(KanbanContext::create_board_impl(self, name, card_prefix)?.0)
     }
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
         KanbanContext::list_boards_impl(self)
@@ -89,16 +93,16 @@ impl KanbanOperations for KanbanContext {
         KanbanContext::get_board_impl(self, id)
     }
     fn update_board(&mut self, id: Uuid, updates: BoardUpdate) -> KanbanResult<Board> {
-        KanbanContext::update_board_impl(self, id, updates)
+        Ok(KanbanContext::update_board_impl(self, id, updates)?.0)
     }
     fn delete_board(&mut self, id: Uuid) -> KanbanResult<()> {
-        KanbanContext::delete_board_impl(self, id)
+        KanbanContext::delete_board_impl(self, id).map(|_| ())
     }
     fn archive_board(&mut self, id: Uuid) -> KanbanResult<()> {
-        KanbanContext::archive_board_impl(self, id)
+        KanbanContext::archive_board_impl(self, id).map(|_| ())
     }
     fn restore_board(&mut self, id: Uuid) -> KanbanResult<()> {
-        KanbanContext::restore_board_impl(self, id)
+        KanbanContext::restore_board_impl(self, id).map(|_| ())
     }
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
         KanbanContext::list_archived_boards_impl(self)
@@ -110,7 +114,7 @@ impl KanbanOperations for KanbanContext {
         name: String,
         position: Option<i32>,
     ) -> KanbanResult<Column> {
-        KanbanContext::create_column_impl(self, board_id, name, position)
+        Ok(KanbanContext::create_column_impl(self, board_id, name, position)?.0)
     }
     fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
         KanbanContext::list_columns_impl(self, board_id)
@@ -119,13 +123,13 @@ impl KanbanOperations for KanbanContext {
         KanbanContext::get_column_impl(self, id)
     }
     fn update_column(&mut self, id: Uuid, updates: ColumnUpdate) -> KanbanResult<Column> {
-        KanbanContext::update_column_impl(self, id, updates)
+        Ok(KanbanContext::update_column_impl(self, id, updates)?.0)
     }
     fn delete_column(&mut self, id: Uuid) -> KanbanResult<()> {
-        KanbanContext::delete_column_impl(self, id)
+        KanbanContext::delete_column_impl(self, id).map(|_| ())
     }
     fn reorder_column(&mut self, id: Uuid, new_position: i32) -> KanbanResult<Column> {
-        KanbanContext::reorder_column_impl(self, id, new_position)
+        Ok(KanbanContext::reorder_column_impl(self, id, new_position)?.0)
     }
 
     fn create_card(
@@ -135,7 +139,7 @@ impl KanbanOperations for KanbanContext {
         title: String,
         options: CreateCardOptions,
     ) -> KanbanResult<Card> {
-        KanbanContext::create_card_impl(self, board_id, column_id, title, options)
+        Ok(KanbanContext::create_card_impl(self, board_id, column_id, title, options)?.0)
     }
     fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
         KanbanContext::list_cards_impl(self, filter)
@@ -156,7 +160,7 @@ impl KanbanOperations for KanbanContext {
         KanbanContext::list_all_sprints_impl(self)
     }
     fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
-        KanbanContext::update_card_impl(self, id, updates)
+        Ok(KanbanContext::update_card_impl(self, id, updates)?.0)
     }
     fn move_card(
         &mut self,
@@ -164,16 +168,16 @@ impl KanbanOperations for KanbanContext {
         column_id: Uuid,
         position: Option<i32>,
     ) -> KanbanResult<Card> {
-        KanbanContext::move_card_impl(self, id, column_id, position)
+        Ok(KanbanContext::move_card_impl(self, id, column_id, position)?.0)
     }
     fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        KanbanContext::archive_card_impl(self, id)
+        KanbanContext::archive_card_impl(self, id).map(|_| ())
     }
     fn restore_card(&mut self, id: Uuid, column_id: Option<Uuid>) -> KanbanResult<Card> {
-        KanbanContext::restore_card_impl(self, id, column_id)
+        Ok(KanbanContext::restore_card_impl(self, id, column_id)?.0)
     }
     fn delete_card(&mut self, id: Uuid) -> KanbanResult<()> {
-        KanbanContext::delete_card_impl(self, id)
+        KanbanContext::delete_card_impl(self, id).map(|_| ())
     }
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         KanbanContext::list_archived_cards_impl(self)
@@ -183,10 +187,10 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
-        KanbanContext::assign_card_to_sprint_impl(self, card_id, sprint_id)
+        Ok(KanbanContext::assign_card_to_sprint_impl(self, card_id, sprint_id)?.0)
     }
     fn unassign_card_from_sprint(&mut self, card_id: Uuid) -> KanbanResult<Card> {
-        KanbanContext::unassign_card_from_sprint_impl(self, card_id)
+        Ok(KanbanContext::unassign_card_from_sprint_impl(self, card_id)?.0)
     }
 
     fn get_card_branch_name(&self, id: Uuid) -> KanbanResult<String> {
@@ -197,23 +201,23 @@ impl KanbanOperations for KanbanContext {
     }
 
     fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
-        KanbanContext::archive_cards_impl(self, ids)
+        Ok(KanbanContext::archive_cards_impl(self, ids)?.0)
     }
     fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
-        KanbanContext::move_cards_impl(self, ids, column_id)
+        Ok(KanbanContext::move_cards_impl(self, ids, column_id)?.0)
     }
     fn update_cards(&mut self, updates: Vec<(Uuid, CardUpdate)>) -> KanbanResult<usize> {
-        KanbanContext::update_cards_impl(self, updates)
+        Ok(KanbanContext::update_cards_impl(self, updates)?.0)
     }
     fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
-        KanbanContext::assign_cards_to_sprint_impl(self, ids, sprint_id)
+        Ok(KanbanContext::assign_cards_to_sprint_impl(self, ids, sprint_id)?.0)
     }
     fn carry_over_sprint_cards(
         &mut self,
         from_sprint_id: Uuid,
         to_sprint_id: Uuid,
     ) -> KanbanResult<usize> {
-        KanbanContext::carry_over_sprint_cards_impl(self, from_sprint_id, to_sprint_id)
+        Ok(KanbanContext::carry_over_sprint_cards_impl(self, from_sprint_id, to_sprint_id)?.0)
     }
 
     fn create_sprint(
@@ -222,7 +226,7 @@ impl KanbanOperations for KanbanContext {
         prefix: Option<String>,
         name: Option<String>,
     ) -> KanbanResult<Sprint> {
-        KanbanContext::create_sprint_impl(self, board_id, prefix, name)
+        Ok(KanbanContext::create_sprint_impl(self, board_id, prefix, name)?.0)
     }
     fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
         KanbanContext::list_sprints_impl(self, board_id)
@@ -231,25 +235,25 @@ impl KanbanOperations for KanbanContext {
         KanbanContext::get_sprint_impl(self, id)
     }
     fn update_sprint(&mut self, id: Uuid, updates: SprintUpdate) -> KanbanResult<Sprint> {
-        KanbanContext::update_sprint_impl(self, id, updates)
+        Ok(KanbanContext::update_sprint_impl(self, id, updates)?.0)
     }
     fn activate_sprint(&mut self, id: Uuid, duration_days: Option<i32>) -> KanbanResult<Sprint> {
-        KanbanContext::activate_sprint_impl(self, id, duration_days)
+        Ok(KanbanContext::activate_sprint_impl(self, id, duration_days)?.0)
     }
     fn complete_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
-        KanbanContext::complete_sprint_impl(self, id)
+        Ok(KanbanContext::complete_sprint_impl(self, id)?.0)
     }
     fn cancel_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
-        KanbanContext::cancel_sprint_impl(self, id)
+        Ok(KanbanContext::cancel_sprint_impl(self, id)?.0)
     }
     fn delete_sprint(&mut self, id: Uuid) -> KanbanResult<()> {
-        KanbanContext::delete_sprint_impl(self, id)
+        KanbanContext::delete_sprint_impl(self, id).map(|_| ())
     }
 
     fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String> {
         KanbanContext::export_board_impl(self, board_id)
     }
     fn import_board(&mut self, data: &str) -> KanbanResult<Board> {
-        KanbanContext::import_board_impl(self, data)
+        Ok(KanbanContext::import_board_impl(self, data)?.0)
     }
 }

--- a/crates/kanban-service/src/context/persistence.rs
+++ b/crates/kanban-service/src/context/persistence.rs
@@ -1,5 +1,5 @@
 use super::KanbanContext;
-use kanban_domain::KanbanResult;
+use kanban_domain::{EntityIds, Invalidation, KanbanResult};
 
 impl KanbanContext {
     /// Backfill `sprint_logs` for cards that have a `sprint_id` but empty logs.
@@ -15,7 +15,7 @@ impl KanbanContext {
     /// persist loop correctly iterates `cards` alone.
     ///
     /// Returns the number of cards that received a backfilled log.
-    pub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {
+    pub fn migrate_sprint_logs(&mut self) -> KanbanResult<(usize, Option<Invalidation>)> {
         // C3b FIDELITY: raw reads — sprint-log migration must touch ALL cards.
         let mut cards = self.backend.list_all_cards()?;
         let sprints = self.backend.list_all_sprints()?;
@@ -23,21 +23,27 @@ impl KanbanContext {
         let before_logs: Vec<_> = cards.iter().map(|c| c.sprint_logs.clone()).collect();
         let count =
             kanban_domain::card_lifecycle::migrate_sprint_logs(&mut cards, &sprints, &boards);
-        if count > 0 {
-            // Invalidate the entire undo history — a data migration
-            // mutates state outside the command pipeline, so any
-            // inverse captured before the migration would now reference
-            // stale entity values.
-            self.undo_stack.clear();
-            tracing::info!("Migrated sprint logs for {} card(s)", count);
-            for (card, before) in cards.into_iter().zip(before_logs) {
-                if card.sprint_logs != before {
-                    self.backend.upsert_card(card)?;
-                }
-            }
-            self.dirty = true;
+        if count == 0 {
+            return Ok((0, None));
         }
-        Ok(count)
+        // Invalidate the entire undo history — a data migration
+        // mutates state outside the command pipeline, so any
+        // inverse captured before the migration would now reference
+        // stale entity values.
+        self.undo_stack.clear();
+        tracing::info!("Migrated sprint logs for {} card(s)", count);
+        let mut written = Vec::new();
+        for (card, before) in cards.into_iter().zip(before_logs) {
+            if card.sprint_logs != before {
+                written.push(card.id);
+                self.backend.upsert_card(card)?;
+            }
+        }
+        self.dirty = true;
+        Ok((
+            count,
+            Some(Invalidation::Entities(EntityIds::cards(written))),
+        ))
     }
 
     /// Reload state from durable storage, discarding any uncommitted
@@ -45,11 +51,11 @@ impl KanbanContext {
     /// before the reload may no longer exist). The audit log is left
     /// untouched — it records what happened, and a reload does not
     /// unhappen it.
-    pub async fn reload(&mut self) -> KanbanResult<()> {
+    pub async fn reload(&mut self) -> KanbanResult<Invalidation> {
         self.backend.reload().await?;
         self.undo_stack.clear();
         self.dirty = false;
-        Ok(())
+        Ok(Invalidation::All)
     }
 
     /// Persist any dirty state to durable storage.

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -2,7 +2,8 @@ use super::KanbanContext;
 use kanban_core::{ClientId, KANBAN_VERSION};
 use kanban_domain::commands::{Command, SprintCommand};
 use kanban_domain::{
-    Board, DataStore, FieldUpdate, KanbanError, KanbanResult, Snapshot, Sprint, SprintUpdate,
+    invalidation_from_inverse, Board, DataStore, FieldUpdate, Invalidation, KanbanError,
+    KanbanResult, Snapshot, Sprint, SprintUpdate,
 };
 use kanban_persistence::PersistenceError;
 use uuid::Uuid;
@@ -18,11 +19,11 @@ pub struct SprintCreateOutcome {
 }
 
 impl KanbanContext {
-    pub(super) fn carry_over_sprint_cards_impl(
+    pub fn carry_over_sprint_cards_impl(
         &mut self,
         from_sprint_id: Uuid,
         to_sprint_id: Uuid,
-    ) -> KanbanResult<usize> {
+    ) -> KanbanResult<(usize, Invalidation)> {
         use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
 
         let from_sprint = self
@@ -73,6 +74,19 @@ impl KanbanContext {
         prefix: Option<String>,
         auto_consume_name: bool,
     ) -> KanbanResult<Sprint> {
+        Ok(self
+            .create_sprint_from_spec_returning(board_id, id, name, prefix, auto_consume_name)?
+            .0)
+    }
+
+    pub(super) fn create_sprint_from_spec_returning(
+        &mut self,
+        board_id: Uuid,
+        id: Option<Uuid>,
+        name: Option<String>,
+        prefix: Option<String>,
+        auto_consume_name: bool,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
         use kanban_domain::commands::CreateSprint;
 
         // FK: the owning board must exist before we mint anything.
@@ -104,10 +118,11 @@ impl KanbanContext {
             explicit_prefix: prefix,
             auto_consume_name,
         }));
-        self.execute(vec![cmd])?;
-        self.get_sprint_impl(id)?.ok_or_else(|| {
+        let invalidation = self.execute(vec![cmd])?;
+        let sprint = self.get_sprint_impl(id)?.ok_or_else(|| {
             KanbanError::Internal("Sprint creation succeeded but sprint not found".into())
-        })
+        })?;
+        Ok((sprint, invalidation))
     }
 
     /// Idempotent PUT-create (create-or-replace) for a sprint keyed on a
@@ -147,7 +162,7 @@ impl KanbanContext {
             start_date: FieldUpdate::NoChange,
             end_date: FieldUpdate::NoChange,
         };
-        let sprint = self.update_sprint_impl(id, updates)?;
+        let (sprint, _inv) = self.update_sprint_impl(id, updates)?;
         Ok(SprintCreateOutcome {
             sprint,
             created: false,
@@ -158,13 +173,13 @@ impl KanbanContext {
     /// for the legacy `(board_id, prefix, name)` create path, so the existing
     /// trait callers do not churn. The service mints the id; CLI/MCP semantics
     /// (no auto-consume of pooled names) are preserved.
-    pub(super) fn create_sprint_impl(
+    pub fn create_sprint_impl(
         &mut self,
         board_id: Uuid,
         prefix: Option<String>,
         name: Option<String>,
-    ) -> KanbanResult<Sprint> {
-        self.create_sprint_from_spec(board_id, None, name, prefix, false)
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        self.create_sprint_from_spec_returning(board_id, None, name, prefix, false)
     }
 
     pub(super) fn list_sprints_impl(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
@@ -175,54 +190,62 @@ impl KanbanContext {
         self.backend.get_sprint(id)
     }
 
-    pub(super) fn update_sprint_impl(
+    pub fn update_sprint_impl(
         &mut self,
         id: Uuid,
         updates: SprintUpdate,
-    ) -> KanbanResult<Sprint> {
+    ) -> KanbanResult<(Sprint, Invalidation)> {
         use kanban_domain::commands::UpdateSprint;
         let cmd = Command::Sprint(SprintCommand::Update(UpdateSprint {
             sprint_id: id,
             updates,
         }));
-        self.execute(vec![cmd])?;
-        self.get_sprint_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Sprint", id))
+        let invalidation = self.execute(vec![cmd])?;
+        let sprint = self
+            .get_sprint_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))?;
+        Ok((sprint, invalidation))
     }
 
-    pub(super) fn activate_sprint_impl(
+    pub fn activate_sprint_impl(
         &mut self,
         id: Uuid,
         duration_days: Option<i32>,
-    ) -> KanbanResult<Sprint> {
+    ) -> KanbanResult<(Sprint, Invalidation)> {
         use kanban_domain::commands::ActivateSprint;
         let duration = duration_days.unwrap_or(14) as u32;
         let cmd = Command::Sprint(SprintCommand::Activate(ActivateSprint {
             sprint_id: id,
             duration_days: duration,
         }));
-        self.execute(vec![cmd])?;
-        self.get_sprint_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Sprint", id))
+        let invalidation = self.execute(vec![cmd])?;
+        let sprint = self
+            .get_sprint_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))?;
+        Ok((sprint, invalidation))
     }
 
-    pub(super) fn complete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<Sprint> {
+    pub fn complete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<(Sprint, Invalidation)> {
         use kanban_domain::commands::CompleteSprint;
         let cmd = Command::Sprint(SprintCommand::Complete(CompleteSprint { sprint_id: id }));
-        self.execute(vec![cmd])?;
-        self.get_sprint_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Sprint", id))
+        let invalidation = self.execute(vec![cmd])?;
+        let sprint = self
+            .get_sprint_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))?;
+        Ok((sprint, invalidation))
     }
 
-    pub(super) fn cancel_sprint_impl(&mut self, id: Uuid) -> KanbanResult<Sprint> {
+    pub fn cancel_sprint_impl(&mut self, id: Uuid) -> KanbanResult<(Sprint, Invalidation)> {
         use kanban_domain::commands::CancelSprint;
         let cmd = Command::Sprint(SprintCommand::Cancel(CancelSprint { sprint_id: id }));
-        self.execute(vec![cmd])?;
-        self.get_sprint_impl(id)?
-            .ok_or_else(|| KanbanError::not_found("Sprint", id))
+        let invalidation = self.execute(vec![cmd])?;
+        let sprint = self
+            .get_sprint_impl(id)?
+            .ok_or_else(|| KanbanError::not_found("Sprint", id))?;
+        Ok((sprint, invalidation))
     }
 
-    pub(super) fn delete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<()> {
+    pub fn delete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
         use kanban_domain::commands::DeleteSprint;
         let cmd = Command::Sprint(SprintCommand::Delete(DeleteSprint {
             sprint_id: id,
@@ -334,7 +357,7 @@ impl KanbanContext {
             .map_err(|e| PersistenceError::Serialization(e.to_string()).into())
     }
 
-    pub(super) fn import_board_impl(&mut self, data: &str) -> KanbanResult<Board> {
+    pub fn import_board_impl(&mut self, data: &str) -> KanbanResult<(Board, Invalidation)> {
         use kanban_domain::commands::BoardCommand;
         use kanban_domain::commands::{Command, CommandContext, ImportEntities};
         use std::collections::HashSet;
@@ -440,6 +463,7 @@ impl KanbanContext {
         self.undo_stack.clear();
         self.dirty = true;
 
-        Ok(board)
+        let invalidation = invalidation_from_inverse(&commands);
+        Ok((board, invalidation))
     }
 }

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -16,7 +16,7 @@ impl KanbanContext {
     /// previous command left behind. The composed inverse is the
     /// per-command inverses in reverse order, so undoing each `Fk_inv`
     /// runs against the state `Fk` itself saw at capture time.
-    pub fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<()> {
+    pub fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<Invalidation> {
         self.execute_with(|_| Ok(commands))
     }
 
@@ -37,7 +37,7 @@ impl KanbanContext {
     pub fn execute_with(
         &mut self,
         build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>,
-    ) -> KanbanResult<()> {
+    ) -> KanbanResult<Invalidation> {
         self.execute_with_extra(kanban_domain::EntityIds::default(), build)
     }
 
@@ -50,7 +50,7 @@ impl KanbanContext {
         &mut self,
         extra: kanban_domain::EntityIds,
         build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>,
-    ) -> KanbanResult<()> {
+    ) -> KanbanResult<Invalidation> {
         if self.backend.remote_writes().is_some() {
             return Err(KanbanError::unsupported(
                 "this operation is not supported over the HTTP backend in v1 (only board/column/card create/update/delete are)",
@@ -92,7 +92,7 @@ impl KanbanContext {
                 Invalidation::Entities(ids)
             }
         };
-        self.record_invalidation(invalidation);
+        self.record_invalidation(invalidation.clone());
 
         self.undo_stack.push(crate::undo_stack::UndoEntry {
             forward: commands,
@@ -100,7 +100,7 @@ impl KanbanContext {
         });
 
         self.dirty = true;
-        Ok(())
+        Ok(invalidation)
     }
 
     /// Undo the most recent batch via inverse-command execution.

--- a/crates/kanban-service/src/test_helpers/fault.rs
+++ b/crates/kanban-service/src/test_helpers/fault.rs
@@ -87,6 +87,13 @@ impl FaultInjectingBackend {
         self.failing.lock().unwrap().insert(method);
     }
 
+    /// Make `reload` return an error until cleared. Separate from [`fail`](Self::fail)
+    /// because `FAULTABLE_READS` scopes `DataStore` reads, not lifecycle calls
+    /// like `KanbanBackend::reload`.
+    pub fn fail_reload(&self) {
+        self.failing.lock().unwrap().insert("reload");
+    }
+
     pub fn clear_faults(&self) {
         self.failing.lock().unwrap().clear();
     }
@@ -405,6 +412,9 @@ impl KanbanBackend for FaultInjectingBackend {
         self.inner.flush().await
     }
     async fn reload(&self) -> KanbanResult<()> {
+        if self.failing.lock().unwrap().contains("reload") {
+            return Err(KanbanError::Database("injected fault: reload".into()));
+        }
         self.inner.reload().await
     }
     fn needs_flush(&self) -> bool {

--- a/crates/kanban-service/tests/fault_injection.rs
+++ b/crates/kanban-service/tests/fault_injection.rs
@@ -225,3 +225,40 @@ async fn test_faultable_preserves_reload_semantics_for_a_durable_backend() {
         "both wrappers must be reachable, in construction order"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_failed_reload_returns_an_error_and_no_invalidation() {
+    use kanban_service::{FetchPlan, FetchRound, LoadedEntities};
+    let inner = InMemoryStore::new();
+    let board = Board::new("Seeded", None::<String>);
+    inner.upsert_board(board.clone()).unwrap();
+    let backend = Arc::new(FaultInjectingBackend::new(
+        Arc::new(inner) as Arc<dyn KanbanBackend>
+    ));
+
+    let mut ctx = kanban_service::KanbanContext::open(
+        backend.clone() as Arc<dyn KanbanBackend>,
+        kanban_core::AppConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    struct BoardListPlan;
+    impl FetchPlan for BoardListPlan {
+        fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+            FetchRound {
+                board_list: true,
+                ..Default::default()
+            }
+        }
+    }
+    let model = kanban_domain::Model::default();
+    let before = ctx.resolve(&BoardListPlan, &model);
+    assert_eq!(before.boards.all.loaded().map(|v| v.len()), Some(1));
+
+    backend.fail_reload();
+    assert!(ctx.reload().await.is_err());
+
+    let after = ctx.resolve(&BoardListPlan, &model);
+    assert_eq!(after.boards.all.loaded().map(|v| v.len()), Some(1));
+}

--- a/crates/kanban-service/tests/migrate_sprint_logs.rs
+++ b/crates/kanban-service/tests/migrate_sprint_logs.rs
@@ -56,7 +56,7 @@ macro_rules! migrate_sprint_logs_tests {
                 backend.upsert_sprint(sprint).unwrap();
                 backend.upsert_card(card).unwrap();
 
-                let migrated = ctx.migrate_sprint_logs().unwrap();
+                let (migrated, _inv) = ctx.migrate_sprint_logs().unwrap();
                 assert_eq!(migrated, 1);
 
                 let card = backend.get_card(card_id).unwrap().unwrap();
@@ -81,7 +81,7 @@ macro_rules! migrate_sprint_logs_tests {
                 backend.upsert_card(card).unwrap();
 
                 let before = backend.list_all_cards().unwrap();
-                let migrated = ctx.migrate_sprint_logs().unwrap();
+                let (migrated, _inv) = ctx.migrate_sprint_logs().unwrap();
                 assert_eq!(
                     migrated, 0,
                     "migrate_sprint_logs should report zero when no card needs backfilling"
@@ -130,7 +130,7 @@ macro_rules! migrate_sprint_logs_tests {
                 backend.upsert_card(card_already_logged).unwrap();
                 backend.upsert_card(card_no_sprint).unwrap();
 
-                let migrated = ctx.migrate_sprint_logs().unwrap();
+                let (migrated, _inv) = ctx.migrate_sprint_logs().unwrap();
                 assert_eq!(migrated, 1, "only the eligible card should be migrated");
 
                 let backfilled = backend.get_card(needs_backfill_id).unwrap().unwrap();

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -1,0 +1,256 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::{
+    BoardUpdate, Card, CardUpdate, DataStore, EntityIds, Invalidation, KanbanOperations,
+    KanbanResult, Model, Prefix, Sprint,
+};
+use kanban_service::{FetchPlan, FetchRound, KanbanContext, LoadedEntities};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+async fn make_ctx() -> KanbanContext {
+    KanbanContext::open(
+        Arc::new(InMemoryStore::new()),
+        kanban_core::AppConfig::default(),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_returns_the_computed_invalidation() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+
+    use kanban_domain::commands::{BoardCommand, Command, UpdateBoard};
+    let inv = ctx.execute(vec![Command::Board(BoardCommand::Update(UpdateBoard {
+        board_id: board.id,
+        updates: BoardUpdate {
+            name: Some("Renamed".into()),
+            ..Default::default()
+        },
+    }))])?;
+
+    assert_eq!(inv, Invalidation::Entities(EntityIds::boards([board.id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_card_only_batch_returns_an_invalidation_naming_no_boards() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+
+    let (_card, inv) = ctx.update_card_impl(
+        card.id,
+        CardUpdate {
+            title: Some("Renamed".into()),
+            ..Default::default()
+        },
+    )?;
+
+    match inv {
+        Invalidation::Entities(ids) => {
+            assert!(ids.cards.contains(&card.id));
+            assert!(ids.boards.is_empty());
+        }
+        Invalidation::All => panic!("expected Entities, got All"),
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reload_returns_all() -> KanbanResult<()> {
+    use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("board.json");
+    let backend = JsonDataStore::new(Arc::new(JsonFileStore::new(&path)));
+    let mut ctx = KanbanContext::open(Arc::new(backend), kanban_core::AppConfig::default()).await?;
+    let inv = ctx.reload().await?;
+    assert_eq!(inv, Invalidation::All);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replace_backend_returns_all() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let inv = ctx.replace_backend(Arc::new(InMemoryStore::new()));
+    assert_eq!(inv, Invalidation::All);
+    Ok(())
+}
+
+fn seed_prefix(store: &InMemoryStore, prefix: &str) {
+    store.upsert_prefix(Prefix::new(prefix)).unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_sprint_logs_invalidates_only_the_cards_it_rewrote() -> KanbanResult<()> {
+    let store = InMemoryStore::new();
+    seed_prefix(&store, "KAN");
+
+    let now = chrono::Utc::now();
+    let board = kanban_domain::Board::create(
+        kanban_domain::NewBoard {
+            name: "B".into(),
+            description: None,
+            sprint_prefix: None,
+            card_prefix: Some("KAN".into()),
+            task_sort_field: None,
+            task_sort_order: None,
+            sprint_duration_days: None,
+            task_list_view: None,
+        },
+        uuid::Uuid::new_v4(),
+        now,
+    )?;
+    store.upsert_board(board.clone())?;
+
+    let column = kanban_domain::Column::create(
+        kanban_domain::NewColumn {
+            board_id: board.id,
+            name: "C".into(),
+            wip_limit: None,
+            default_status: None,
+        },
+        uuid::Uuid::new_v4(),
+        0,
+        now,
+    )?;
+    store.upsert_column(column.clone())?;
+
+    let sprint: Sprint = Sprint::new(board.id, 1, None, None::<String>);
+    let sprint_id = sprint.id;
+    store.upsert_sprint(sprint)?;
+
+    let mut eligible = Card::create(
+        kanban_domain::NewCard {
+            column_id: column.id,
+            title: "Eligible".into(),
+            description: None,
+            priority: kanban_domain::CardPriority::Medium,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+        uuid::Uuid::new_v4(),
+        1,
+        "KAN".into(),
+        now,
+        board.id,
+    )?;
+    eligible.sprint_id = Some(sprint_id);
+    eligible.sprint_logs = Vec::new();
+    let eligible_id = eligible.id;
+    store.upsert_card(eligible)?;
+
+    let untouched = Card::create(
+        kanban_domain::NewCard {
+            column_id: column.id,
+            title: "Untouched".into(),
+            description: None,
+            priority: kanban_domain::CardPriority::Medium,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+        uuid::Uuid::new_v4(),
+        2,
+        "KAN".into(),
+        now,
+        board.id,
+    )?;
+    let untouched_id = untouched.id;
+    store.upsert_card(untouched)?;
+
+    let mut ctx = KanbanContext::open(Arc::new(store), kanban_core::AppConfig::default()).await?;
+    let (n, inv) = ctx.migrate_sprint_logs()?;
+    assert_eq!(n, 1);
+    match inv {
+        Some(Invalidation::Entities(ids)) => {
+            assert_eq!(ids.cards, HashSet::from([eligible_id]));
+            assert!(!ids.cards.contains(&untouched_id));
+        }
+        other => panic!("expected Some(Entities), got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_no_op_sprint_log_migration_returns_no_invalidation() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let result = ctx.migrate_sprint_logs()?;
+    assert_eq!(result, (0, None));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_board_derives_its_invalidation_from_the_forward_batch() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let json = ctx.export_board(Some(board.id))?;
+
+    let mut dest = make_ctx().await;
+    let (_board, inv) = dest.import_board_impl(&json)?;
+    assert_eq!(inv, Invalidation::All);
+    Ok(())
+}
+
+struct BoardListPlan;
+impl FetchPlan for BoardListPlan {
+    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            board_list: true,
+            ..Default::default()
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_through_the_context_reaches_the_backend() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+
+    let resolved = ctx.resolve(&BoardListPlan, &Model::default());
+    let v = resolved
+        .boards
+        .all
+        .loaded()
+        .expect("expected Loaded, got something else");
+    assert_eq!(v.len(), 1);
+    assert_eq!(v[0].id, board.id);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_takes_a_shared_borrow() -> KanbanResult<()> {
+    let ctx = make_ctx().await;
+    let borrowed = &ctx;
+    let _a = borrowed.resolve(&BoardListPlan, &Model::default());
+    let _b = borrowed.resolve(&BoardListPlan, &Model::default());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_clear_history_returns_no_invalidation_because_it_mutates_no_entity(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+
+    let _unit: () = ctx.clear_history()?;
+
+    assert!(ctx.get_board(board.id)?.is_some());
+    assert!(ctx.get_column(col.id)?.is_some());
+    assert!(ctx.get_card(card.id)?.is_some());
+    Ok(())
+}
+
+/// Guards `Send`, which kanban-server's `Arc<tokio::sync::Mutex<KanbanContext>>`
+/// needs. Would NOT catch a `RefCell` inside `KanbanContext`, because
+/// `tokio::sync::Mutex<T>` is `Sync` for any `T: Send`.
+#[test]
+fn test_kanban_context_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<KanbanContext>();
+}

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -99,7 +99,7 @@ impl TuiContext {
     }
 
     pub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {
-        let result = self.inner.migrate_sprint_logs()?;
+        let (result, _invalidation) = self.inner.migrate_sprint_logs()?;
         if result > 0 && self.save_coordinator.has_save_channel() {
             self.save_coordinator.queue_flush();
         }
@@ -139,7 +139,7 @@ impl TuiContext {
     }
 
     pub fn replace_backend(&mut self, backend: Arc<dyn KanbanBackend>) {
-        self.inner.replace_backend(backend)
+        self.inner.replace_backend(backend);
     }
 
     pub async fn save(&self) -> KanbanResult<()> {
@@ -147,7 +147,7 @@ impl TuiContext {
     }
 
     pub async fn reload(&mut self) -> KanbanResult<()> {
-        self.inner.reload().await
+        self.inner.reload().await.map(|_| ())
     }
 
     pub fn data_store(&self) -> &dyn kanban_domain::DataStore {


### PR DESCRIPTION
## Summary

- `KanbanContext::execute`, `execute_with`, `execute_with_extra`, `reload`, `replace_backend` and `migrate_sprint_logs` now return the `Invalidation` they computed instead of discarding it.
- All 29 mutating `*_impl` inherent methods on `KanbanContext` are widened from `pub(super)` to `pub` and now return `(T, Invalidation)` (or `Invalidation` where `T` was `()`), so a Model-owning caller in another crate can reach the value. The 22 read-only `*_impl` methods are unchanged.
- Added `KanbanContext::resolve(&self, &dyn FetchPlan, &dyn LoadedEntities) -> Resolved`, a thin wrapper over the existing `kanban_service::resolve` free function.
- `KanbanOperations` (in kanban-domain) and its trait impl signatures are unchanged. Every trait delegation discards the `Invalidation` explicitly via `.0` or `.map(|_| ())` on its single delegation line.
- No `#[must_use]` attribute is added anywhere. That plus the wider caller sweep is separate follow-up work; until it lands this change is a compile-time no-op for existing callers.

### Corrections made to the original card during implementation

- The card's acceptance criterion that `kanban-mcp/**`, `kanban-cli/**` and `kanban-tui/**` stay byte-identical was not achievable: six sites in those crates plus `kanban-server` use `execute`/`reload`/`replace_backend`/`migrate_sprint_logs` as tail expressions or in exhaustive `Ok(())` matches, which are hard compile errors once the return type changes, independent of `#[must_use]`. Fixed with minimal, signature-preserving repairs in `kanban-cli/src/context.rs`, `kanban-mcp/src/context.rs`, `kanban-server/src/watch.rs` and three sites in `kanban-tui/src/tui_context.rs`.
- Four `create_*_from_spec` helpers (`create_board_from_spec`, `create_card_from_spec`, `create_column_from_spec`, `create_sprint_from_spec`) keep their existing public signatures, since kanban-mcp and kanban-server call them directly. Each gained a private `_returning` twin that returns the pair; the public method delegates and discards. This widens the audited-discard count from 29 to 37 (29 trait-block delegations + 4 `*_from_spec` wrappers + 4 `create_or_replace_*` facades).
- `migrate_sprint_logs` now returns `KanbanResult<(usize, Option<Invalidation>)>`: `None` on a no-op, `Some(Entities(...))` naming only the cards actually rewritten.
- `import_board_impl` derives its invalidation by calling `invalidation_from_inverse` over its own forward batch (per the existing helper's contract), not a hardcoded `All` literal: it currently evaluates to `All` because the command always carries a graph payload, which makes `touched_entities` unenumerable for it.
- Added `FaultInjectingBackend::fail_reload`, separate from `fail()`, since `FAULTABLE_READS` scopes `DataStore` reads, not the `KanbanBackend::reload` lifecycle call.

## Test plan

- [x] `cargo test -p kanban-service --all-features`: full suite green, including the new `mutation_invalidation.rs` and the added `fault_injection.rs` case.
- [x] `cargo test -p kanban-cli -p kanban-mcp -p kanban-server -p kanban-tui --all-features`: green.
- [x] `cargo fmt --all -- --check`: clean.
- [x] `cargo clippy --all-targets --all-features -p kanban-service -p kanban-cli -p kanban-mcp -p kanban-server -p kanban-tui -- -D warnings`: clean.
- [x] Mutation check: reverted `execute_with_extra` to a blunt `Invalidation::All`, confirmed `test_a_card_only_batch_returns_an_invalidation_naming_no_boards` fails (its `ids.boards.is_empty()` assertion), then restored the real implementation and confirmed green again.
- [x] Classifier re-run on this branch (`git grep` over the trait-block + `*_impl` names) confirms 29 mutating / 22 read-only, matching the `pub`/`pub(super)` split in this diff.
