### PR TITLE
KAN-1477 feat(domain,service): resolve fetches a board's archived-card markers into their own tier

### DIFF
--- a/.changeset/kan-1477-resolver-fetches-archived-by-board.md
+++ b/.changeset/kan-1477-resolver-fetches-archived-by-board.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain,service: `Resolved` gains a fourth tier, `archived_cards: Collection<ArchivedCard>`, and `FetchRound` gains the two request fields that fill it, `archived_card_list: bool` and `archived_cards_by_board: Vec<Uuid>`. The resolver populates the flat tier from `DataStore::list_archived_cards` and the board-scoped tier from `list_archived_cards_by_board`, mapping a read error to `LoadState::Failed` rather than collapsing it to an empty list. Nothing in `Model`, `LoadedState` or `Overlay` changes, so nobody consumes the new tier yet. It is a `minor` bump because adding public fields to public, non-`#[non_exhaustive]` structs on crates that publish to crates.io is both new public API and breaking for any exhaustive struct literal.

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use uuid::Uuid;
 
+use crate::archived_card::ArchivedCard;
 use crate::board::Board;
 use crate::card::Card;
 use crate::column::Column;
@@ -28,6 +29,8 @@ use crate::sprint::Sprint;
 /// - `columns.by_parent` is keyed by board id (`list_columns_by_board`)
 /// - `cards.by_parent` is keyed by column id (`list_cards_by_column`)
 /// - `sprints.by_parent` is keyed by board id (`list_sprints_by_board`)
+/// - `archived_cards.by_parent` is keyed by board id
+///   (`list_archived_cards_by_board`)
 /// - `boards.by_parent` is unused and stays permanently empty: a board has no
 ///   parent.
 ///
@@ -76,6 +79,9 @@ pub struct Resolved {
     pub columns: Collection<Column>,
     pub cards: Collection<Card>,
     pub sprints: Collection<Sprint>,
+    /// Archival markers, not cards. `by_id` stays permanently empty: no
+    /// `FetchRound` tier requests a single marker.
+    pub archived_cards: Collection<ArchivedCard>,
     pub graph: LoadState<DependencyGraph>,
 }
 

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -75,6 +75,9 @@ pub struct FetchRound {
     pub cards_by_column: Vec<Uuid>,
     /// Board ids whose sprints are wanted.
     pub sprints_by_board: Vec<Uuid>,
+    pub archived_card_list: bool,
+    /// Board ids whose archived-card markers are wanted.
+    pub archived_cards_by_board: Vec<Uuid>,
 }
 
 impl FetchRound {
@@ -90,6 +93,8 @@ impl FetchRound {
             && self.columns_by_board.is_empty()
             && self.cards_by_column.is_empty()
             && self.sprints_by_board.is_empty()
+            && !self.archived_card_list
+            && self.archived_cards_by_board.is_empty()
     }
 }
 

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -302,6 +302,21 @@ mod tests {
     }
 
     #[test]
+    fn test_an_archived_round_is_not_empty() {
+        let list_round = FetchRound {
+            archived_card_list: true,
+            ..Default::default()
+        };
+        assert!(!list_round.is_empty());
+
+        let scoped_round = FetchRound {
+            archived_cards_by_board: vec![Uuid::new_v4()],
+            ..Default::default()
+        };
+        assert!(!scoped_round.is_empty());
+    }
+
+    #[test]
     fn test_loaded_state_distinguishes_all_three_tiers() {
         let column_id = Uuid::new_v4();
         let card_id = Uuid::new_v4();

--- a/crates/kanban-service/src/read_recorder.rs
+++ b/crates/kanban-service/src/read_recorder.rs
@@ -206,7 +206,13 @@ impl DataStore for RecordingStore {
     }
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         self.record("list_archived_cards", vec![]);
+        self.check("list_archived_cards")?;
         self.inner.list_archived_cards()
+    }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.record("list_archived_cards_by_board", vec![board_id]);
+        self.check("list_archived_cards_by_board")?;
+        self.inner.list_archived_cards_by_board(board_id)
     }
     fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
         self.inner.insert_archived_card(ac)

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -95,6 +95,8 @@ struct Fetched {
     columns_by_board: HashSet<Uuid>,
     cards_by_column: HashSet<Uuid>,
     sprints_by_board: HashSet<Uuid>,
+    archived_card_list: bool,
+    archived_cards_by_board: HashSet<Uuid>,
 }
 
 impl Fetched {
@@ -113,6 +115,9 @@ impl Fetched {
             .extend(round.cards_by_column.iter().copied());
         self.sprints_by_board
             .extend(round.sprints_by_board.iter().copied());
+        self.archived_card_list |= round.archived_card_list;
+        self.archived_cards_by_board
+            .extend(round.archived_cards_by_board.iter().copied());
     }
 }
 
