### PR TITLE
KAN-1426 test(service): resolve/invalidate parity contract harness

### DIFF
--- a/.changeset/kan-1426-resolve-invalidate-parity-contract-across.md
+++ b/.changeset/kan-1426-resolve-invalidate-parity-contract-across.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain,service: add a resolve/invalidate parity contract harness that pins `resolve`'s `LoadState` mapping (absent card/column/sprint resolves to `Missing`, a backend read or list error resolves to `Failed`, `Missing` is terminal, `Failed` is retried) across the in-memory, JSON, and SQLite backends, and document the archival semantics of `DataStore::get_card` and `DataStore::list_all_cards` on the trait itself.

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -43,7 +43,11 @@ pub trait DataStore: Send + Sync {
     fn delete_columns_by_board(&self, board_id: Uuid) -> KanbanResult<()>;
 
     // Card
+    /// Returns the row regardless of archival status: an archived card is
+    /// still `Some`.
     fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>>;
+    /// Excludes archived cards, so a card's absence here is not evidence the
+    /// card is gone.
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>>;
     fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>>;
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>>;

--- a/crates/kanban-persistence-json/tests/contract.rs
+++ b/crates/kanban-persistence-json/tests/contract.rs
@@ -17,4 +17,5 @@ mod tier1 {
 mod tier2 {
     kanban_service::context_contract_tests!(super::json_backend_factory);
     kanban_service::durable_prefix_contract_tests!(super::json_backend_factory);
+    kanban_service::cache_contract_tests!(super::json_backend_factory);
 }

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -1,0 +1,369 @@
+use super::super::fault::faultable;
+use super::super::BackendFactory;
+use crate::fetch_plan::{FetchPlan, FetchRound, LoadedEntities};
+use crate::KanbanContext;
+use kanban_core::AppConfig;
+use kanban_domain::{DerivedProjections, KanbanOperations, Model, NoProjections, Resolved};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+/// A plan that always requests the same fixed round, regardless of what has
+/// already loaded. `resolve` still terminates in one pass, because a round
+/// is narrowed against what this call has already fetched before it is
+/// dispatched, and a constant round narrows to empty on the second pass.
+pub struct StaticPlan(pub FetchRound);
+
+impl FetchPlan for StaticPlan {
+    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+        self.0.clone()
+    }
+}
+
+fn apply(model: &mut Model, resolved: Resolved) {
+    let changed = model.apply_resolved(resolved);
+    NoProjections.resync(model, changed);
+}
+
+pub async fn test_an_absent_card_resolves_missing_not_failed(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+    let model = Model::default();
+    let ghost = Uuid::new_v4();
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            cards: vec![ghost],
+            ..Default::default()
+        }),
+        &model,
+    );
+
+    let state = resolved
+        .cards
+        .by_id
+        .get(&ghost)
+        .expect("ghost card requested");
+    assert!(state.is_missing());
+    assert!(!state.is_failed());
+
+    let mut model = model;
+    apply(&mut model, resolved);
+}
+
+pub async fn test_an_absent_column_resolves_missing_not_failed(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+    let model = Model::default();
+    let ghost = Uuid::new_v4();
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            columns: vec![ghost],
+            ..Default::default()
+        }),
+        &model,
+    );
+
+    let state = resolved
+        .columns
+        .by_id
+        .get(&ghost)
+        .expect("ghost column requested");
+    assert!(state.is_missing());
+    assert!(!state.is_failed());
+
+    let mut model = model;
+    apply(&mut model, resolved);
+}
+
+pub async fn test_an_absent_sprint_resolves_missing_not_failed(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+    let model = Model::default();
+    let ghost = Uuid::new_v4();
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            sprints: vec![ghost],
+            ..Default::default()
+        }),
+        &model,
+    );
+
+    let state = resolved
+        .sprints
+        .by_id
+        .get(&ghost)
+        .expect("ghost sprint requested");
+    assert!(state.is_missing());
+    assert!(!state.is_failed());
+
+    let mut model = model;
+    apply(&mut model, resolved);
+}
+
+pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+    let mut model = Model::default();
+
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let column = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let card = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let plan = StaticPlan(FetchRound {
+        cards: vec![card.id],
+        ..Default::default()
+    });
+
+    let resolved = ctx.resolve(&plan, &model);
+    assert!(resolved
+        .cards
+        .by_id
+        .get(&card.id)
+        .expect("card requested")
+        .is_loaded());
+    apply(&mut model, resolved);
+    assert!(model.card_by_id_state(card.id).is_loaded());
+
+    let _invalidation = ctx.delete_card_impl(card.id).unwrap();
+
+    let resolved2 = ctx.resolve(&plan, &model);
+    assert!(resolved2
+        .cards
+        .by_id
+        .get(&card.id)
+        .expect("card requested again")
+        .is_missing());
+    apply(&mut model, resolved2);
+    assert!(model.card_by_id_state(card.id).is_missing());
+    assert!(!model
+        .cards_state()
+        .loaded_or_empty()
+        .iter()
+        .any(|c| c.id == card.id));
+}
+
+pub async fn test_a_backend_read_error_resolves_failed_not_missing(factory: BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let (factory, handles) = faultable(factory);
+    let backend = factory(&path);
+    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let model = Model::default();
+
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let column = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let card = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    handle.fail("get_card");
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            cards: vec![card.id],
+            ..Default::default()
+        }),
+        &model,
+    );
+
+    let state = resolved.cards.by_id.get(&card.id).expect("card requested");
+    assert!(state.is_failed());
+    assert!(!state.is_missing());
+}
+
+pub async fn test_a_backend_list_error_resolves_the_list_failed_not_empty(factory: BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let (factory, handles) = faultable(factory);
+    let backend = factory(&path);
+    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let model = Model::default();
+
+    handle.fail("list_all_cards");
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            card_list: true,
+            ..Default::default()
+        }),
+        &model,
+    );
+
+    assert!(resolved.cards.all.is_failed());
+    assert!(!resolved.cards.all.is_loaded());
+}
+
+pub async fn test_a_backend_list_error_resolves_the_column_list_failed_not_empty(
+    factory: BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let (factory, handles) = faultable(factory);
+    let backend = factory(&path);
+    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let model = Model::default();
+
+    handle.fail("list_all_columns");
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            column_list: true,
+            ..Default::default()
+        }),
+        &model,
+    );
+
+    assert!(resolved.columns.all.is_failed());
+    assert!(!resolved.columns.all.is_loaded());
+}
+
+pub async fn test_a_backend_list_error_resolves_the_sprint_list_failed_not_empty(
+    factory: BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let (factory, handles) = faultable(factory);
+    let backend = factory(&path);
+    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let model = Model::default();
+
+    handle.fail("list_all_sprints");
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            sprint_list: true,
+            ..Default::default()
+        }),
+        &model,
+    );
+
+    assert!(resolved.sprints.all.is_failed());
+    assert!(!resolved.sprints.all.is_loaded());
+}
+
+pub async fn test_a_failed_read_is_retried_on_the_next_resolve(factory: BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let (factory, handles) = faultable(factory);
+    let backend = factory(&path);
+    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let mut model = Model::default();
+
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let column = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let card = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    handle.fail("get_card");
+
+    let plan = StaticPlan(FetchRound {
+        cards: vec![card.id],
+        ..Default::default()
+    });
+
+    let resolved = ctx.resolve(&plan, &model);
+    assert!(resolved
+        .cards
+        .by_id
+        .get(&card.id)
+        .expect("card requested")
+        .is_failed());
+    apply(&mut model, resolved);
+
+    handle.clear_faults();
+    handle.clear_ops();
+
+    let resolved2 = ctx.resolve(&plan, &model);
+    assert!(resolved2
+        .cards
+        .by_id
+        .get(&card.id)
+        .expect("card requested again")
+        .is_loaded());
+    assert_eq!(handle.op_count("get_card"), 1);
+}
+
+pub async fn test_a_missing_read_is_not_retried_on_the_next_resolve(factory: BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let (factory, handles) = faultable(factory);
+    let backend = factory(&path);
+    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let mut model = Model::default();
+    let ghost = Uuid::new_v4();
+
+    let plan = StaticPlan(FetchRound {
+        cards: vec![ghost],
+        ..Default::default()
+    });
+
+    let resolved = ctx.resolve(&plan, &model);
+    apply(&mut model, resolved);
+    assert!(model.card_by_id_state(ghost).is_missing());
+
+    handle.clear_ops();
+    handle.fail("get_card");
+
+    let resolved2 = ctx.resolve(&plan, &model);
+    assert!(!resolved2.cards.by_id.contains_key(&ghost));
+    apply(&mut model, resolved2);
+
+    assert!(model.card_by_id_state(ghost).is_missing());
+    assert_eq!(handle.op_count("get_card"), 0);
+}

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -132,12 +132,13 @@ pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &
         )
         .unwrap();
 
