### PR TITLE
KAN-1451 refactor(service,domain,mcp,tui): repoint consumers at the returned Invalidation

### DIFF
--- a/.changeset/kan-1451-repoint-consumers-at-returned-invalidation.md
+++ b/.changeset/kan-1451-repoint-consumers-at-returned-invalidation.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain,service,mcp,tui: `Invalidation` is now `#[must_use]`, and `KanbanContext::undo`/`redo` return `KanbanResult<Option<Invalidation>>` instead of `KanbanResult<bool>`, carrying the invalidation the reversed or replayed batch implies rather than discarding it. `KanbanContext::last_invalidation` and its backing field are removed; every caller now reads the value returned from `execute`, `execute_with`, `execute_with_extra`, `undo`, or `redo` directly. `McpContext::undo`/`redo` forward the same `Option<Invalidation>` return type. `TuiContext::undo`/`redo` are unchanged and still return `bool`, since kanban-tui has no consumer for the invalidation yet.

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -80,6 +80,7 @@ impl EntityIds {
 /// from its own fields (an empty batch counts as unenumerable, never as "no
 /// invalidation").
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum Invalidation {
     Entities(EntityIds),
     All,

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -3,7 +3,7 @@ use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
     CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
-    KanbanOperations, SortOrder, Sprint, SprintUpdate, DEFAULT_BOARD_SORT_LIVE,
+    Invalidation, KanbanOperations, SortOrder, Sprint, SprintUpdate, DEFAULT_BOARD_SORT_LIVE,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use std::str::FromStr;
@@ -153,11 +153,11 @@ impl McpContext {
         self.inner.clear_history()
     }
 
-    pub fn undo(&mut self) -> KanbanResult<bool> {
+    pub fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
         self.inner.undo()
     }
 
-    pub fn redo(&mut self) -> KanbanResult<bool> {
+    pub fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
         self.inner.redo()
     }
 

--- a/crates/kanban-mcp/src/tools/transfer.rs
+++ b/crates/kanban-mcp/src/tools/transfer.rs
@@ -42,7 +42,7 @@ impl KanbanMcpServer {
     #[tool(description = "Undo the last operation")]
     pub async fn tool_undo(&self) -> Result<CallToolResult, McpError> {
         let mut guard = self.ctx.lock().await;
-        if guard.undo().map_err(kanban_err_to_mcp)? {
+        if guard.undo().map_err(kanban_err_to_mcp)?.is_some() {
             guard.save().await.map_err(kanban_err_to_mcp)?;
             Ok(CallToolResult::success(vec![Content::text(
                 "Undo successful",
@@ -57,7 +57,7 @@ impl KanbanMcpServer {
     #[tool(description = "Redo the last undone operation")]
     pub async fn tool_redo(&self) -> Result<CallToolResult, McpError> {
         let mut guard = self.ctx.lock().await;
-        if guard.redo().map_err(kanban_err_to_mcp)? {
+        if guard.redo().map_err(kanban_err_to_mcp)?.is_some() {
             guard.save().await.map_err(kanban_err_to_mcp)?;
             Ok(CallToolResult::success(vec![Content::text(
                 "Redo successful",

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -643,7 +643,7 @@ async fn test_mcp_undo_reverses_create_board() {
     ctx.create_board("Board".into(), None).unwrap();
     assert_eq!(ctx.list_boards().unwrap().len(), 1);
 
-    assert!(ctx.undo().unwrap());
+    assert!(ctx.undo().unwrap().is_some());
     assert!(ctx.list_boards().unwrap().is_empty());
 }
 
@@ -654,7 +654,7 @@ async fn test_mcp_redo_restores_undone_board() {
     ctx.undo().unwrap();
     assert!(ctx.list_boards().unwrap().is_empty());
 
-    assert!(ctx.redo().unwrap());
+    assert!(ctx.redo().unwrap().is_some());
     assert_eq!(ctx.list_boards().unwrap().len(), 1);
 }
 

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1,5 +1,5 @@
 use kanban_core::AppConfig;
-use kanban_domain::{KanbanOperations, KanbanResult};
+use kanban_domain::{Invalidation, KanbanOperations, KanbanResult};
 use kanban_mcp::context::McpContext;
 use kanban_service::{KanbanContext, StoreManager};
 use tempfile::TempDir;
@@ -659,10 +659,34 @@ async fn test_mcp_redo_restores_undone_board() {
 }
 
 #[tokio::test]
-async fn test_mcp_undo_on_empty_returns_false() {
+async fn test_mcp_undo_on_empty_returns_none() {
     let (mut ctx, _tmp) = setup().await;
     assert!(!ctx.can_undo());
-    assert!(!ctx.undo().unwrap());
+    assert!(ctx.undo().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_mcp_context_undo_returns_the_invalidation_not_a_bool() {
+    let (mut ctx, _tmp) = setup().await;
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let card = ctx
+        .create_card(board.id, col.id, "Card".into(), Default::default())
+        .unwrap();
+    ctx.update_card(
+        card.id,
+        kanban_domain::CardUpdate {
+            title: Some("x".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let inv = ctx.undo().unwrap().expect("undo applied");
+    match inv {
+        Invalidation::Entities(ids) => assert!(ids.cards.contains(&card.id)),
+        Invalidation::All => panic!("expected Entities, got All"),
+    }
 }
 
 #[tokio::test]

--- a/crates/kanban-persistence-sqlite/tests/with_transaction.rs
+++ b/crates/kanban-persistence-sqlite/tests/with_transaction.rs
@@ -193,18 +193,19 @@ async fn test_undo_capture_inverse_reads_uncommitted_sibling_write() {
         .unwrap();
 
     let card_id = uuid::Uuid::new_v4();
-    ctx.execute(vec![Command::Card(CardCommand::Create(CreateCard {
-        id: card_id,
-        card_number: 1,
-        board_id: board.id,
-        column_id: col_a.id,
-        title: "Card".into(),
-        position: 0,
-        options: CreateCardOptions::default(),
-        timestamp: chrono::Utc::now(),
-        default_card_prefix: "task".to_string(),
-    }))])
-    .unwrap();
+    let _ = ctx
+        .execute(vec![Command::Card(CardCommand::Create(CreateCard {
+            id: card_id,
+            card_number: 1,
+            board_id: board.id,
+            column_id: col_a.id,
+            title: "Card".into(),
+            position: 0,
+            options: CreateCardOptions::default(),
+            timestamp: chrono::Utc::now(),
+            default_card_prefix: "task".to_string(),
+        }))])
+        .unwrap();
 
     // Second batch: MoveCard's WIP check / capture_inverse reads state the
     // first command in this same batch just wrote. Reuse Create+Move in one
@@ -229,7 +230,8 @@ async fn test_undo_capture_inverse_reads_uncommitted_sibling_write() {
             new_position: 0,
         })),
     ]);
-    result.expect("batch must succeed: MoveCard's capture_inverse must see the sibling create");
+    let _ =
+        result.expect("batch must succeed: MoveCard's capture_inverse must see the sibling create");
 
     assert_eq!(
         ctx.data_store()

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -37,7 +37,6 @@ pub struct KanbanContext {
     pub(super) conflict_pending: bool,
     pub(super) session_id: Uuid,
     pub(super) app_type: AppType,
-    pub(super) last_invalidation: Option<Invalidation>,
 }
 ```
 
@@ -107,14 +106,13 @@ entity ids from before the reload may no longer exist.
 ctx.execute(commands: Vec<Command>) -> KanbanResult<Invalidation>
 ctx.execute_with(build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<Invalidation>
 ctx.execute_with_extra(extra: EntityIds, build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<Invalidation>
-ctx.undo() -> KanbanResult<bool>   // Ok(false) if there was nothing to undo
-ctx.redo() -> KanbanResult<bool>   // Ok(false) if there was nothing to redo
+ctx.undo() -> KanbanResult<Option<Invalidation>>   // None if there was nothing to undo
+ctx.redo() -> KanbanResult<Option<Invalidation>>   // None if there was nothing to redo
 ctx.can_undo() -> bool
 ctx.can_redo() -> bool
 ctx.undo_depth() -> usize
 ctx.redo_depth() -> usize
 ctx.clear_history() -> KanbanResult<()>
-ctx.last_invalidation() -> Option<&Invalidation>
 ```
 
 Every undoable command captures an inverse at `execute` time; the
@@ -127,13 +125,15 @@ ready to retry the same entry. `execute` also appends the forward batch to
 the `CommandStore` audit log via `backend.append_batch` — informational
 only, it records what happened but does not drive undo.
 
-Every path that commits a batch (`execute`, `undo`, `redo`) records the
-`Invalidation` that batch implies; `last_invalidation()` returns `None`
-until a batch has committed on this context. A builder that writes state no
-command in the batch describes through `touched_entities` (a prefix row is
-the current example) declares it through `execute_with_extra`, whose
-`extra: EntityIds` is unioned into the derived invalidation unless that is
-already `Invalidation::All`.
+Every path that commits a batch (`execute`, `undo`, `redo`) RETURNS the
+`Invalidation` that batch implies, rather than stashing it on the context.
+`undo`/`redo` return `None` when the stack was empty and nothing committed.
+`Invalidation` is `#[must_use]`, so a caller cannot silently drop the value
+a mutation produced. A builder that writes state no command in the batch
+describes through `touched_entities` (a prefix row is the current example)
+declares it through `execute_with_extra`, whose `extra: EntityIds` is
+unioned into the derived invalidation unless that is already
+`Invalidation::All`.
 
 ### Board Operations
 

--- a/crates/kanban-service/src/context/core.rs
+++ b/crates/kanban-service/src/context/core.rs
@@ -22,7 +22,6 @@ impl KanbanContext {
             conflict_pending: false,
             session_id: Uuid::new_v4(),
             app_type: AppType::Unknown,
-            last_invalidation: None,
         }
     }
 

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -2,8 +2,8 @@ use crate::backend::KanbanBackend;
 use kanban_core::{AppConfig, AppType};
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter,
-    CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, Invalidation,
-    KanbanOperations, KanbanResult, Sprint, SprintUpdate,
+    CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, KanbanOperations,
+    KanbanResult, Sprint, SprintUpdate,
 };
 use serde::Serialize;
 use std::sync::Arc;
@@ -67,16 +67,13 @@ pub struct KanbanContext {
     pub(super) session_id: Uuid,
     /// Which application surface owns this context. Default: Unknown.
     pub(super) app_type: AppType,
-    /// The invalidation implied by the most recent command batch that
-    /// committed, forward or inverse. `None` until one has.
-    pub(super) last_invalidation: Option<Invalidation>,
 }
 
 // The `KanbanOperations` trait impl must live in a single block (Rust forbids
 // splitting a trait impl across files), so it forwards to the entity-focused
 // inherent methods in `boards`/`columns`/`cards`/`cards_batch`/`sprints`.
 /// Forwards to the entity-focused `*_impl` inherent methods, discarding the
-/// [`Invalidation`] each one now returns. A caller that wants the value calls
+/// [`kanban_domain::Invalidation`] each one now returns. A caller that wants the value calls
 /// the `*_impl` method directly rather than through this trait; see
 /// `KanbanContext::resolve` and the `*_impl` methods' `pub` visibility.
 impl KanbanOperations for KanbanContext {

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -92,8 +92,6 @@ impl KanbanContext {
                 Invalidation::Entities(ids)
             }
         };
-        self.record_invalidation(invalidation.clone());
-
         self.undo_stack.push(crate::undo_stack::UndoEntry {
             forward: commands,
             inverse: inverses,
@@ -106,10 +104,10 @@ impl KanbanContext {
     /// Undo the most recent batch via inverse-command execution.
     /// The cursor advances only if the inverse commits successfully —
     /// a failed undo leaves the stack ready to retry the same entry.
-    pub fn undo(&mut self) -> KanbanResult<bool> {
+    pub fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
         let inverse = match self.undo_stack.peek_undo() {
             Some(entry) => entry.inverse.clone(),
-            None => return Ok(false),
+            None => return Ok(None),
         };
         let invalidation = invalidation_from_inverse(&inverse);
         let backend = Arc::clone(&self.backend);
@@ -119,18 +117,17 @@ impl KanbanContext {
             inverse.iter().try_for_each(|cmd| cmd.execute(&ctx))
         }))?;
         self.undo_stack.commit_undo();
-        self.record_invalidation(invalidation);
         self.dirty = true;
-        Ok(true)
+        Ok(Some(invalidation))
     }
 
     /// Redo the next undone batch via forward-command execution.
     /// The cursor advances only if the forward batch commits — a failed
     /// redo leaves the stack ready to retry the same entry.
-    pub fn redo(&mut self) -> KanbanResult<bool> {
+    pub fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
         let forward = match self.undo_stack.peek_redo() {
             Some(entry) => entry.forward.clone(),
-            None => return Ok(false),
+            None => return Ok(None),
         };
         let invalidation = invalidation_from_inverse(&forward);
         let backend = Arc::clone(&self.backend);
@@ -140,9 +137,8 @@ impl KanbanContext {
             forward.iter().try_for_each(|cmd| cmd.execute(&ctx))
         }))?;
         self.undo_stack.commit_redo();
-        self.record_invalidation(invalidation);
         self.dirty = true;
-        Ok(true)
+        Ok(Some(invalidation))
     }
 
     pub fn can_undo(&self) -> bool {
@@ -168,17 +164,6 @@ impl KanbanContext {
         self.undo_stack.redo_depth()
     }
 
-    fn record_invalidation(&mut self, invalidation: Invalidation) {
-        self.last_invalidation = Some(invalidation);
-    }
-
-    /// The invalidation implied by the most recently committed command
-    /// batch, forward or inverse. `None` means nothing has committed on
-    /// this context yet; `Some(Invalidation::All)` means something
-    /// committed whose blast radius could not be enumerated.
-    pub fn last_invalidation(&self) -> Option<&Invalidation> {
-        self.last_invalidation.as_ref()
-    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -163,7 +163,6 @@ impl KanbanContext {
     pub fn redo_depth(&self) -> usize {
         self.undo_stack.redo_depth()
     }
-
 }
 
 #[cfg(test)]

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -577,7 +577,7 @@ pub async fn test_board_delete_undo_full_graph_roundtrip(factory: &BackendFactor
     );
     assert_eq!(empty.graph.len(), 0, "dependency edge gone after delete");
 
-    assert!(ctx.undo().unwrap(), "undo returned true");
+    assert!(ctx.undo().unwrap().is_some(), "undo returned true");
 
     ctx.save().await.unwrap();
     let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());

--- a/crates/kanban-service/src/test_helpers/contract/board.rs
+++ b/crates/kanban-service/src/test_helpers/contract/board.rs
@@ -299,7 +299,7 @@ pub async fn test_undo_column_delete_restores_completion_membership(factory: &Ba
     .unwrap();
 
     ctx.delete_column(cols[2].id).unwrap();
-    assert!(ctx.undo().unwrap(), "undo must apply");
+    assert!(ctx.undo().unwrap().is_some(), "undo must apply");
 
     let restored = ctx
         .get_column(cols[2].id)

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -436,7 +436,7 @@ pub async fn test_reload_picks_up_external_changes(factory: &BackendFactory) {
     ctx_b.create_board("Board B".into(), None).unwrap();
     ctx_b.save().await.unwrap();
 
-    ctx_a.reload().await.unwrap();
+    let _ = ctx_a.reload().await.unwrap();
     let boards = ctx_a.list_boards().unwrap();
     assert_eq!(boards.len(), 2);
     assert!(boards.iter().any(|b| b.name == "Board B"));

--- a/crates/kanban-service/src/test_helpers/contract/prefix.rs
+++ b/crates/kanban-service/src/test_helpers/contract/prefix.rs
@@ -446,19 +446,20 @@ pub async fn test_creating_a_subcard_leaves_its_namespace_backed(factory: &Backe
         .unwrap();
 
     let subcard_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
-        CreateSubcardCommand {
-            id: subcard_id,
-            parent_id: parent.id,
-            board_id: board.id,
-            column_id: col.id,
-            title: "subcard".into(),
-            description: None,
-            position: 0,
-            default_card_prefix: "task".into(),
-        },
-    ))])
-    .unwrap();
+    let _ = ctx
+        .execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+            CreateSubcardCommand {
+                id: subcard_id,
+                parent_id: parent.id,
+                board_id: board.id,
+                column_id: col.id,
+                title: "subcard".into(),
+                description: None,
+                position: 0,
+                default_card_prefix: "task".into(),
+            },
+        ))])
+        .unwrap();
 
     ctx.backend().flush().await.unwrap();
     drop(ctx);

--- a/crates/kanban-service/tests/audit_log_append_only.rs
+++ b/crates/kanban-service/tests/audit_log_append_only.rs
@@ -39,11 +39,11 @@ async fn test_audit_log_records_all_forward_executes_in_order() -> KanbanResult<
     let (_, cmd_b) = create_board_cmd("B", 1);
     let (_, cmd_c) = create_board_cmd("C", 2);
 
-    ctx.execute(vec![cmd_a])?;
+    let _ = ctx.execute(vec![cmd_a])?;
     assert_eq!(backend.batch_count()?, baseline + 1);
-    ctx.execute(vec![cmd_b])?;
+    let _ = ctx.execute(vec![cmd_b])?;
     assert_eq!(backend.batch_count()?, baseline + 2);
-    ctx.execute(vec![cmd_c])?;
+    let _ = ctx.execute(vec![cmd_c])?;
     assert_eq!(backend.batch_count()?, baseline + 3);
 
     let batches = backend.load_batches(baseline, baseline + 3)?;
@@ -68,13 +68,13 @@ async fn test_audit_log_does_not_rewind_on_undo() -> KanbanResult<()> {
     let (_, cmd_a) = create_board_cmd("A", 0);
     let (_, cmd_b) = create_board_cmd("B", 1);
 
-    ctx.execute(vec![cmd_a])?;
-    ctx.execute(vec![cmd_b])?;
+    let _ = ctx.execute(vec![cmd_a])?;
+    let _ = ctx.execute(vec![cmd_b])?;
     assert_eq!(backend.batch_count()?, baseline + 2);
 
     // Undo B. UndoStack cursor moves back; audit log is untouched —
     // "the user undid B" is itself an event, not a deletion.
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(
         backend.batch_count()?,
         baseline + 2,
@@ -82,7 +82,7 @@ async fn test_audit_log_does_not_rewind_on_undo() -> KanbanResult<()> {
     );
 
     // Undo A. Same story.
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(
         backend.batch_count()?,
         baseline + 2,
@@ -101,17 +101,17 @@ async fn test_audit_log_preserves_abandoned_redo_tail_on_branching_execute() -> 
     let (_, cmd_b) = create_board_cmd("B", 1);
     let (_, cmd_c) = create_board_cmd("C", 2);
 
-    ctx.execute(vec![cmd_a])?;
-    ctx.execute(vec![cmd_b])?;
+    let _ = ctx.execute(vec![cmd_a])?;
+    let _ = ctx.execute(vec![cmd_b])?;
 
     // Undo B — B is now in the UndoStack's redo tail.
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.redo_depth(), 1, "B is parked in the redo tail");
 
     // Execute C — UndoStack drops B from its tail (the user branched
     // off the partial undo). The audit log, however, must still
     // record that B happened.
-    ctx.execute(vec![cmd_c])?;
+    let _ = ctx.execute(vec![cmd_c])?;
     assert_eq!(
         ctx.redo_depth(),
         0,

--- a/crates/kanban-service/tests/board_archive.rs
+++ b/crates/kanban-service/tests/board_archive.rs
@@ -56,7 +56,7 @@ async fn test_archive_board_is_undoable() -> KanbanResult<()> {
     ctx.archive_board(board_id)?;
     assert!(ctx.boards()?.is_empty());
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 1, "undo returns the board to live");
     assert!(ctx.list_archived_boards()?.is_empty());
     Ok(())
@@ -99,7 +99,7 @@ async fn test_delete_archived_board_undo_restores_as_archived() -> KanbanResult<
     ctx.delete_board(board_id)?;
     assert!(ctx.list_archived_boards()?.is_empty());
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     // Restored AS archived (not live), with its subtree.
     assert!(ctx.boards()?.is_empty(), "not restored to the live set");
     let archived = ctx.list_archived_boards()?;

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -82,7 +82,7 @@ async fn test_archive_undo_and_restore_return_board_to_live() -> KanbanResult<()
 
     ctx.archive_board(board_id)?;
     assert!(ctx.boards()?.is_empty());
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 1, "undo returned the board to live");
     assert!(ctx.list_archived_boards()?.is_empty());
     // The subtree must survive undo-of-archive, not just the head (KAN-863).
@@ -154,7 +154,7 @@ async fn test_delete_works_on_archived_board_and_undo_restores_as_archived() -> 
     assert!(ctx.list_all_columns()?.is_empty(), "subtree cascaded");
     assert!(ctx.list_all_cards()?.is_empty());
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(ctx.boards()?.is_empty(), "not restored to the live set");
     let archived = ctx.list_archived_boards()?;
     assert_eq!(archived.len(), 1, "restored as archived");

--- a/crates/kanban-service/tests/card_metadata_editor_format.rs
+++ b/crates/kanban-service/tests/card_metadata_editor_format.rs
@@ -31,7 +31,7 @@ async fn test_editor_yyyy_mm_dd_due_date_is_persisted_as_midnight_utc() -> Kanba
     let dto: CardMetadataDto = serde_json::from_str(&metadata_json(r#""2024-01-15""#))
         .expect("YYYY-MM-DD must deserialize through the editor DTO");
 
-    ctx.execute(vec![Command::Card(CardCommand::ApplyMetadata(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::ApplyMetadata(
         ApplyCardMetadata {
             card_id: card.id,
             dto,
@@ -57,7 +57,7 @@ async fn test_editor_rfc3339_due_date_is_persisted_at_exact_instant() -> KanbanR
     let dto: CardMetadataDto =
         serde_json::from_str(&metadata_json(r#""2024-01-15T14:30:00Z""#)).unwrap();
 
-    ctx.execute(vec![Command::Card(CardCommand::ApplyMetadata(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::ApplyMetadata(
         ApplyCardMetadata {
             card_id: card.id,
             dto,
@@ -99,7 +99,7 @@ async fn test_editor_yyyy_mm_dd_due_date_round_trips_back_through_serializer() -
     let card = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
 
     let dto: CardMetadataDto = serde_json::from_str(&metadata_json(r#""2024-01-15""#)).unwrap();
-    ctx.execute(vec![Command::Card(CardCommand::ApplyMetadata(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::ApplyMetadata(
         ApplyCardMetadata {
             card_id: card.id,
             dto,

--- a/crates/kanban-service/tests/completion_sync.rs
+++ b/crates/kanban-service/tests/completion_sync.rs
@@ -346,7 +346,7 @@ async fn test_undo_after_update_card_status_done_reverses_both_status_and_column
     assert_eq!(card_done.column_id, fx.done_id);
     assert_eq!(card_done.status, CardStatus::Done);
 
-    assert!(ctx.undo()?, "undo should report success");
+    assert!(ctx.undo()?.is_some(), "undo should report success");
     let card_after_undo = ctx.get_card(fx.card_id)?.unwrap();
     assert_eq!(
         card_after_undo.column_id, fx.backlog_id,
@@ -586,7 +586,7 @@ async fn test_undo_after_update_cards_batch_reverses_every_chained_command() -> 
         ),
     ])?;
 
-    assert!(ctx.undo()?, "undo should report success");
+    assert!(ctx.undo()?.is_some(), "undo should report success");
 
     for id in [fx.card_id, card2.id, card3.id] {
         let card = ctx.get_card(id)?.unwrap();

--- a/crates/kanban-service/tests/configured_default_card_prefix.rs
+++ b/crates/kanban-service/tests/configured_default_card_prefix.rs
@@ -129,19 +129,20 @@ async fn test_subcard_creation_allocates_from_the_configured_default_card_prefix
         .unwrap();
 
     let subcard_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
-        CreateSubcardCommand {
-            id: subcard_id,
-            parent_id: parent.id,
-            board_id: board.id,
-            column_id: column.id,
-            title: "child".into(),
-            description: None,
-            position: 1,
-            default_card_prefix: "feat".into(),
-        },
-    ))])
-    .unwrap();
+    let _ = ctx
+        .execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+            CreateSubcardCommand {
+                id: subcard_id,
+                parent_id: parent.id,
+                board_id: board.id,
+                column_id: column.id,
+                title: "child".into(),
+                description: None,
+                position: 1,
+                default_card_prefix: "feat".into(),
+            },
+        ))])
+        .unwrap();
 
     let subcard = ctx.get_card(subcard_id).unwrap().unwrap();
     assert_eq!(subcard.prefix, "feat");

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -186,7 +186,7 @@ async fn test_open_context_undo_before_any_execute_is_noop() -> KanbanResult<()>
     let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
 
     assert!(
-        !ctx.undo()?,
+        ctx.undo()?.is_none(),
         "undo before any execute must return false (nothing to undo)"
     );
     Ok(())
@@ -202,7 +202,7 @@ async fn test_open_context_undo_works_after_execute() -> KanbanResult<()> {
     ctx.create_board("B".into(), None)?;
     assert_eq!(ctx.boards()?.len(), 1);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(
         ctx.boards()?.is_empty(),
         "undo must revert the board creation"
@@ -250,7 +250,7 @@ async fn test_open_context_reload_delegates_to_backend() -> KanbanResult<()> {
     // Before reload the context cache is stale.
     assert!(ctx.boards()?.is_empty(), "must be stale before reload");
 
-    ctx.reload().await?;
+    let _ = ctx.reload().await?;
     let boards = ctx.boards()?;
     assert_eq!(boards.len(), 1);
     assert_eq!(boards[0].name, "External");
@@ -269,12 +269,12 @@ async fn test_undo_redo_work_with_lazy_json_backend() -> KanbanResult<()> {
     ctx.create_board("B".into(), None)?;
     assert_eq!(ctx.boards()?.len(), 2);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let boards = ctx.boards()?;
     assert_eq!(boards.len(), 1);
     assert_eq!(boards[0].name, "A");
 
-    assert!(ctx.redo()?);
+    assert!(ctx.redo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 2);
     Ok(())
 }
@@ -290,7 +290,7 @@ async fn test_can_undo_returns_false_after_reload() -> KanbanResult<()> {
     assert!(ctx.can_undo(), "must be undoable before reload");
 
     ctx.save().await?;
-    ctx.reload().await?;
+    let _ = ctx.reload().await?;
 
     assert!(!ctx.can_undo(), "undo history must be invalid after reload");
     Ok(())
@@ -313,7 +313,7 @@ async fn test_reload_after_external_json_change_returns_updated_data() -> Kanban
     external.flush().await?;
 
     // reload() clears the lazy cache; next read loads the updated file.
-    ctx.reload().await?;
+    let _ = ctx.reload().await?;
     let boards = ctx.boards()?;
     assert_eq!(boards.len(), 1);
     assert_eq!(boards[0].name, "External");
@@ -387,7 +387,7 @@ async fn test_replace_backend_resets_undo_history() -> KanbanResult<()> {
     ctx.create_board("A".into(), None)?;
     assert!(ctx.can_undo());
 
-    ctx.replace_backend(make_json_backend(&dir.path().join("b.json")));
+    let _ = ctx.replace_backend(make_json_backend(&dir.path().join("b.json")));
     assert!(!ctx.can_undo(), "replace_backend must reset undo history");
     Ok(())
 }
@@ -405,7 +405,7 @@ async fn test_replace_backend_resets_redo_history() -> KanbanResult<()> {
     ctx.undo()?;
     assert!(ctx.can_redo());
 
-    ctx.replace_backend(make_json_backend(&dir.path().join("b.json")));
+    let _ = ctx.replace_backend(make_json_backend(&dir.path().join("b.json")));
     assert!(!ctx.can_redo(), "replace_backend must reset redo history");
     Ok(())
 }
@@ -430,7 +430,7 @@ async fn test_replace_backend_reads_go_to_new_backend() -> KanbanResult<()> {
     assert_eq!(ctx.boards()?.len(), 1);
     assert_eq!(ctx.boards()?[0].name, "A");
 
-    ctx.replace_backend(make_json_backend(&path_b));
+    let _ = ctx.replace_backend(make_json_backend(&path_b));
     let boards = ctx.boards()?;
     assert_eq!(boards.len(), 1);
     assert_eq!(boards[0].name, "B", "reads must come from the new backend");
@@ -449,7 +449,7 @@ async fn test_replace_backend_clears_dirty_flag() -> KanbanResult<()> {
     ctx.create_board("A".into(), None)?;
     assert!(ctx.is_dirty());
 
-    ctx.replace_backend(make_json_backend(&dir.path().join("b.json")));
+    let _ = ctx.replace_backend(make_json_backend(&dir.path().join("b.json")));
     assert!(!ctx.is_dirty(), "replace_backend must clear the dirty flag");
     Ok(())
 }
@@ -482,7 +482,7 @@ async fn test_open_session_undo_preserves_preexisting_boards() -> KanbanResult<(
     ctx.create_board("B2".into(), None)?;
     assert_eq!(ctx.boards()?.len(), 3);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let boards = ctx.boards()?;
     assert_eq!(boards.len(), 2);
     let names: Vec<&str> = boards.iter().map(|b| b.name.as_str()).collect();
@@ -503,7 +503,7 @@ async fn test_replace_backend_then_execute_succeeds() -> KanbanResult<()> {
     )
     .await?;
 
-    ctx.replace_backend(make_json_backend(&dir.path().join("b.json")));
+    let _ = ctx.replace_backend(make_json_backend(&dir.path().join("b.json")));
 
     ctx.create_board("B".into(), None)?;
     assert_eq!(ctx.boards()?.len(), 1);
@@ -543,7 +543,7 @@ async fn test_reload_does_not_mark_backend_dirty() {
     ctx.create_board("B".into(), None).unwrap();
     ctx.save().await.unwrap();
 
-    ctx.reload().await.unwrap();
+    let _ = ctx.reload().await.unwrap();
 
     assert!(
         !backend.needs_flush(),

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -174,7 +174,7 @@ macro_rules! cascade_tests {
                 assert!(backend.list_all_sprints().unwrap().is_empty());
                 assert_eq!(backend.get_graph().unwrap().len(), 0);
 
-                let undone = ctx.undo().unwrap();
+                let undone = ctx.undo().unwrap().is_some();
                 assert!(undone, "undo should report success");
 
                 // A single undo restores the ENTIRE cascade - the SAME entities
@@ -382,7 +382,7 @@ macro_rules! cascade_tests {
                     "delete_board must remove the board's sprints even with no columns"
                 );
 
-                let undone = ctx.undo().unwrap();
+                let undone = ctx.undo().unwrap().is_some();
                 assert!(undone, "undo should report success");
 
                 assert!(

--- a/crates/kanban-service/tests/execute_with.rs
+++ b/crates/kanban-service/tests/execute_with.rs
@@ -87,31 +87,35 @@ async fn test_execute_with_records_the_built_batch_for_undo() {
     let col = c.create_column(board.id, "Todo".into(), None).unwrap();
     let id = Uuid::new_v4();
 
-    c.execute_with(|store| {
-        // Constructed directly rather than through `c.create_card`, so the
-        // prefix row `allocate_card_number` would normally mint must be
-        // seeded by hand.
-        store.upsert_prefix(Prefix {
-            name: "kan".into(),
-            card_counter: 7,
-            sprint_counter: 0,
-        })?;
-        Ok(vec![Command::Card(CardCommand::Create(CreateCard {
-            id,
-            card_number: 7,
-            board_id: board.id,
-            column_id: col.id,
-            title: "built".into(),
-            position: 0,
-            options: CreateCardOptions::default(),
-            timestamp: chrono::Utc::now(),
-            default_card_prefix: "task".to_string(),
-        }))])
-    })
-    .unwrap();
+    let _ = c
+        .execute_with(|store| {
+            // Constructed directly rather than through `c.create_card`, so the
+            // prefix row `allocate_card_number` would normally mint must be
+            // seeded by hand.
+            store.upsert_prefix(Prefix {
+                name: "kan".into(),
+                card_counter: 7,
+                sprint_counter: 0,
+            })?;
+            Ok(vec![Command::Card(CardCommand::Create(CreateCard {
+                id,
+                card_number: 7,
+                board_id: board.id,
+                column_id: col.id,
+                title: "built".into(),
+                position: 0,
+                options: CreateCardOptions::default(),
+                timestamp: chrono::Utc::now(),
+                default_card_prefix: "task".to_string(),
+            }))])
+        })
+        .unwrap();
 
     assert!(c.get_card(id).unwrap().is_some(), "the card was created");
-    assert!(c.undo().unwrap(), "the built batch must be undoable");
+    assert!(
+        c.undo().unwrap().is_some(),
+        "the built batch must be undoable"
+    );
     assert!(
         c.get_card(id).unwrap().is_none(),
         "undo must reverse the commands the BUILDER produced, not an empty batch"
@@ -137,7 +141,7 @@ async fn test_execute_with_propagates_a_builder_error_and_records_nothing() {
 
     // Undo now reverses the earlier create, proving the failed builder pushed
     // nothing onto the stack.
-    assert!(c.undo().unwrap());
+    assert!(c.undo().unwrap().is_some());
     assert!(
         c.get_card(before.id).unwrap().is_none(),
         "the undo stack must be untouched by a failed builder"

--- a/crates/kanban-service/tests/execute_with_extra.rs
+++ b/crates/kanban-service/tests/execute_with_extra.rs
@@ -17,11 +17,8 @@ async fn make_ctx() -> KanbanContext {
     .unwrap()
 }
 
-fn entities(ctx: &KanbanContext) -> &EntityIds {
-    match ctx
-        .last_invalidation()
-        .expect("expected a recorded invalidation, found None")
-    {
+fn entities(inv: Invalidation) -> EntityIds {
+    match inv {
         Invalidation::Entities(ids) => ids,
         Invalidation::All => panic!("expected Entities, got All"),
     }
@@ -34,7 +31,7 @@ async fn test_execute_with_extra_merges_the_extra_into_the_derived_entities() ->
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
 
-    ctx.execute_with_extra(EntityIds::default().with_prefixes(), |_| {
+    let inv = ctx.execute_with_extra(EntityIds::default().with_prefixes(), |_| {
         Ok(vec![Command::Card(CardCommand::Update(UpdateCard {
             card_id: card.id,
             updates: CardUpdate {
@@ -44,7 +41,7 @@ async fn test_execute_with_extra_merges_the_extra_into_the_derived_entities() ->
         }))])
     })?;
 
-    let ids = entities(&ctx);
+    let ids = entities(inv);
     assert_eq!(ids.cards, HashSet::from([card.id]));
     assert!(ids.prefixes);
     Ok(())
@@ -56,7 +53,7 @@ async fn test_execute_with_extra_does_not_downgrade_all_to_entities() -> KanbanR
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
 
-    ctx.execute_with_extra(EntityIds::default().with_prefixes(), |_| {
+    let inv = ctx.execute_with_extra(EntityIds::default().with_prefixes(), |_| {
         Ok(vec![Command::Card(CardCommand::Create(CreateCard {
             id: Uuid::new_v4(),
             card_number: 1,
@@ -70,7 +67,7 @@ async fn test_execute_with_extra_does_not_downgrade_all_to_entities() -> KanbanR
         }))])
     })?;
 
-    assert_eq!(ctx.last_invalidation(), Some(&Invalidation::All));
+    assert_eq!(inv, Invalidation::All);
     Ok(())
 }
 
@@ -81,7 +78,7 @@ async fn test_plain_execute_with_records_no_prefixes() -> KanbanResult<()> {
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
 
-    ctx.execute_with(|_| {
+    let inv = ctx.execute_with(|_| {
         Ok(vec![Command::Card(CardCommand::Update(UpdateCard {
             card_id: card.id,
             updates: CardUpdate {
@@ -91,24 +88,23 @@ async fn test_plain_execute_with_records_no_prefixes() -> KanbanResult<()> {
         }))])
     })?;
 
-    let ids = entities(&ctx);
+    let ids = entities(inv);
     assert_eq!(ids.cards, HashSet::from([card.id]));
     assert!(!ids.prefixes);
     Ok(())
 }
 
-/// Passes unmodified today; a forward guard, not a discriminating test.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_service_create_card_records_an_invalidation_covering_prefixes() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
-    ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
 
-    let covers_prefixes = match ctx.last_invalidation() {
-        Some(Invalidation::All) => true,
-        Some(Invalidation::Entities(ids)) => ids.prefixes,
-        None => false,
+    let (_card, inv) = ctx.create_card_impl(board.id, col.id, "A".into(), Default::default())?;
+
+    let covers_prefixes = match inv {
+        Invalidation::All => true,
+        Invalidation::Entities(ids) => ids.prefixes,
     };
     assert!(covers_prefixes);
     Ok(())

--- a/crates/kanban-service/tests/import_merges_dependency_graph.rs
+++ b/crates/kanban-service/tests/import_merges_dependency_graph.rs
@@ -224,18 +224,19 @@ async fn assert_undo_restores_pre_import_graph(mut src: KanbanContext, mut dest:
     let imported: kanban_domain::Snapshot = serde_json::from_str(&exported).unwrap();
     let (dest_board_id, dest_a, dest_b, dest_c) = seed_board_with_all_three_kinds(&mut dest);
 
-    dest.execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
-        boards: imported.boards,
-        columns: imported.columns,
-        cards: imported.cards,
-        archived_cards: imported.archived_cards,
-        archived_boards: imported.archived_boards,
-        sprints: imported.sprints,
-        graph: Some(imported.graph),
-        prefixes: imported.prefixes,
-        default_sprint_prefix: None,
-    }))])
-    .unwrap();
+    let _ = dest
+        .execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
+            boards: imported.boards,
+            columns: imported.columns,
+            cards: imported.cards,
+            archived_cards: imported.archived_cards,
+            archived_boards: imported.archived_boards,
+            sprints: imported.sprints,
+            graph: Some(imported.graph),
+            prefixes: imported.prefixes,
+            default_sprint_prefix: None,
+        }))])
+        .unwrap();
     dest.undo().unwrap();
 
     let dest_relations = dest.list_relations_for_board(dest_board_id).unwrap();
@@ -358,26 +359,27 @@ fn seed_board_with_all_three_kinds_plus_archived_edges(
     use kanban_domain::commands::{AddBlocks, AddRelates, AddSpawns, Command, DependencyCommand};
 
     let (board_id, a, b, c) = seed_board_with_all_three_kinds(ctx);
-    ctx.execute(vec![
-        Command::Dependency(DependencyCommand::AddSpawns(AddSpawns {
-            source: a,
-            target: c,
-            as_archived: true,
-        })),
-        Command::Dependency(DependencyCommand::AddBlocks(AddBlocks {
-            source: b,
-            target: c,
-            severity: Severity::Medium,
-            as_archived: true,
-        })),
-        Command::Dependency(DependencyCommand::AddRelates(AddRelates {
-            source: a,
-            target: b,
-            kind: RelatesKind::General,
-            as_archived: true,
-        })),
-    ])
-    .unwrap();
+    let _ = ctx
+        .execute(vec![
+            Command::Dependency(DependencyCommand::AddSpawns(AddSpawns {
+                source: a,
+                target: c,
+                as_archived: true,
+            })),
+            Command::Dependency(DependencyCommand::AddBlocks(AddBlocks {
+                source: b,
+                target: c,
+                severity: Severity::Medium,
+                as_archived: true,
+            })),
+            Command::Dependency(DependencyCommand::AddRelates(AddRelates {
+                source: a,
+                target: b,
+                kind: RelatesKind::General,
+                as_archived: true,
+            })),
+        ])
+        .unwrap();
     (board_id, a, b, c)
 }
 
@@ -405,18 +407,19 @@ async fn assert_undoing_an_import_removes_an_archived_edge_it_added(
 
     let (dest_board_id, dest_a, dest_b, dest_c) = seed_board_with_all_three_kinds(&mut dest);
 
-    dest.execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
-        boards: imported.boards,
-        columns: imported.columns,
-        cards: imported.cards,
-        archived_cards: imported.archived_cards,
-        archived_boards: imported.archived_boards,
-        sprints: imported.sprints,
-        graph: Some(imported.graph),
-        prefixes: imported.prefixes,
-        default_sprint_prefix: None,
-    }))])
-    .unwrap();
+    let _ = dest
+        .execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
+            boards: imported.boards,
+            columns: imported.columns,
+            cards: imported.cards,
+            archived_cards: imported.archived_cards,
+            archived_boards: imported.archived_boards,
+            sprints: imported.sprints,
+            graph: Some(imported.graph),
+            prefixes: imported.prefixes,
+            default_sprint_prefix: None,
+        }))])
+        .unwrap();
     dest.undo().unwrap();
 
     let dest_relations = dest.list_relations_for_board(dest_board_id).unwrap();
@@ -539,14 +542,15 @@ async fn assert_undoing_an_import_leaves_a_pre_existing_archived_edge_alone(
         .unwrap()
         .id;
 
-    dest.execute(vec![Command::Dependency(DependencyCommand::AddSpawns(
-        AddSpawns {
-            source: dest_d,
-            target: dest_e,
-            as_archived: true,
-        },
-    ))])
-    .unwrap();
+    let _ = dest
+        .execute(vec![Command::Dependency(DependencyCommand::AddSpawns(
+            AddSpawns {
+                source: dest_d,
+                target: dest_e,
+                as_archived: true,
+            },
+        ))])
+        .unwrap();
 
     // An independently-seeded board/card set (fresh ids, no collision with
     // `dest`) so the import's boards/columns/cards are valid to merge, but a
@@ -558,18 +562,19 @@ async fn assert_undoing_an_import_leaves_a_pre_existing_archived_edge_alone(
     let mut hand_built_graph = DependencyGraph::new();
     hand_built_graph.set_parent(dest_e, dest_d).unwrap();
 
-    dest.execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
-        boards: imported.boards,
-        columns: imported.columns,
-        cards: imported.cards,
-        archived_cards: imported.archived_cards,
-        archived_boards: imported.archived_boards,
-        sprints: imported.sprints,
-        graph: Some(hand_built_graph),
-        prefixes: imported.prefixes,
-        default_sprint_prefix: None,
-    }))])
-    .unwrap();
+    let _ = dest
+        .execute(vec![Command::Board(BoardCommand::Import(ImportEntities {
+            boards: imported.boards,
+            columns: imported.columns,
+            cards: imported.cards,
+            archived_cards: imported.archived_cards,
+            archived_boards: imported.archived_boards,
+            sprints: imported.sprints,
+            graph: Some(hand_built_graph),
+            prefixes: imported.prefixes,
+            default_sprint_prefix: None,
+        }))])
+        .unwrap();
     dest.undo().unwrap();
 
     let graph = dest.backend().get_graph().unwrap();

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -31,7 +31,7 @@ async fn test_inverse_create_board_restores_state() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let id = Uuid::new_v4();
 
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id,
         name: "Tier1 inverse".into(),
         card_prefix: None,
@@ -41,7 +41,7 @@ async fn test_inverse_create_board_restores_state() -> KanbanResult<()> {
     assert_eq!(ctx.boards()?.len(), 1, "forward execute creates board");
     assert!(ctx.can_undo(), "undo is available after execute");
 
-    assert!(ctx.undo()?, "undo via inverse-command path");
+    assert!(ctx.undo()?.is_some(), "undo via inverse-command path");
     assert_eq!(
         ctx.boards()?.len(),
         0,
@@ -58,7 +58,7 @@ async fn test_inverse_create_column_restores_state() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     // Need a board first to host the column.
     let board_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: board_id,
         name: "Host".into(),
         card_prefix: None,
@@ -66,7 +66,7 @@ async fn test_inverse_create_column_restores_state() -> KanbanResult<()> {
     }))])?;
 
     let col_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
         id: col_id,
         board_id,
         name: "TODO".into(),
@@ -75,7 +75,7 @@ async fn test_inverse_create_column_restores_state() -> KanbanResult<()> {
     }))])?;
     assert_eq!(ctx.columns()?.len(), 1, "forward execute creates column");
 
-    assert!(ctx.undo()?, "undo via inverse-command path");
+    assert!(ctx.undo()?.is_some(), "undo via inverse-command path");
     assert_eq!(
         ctx.columns()?.len(),
         0,
@@ -91,13 +91,13 @@ async fn test_inverse_update_column_restores_prior_fields() -> KanbanResult<()> 
     let mut ctx = make_ctx().await;
     let board_id = Uuid::new_v4();
     let col_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: board_id,
         name: "Host".into(),
         card_prefix: None,
         position: 0,
     }))])?;
-    ctx.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
         id: col_id,
         board_id,
         name: "Original".into(),
@@ -106,7 +106,7 @@ async fn test_inverse_update_column_restores_prior_fields() -> KanbanResult<()> 
     }))])?;
 
     // Update both name and position; leave wip_limit unchanged.
-    ctx.execute(vec![Command::Column(ColumnCommand::Update(UpdateColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Update(UpdateColumn {
         column_id: col_id,
         updates: ColumnUpdate {
             name: Some("Renamed".into()),
@@ -119,7 +119,7 @@ async fn test_inverse_update_column_restores_prior_fields() -> KanbanResult<()> 
     assert_eq!(after.name, "Renamed");
     assert_eq!(after.position, 99);
 
-    assert!(ctx.undo()?, "undo via inverse-command path");
+    assert!(ctx.undo()?.is_some(), "undo via inverse-command path");
     let restored = &ctx.columns()?[0];
     assert_eq!(restored.name, "Original", "name restored");
     assert_eq!(restored.position, 5, "position restored");
@@ -139,7 +139,7 @@ async fn test_inverse_update_card_restores_prior_fields() -> KanbanResult<()> {
     )?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::Update(UpdateCard {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Update(UpdateCard {
         card_id: card.id,
         updates: CardUpdate {
             title: Some("Renamed".into()),
@@ -151,7 +151,7 @@ async fn test_inverse_update_card_restores_prior_fields() -> KanbanResult<()> {
     assert_eq!(after.title, "Renamed");
     assert_eq!(after.priority, CardPriority::High);
 
-    assert!(ctx.undo()?, "undo via inverse-command path");
+    assert!(ctx.undo()?.is_some(), "undo via inverse-command path");
     let restored = ctx.get_card(card.id)?.unwrap();
     assert_eq!(restored.title, "Original title", "title restored");
     assert_eq!(
@@ -174,7 +174,7 @@ async fn test_inverse_move_card_restores_column_and_position() -> KanbanResult<(
     let before_col = card.column_id;
     let before_pos = card.position;
 
-    ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
         card_id: card.id,
         new_column_id: col_b.id,
         new_position: 7,
@@ -183,7 +183,7 @@ async fn test_inverse_move_card_restores_column_and_position() -> KanbanResult<(
     assert_eq!(moved.column_id, col_b.id);
     assert_eq!(moved.position, 7);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.get_card(card.id)?.unwrap();
     assert_eq!(restored.column_id, before_col);
     assert_eq!(restored.position, before_pos);
@@ -197,7 +197,7 @@ async fn test_inverse_unassign_card_from_sprint_reassigns() -> KanbanResult<()> 
     let col = ctx.create_column(board.id, "TODO".into(), None)?;
     let card = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
     let sprint = ctx.create_sprint(board.id, None, None)?;
-    ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
         AssignCardsToSprint {
             ids: vec![card.id],
             sprint_id: sprint.id,
@@ -205,7 +205,7 @@ async fn test_inverse_unassign_card_from_sprint_reassigns() -> KanbanResult<()> 
     ))])?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::UnassignFromSprint(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::UnassignFromSprint(
         UnassignCardFromSprint {
             card_id: card.id,
             timestamp: chrono::Utc::now(),
@@ -213,7 +213,10 @@ async fn test_inverse_unassign_card_from_sprint_reassigns() -> KanbanResult<()> 
     ))])?;
     assert!(ctx.get_card(card.id)?.unwrap().sprint_id.is_none());
 
-    assert!(ctx.undo()?, "undo re-assigns the card to its prior sprint");
+    assert!(
+        ctx.undo()?.is_some(),
+        "undo re-assigns the card to its prior sprint"
+    );
     assert_eq!(
         ctx.get_card(card.id)?.unwrap().sprint_id,
         Some(sprint.id),
@@ -233,7 +236,7 @@ async fn test_inverse_activate_sprint_reverts_to_planning() -> KanbanResult<()> 
     assert_eq!(before.status, SprintStatus::Planning);
     assert!(before.start_date.is_none());
 
-    ctx.execute(vec![Command::Sprint(SprintCommand::Activate(
+    let _ = ctx.execute(vec![Command::Sprint(SprintCommand::Activate(
         ActivateSprint {
             sprint_id: sprint.id,
             duration_days: 14,
@@ -244,7 +247,7 @@ async fn test_inverse_activate_sprint_reverts_to_planning() -> KanbanResult<()> 
     assert!(after.start_date.is_some());
     assert!(after.end_date.is_some());
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.get_sprint(sprint.id)?.unwrap();
     assert_eq!(
         restored.status,
@@ -261,7 +264,7 @@ async fn test_inverse_complete_sprint_reverts_to_active() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), None)?;
     let sprint = ctx.create_sprint(board.id, None, None)?;
-    ctx.execute(vec![Command::Sprint(SprintCommand::Activate(
+    let _ = ctx.execute(vec![Command::Sprint(SprintCommand::Activate(
         ActivateSprint {
             sprint_id: sprint.id,
             duration_days: 14,
@@ -269,7 +272,7 @@ async fn test_inverse_complete_sprint_reverts_to_active() -> KanbanResult<()> {
     ))])?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Sprint(SprintCommand::Complete(
+    let _ = ctx.execute(vec![Command::Sprint(SprintCommand::Complete(
         CompleteSprint {
             sprint_id: sprint.id,
         },
@@ -279,7 +282,7 @@ async fn test_inverse_complete_sprint_reverts_to_active() -> KanbanResult<()> {
         SprintStatus::Completed
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(
         ctx.get_sprint(sprint.id)?.unwrap().status,
         SprintStatus::Active,
@@ -295,7 +298,7 @@ async fn test_inverse_cancel_sprint_reverts_to_prior_status() -> KanbanResult<()
     let sprint = ctx.create_sprint(board.id, None, None)?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Sprint(SprintCommand::Cancel(CancelSprint {
+    let _ = ctx.execute(vec![Command::Sprint(SprintCommand::Cancel(CancelSprint {
         sprint_id: sprint.id,
     }))])?;
     assert_eq!(
@@ -303,7 +306,7 @@ async fn test_inverse_cancel_sprint_reverts_to_prior_status() -> KanbanResult<()
         SprintStatus::Cancelled
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(
         ctx.get_sprint(sprint.id)?.unwrap().status,
         SprintStatus::Planning,
@@ -321,7 +324,7 @@ async fn test_inverse_add_blocks_removes_edge() -> KanbanResult<()> {
     let b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Dependency(DependencyCommand::AddBlocks(
+    let _ = ctx.execute(vec![Command::Dependency(DependencyCommand::AddBlocks(
         AddBlocks {
             source: a.id,
             target: b.id,
@@ -331,7 +334,7 @@ async fn test_inverse_add_blocks_removes_edge() -> KanbanResult<()> {
     ))])?;
     assert!(ctx.graph()?.contains(a.id, b.id), "edge added by forward");
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(
         !ctx.graph()?.contains(a.id, b.id),
         "edge removed by inverse"
@@ -348,7 +351,7 @@ async fn test_inverse_add_relates_to_removes_edge() -> KanbanResult<()> {
     let b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Dependency(DependencyCommand::AddRelates(
+    let _ = ctx.execute(vec![Command::Dependency(DependencyCommand::AddRelates(
         AddRelates {
             source: a.id,
             target: b.id,
@@ -361,7 +364,7 @@ async fn test_inverse_add_relates_to_removes_edge() -> KanbanResult<()> {
         "relates edge added by forward"
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(
         !ctx.graph()?.contains(a.id, b.id),
         "relates edge removed by inverse"
@@ -376,7 +379,7 @@ async fn test_inverse_remove_parent_reestablishes_relation() -> KanbanResult<()>
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let parent = ctx.create_card(board.id, col.id, "Parent".into(), Default::default())?;
     let child = ctx.create_card(board.id, col.id, "Child".into(), Default::default())?;
-    ctx.execute(vec![Command::Dependency(DependencyCommand::AddSpawns(
+    let _ = ctx.execute(vec![Command::Dependency(DependencyCommand::AddSpawns(
         AddSpawns {
             source: parent.id,
             target: child.id,
@@ -385,7 +388,7 @@ async fn test_inverse_remove_parent_reestablishes_relation() -> KanbanResult<()>
     ))])?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Dependency(DependencyCommand::RemoveSpawns(
+    let _ = ctx.execute(vec![Command::Dependency(DependencyCommand::RemoveSpawns(
         RemoveSpawns {
             source: parent.id,
             target: child.id,
@@ -398,7 +401,7 @@ async fn test_inverse_remove_parent_reestablishes_relation() -> KanbanResult<()>
         "parent edge removed by forward"
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(
         ctx.graph()?.contains(parent.id, child.id),
         "parent edge re-established by inverse"
@@ -412,7 +415,7 @@ async fn test_inverse_delete_column_recreates_with_fields() -> KanbanResult<()> 
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "Reborn".into(), None)?;
     // Set a wip_limit so the inverse needs to chain CreateColumn + UpdateColumn.
-    ctx.execute(vec![Command::Column(ColumnCommand::Update(UpdateColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Update(UpdateColumn {
         column_id: col.id,
         updates: ColumnUpdate {
             wip_limit: FieldUpdate::Set(7),
@@ -422,12 +425,12 @@ async fn test_inverse_delete_column_recreates_with_fields() -> KanbanResult<()> 
     let original_pos = ctx.columns()?[0].position;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Column(ColumnCommand::Delete(DeleteColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Delete(DeleteColumn {
         column_id: col.id,
     }))])?;
     assert_eq!(ctx.columns()?.len(), 0, "column deleted by forward");
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = &ctx.columns()?[0];
     assert_eq!(restored.id, col.id, "id restored");
     assert_eq!(restored.name, "Reborn", "name restored");
@@ -441,7 +444,7 @@ async fn test_undo_column_delete_restores_its_default_status() -> KanbanResult<(
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "Doing".into(), None)?;
-    ctx.execute(vec![Command::Column(ColumnCommand::Update(UpdateColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Update(UpdateColumn {
         column_id: col.id,
         updates: ColumnUpdate {
             default_status: Some(Some(CardStatus::InProgress)),
@@ -450,12 +453,12 @@ async fn test_undo_column_delete_restores_its_default_status() -> KanbanResult<(
     }))])?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Column(ColumnCommand::Delete(DeleteColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Delete(DeleteColumn {
         column_id: col.id,
     }))])?;
     assert_eq!(ctx.columns()?.len(), 0, "column deleted by forward");
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = &ctx.columns()?[0];
     assert_eq!(restored.id, col.id, "id restored");
     assert_eq!(
@@ -472,7 +475,7 @@ async fn test_inverse_update_board_restores_fields() -> KanbanResult<()> {
     let board = ctx.create_board("Original".into(), None)?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Board(BoardCommand::Update(UpdateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Update(UpdateBoard {
         board_id: board.id,
         updates: BoardUpdate {
             name: Some("Renamed".into()),
@@ -484,7 +487,7 @@ async fn test_inverse_update_board_restores_fields() -> KanbanResult<()> {
     assert_eq!(after.name, "Renamed");
     assert_eq!(after.description, Some("A new description".into()));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.boards()?.into_iter().next().unwrap();
     assert_eq!(restored.name, "Original");
     assert_eq!(restored.description, None);
@@ -500,7 +503,7 @@ async fn test_inverse_set_board_task_sort_reverts() -> KanbanResult<()> {
     let original_order = before.task_sort_order;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Board(BoardCommand::SetTaskSort(
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::SetTaskSort(
         SetBoardTaskSort {
             board_id: board.id,
             field: SortField::Priority,
@@ -510,7 +513,7 @@ async fn test_inverse_set_board_task_sort_reverts() -> KanbanResult<()> {
     let after = ctx.boards()?.into_iter().next().unwrap();
     assert_eq!(after.task_sort_field, SortField::Priority);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.boards()?.into_iter().next().unwrap();
     assert_eq!(restored.task_sort_field, original_field);
     assert_eq!(restored.task_sort_order, original_order);
@@ -529,7 +532,7 @@ async fn test_inverse_set_board_task_list_view_reverts() -> KanbanResult<()> {
     } else {
         TaskListView::Flat
     };
-    ctx.execute(vec![Command::Board(BoardCommand::SetTaskListView(
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::SetTaskListView(
         SetBoardTaskListView {
             board_id: board.id,
             view: target,
@@ -540,7 +543,7 @@ async fn test_inverse_set_board_task_list_view_reverts() -> KanbanResult<()> {
         target
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(
         ctx.boards()?.into_iter().next().unwrap().task_list_view,
         original
@@ -555,7 +558,7 @@ async fn test_inverse_apply_board_settings_restores_prior_settings() -> KanbanRe
     let board = ctx.create_board("B".into(), Some("KAN".into()))?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Board(BoardCommand::ApplySettings(
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::ApplySettings(
         ApplyBoardSettings {
             board_id: board.id,
             dto: BoardSettingsDto {
@@ -571,7 +574,7 @@ async fn test_inverse_apply_board_settings_restores_prior_settings() -> KanbanRe
     assert_eq!(after.sprint_duration_days, Some(21));
     assert_eq!(after.sprint_names, vec!["alpha", "beta"]);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.boards()?.into_iter().next().unwrap();
     assert_eq!(
         restored.sprint_prefix, None,
@@ -596,7 +599,7 @@ async fn test_inverse_update_sprint_restores_prefix() -> KanbanResult<()> {
     ctx.clear_history()?;
     let before_prefix = sprint.prefix.clone();
 
-    ctx.execute(vec![Command::Sprint(SprintCommand::Update(UpdateSprint {
+    let _ = ctx.execute(vec![Command::Sprint(SprintCommand::Update(UpdateSprint {
         sprint_id: sprint.id,
         updates: SprintUpdate {
             prefix: FieldUpdate::Set("SPR".into()),
@@ -606,7 +609,7 @@ async fn test_inverse_update_sprint_restores_prefix() -> KanbanResult<()> {
     let after = ctx.get_sprint(sprint.id)?.unwrap();
     assert_eq!(after.prefix, Some("SPR".into()));
 
-    assert!(ctx.undo()?, "undo via inverse-command path");
+    assert!(ctx.undo()?.is_some(), "undo via inverse-command path");
     let restored = ctx.get_sprint(sprint.id)?.unwrap();
     assert_eq!(restored.prefix, before_prefix, "prefix restored");
     Ok(())
@@ -621,7 +624,7 @@ async fn test_inverse_set_parent_removes_edge() -> KanbanResult<()> {
     let child = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Dependency(DependencyCommand::AddSpawns(
+    let _ = ctx.execute(vec![Command::Dependency(DependencyCommand::AddSpawns(
         AddSpawns {
             source: parent.id,
             target: child.id,
@@ -633,7 +636,7 @@ async fn test_inverse_set_parent_removes_edge() -> KanbanResult<()> {
         "parent edge added"
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(
         !ctx.graph()?.contains(parent.id, child.id),
         "parent edge removed by inverse"
@@ -650,7 +653,7 @@ async fn test_inverse_create_subcard_removes_card_and_archive_trail() -> KanbanR
     ctx.clear_history()?;
 
     let subcard_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+    let _ = ctx.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
         CreateSubcardCommand {
             id: subcard_id,
             parent_id: parent.id,
@@ -665,7 +668,7 @@ async fn test_inverse_create_subcard_removes_card_and_archive_trail() -> KanbanR
     assert_eq!(ctx.cards()?.len(), 2);
     assert!(ctx.graph()?.contains(parent.id, subcard_id));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.len(), 1, "subcard gone");
     assert!(
         ctx.archived_cards()?.is_empty(),
@@ -687,7 +690,7 @@ async fn test_inverse_apply_card_metadata_restores_fields() -> KanbanResult<()> 
     let card = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::ApplyMetadata(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::ApplyMetadata(
         ApplyCardMetadata {
             card_id: card.id,
             dto: CardMetadataDto {
@@ -702,7 +705,7 @@ async fn test_inverse_apply_card_metadata_restores_fields() -> KanbanResult<()> 
     assert_eq!(after.priority, CardPriority::High);
     assert_eq!(after.points, Some(8));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.get_card(card.id)?.unwrap();
     assert_eq!(restored.priority, CardPriority::Medium);
     assert_eq!(restored.points, None, "points cleared back to None");
@@ -720,13 +723,13 @@ async fn test_inverse_archive_cards_restores_each() -> KanbanResult<()> {
     let pre_pos_b = b.position;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards {
         ids: vec![a.id, b.id],
     }))])?;
     assert_eq!(ctx.cards()?.len(), 0);
     assert_eq!(ctx.archived_cards()?.len(), 2);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.len(), 2, "both cards restored");
     assert_eq!(ctx.archived_cards()?.len(), 0);
     let restored_a = ctx.get_card(a.id)?.unwrap();
@@ -747,7 +750,7 @@ async fn test_inverse_assign_cards_to_sprint_restores_prior_bindings() -> Kanban
     let s1 = ctx.create_sprint(board.id, None, None)?;
     let s2 = ctx.create_sprint(board.id, None, None)?;
     // Put card_other into s1 first; card_unassigned has no sprint.
-    ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
         AssignCardsToSprint {
             ids: vec![card_other.id],
             sprint_id: s1.id,
@@ -756,7 +759,7 @@ async fn test_inverse_assign_cards_to_sprint_restores_prior_bindings() -> Kanban
     ctx.clear_history()?;
 
     // Now assign both to s2.
-    ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
         AssignCardsToSprint {
             ids: vec![card_unassigned.id, card_other.id],
             sprint_id: s2.id,
@@ -768,7 +771,7 @@ async fn test_inverse_assign_cards_to_sprint_restores_prior_bindings() -> Kanban
     );
     assert_eq!(ctx.get_card(card_other.id)?.unwrap().sprint_id, Some(s2.id));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(
         ctx.get_card(card_unassigned.id)?
             .unwrap()
@@ -796,7 +799,7 @@ async fn test_inverse_assign_cards_to_sprint_restores_sprint_logs() -> KanbanRes
     let card = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
     let s1 = ctx.create_sprint(board.id, None, None)?;
     let s2 = ctx.create_sprint(board.id, None, None)?;
-    ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
         AssignCardsToSprint {
             ids: vec![card.id],
             sprint_id: s1.id,
@@ -805,7 +808,7 @@ async fn test_inverse_assign_cards_to_sprint_restores_sprint_logs() -> KanbanRes
     let baseline_logs = ctx.get_card(card.id)?.unwrap().sprint_logs.clone();
     assert_eq!(baseline_logs.len(), 1, "fixture: one log entry on s1");
 
-    ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::AssignToSprint(
         AssignCardsToSprint {
             ids: vec![card.id],
             sprint_id: s2.id,
@@ -817,7 +820,7 @@ async fn test_inverse_assign_cards_to_sprint_restores_sprint_logs() -> KanbanRes
         "forward appends a log for s2"
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.get_card(card.id)?.unwrap();
     assert_eq!(restored.sprint_id, Some(s1.id), "sprint_id restored to s1");
     assert_eq!(
@@ -826,8 +829,8 @@ async fn test_inverse_assign_cards_to_sprint_restores_sprint_logs() -> KanbanRes
     );
 
     // Redo + undo again must be idempotent.
-    assert!(ctx.redo()?);
-    assert!(ctx.undo()?);
+    assert!(ctx.redo()?.is_some());
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.get_card(card.id)?.unwrap();
     assert_eq!(
         restored.sprint_logs, baseline_logs,
@@ -848,7 +851,7 @@ async fn test_inverse_unassign_card_from_sprint_restores_sprint_logs() -> Kanban
     assert_eq!(baseline_logs.len(), 1);
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::UnassignFromSprint(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::UnassignFromSprint(
         UnassignCardFromSprint {
             card_id: card.id,
             timestamp: chrono::Utc::now(),
@@ -861,7 +864,7 @@ async fn test_inverse_unassign_card_from_sprint_restores_sprint_logs() -> Kanban
         "forward closes the current log"
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     let restored = ctx.get_card(card.id)?.unwrap();
     assert_eq!(restored.sprint_id, Some(sprint.id));
     assert_eq!(
@@ -880,12 +883,12 @@ async fn test_inverse_compact_column_positions_restores_gaps() -> KanbanResult<(
     let b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
     let c = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
     // Create a gap by moving b out then back at a non-sequential pos.
-    ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
         card_id: b.id,
         new_column_id: col.id,
         new_position: 100,
     }))])?;
-    ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
         card_id: c.id,
         new_column_id: col.id,
         new_position: 200,
@@ -895,7 +898,7 @@ async fn test_inverse_compact_column_positions_restores_gaps() -> KanbanResult<(
     let pre_pos_c = ctx.get_card(c.id)?.unwrap().position;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::CompactPositions(
+    let _ = ctx.execute(vec![Command::Card(CardCommand::CompactPositions(
         CompactColumnPositions { column_id: col.id },
     ))])?;
     // After compact, positions are 0, 1, 2.
@@ -910,7 +913,7 @@ async fn test_inverse_compact_column_positions_restores_gaps() -> KanbanResult<(
         vec![0, 1, 2]
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.get_card(a.id)?.unwrap().position, pre_pos_a);
     assert_eq!(ctx.get_card(b.id)?.unwrap().position, pre_pos_b);
     assert_eq!(ctx.get_card(c.id)?.unwrap().position, pre_pos_c);
@@ -928,7 +931,7 @@ async fn test_inverse_remove_blocks_restores_blocks_edge() -> KanbanResult<()> {
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
     let b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
-    ctx.execute(vec![Command::Dependency(DependencyCommand::AddBlocks(
+    let _ = ctx.execute(vec![Command::Dependency(DependencyCommand::AddBlocks(
         AddBlocks {
             source: a.id,
             target: b.id,
@@ -938,7 +941,7 @@ async fn test_inverse_remove_blocks_restores_blocks_edge() -> KanbanResult<()> {
     ))])?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Dependency(DependencyCommand::RemoveBlocks(
+    let _ = ctx.execute(vec![Command::Dependency(DependencyCommand::RemoveBlocks(
         RemoveBlocks {
             source: a.id,
             target: b.id,
@@ -948,7 +951,7 @@ async fn test_inverse_remove_blocks_restores_blocks_edge() -> KanbanResult<()> {
     ))])?;
     assert!(!ctx.graph()?.contains(a.id, b.id));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(
         ctx.graph()?.contains(a.id, b.id),
         "edge restored by inverse"
@@ -994,12 +997,15 @@ async fn test_inverse_attach_replays_tolerant_remove_after_independent_detach() 
     // The second undo replays the tolerant RemoveSpawns inverse against
     // an edge that no longer exists; without tolerate_missing this
     // would fail with EdgeNotFound.
-    assert!(ctx.undo()?, "undo the detach");
+    assert!(ctx.undo()?.is_some(), "undo the detach");
     assert!(
         ctx.graph()?.contains(parent.id, child.id),
         "undo of detach restores the edge"
     );
-    assert!(ctx.undo()?, "undo the attach (tolerant remove inverse)");
+    assert!(
+        ctx.undo()?.is_some(),
+        "undo the attach (tolerant remove inverse)"
+    );
     assert!(
         !ctx.graph()?.contains(parent.id, child.id),
         "undo of attach removes the edge"
@@ -1016,7 +1022,7 @@ async fn test_inverse_create_card_removes_card_and_archive_trail() -> KanbanResu
     ctx.clear_history()?;
 
     let card_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Card(CardCommand::Create(CreateCard {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Create(CreateCard {
         id: card_id,
         card_number: 1,
         board_id: board.id,
@@ -1029,7 +1035,7 @@ async fn test_inverse_create_card_removes_card_and_archive_trail() -> KanbanResu
     }))])?;
     assert_eq!(ctx.cards()?.len(), 1);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.len(), 0, "live card gone after undo");
     assert!(
         ctx.archived_cards()?.is_empty(),
@@ -1038,7 +1044,7 @@ async fn test_inverse_create_card_removes_card_and_archive_trail() -> KanbanResu
     );
 
     // Verify the no-trail invariant: deleting the column now succeeds.
-    ctx.execute(vec![Command::Column(ColumnCommand::Delete(DeleteColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Delete(DeleteColumn {
         column_id: col.id,
     }))])?;
     assert_eq!(ctx.columns()?.len(), 0);
@@ -1052,14 +1058,14 @@ async fn test_inverse_restore_card_archives_it() -> KanbanResult<()> {
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let card = ctx.create_card(board.id, col.id, "Reborn".into(), Default::default())?;
-    ctx.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards {
         ids: vec![card.id],
     }))])?;
     assert_eq!(ctx.cards()?.len(), 0);
     assert_eq!(ctx.archived_cards()?.len(), 1);
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::Restore(RestoreCard {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Restore(RestoreCard {
         card_id: card.id,
         column_id: col.id,
         position: 0,
@@ -1068,7 +1074,7 @@ async fn test_inverse_restore_card_archives_it() -> KanbanResult<()> {
     assert_eq!(ctx.cards()?.len(), 1);
     assert_eq!(ctx.archived_cards()?.len(), 0);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(
         ctx.cards()?.len(),
         0,
@@ -1083,14 +1089,14 @@ async fn test_inverse_create_board_redo_round_trip() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let id = Uuid::new_v4();
 
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id,
         name: "Round-trip".into(),
         card_prefix: None,
         position: 7,
     }))])?;
     ctx.undo()?;
-    assert!(ctx.redo()?, "redo must succeed");
+    assert!(ctx.redo()?.is_some(), "redo must succeed");
 
     let boards = ctx.boards()?;
     assert_eq!(boards.len(), 1);
@@ -1176,7 +1182,7 @@ async fn test_composite_round_trip_undo_returns_to_baseline() -> KanbanResult<()
     // Undo every step.
     for step in (1..=ROUND_TRIP_STEPS).rev() {
         assert!(
-            ctx.undo()?,
+            ctx.undo()?.is_some(),
             "undo step {step} must succeed; undo_depth = {}",
             ctx.undo_depth()
         );
@@ -1246,7 +1252,10 @@ async fn test_composite_round_trip_redo_restores_forward_state() -> KanbanResult
     }
     // Redo all
     while ctx.can_redo() {
-        assert!(ctx.redo()?, "redo must succeed during full replay");
+        assert!(
+            ctx.redo()?.is_some(),
+            "redo must succeed during full replay"
+        );
     }
 
     let replayed = ctx.snapshot()?;
@@ -1300,7 +1309,7 @@ async fn test_failed_undo_leaves_undo_stack_pinned_for_retry() -> KanbanResult<(
     let card = ctx.create_card(board.id, col_a.id, "C".into(), Default::default())?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
         card_id: card.id,
         new_column_id: col_b.id,
         new_position: 0,
@@ -1339,7 +1348,7 @@ async fn test_failed_redo_leaves_undo_stack_pinned_for_retry() -> KanbanResult<(
     let card = ctx.create_card(board.id, col_a.id, "C".into(), Default::default())?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
+    let _ = ctx.execute(vec![Command::Card(CardCommand::Move(MoveCard {
         card_id: card.id,
         new_column_id: col_b.id,
         new_position: 0,
@@ -1380,12 +1389,12 @@ async fn test_undo_chain_through_archive_create_create_column_succeeds() -> Kanb
     assert_eq!(ctx.archived_cards()?.len(), 1);
 
     // Undo archive — card is live again.
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.len(), 1);
     assert_eq!(ctx.archived_cards()?.len(), 0);
 
     // Undo create_card — card is gone with no archive trail.
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.len(), 0);
     assert_eq!(
         ctx.archived_cards()?.len(),
@@ -1395,11 +1404,11 @@ async fn test_undo_chain_through_archive_create_create_column_succeeds() -> Kanb
 
     // Undo create_column — column delete should not be blocked by a
     // stale archive entry.
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.columns()?.len(), 0);
 
     // Undo create_board.
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 0);
 
     assert!(!ctx.can_undo());
@@ -1457,7 +1466,7 @@ async fn test_inverse_delete_board_restores_full_cascade() -> KanbanResult<()> {
     assert!(ctx.sprints()?.is_empty(), "sprints deleted");
     assert_eq!(ctx.graph()?.len(), 0, "card graph edges deleted");
 
-    assert!(ctx.undo()?, "cascade undo must succeed");
+    assert!(ctx.undo()?.is_some(), "cascade undo must succeed");
 
     let restored = ctx.snapshot()?;
     let restored_board_ids: std::collections::HashSet<_> =
@@ -1541,7 +1550,7 @@ async fn test_inverse_cascade_preserves_archived_incident_edge_state() -> Kanban
     assert_eq!(ctx.graph()?.len(), 0, "graph cleared by cascade");
 
     // Undo restores everything.
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
 
     let restored = ctx.graph()?;
     assert_eq!(restored.len(), 2, "both edges restored in history");

--- a/crates/kanban-service/tests/list_cards_filters.rs
+++ b/crates/kanban-service/tests/list_cards_filters.rs
@@ -29,7 +29,7 @@ struct Setup {
 
 async fn setup(ctx: &mut KanbanContext) -> KanbanResult<Setup> {
     let board_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: board_id,
         name: "B".into(),
         card_prefix: None,
@@ -37,7 +37,7 @@ async fn setup(ctx: &mut KanbanContext) -> KanbanResult<Setup> {
     }))])?;
 
     let column_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
         id: column_id,
         board_id,
         name: "Todo".into(),
@@ -48,7 +48,7 @@ async fn setup(ctx: &mut KanbanContext) -> KanbanResult<Setup> {
     let sprint_a = Uuid::new_v4();
     let sprint_b = Uuid::new_v4();
     for (id, name) in [(sprint_a, "S-A"), (sprint_b, "S-B")] {
-        ctx.execute(vec![Command::Sprint(SprintCommand::Create(CreateSprint {
+        let _ = ctx.execute(vec![Command::Sprint(SprintCommand::Create(CreateSprint {
             id,
             board_id,
             name: Some(name.into()),
@@ -64,7 +64,7 @@ async fn setup(ctx: &mut KanbanContext) -> KanbanResult<Setup> {
         .enumerate()
     {
         let id = Uuid::new_v4();
-        ctx.execute(vec![Command::Card(CardCommand::Create(CreateCard {
+        let _ = ctx.execute(vec![Command::Card(CardCommand::Create(CreateCard {
             id,
             card_number: (i as u32) + 1,
             board_id,

--- a/crates/kanban-service/tests/list_cards_sort.rs
+++ b/crates/kanban-service/tests/list_cards_sort.rs
@@ -36,7 +36,7 @@ async fn seed_three_cards_with_due_dates(
     ctx: &mut KanbanContext,
 ) -> KanbanResult<(Uuid, Uuid, Uuid, Uuid)> {
     let board_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: board_id,
         name: "B".into(),
         card_prefix: None,
@@ -44,7 +44,7 @@ async fn seed_three_cards_with_due_dates(
     }))])?;
 
     let column_id = Uuid::new_v4();
-    ctx.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
+    let _ = ctx.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
         id: column_id,
         board_id,
         name: "Todo".into(),
@@ -55,7 +55,7 @@ async fn seed_three_cards_with_due_dates(
     let mut ids = Vec::new();
     for (i, _label) in ["a", "b", "c"].iter().enumerate() {
         let id = Uuid::new_v4();
-        ctx.execute(vec![Command::Card(CardCommand::Create(CreateCard {
+        let _ = ctx.execute(vec![Command::Card(CardCommand::Create(CreateCard {
             id,
             card_number: (i as u32) + 1,
             board_id,
@@ -78,7 +78,7 @@ async fn seed_three_cards_with_due_dates(
         (ids[1], dt("2026-12-01T00:00:00Z")),
     ];
     for (id, when) in due_dates {
-        ctx.execute(vec![Command::Card(CardCommand::Update(UpdateCard {
+        let _ = ctx.execute(vec![Command::Card(CardCommand::Update(UpdateCard {
             card_id: id,
             updates: CardUpdate {
                 due_date: FieldUpdate::Set(when),
@@ -95,7 +95,7 @@ async fn test_list_cards_uses_board_task_sort_field_by_default() -> KanbanResult
     let mut ctx = make_ctx().await;
     let (board_id, earliest, middle, latest) = seed_three_cards_with_due_dates(&mut ctx).await?;
 
-    ctx.execute(vec![Command::Board(BoardCommand::SetTaskSort(
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::SetTaskSort(
         SetBoardTaskSort {
             board_id,
             field: SortField::DueDate,

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -246,6 +246,58 @@ async fn test_clear_history_returns_no_invalidation_because_it_mutates_no_entity
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undo_returns_the_inverse_batchs_invalidation() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+    ctx.update_card_impl(
+        card.id,
+        CardUpdate {
+            title: Some("x".into()),
+            ..Default::default()
+        },
+    )?;
+
+    let inv = ctx.undo()?.expect("undo applied");
+    assert_eq!(inv, Invalidation::Entities(EntityIds::cards([card.id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undo_on_an_empty_stack_returns_none() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    assert!(ctx.undo()?.is_none());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_redo_returns_the_forward_batchs_invalidation() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+    ctx.undo()?;
+
+    let inv = ctx.redo()?.expect("redo applied");
+    match inv {
+        Invalidation::Entities(ids) => {
+            assert!(ids.cards.contains(&card.id));
+            assert!(ids.boards.contains(&board.id));
+        }
+        Invalidation::All => panic!("expected Entities, got All"),
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_redo_with_nothing_to_redo_returns_none() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    assert!(ctx.redo()?.is_none());
+    Ok(())
+}
+
 /// Guards `Send`, which kanban-server's `Arc<tokio::sync::Mutex<KanbanContext>>`
 /// needs. Would NOT catch a `RefCell` inside `KanbanContext`, because
 /// `tokio::sync::Mutex<T>` is `Sync` for any `T: Send`.

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -252,7 +252,7 @@ async fn test_undo_returns_the_inverse_batchs_invalidation() -> KanbanResult<()>
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
-    ctx.update_card_impl(
+    let _ = ctx.update_card_impl(
         card.id,
         CardUpdate {
             title: Some("x".into()),

--- a/crates/kanban-service/tests/open_context.rs
+++ b/crates/kanban-service/tests/open_context.rs
@@ -100,7 +100,7 @@ async fn test_open_deferred_context_executes_immediately() {
         card_prefix: None,
         position: 0,
     }));
-    ctx.execute(vec![cmd]).expect("execute should succeed");
+    let _ = ctx.execute(vec![cmd]).expect("execute should succeed");
     assert_eq!(ctx.boards().unwrap().len(), 1);
 }
 
@@ -128,7 +128,8 @@ fn test_execute_records_one_command_batch_with_provenance() {
         position: 0,
     }));
 
-    ctx.execute(vec![cmd.clone()])
+    let _ = ctx
+        .execute(vec![cmd.clone()])
         .expect("execute should succeed");
 
     let (batches, batch_count) = store.load_all_batches().unwrap();
@@ -180,7 +181,7 @@ fn test_execute_with_app_type_records_that_app_type() {
         position: 0,
     }));
 
-    ctx.execute(vec![cmd]).expect("execute should succeed");
+    let _ = ctx.execute(vec![cmd]).expect("execute should succeed");
 
     let (batches, _) = store.load_all_batches().unwrap();
     assert_eq!(batches.len(), 1);

--- a/crates/kanban-service/tests/prefix_allocation.rs
+++ b/crates/kanban-service/tests/prefix_allocation.rs
@@ -222,19 +222,20 @@ async fn test_a_subcard_allocates_from_the_same_counter_as_its_siblings() {
         .unwrap();
 
     let subcard_id = Uuid::new_v4();
-    c.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
-        CreateSubcardCommand {
-            id: subcard_id,
-            parent_id: parent.id,
-            board_id: board.id,
-            column_id: col.id,
-            title: "sub".into(),
-            description: None,
-            position: 1,
-            default_card_prefix: "task".to_string(),
-        },
-    ))])
-    .unwrap();
+    let _ = c
+        .execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+            CreateSubcardCommand {
+                id: subcard_id,
+                parent_id: parent.id,
+                board_id: board.id,
+                column_id: col.id,
+                title: "sub".into(),
+                description: None,
+                position: 1,
+                default_card_prefix: "task".to_string(),
+            },
+        ))])
+        .unwrap();
 
     let sub = c.get_card(subcard_id).unwrap().unwrap();
     assert_eq!(

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -157,10 +157,10 @@ async fn test_sqlite_backend_undo_redo() {
     ctx.create_board("Board 1".to_string(), None).unwrap();
     assert_eq!(ctx.list_boards().unwrap().len(), 1);
 
-    assert!(ctx.undo().unwrap());
+    assert!(ctx.undo().unwrap().is_some());
     assert_eq!(ctx.list_boards().unwrap().len(), 0);
 
-    assert!(ctx.redo().unwrap());
+    assert!(ctx.redo().unwrap().is_some());
     assert_eq!(ctx.list_boards().unwrap().len(), 1);
 }
 

--- a/crates/kanban-service/tests/subcard_wip_limit.rs
+++ b/crates/kanban-service/tests/subcard_wip_limit.rs
@@ -89,19 +89,20 @@ async fn test_create_subcard_into_a_column_with_room_still_succeeds() {
         .unwrap();
 
     let subcard_id = Uuid::new_v4();
-    c.execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
-        CreateSubcardCommand {
-            id: subcard_id,
-            parent_id: parent.id,
-            board_id: board.id,
-            column_id: col.id,
-            title: "Subcard".into(),
-            description: None,
-            position: 1,
-            default_card_prefix: "task".to_string(),
-        },
-    ))])
-    .expect("column has room, so the subcard must be created");
+    let _ = c
+        .execute(vec![Command::Dependency(DependencyCommand::CreateSubcard(
+            CreateSubcardCommand {
+                id: subcard_id,
+                parent_id: parent.id,
+                board_id: board.id,
+                column_id: col.id,
+                title: "Subcard".into(),
+                description: None,
+                position: 1,
+                default_card_prefix: "task".to_string(),
+            },
+        ))])
+        .expect("column has room, so the subcard must be created");
 
     assert_eq!(c.backend().list_cards_by_column(col.id).unwrap().len(), 2);
     assert!(

--- a/crates/kanban-service/tests/undo_invalidation.rs
+++ b/crates/kanban-service/tests/undo_invalidation.rs
@@ -13,20 +13,11 @@ async fn make_ctx() -> KanbanContext {
     .unwrap()
 }
 
-fn entities(ctx: &KanbanContext) -> &EntityIds {
-    match ctx
-        .last_invalidation()
-        .expect("expected a recorded invalidation, found None")
-    {
+fn entities(inv: Invalidation) -> EntityIds {
+    match inv {
         Invalidation::Entities(ids) => ids,
         Invalidation::All => panic!("expected Entities, got All"),
     }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_a_fresh_context_has_no_recorded_invalidation() {
-    let ctx = make_ctx().await;
-    assert!(ctx.last_invalidation().is_none());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -36,7 +27,7 @@ async fn test_forward_execution_records_the_derived_invalidation() -> KanbanResu
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
 
-    ctx.update_card(
+    let (_card, inv) = ctx.update_card_impl(
         card.id,
         CardUpdate {
             title: Some("Renamed".into()),
@@ -44,7 +35,7 @@ async fn test_forward_execution_records_the_derived_invalidation() -> KanbanResu
         },
     )?;
 
-    assert_eq!(entities(&ctx).cards, HashSet::from([card.id]));
+    assert_eq!(entities(inv).cards, HashSet::from([card.id]));
     Ok(())
 }
 
@@ -56,14 +47,14 @@ async fn test_undo_records_the_invalidation_of_the_entry_it_reverses() -> Kanban
     let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
     let card_b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
 
-    ctx.update_card(
+    let _ = ctx.update_card_impl(
         card_a.id,
         CardUpdate {
             title: Some("A2".into()),
             ..Default::default()
         },
     )?;
-    ctx.update_card(
+    let _ = ctx.update_card_impl(
         card_b.id,
         CardUpdate {
             title: Some("B2".into()),
@@ -71,11 +62,11 @@ async fn test_undo_records_the_invalidation_of_the_entry_it_reverses() -> Kanban
         },
     )?;
 
-    assert!(ctx.undo()?);
-    assert_eq!(entities(&ctx).cards, HashSet::from([card_b.id]));
+    let inv = ctx.undo()?.expect("undo applied");
+    assert_eq!(entities(inv).cards, HashSet::from([card_b.id]));
 
-    assert!(ctx.undo()?);
-    let ids = entities(&ctx);
+    let inv = ctx.undo()?.expect("undo applied");
+    let ids = entities(inv);
     assert_eq!(ids.cards, HashSet::from([card_a.id]));
     assert!(!ids.cards.contains(&card_b.id));
 
@@ -87,18 +78,19 @@ async fn test_redo_records_the_invalidation_of_the_forward_batch() -> KanbanResu
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
-    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
+    let (card, create_inv) =
+        ctx.create_card_impl(board.id, col.id, "A".into(), Default::default())?;
 
     assert_eq!(
-        ctx.last_invalidation(),
-        Some(&Invalidation::All),
+        create_inv,
+        Invalidation::All,
         "create's inverse is DeleteCard, which is unenumerable"
     );
 
-    assert!(ctx.undo()?);
-    assert!(ctx.redo()?);
+    let _ = ctx.undo()?.expect("undo applied");
+    let inv = ctx.redo()?.expect("redo applied");
 
-    let ids = entities(&ctx);
+    let ids = entities(inv);
     assert_eq!(ids.cards, HashSet::from([card.id]));
     assert_eq!(ids.boards, HashSet::from([board.id]));
 
@@ -113,41 +105,40 @@ async fn test_undo_of_a_batch_whose_inverse_is_unenumerable_records_all() -> Kan
     let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
     let _card_c = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
 
-    ctx.update_card(
+    let (_card, update_inv) = ctx.update_card_impl(
         card_a.id,
         CardUpdate {
             title: Some("A2".into()),
             ..Default::default()
         },
     )?;
-    assert_eq!(entities(&ctx).cards, HashSet::from([card_a.id]));
+    assert_eq!(entities(update_inv).cards, HashSet::from([card_a.id]));
 
-    assert!(ctx.undo()?);
-    assert_eq!(entities(&ctx).cards, HashSet::from([card_a.id]));
+    let inv = ctx.undo()?.expect("undo applied");
+    assert_eq!(entities(inv).cards, HashSet::from([card_a.id]));
 
-    assert!(ctx.undo()?);
-    assert_eq!(ctx.last_invalidation(), Some(&Invalidation::All));
+    let inv = ctx.undo()?.expect("undo applied");
+    assert_eq!(inv, Invalidation::All);
 
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_a_failed_undo_leaves_the_previously_recorded_invalidation_intact() -> KanbanResult<()>
-{
+async fn test_a_failed_undo_returns_an_error_and_leaves_the_entry_retryable() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
     let card_b = ctx.create_card(board.id, col.id, "B".into(), Default::default())?;
 
-    ctx.update_card(
+    let _ = ctx.update_card_impl(
         card_a.id,
         CardUpdate {
             title: Some("A2".into()),
             ..Default::default()
         },
     )?;
-    ctx.update_card(
+    let _ = ctx.update_card_impl(
         card_b.id,
         CardUpdate {
             title: Some("B2".into()),
@@ -155,15 +146,14 @@ async fn test_a_failed_undo_leaves_the_previously_recorded_invalidation_intact()
         },
     )?;
 
-    assert!(ctx.undo()?);
-    assert_eq!(entities(&ctx).cards, HashSet::from([card_b.id]));
+    let _ = ctx.undo()?.expect("undo applied");
 
     ctx.data_store().delete_card(card_a.id)?;
 
+    let depth_before = ctx.undo_depth();
     assert!(ctx.undo().is_err());
-    let ids = entities(&ctx);
-    assert_eq!(ids.cards, HashSet::from([card_b.id]));
-    assert!(!ids.cards.contains(&card_a.id));
+    assert_eq!(ctx.undo_depth(), depth_before);
+    assert!(ctx.can_undo());
 
     Ok(())
 }
@@ -171,15 +161,13 @@ async fn test_a_failed_undo_leaves_the_previously_recorded_invalidation_intact()
 #[tokio::test(flavor = "multi_thread")]
 async fn test_undo_with_an_empty_stack_records_nothing() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
-    assert!(!ctx.undo()?);
-    assert!(ctx.last_invalidation().is_none());
+    assert!(ctx.undo()?.is_none());
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_redo_with_an_empty_stack_records_nothing() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
-    assert!(!ctx.redo()?);
-    assert!(ctx.last_invalidation().is_none());
+    assert!(ctx.redo()?.is_none());
     Ok(())
 }

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -60,7 +60,7 @@ async fn test_execute_enables_undo() -> KanbanResult<()> {
         card_prefix: None,
         position: 0,
     }));
-    ctx.execute(vec![cmd])?;
+    let _ = ctx.execute(vec![cmd])?;
     assert!(ctx.can_undo());
     Ok(())
 }
@@ -74,10 +74,10 @@ async fn test_undo_restores_previous_state() -> KanbanResult<()> {
         card_prefix: None,
         position: 0,
     }));
-    ctx.execute(vec![cmd])?;
+    let _ = ctx.execute(vec![cmd])?;
     assert_eq!(ctx.boards()?.len(), 1);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(ctx.boards()?.is_empty());
     Ok(())
 }
@@ -91,11 +91,11 @@ async fn test_redo_restores_undone_state() -> KanbanResult<()> {
         card_prefix: None,
         position: 0,
     }));
-    ctx.execute(vec![cmd])?;
+    let _ = ctx.execute(vec![cmd])?;
     ctx.undo()?;
     assert!(ctx.boards()?.is_empty());
 
-    assert!(ctx.redo()?);
+    assert!(ctx.redo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 1);
     Ok(())
 }
@@ -109,7 +109,7 @@ async fn test_undo_on_empty_returns_false() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_new_action_after_undo_clears_redo() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "A".into(),
         card_prefix: None,
@@ -118,7 +118,7 @@ async fn test_new_action_after_undo_clears_redo() -> KanbanResult<()> {
     ctx.undo()?;
     assert!(ctx.can_redo());
 
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "B".into(),
         card_prefix: None,
@@ -134,7 +134,7 @@ async fn test_reload_clears_undo_history() -> KanbanResult<()> {
     let path = dir.path().join("board.json");
     let mut ctx = open_context(path.to_str().unwrap(), kanban_core::AppConfig::default()).await?;
 
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "B".into(),
         card_prefix: None,
@@ -142,7 +142,7 @@ async fn test_reload_clears_undo_history() -> KanbanResult<()> {
     }))])?;
     ctx.save().await?;
 
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "B2".into(),
         card_prefix: None,
@@ -150,7 +150,7 @@ async fn test_reload_clears_undo_history() -> KanbanResult<()> {
     }))])?;
     assert!(ctx.can_undo());
 
-    ctx.reload().await?;
+    let _ = ctx.reload().await?;
     assert!(!ctx.can_undo(), "reload must reset undo history");
     Ok(())
 }
@@ -160,7 +160,7 @@ async fn test_dirty_flag_lifecycle() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     assert!(!ctx.is_dirty());
 
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "B".into(),
         card_prefix: None,
@@ -220,7 +220,7 @@ async fn test_archive_cards_creates_single_undo_entry() -> KanbanResult<()> {
     assert_eq!(ctx.cards()?.len(), 0);
     assert_eq!(ctx.archived_cards()?.len(), 3);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.len(), 3);
     assert_eq!(ctx.archived_cards()?.len(), 0);
     assert!(!ctx.can_undo());
@@ -328,7 +328,7 @@ async fn test_reload_resets_undo_history() -> KanbanResult<()> {
     ctx.create_board("B2".into(), None)?;
     assert!(ctx.can_undo());
 
-    ctx.reload().await?;
+    let _ = ctx.reload().await?;
     assert!(!ctx.can_undo(), "reload must reset undo history");
     Ok(())
 }
@@ -336,7 +336,7 @@ async fn test_reload_resets_undo_history() -> KanbanResult<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_undo_pops_before_pushing_to_redo() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "B".into(),
         card_prefix: None,
@@ -344,14 +344,14 @@ async fn test_undo_pops_before_pushing_to_redo() -> KanbanResult<()> {
     }))])?;
     ctx.clear_history()?;
 
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "B2".into(),
         card_prefix: None,
         position: 0,
     }))])?;
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.redo_depth(), 1);
     assert_eq!(ctx.undo_depth(), 0);
     Ok(())
@@ -360,7 +360,7 @@ async fn test_undo_pops_before_pushing_to_redo() -> KanbanResult<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_redo_pops_before_pushing_to_undo() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "B".into(),
         card_prefix: None,
@@ -368,7 +368,7 @@ async fn test_redo_pops_before_pushing_to_undo() -> KanbanResult<()> {
     }))])?;
     ctx.undo()?;
 
-    assert!(ctx.redo()?);
+    assert!(ctx.redo()?.is_some());
     assert_eq!(ctx.undo_depth(), 1);
     assert_eq!(ctx.redo_depth(), 0);
     Ok(())
@@ -377,7 +377,7 @@ async fn test_redo_pops_before_pushing_to_undo() -> KanbanResult<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_undo_on_empty_history_does_not_corrupt() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
-    assert!(!ctx.undo()?);
+    assert!(ctx.undo()?.is_none());
     assert_eq!(ctx.undo_depth(), 0);
     assert_eq!(ctx.redo_depth(), 0);
     Ok(())
@@ -463,7 +463,7 @@ async fn test_move_cards_single_undo_entry() -> KanbanResult<()> {
     ctx.move_cards(vec![c1.id, c2.id], col2.id)?;
     assert!(ctx.cards()?.iter().all(|c| c.column_id == col2.id));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(ctx.cards()?.iter().all(|c| c.column_id == col1.id));
     assert!(!ctx.can_undo());
     Ok(())
@@ -500,7 +500,7 @@ async fn test_assign_cards_to_sprint_creates_single_undo_entry() -> KanbanResult
     assert_eq!(ctx.get_card(c2.id)?.unwrap().sprint_id, Some(sprint.id));
     assert_eq!(ctx.get_card(c3.id)?.unwrap().sprint_id, Some(sprint.id));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.get_card(c1.id)?.unwrap().sprint_id, None);
     assert_eq!(ctx.get_card(c2.id)?.unwrap().sprint_id, None);
     assert_eq!(ctx.get_card(c3.id)?.unwrap().sprint_id, None);
@@ -558,10 +558,10 @@ async fn test_execute_batch_success_is_undoable() -> KanbanResult<()> {
             position: 0,
         })),
     ];
-    ctx.execute(batch)?;
+    let _ = ctx.execute(batch)?;
     assert_eq!(ctx.boards()?.len(), 3);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 1);
     assert!(!ctx.can_undo());
     Ok(())
@@ -586,10 +586,10 @@ async fn test_import_entities_is_undoable() -> KanbanResult<()> {
         prefixes: vec![],
         ..Default::default()
     }));
-    ctx.execute(vec![cmd])?;
+    let _ = ctx.execute(vec![cmd])?;
     assert_eq!(ctx.boards()?.len(), 2);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 1);
     assert_eq!(ctx.boards()?[0].name, "B1");
     Ok(())
@@ -619,7 +619,7 @@ async fn test_archive_cards_detailed_all_valid_creates_single_undo_entry() -> Ka
     assert!(ctx.is_dirty());
     assert_eq!(ctx.archived_cards()?.len(), 2);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.len(), 2);
     assert_eq!(ctx.archived_cards()?.len(), 0);
     assert!(
@@ -661,7 +661,7 @@ async fn test_detailed_archive_partial_success_is_undoable() -> KanbanResult<()>
     assert!(ctx.is_dirty());
     assert_eq!(ctx.archived_cards()?.len(), 1);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.len(), 1);
     assert_eq!(ctx.archived_cards()?.len(), 0);
     Ok(())
@@ -684,7 +684,7 @@ async fn test_move_cards_detailed_all_valid_creates_single_undo_entry() -> Kanba
     assert!(ctx.is_dirty());
     assert!(ctx.cards()?.iter().all(|c| c.column_id == col_b.id));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert!(ctx.cards()?.iter().all(|c| c.column_id == col_a.id));
     assert!(
         !ctx.can_undo(),
@@ -729,7 +729,7 @@ async fn test_move_cards_detailed_partial_success_is_undoable() -> KanbanResult<
     assert!(ctx.is_dirty());
     assert_eq!(ctx.cards()?.first().unwrap().column_id, col_b.id);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.cards()?.first().unwrap().column_id, col_a.id);
     Ok(())
 }
@@ -753,7 +753,7 @@ async fn test_assign_cards_to_sprint_detailed_all_valid_creates_single_undo_entr
     assert_eq!(ctx.get_card(c1.id)?.unwrap().sprint_id, Some(sprint.id));
     assert_eq!(ctx.get_card(c2.id)?.unwrap().sprint_id, Some(sprint.id));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.get_card(c1.id)?.unwrap().sprint_id, None);
     assert_eq!(ctx.get_card(c2.id)?.unwrap().sprint_id, None);
     assert!(
@@ -800,7 +800,7 @@ async fn test_assign_cards_to_sprint_detailed_partial_success_is_undoable() -> K
     assert!(ctx.is_dirty());
     assert_eq!(ctx.get_card(card.id)?.unwrap().sprint_id, Some(sprint.id));
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.get_card(card.id)?.unwrap().sprint_id, None);
     Ok(())
 }
@@ -832,7 +832,7 @@ async fn test_compact_column_positions_is_undoable() -> KanbanResult<()> {
     let cmd = Command::Card(CardCommand::CompactPositions(CompactColumnPositions {
         column_id: col.id,
     }));
-    ctx.execute(vec![cmd])?;
+    let _ = ctx.execute(vec![cmd])?;
     assert_eq!(
         ctx.cards()?
             .iter()
@@ -850,7 +850,7 @@ async fn test_compact_column_positions_is_undoable() -> KanbanResult<()> {
         1
     );
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(
         ctx.cards()?
             .iter()
@@ -943,20 +943,20 @@ async fn test_multi_step_undo_redo_full_cycle() -> KanbanResult<()> {
     assert_eq!(ctx.boards()?.len(), 3);
     assert_eq!(ctx.undo_depth(), 3);
 
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 2);
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 1);
-    assert!(ctx.undo()?);
+    assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 0);
     assert!(!ctx.can_undo());
     assert_eq!(ctx.redo_depth(), 3);
 
-    assert!(ctx.redo()?);
+    assert!(ctx.redo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 1);
-    assert!(ctx.redo()?);
+    assert!(ctx.redo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 2);
-    assert!(ctx.redo()?);
+    assert!(ctx.redo()?.is_some());
     assert_eq!(ctx.boards()?.len(), 3);
     assert!(!ctx.can_redo());
     assert_eq!(ctx.undo_depth(), 3);
@@ -966,14 +966,14 @@ async fn test_multi_step_undo_redo_full_cycle() -> KanbanResult<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_redo_past_end_returns_false() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
-    assert!(!ctx.redo()?);
+    assert!(ctx.redo()?.is_none());
 
     ctx.create_board("B".into(), None)?;
-    assert!(!ctx.redo()?);
+    assert!(ctx.redo()?.is_none());
 
     ctx.undo()?;
-    assert!(ctx.redo()?);
-    assert!(!ctx.redo()?);
+    assert!(ctx.redo()?.is_some());
+    assert!(ctx.redo()?.is_none());
     Ok(())
 }
 
@@ -1013,7 +1013,7 @@ async fn test_undo_extends_past_old_200_step_cap() -> KanbanResult<()> {
 
     let total = 250usize;
     for i in 0..total {
-        ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+        let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
             id: uuid::Uuid::new_v4(),
             name: format!("B{i}"),
             card_prefix: None,
@@ -1029,7 +1029,7 @@ async fn test_undo_extends_past_old_200_step_cap() -> KanbanResult<()> {
     assert_eq!(ctx.boards()?.len(), total);
 
     for _ in 0..total {
-        assert!(ctx.undo()?);
+        assert!(ctx.undo()?.is_some());
     }
     assert!(
         !ctx.can_undo(),
@@ -1046,7 +1046,7 @@ async fn test_undo_extends_past_old_200_step_cap() -> KanbanResult<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_can_redo_uses_cached_count() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
-    ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
+    let _ = ctx.execute(vec![Command::Board(BoardCommand::Create(CreateBoard {
         id: uuid::Uuid::new_v4(),
         name: "B".into(),
         card_prefix: None,

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1209,20 +1209,30 @@ mod create_card_factory_tests {
         assert_eq!(after, before + 1);
     }
 
-    /// Passes unmodified today; a forward guard, not a discriminating test.
     #[test]
     fn test_tui_create_card_records_an_invalidation_covering_prefixes() {
         let mut app = App::test_default();
         seed_active_board_with_column(&mut app);
+        let (board_id, column_id) = active_ids(&app);
 
         app.input.set("Ship it".to_string());
         app.create_card();
         app.input.clear();
 
-        let covers_prefixes = match app.ctx.inner_mut().last_invalidation() {
-            Some(kanban_domain::Invalidation::All) => true,
-            Some(kanban_domain::Invalidation::Entities(ids)) => ids.prefixes,
-            None => false,
+        let (_card, inv) = app
+            .ctx
+            .inner_mut()
+            .create_card_impl(
+                board_id,
+                column_id,
+                "Ship it again".into(),
+                Default::default(),
+            )
+            .unwrap();
+
+        let covers_prefixes = match inv {
+            kanban_domain::Invalidation::All => true,
+            kanban_domain::Invalidation::Entities(ids) => ids.prefixes,
         };
         assert!(covers_prefixes);
     }
@@ -1254,8 +1264,26 @@ mod create_card_factory_tests {
 
         assert!(app.ctx.save_coordinator.has_pending_saves());
 
-        match app.ctx.inner_mut().last_invalidation() {
-            Some(kanban_domain::Invalidation::Entities(ids)) => {
+        let second_inv = app
+            .ctx
+            .inner_mut()
+            .execute_with_extra(kanban_domain::EntityIds::default().with_prefixes(), |_| {
+                Ok(vec![kanban_domain::commands::Command::Card(
+                    kanban_domain::commands::CardCommand::Update(
+                        kanban_domain::commands::UpdateCard {
+                            card_id: card.id,
+                            updates: kanban_domain::CardUpdate {
+                                title: Some("y".into()),
+                                ..Default::default()
+                            },
+                        },
+                    ),
+                )])
+            })
+            .unwrap();
+
+        match second_inv {
+            kanban_domain::Invalidation::Entities(ids) => {
                 assert_eq!(ids.cards, std::collections::HashSet::from([card.id]));
                 assert!(ids.prefixes);
             }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -42,7 +42,7 @@ impl TuiContext {
     }
 
     pub fn execute_commands_batch(&mut self, commands: Vec<Command>) -> KanbanResult<()> {
-        self.inner.execute(commands)?;
+        let _ = self.inner.execute(commands)?;
         if self.save_coordinator.has_save_channel() {
             self.save_coordinator.queue_flush();
         }
@@ -61,7 +61,7 @@ impl TuiContext {
         extra: kanban_domain::EntityIds,
         build: impl FnOnce(&dyn kanban_domain::DataStore) -> KanbanResult<Vec<Command>>,
     ) -> KanbanResult<()> {
-        self.inner.execute_with_extra(extra, build)?;
+        let _ = self.inner.execute_with_extra(extra, build)?;
         if self.save_coordinator.has_save_channel() {
             self.save_coordinator.queue_flush();
         }
@@ -139,7 +139,7 @@ impl TuiContext {
     }
 
     pub fn replace_backend(&mut self, backend: Arc<dyn KanbanBackend>) {
-        self.inner.replace_backend(backend);
+        let _ = self.inner.replace_backend(backend);
     }
 
     pub async fn save(&self) -> KanbanResult<()> {

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -71,19 +71,19 @@ impl TuiContext {
     // --- Delegation: state methods ---
 
     pub fn undo(&mut self) -> KanbanResult<bool> {
-        let result = self.inner.undo()?;
-        if result && self.save_coordinator.has_save_channel() {
+        let applied = self.inner.undo()?.is_some();
+        if applied && self.save_coordinator.has_save_channel() {
             self.save_coordinator.queue_flush();
         }
-        Ok(result)
+        Ok(applied)
     }
 
     pub fn redo(&mut self) -> KanbanResult<bool> {
-        let result = self.inner.redo()?;
-        if result && self.save_coordinator.has_save_channel() {
+        let applied = self.inner.redo()?.is_some();
+        if applied && self.save_coordinator.has_save_channel() {
             self.save_coordinator.queue_flush();
         }
-        Ok(result)
+        Ok(applied)
     }
 
     pub fn can_undo(&self) -> bool {


### PR DESCRIPTION
## Summary

- `kanban_domain::Invalidation` is now `#[must_use]`.
- `KanbanContext::undo`/`redo` now return `KanbanResult<Option<Invalidation>>` instead of `KanbanResult<bool>`, carrying the invalidation the reversed or replayed batch implies.
- `KanbanContext::last_invalidation` and its backing field are removed. Every caller now reads the value returned from `execute`, `execute_with`, `execute_with_extra`, `undo`, or `redo` directly, instead of stashing and re-reading it off the context.
- `McpContext::undo`/`redo` forward the same `Option<Invalidation>` return type, so KAN-1447 has the value it needs.
- `TuiContext::undo`/`redo` are intentionally left returning `bool`. kanban-tui has no consumer for the invalidation until it gets a `Model` (KAN-1448), and that plumbing belongs to KAN-1427.

## Deviations from the card

- Baseline was `origin/develop` at `1dd58b4f` (KAN-1424, #699), not the card's `baf76b30`. All figures below were re-derived against that tip.
- `#[must_use]` was in fact absent from `Invalidation` before this PR (contrary to the card's Step-1 self-check, which told the implementer to stop). The card's own dated correction block says this PR owns adding it, so that is what happened here.
- The re-derived sweep grep:
  ```
  git grep -n 'ctx\.execute\|ctx\.undo()\|ctx\.redo()\|\.execute_with' -- crates \
    | grep -v 'kanban-service/src/context/' \
    | awk -F: '{print $1}' | sort -u | wc -l
  ```
  returned 45 files, not the card's 44 (KAN-1424 added `crates/kanban-service/tests/mutation_invalidation.rs` to the set).
- That grep was also both incomplete and unsound versus what the compiler actually required once `#[must_use]` landed:
  - Missed entirely: `crates/kanban-service/src/test_helpers/contract/lifecycle.rs`, the five `replace_backend` statement sites in `crates/kanban-service/tests/context_open.rs`, and several files the grep's `.execute(` pattern didn't match across a rustfmt-wrapped call (`crates/kanban-service/tests/subcard_wip_limit.rs`, `configured_default_card_prefix.rs`, `card_metadata_editor_format.rs`, `list_cards_filters.rs`, `list_cards_sort.rs`, `audit_log_append_only.rs`, `board_archive.rs`, `board_archive_sqlite.rs`, `completion_sync.rs`, `import_merges_dependency_graph.rs`, `prefix_allocation.rs`, `crates/kanban-persistence-sqlite/tests/with_transaction.rs`).
  - False positives (touched no `Option<Invalidation>` or `Invalidation`): `crates/kanban-cli/src/handlers/board.rs` (its `execute_commands` wrapper already returns `KanbanResult<()>`), `crates/kanban-tui/src/state/mod.rs` (a doc comment), and the `crates/kanban-tui/src/{app/command_execution.rs,handlers/detail_view_handlers.rs,app/export_import.rs}` call sites, all of which go through `TuiContext`, which still returns `bool`/`()`.
  - The compiler (`cargo clippy --workspace --all-targets --all-features -- -D warnings`), not the grep, was used as the authority; every file it named was fixed, in the pattern `let _ = ctx.execute(...)` for discards or `.is_some()`/`.is_none()` for boolean assertions.
- `McpContext` is the real type name; the card called it `McpKanbanContext`.
- Ported `last_invalidation()` assertions in `crates/kanban-service/tests/undo_invalidation.rs`:
  - `test_a_fresh_context_has_no_recorded_invalidation` is deleted. There is no returned-value equivalent (a fresh context makes no call to observe), and its content is fully covered by the new `test_undo_on_an_empty_stack_returns_none` in `mutation_invalidation.rs`.
  - `test_a_failed_undo_leaves_the_previously_recorded_invalidation_intact` is renamed to `test_a_failed_undo_returns_an_error_and_leaves_the_entry_retryable`, since its subject (the stash) is gone. It now asserts the strictly stronger properties: the second `undo()` returns `Err`, `undo_depth()` is unchanged across the failure, and `can_undo()` is still `true`.
  - Every other assertion was ported to bind the returned `Invalidation`/`Option<Invalidation>` directly rather than reading `ctx.last_invalidation()` afterward; none were weakened.
  - Two tests in `execute_with_extra.rs` and `card_handlers.rs` that previously observed an invalidation produced through a path that discards it (the `KanbanOperations` facade / `App::create_card`) were re-routed through the `pub` `*_impl` methods that do return it, rather than left unfixable.
- Bump is `minor`, not the card's suggested `patch`: this removes a public item (`KanbanContext::last_invalidation`) and changes public signatures (`KanbanContext::undo`/`redo`, `McpContext::undo`/`redo`), which `.changeset/README.md`'s pre-1.0 section calls out as breaking.
- The README had a fourth passage the card didn't name (`crates/kanban-service/README.md:110-111`, documenting `ctx.undo()`/`redo() -> KanbanResult<bool>`), fixed alongside the three the card did name.
- `ctx.last_invalidation()` no longer resolving was verified empirically: a scratch `#[cfg(test)]` probe calling it produced `error[E0599]: no method named `last_invalidation` found for reference `&context::KanbanContext``, then the probe was reverted (not committed). `git grep -n last_invalidation -- crates/` now returns nothing.
- Verified empirically that `Option<T>` is not `#[must_use]` in std: `ctx.undo()?;` in statement position compiles silently even after this change. This is expected and not widened in scope; the `#[must_use]` guard installed here covers `execute*`, `reload`, `replace_backend`, and the `*_impl` tuples, not `undo`/`redo` themselves, and calling undo purely for its side effect remains legitimate.
- `crates/kanban-service/tests/undo_invalidation.rs` had 8 `fn test_` before this change (matching the card's stated count); it now has 7 due to the one deletion documented above (an 8th, `test_a_failed_undo_...`, was renamed, not removed).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p kanban-domain --all-features`
- [x] `cargo test -p kanban-service --all-features`
- [x] `cargo test -p kanban-mcp --all-features`
- [x] `cargo test -p kanban-tui --all-features`
- [x] `cargo test -p kanban-persistence-sqlite --all-features`
- [x] `cargo check -p kanban-server -p kanban-cli`
- [x] Mutation check: forced `undo()`'s success path to return `Ok(None)`, confirmed `test_undo_returns_the_inverse_batchs_invalidation` fails, reverted (not committed).