@@ -150,6 +155,11 @@ fn narrow_to_outstanding(
         columns_by_board: outstanding_scoped(round.columns_by_board, &fetched.columns_by_board),
         cards_by_column: outstanding_scoped(round.cards_by_column, &fetched.cards_by_column),
         sprints_by_board: outstanding_scoped(round.sprints_by_board, &fetched.sprints_by_board),
+        archived_card_list: round.archived_card_list && !fetched.archived_card_list,
+        archived_cards_by_board: outstanding_scoped(
+            round.archived_cards_by_board,
+            &fetched.archived_cards_by_board,
+        ),
     }
 }
 
@@ -181,6 +191,12 @@ fn fetch_round(round: &FetchRound, store: &dyn DataStore, resolved: &mut Resolve
     if round.graph {
         resolved.graph = match store.get_graph() {
             Ok(g) => LoadState::Loaded(g),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+    }
+    if round.archived_card_list {
+        resolved.archived_cards.all = match store.list_archived_cards() {
+            Ok(v) => LoadState::Loaded(v),
             Err(e) => LoadState::Failed(Arc::new(e)),
         };
     }
@@ -230,6 +246,13 @@ fn fetch_round(round: &FetchRound, store: &dyn DataStore, resolved: &mut Resolve
             Err(e) => LoadState::Failed(Arc::new(e)),
         };
         resolved.sprints.by_parent.insert(board_id, state);
+    }
+    for &board_id in &round.archived_cards_by_board {
+        let state = match store.list_archived_cards_by_board(board_id) {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+        resolved.archived_cards.by_parent.insert(board_id, state);
     }
 }
 

--- a/crates/kanban-service/src/resolve/tests/archived.rs
+++ b/crates/kanban-service/src/resolve/tests/archived.rs
@@ -1,0 +1,148 @@
+use crate::fetch_plan::FetchRound;
+
+use super::{
+    seed_archived_card, seed_board, seed_board_with_column, seed_card, seed_column, store,
+    FixedPlan, OneShotPlan, StubLoaded,
+};
+use crate::read_recorder::{assert_ops, ReadOp};
+use crate::resolve::resolve;
+
+#[test]
+fn test_a_board_scoped_archived_card_round_resolves_the_boards_markers() {
+    let store = store();
+    let (board_a, col_a) = seed_board_with_column(&store);
+    let card_a = seed_card(&store, &board_a, &col_a, "a");
+    let marker_a = seed_archived_card(&store, &board_a, &card_a);
+
+    let board_b = seed_board(&store, "b");
+    let col_b = seed_column(&store, &board_b, "c");
+    let card_b = seed_card(&store, &board_b, &col_b, "b");
+    let _marker_b = seed_archived_card(&store, &board_b, &card_b);
+
+    let loaded = StubLoaded::default();
+    let plan = OneShotPlan::new(FetchRound {
+        archived_cards_by_board: vec![board_a.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_archived_cards_by_board",
+            ids: vec![board_a.id],
+        }],
+    );
+    let scoped = resolved.archived_cards.by_parent[&board_a.id]
+        .loaded()
+        .unwrap();
+    assert_eq!(scoped.len(), 1);
+    assert_eq!(scoped[0].entity_id, marker_a.entity_id);
+    assert!(resolved.archived_cards.all.is_not_loaded());
+    assert!(resolved.archived_cards.by_id.is_empty());
+}
+
+#[test]
+fn test_an_archived_card_read_error_resolves_failed_not_empty() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    let _marker = seed_archived_card(&store, &board, &card);
+    store.fail_method("list_archived_cards_by_board");
+
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        archived_cards_by_board: vec![board.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    let state = &resolved.archived_cards.by_parent[&board.id];
+    assert!(state.is_failed());
+    assert!(!state.is_loaded());
+    assert!(!state.is_missing());
+}
+
+#[test]
+fn test_a_flat_archived_card_round_resolves_every_marker() {
+    let store = store();
+    let (board_a, col_a) = seed_board_with_column(&store);
+    let card_a = seed_card(&store, &board_a, &col_a, "a");
+    seed_archived_card(&store, &board_a, &card_a);
+
+    let board_b = seed_board(&store, "b");
+    let col_b = seed_column(&store, &board_b, "c");
+    let card_b = seed_card(&store, &board_b, &col_b, "b");
+    seed_archived_card(&store, &board_b, &card_b);
+
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        archived_card_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_archived_cards",
+            ids: vec![],
+        }],
+    );
+    let all = resolved.archived_cards.all.loaded().unwrap();
+    assert_eq!(all.len(), 2);
+    assert!(resolved.archived_cards.by_parent.is_empty());
+    assert!(resolved.archived_cards.by_id.is_empty());
+}
+
+#[test]
+fn test_an_unrequested_archived_tier_stays_not_loaded() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    seed_archived_card(&store, &board, &card);
+
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        card_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.cards.all.is_loaded());
+    assert!(resolved.archived_cards.is_untouched());
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_all_cards",
+            ids: vec![],
+        }],
+    );
+}
+
+#[test]
+fn test_a_plan_that_repeats_an_archived_scope_fetches_it_once_and_halts() {
+    let store = store();
+    let (board, _column) = seed_board_with_column(&store);
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        archived_cards_by_board: vec![board.id],
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.archived_cards.by_parent[&board.id].is_loaded());
+    let ops = store.ops();
+    let ops = ops.lock().unwrap();
+    assert_eq!(
+        ops.iter()
+            .filter(|op| op.method == "list_archived_cards_by_board")
+            .count(),
+        1
+    );
+}