-    let plan = StaticPlan(FetchRound {
+    let plan_with_list = StaticPlan(FetchRound {
+        card_list: true,
         cards: vec![card.id],
         ..Default::default()
     });
 
-    let resolved = ctx.resolve(&plan, &model);
+    let resolved = ctx.resolve(&plan_with_list, &model);
     assert!(resolved
         .cards
         .by_id
@@ -146,10 +147,20 @@ pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &
         .is_loaded());
     apply(&mut model, resolved);
     assert!(model.card_by_id_state(card.id).is_loaded());
+    assert!(model
+        .cards_state()
+        .loaded_or_empty()
+        .iter()
+        .any(|c| c.id == card.id));
 
     let _invalidation = ctx.delete_card_impl(card.id).unwrap();
 
-    let resolved2 = ctx.resolve(&plan, &model);
+    let plan_by_id_only = StaticPlan(FetchRound {
+        cards: vec![card.id],
+        ..Default::default()
+    });
+
+    let resolved2 = ctx.resolve(&plan_by_id_only, &model);
     assert!(resolved2
         .cards
         .by_id

--- a/crates/kanban-service/src/test_helpers/contract/mod.rs
+++ b/crates/kanban-service/src/test_helpers/contract/mod.rs
@@ -1,5 +1,6 @@
 pub mod archive;
 pub mod board;
+pub mod cache;
 pub mod card;
 pub mod column;
 pub mod edge;

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -434,3 +434,51 @@ macro_rules! durable_prefix_contract_tests {
         }
     };
 }
+
+/// `resolve`'s `LoadState` mapping and its terminality rules, held to one
+/// spec on every backend. Do not narrow this macro to a subset of backends.
+#[macro_export]
+macro_rules! cache_contract_tests {
+    ($factory_fn:expr) => {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_an_absent_card_resolves_missing_not_failed() {
+            $crate::test_helpers::contract::cache::test_an_absent_card_resolves_missing_not_failed(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_an_absent_column_resolves_missing_not_failed() {
+            $crate::test_helpers::contract::cache::test_an_absent_column_resolves_missing_not_failed(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_an_absent_sprint_resolves_missing_not_failed() {
+            $crate::test_helpers::contract::cache::test_an_absent_sprint_resolves_missing_not_failed(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_deleted_card_resolves_missing_on_a_second_resolve() {
+            $crate::test_helpers::contract::cache::test_a_deleted_card_resolves_missing_on_a_second_resolve(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_backend_read_error_resolves_failed_not_missing() {
+            $crate::test_helpers::contract::cache::test_a_backend_read_error_resolves_failed_not_missing($factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_backend_list_error_resolves_the_list_failed_not_empty() {
+            $crate::test_helpers::contract::cache::test_a_backend_list_error_resolves_the_list_failed_not_empty($factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_backend_list_error_resolves_the_column_list_failed_not_empty() {
+            $crate::test_helpers::contract::cache::test_a_backend_list_error_resolves_the_column_list_failed_not_empty($factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_backend_list_error_resolves_the_sprint_list_failed_not_empty() {
+            $crate::test_helpers::contract::cache::test_a_backend_list_error_resolves_the_sprint_list_failed_not_empty($factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_failed_read_is_retried_on_the_next_resolve() {
+            $crate::test_helpers::contract::cache::test_a_failed_read_is_retried_on_the_next_resolve($factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_missing_read_is_not_retried_on_the_next_resolve() {
+            $crate::test_helpers::contract::cache::test_a_missing_read_is_not_retried_on_the_next_resolve($factory_fn()).await;
+        }
+    };
+}

--- a/crates/kanban-service/tests/archival_contract.rs
+++ b/crates/kanban-service/tests/archival_contract.rs
@@ -77,16 +77,19 @@ fn in_memory_backend_factory() -> BackendFactory {
 mod in_memory {
     kanban_service::context_contract_tests!(super::in_memory_backend_factory);
     kanban_service::durable_prefix_contract_tests!(super::in_memory_backend_factory);
+    kanban_service::cache_contract_tests!(super::in_memory_backend_factory);
 }
 
 mod json {
     kanban_service::context_contract_tests!(super::json_backend_factory);
     kanban_service::durable_prefix_contract_tests!(super::json_backend_factory);
+    kanban_service::cache_contract_tests!(super::json_backend_factory);
 }
 
 mod sqlite {
     kanban_service::context_contract_tests!(super::sqlite_backend_factory);
     kanban_service::durable_prefix_contract_tests!(super::sqlite_backend_factory);
+    kanban_service::cache_contract_tests!(super::sqlite_backend_factory);
 }
 
 /// Optimistic-concurrency conflict detection is a FILE-store feature (it versions


### PR DESCRIPTION
## Summary

- Add `crates/kanban-service/src/test_helpers/contract/cache.rs`: `StaticPlan` (a `FetchPlan` that returns a fixed round) plus ten contract functions pinning `resolve`'s `LoadState` mapping: absent card/column/sprint resolves to `Missing` not `Failed`; a deleted card resolves `Missing` on a second `resolve` call with no invalidation step needed; a backend read or list error resolves to `Failed` (never silently downgraded to `Loaded(vec![])`); `Failed` reads are retried on the next resolve; `Missing` reads are not.
- Add `cache_contract_tests!` macro (`crates/kanban-service/src/test_helpers/mod.rs`) registering all ten functions, invoked against in-memory, JSON, and SQLite in `crates/kanban-service/tests/archival_contract.rs`, and against JSON again in `crates/kanban-persistence-json/tests/contract.rs`.
- Document the archival semantics of `DataStore::get_card` (returns the row regardless of archival status) and `DataStore::list_all_cards` (excludes archived cards) directly on the trait declarations in `crates/kanban-domain/src/data_store.rs`.

## Verification

- `cargo test -p kanban-service --features test-helpers --test archival_contract -- test_an_absent test_a_deleted test_a_backend test_a_failed test_a_missing`: 30 passed (10 functions x 3 backends).
- `cargo test -p kanban-persistence-json --test contract -- test_an_absent test_a_deleted test_a_backend test_a_failed test_a_missing`: 10 passed (JSON repeat).
- Mutation checks against `crates/kanban-service/src/resolve.rs`, each reverted after confirming red:
  - A (swap the three per-id `Ok(None) => Missing` arms to `Failed`): 12 tests went red across all three backends.
  - B (swap the three list `Err => Failed` arms to `Loaded(vec![])`): 9 tests went red across all three backends.
  - C (remove the `Missing`-terminality filter from `outstanding`): 3 tests went red across all three backends.
- `cargo test -p kanban-service --features test-helpers`, `cargo test -p kanban-persistence-json`, `cargo test -p kanban-domain`: all green, no failures.
- `cargo clippy -p kanban-service --features test-helpers --all-targets -- -D warnings`, `cargo clippy -p kanban-domain --all-features -- -D warnings`, `cargo clippy -p kanban-persistence-json --all-features --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Counts: `cache.rs` has exactly 10 `pub async fn test_*` functions (6 by-value for fault-injection tests, 4 by-reference); the macro has exactly 10 arms; `test_helpers/mod.rs`'s total `async fn test_` count moved from 96 to 106.

Changeset: `minor`, since this adds new public API (`kanban_service::test_helpers::contract::cache`, ten public functions, `StaticPlan`, and the crate-root `cache_contract_tests!` macro).