--- a/crates/kanban-service/src/resolve/tests/mod.rs
+++ b/crates/kanban-service/src/resolve/tests/mod.rs
@@ -3,7 +3,9 @@
 use std::cell::{Cell, RefCell};
 
 use kanban_domain::resolved::Collection;
-use kanban_domain::{Board, Card, Column, DataStore, DependencyGraph, LoadState, Sprint};
+use kanban_domain::{
+    ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, LoadState, Sprint,
+};
 use uuid::Uuid;
 
 use crate::fetch_plan::{
@@ -12,6 +14,7 @@ use crate::fetch_plan::{
 };
 use crate::read_recorder::RecordingStore;
 
+mod archived;
 mod multi_round;
 mod overlay;
 mod resolve;
@@ -201,6 +204,16 @@ pub(super) fn seed_sprint(store: &RecordingStore, board: &Board) -> Sprint {
     let sprint = Sprint::new(board.id, 1, None, None::<String>);
     store.upsert_sprint(sprint.clone()).unwrap();
     sprint
+}
+
+pub(super) fn seed_archived_card(
+    store: &RecordingStore,
+    board: &Board,
+    card: &Card,
+) -> ArchivedCard {
+    let marker = ArchivedCard::new(card.id, board.id);
+    store.insert_archived_card(marker).unwrap();
+    marker
 }
 
 pub(super) fn seed_board_with_column(store: &RecordingStore) -> (Board, Column) {


### PR DESCRIPTION
## What

Adds a fourth `Collection<ArchivedCard>` tier, `archived_cards`, to `kanban_domain::Resolved`, and two request fields to `kanban_service::FetchRound`: `archived_card_list: bool` and `archived_cards_by_board: Vec<Uuid>`. `resolve`'s two `fetch_round` blocks populate the tier from `DataStore::list_archived_cards` and `list_archived_cards_by_board`, mapping a read error to `LoadState::Failed` rather than an empty list.

Nothing in `Model`, `LoadedState` or `Overlay` changes. The tier is written by the resolver and consumed by nobody until a follow-up card wires it into `Model`.

## Why the scope guard on the card had to be overridden

The card said not to extend `Fetched`, `Overlay` or `narrow_to_outstanding`. That is unimplementable as written:

- `narrow_to_outstanding` builds the tree's only exhaustive `FetchRound { .. }` literal (`resolve.rs:141`). Adding two fields to `FetchRound` without extending that literal is an immediate `E0063`.
- A naive pass-through fix (`archived_cards_by_board: round.archived_cards_by_board`) compiles and looks right, but it hangs `resolve` forever for any plan that keeps naming the same board scope, including `FixedPlan`, which four of the six new tests use. Confirmed by mutation testing: reverting `narrow_to_outstanding`'s scoped narrowing to a pass-through made `test_a_plan_that_repeats_an_archived_scope_fetches_it_once_and_halts` hang (30s timeout, no output), then restoring the real narrowing made it pass again.

`Overlay` genuinely needed no change: it implements `LoadedState`/`LoadedEntities`, whose method sets this change leaves untouched, and the `Fetched`-based narrowing only consults call-local state, never `loaded`.

A follow-up card that wires this tier into `Model` will find the `Fetched`/`narrow_to_outstanding` half of its own scope already landed here.

## Fixture fix required before any test could assert anything

`RecordingStore` had no `list_archived_cards_by_board` override, so it fell through to the `DataStore` trait default, which calls `list_archived_cards` and filters. Consequence: `assert_ops` would see the wrong method name, and `fail_method("list_archived_cards_by_board")` would be a silent no-op. Also, `RecordingStore::list_archived_cards` recorded but never called `self.check(...)`, so it could not be faulted either. Both fixed in the Red commit.

## Red proof

```
error[E0063]: missing fields `archived_card_list` and `archived_cards_by_board` in initializer of `FetchRound`
   --> crates/kanban-service/src/resolve.rs:141:5
    |
141 |     FetchRound {
    |     ^^^^^^^^^^ missing `archived_card_list` and `archived_cards_by_board`

error[E0609]: no field `archived_cards` on type `Resolved`
  --> crates/kanban-service/src/resolve/tests/archived.rs:...
   |
   = note: available fields are: `boards`, `columns`, `cards`, `sprints`, `graph`
```
(9 occurrences of E0609 total, one per assertion touching `resolved.archived_cards` across the five new resolve tests, plus one E0560-shaped E0063 blocking the crate before the test binary itself could even compile.)

## Literal re-derivation

`git grep -c 'Resolved {' -- crates/` reports 53 raw hits across 7 files. Brace-matched by hand, only 50 are actual struct literals across 5 files (`apply.rs` 30, `invalidate.rs` 12, `resolved.rs` 2, `model_loaded.rs` 4, `controller/mod.rs` 2); the other 3 are `pub struct Resolved {` plus two `-> Resolved {` return types. All 50 literals already spread `..Default::default()`, so none needed editing for the new field to land silently, as expected.

## Tests

- `test_a_board_scoped_archived_card_round_resolves_the_boards_markers`
- `test_an_archived_card_read_error_resolves_failed_not_empty`
- `test_a_flat_archived_card_round_resolves_every_marker`
- `test_an_unrequested_archived_tier_stays_not_loaded`
- `test_a_plan_that_repeats_an_archived_scope_fetches_it_once_and_halts`
- `test_an_archived_round_is_not_empty`

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -p kanban-service -p kanban-domain -- -D warnings`
- `cargo test -p kanban-service -p kanban-domain --all-features`
- `cargo check --workspace --all-features`

All green. Full `cargo test --workspace` left to CI per the implementer instructions.

## Known gap noted, not fixed here

`HttpBackend` does not override `list_archived_cards_by_board` and its `list_archived_cards` returns `unsupported`, so a plan naming this tier over the HTTP backend resolves `Failed`, not empty. Pre-existing, deliberate, out of scope for this card.
