### PR TITLE
KAN-1478 feat(domain,service): model holds the board-scoped archived-card tier

### DIFF
--- a/.changeset/kan-1478-model-archived-card-tier.md
+++ b/.changeset/kan-1478-model-archived-card-tier.md
@@ -1,0 +1,12 @@
+---
+bump: minor
+---
+
+domain,service: `Model` gains a board-scoped archived-card marker tier
+(`board_archived_cards_state`, `archived_cards_state`), applied from a
+resolve pass's `archived_cards.by_parent`, cleared on `load_from_snapshot`
+and marked `Failed` alongside the rest of the card tier by `mark_failed`.
+`LoadedState` gains two new required methods, `archived_card_list` and
+`archived_cards_of_board`, implemented on `Model` and `Overlay`, letting a
+fetch plan see an already-loaded archived scope and stop refetching it on
+a later resolve call within the same process.

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -122,6 +122,11 @@ impl Model {
         );
         apply_scopes(&mut self.sprints_by_board, sprints_by_parent);
 
+        apply_scopes(
+            &mut self.archived_cards_by_board,
+            resolved.archived_cards.by_parent,
+        );
+
         if !resolved.graph.is_not_loaded() {
             self.graph = resolved.graph;
         }
@@ -168,6 +173,9 @@ impl Model {
                 *state = LoadState::Failed(Arc::clone(&err));
             }
             for state in self.cards_by_id.values_mut() {
+                *state = LoadState::Failed(Arc::clone(&err));
+            }
+            for state in self.archived_cards_by_board.values_mut() {
                 *state = LoadState::Failed(Arc::clone(&err));
             }
         }

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -1048,8 +1048,34 @@ mod tests {
         let state = m.board_archived_cards_state(board.id);
         assert!(state.is_failed());
         assert!(!state.is_not_loaded());
+    }
 
-        let _ = m.mark_failed(EntityIds::default(), err);
+    #[test]
+    fn test_mark_failed_leaves_the_archived_tier_loaded_when_cards_are_not_named() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let card = Card::new(board.id, column.id, "task", 0);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(
+            board.id,
+            LoadState::Loaded(vec![ArchivedCard::new(card.id, board.id)]),
+        );
+        let _ = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        let _ = m.mark_failed(EntityIds::boards([board.id]), err);
+
+        let state = m.board_archived_cards_state(board.id);
+        assert!(state.is_loaded());
+        assert!(!state.is_failed());
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -961,6 +961,118 @@ mod tests {
     }
 
     #[test]
+    fn test_applying_a_board_scoped_archived_result_is_readable_by_board() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let card = Card::new(board.id, column.id, "task", 0);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(
+            board.id,
+            LoadState::Loaded(vec![ArchivedCard::new(card.id, board.id)]),
+        );
+        let _ = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let scoped = m
+            .board_archived_cards_state(board.id)
+            .loaded()
+            .copied()
+            .unwrap();
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].entity_id, card.id);
+
+        assert!(m.archived_card_ids().is_empty());
+        assert!(m.archived_card_markers().is_empty());
+    }
+
+    #[test]
+    fn test_a_failed_archived_read_is_readable_as_failed() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let err = Arc::new(KanbanError::unsupported("boom"));
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(board.id, LoadState::Failed(Arc::clone(&err)));
+        let _ = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let state = m.board_archived_cards_state(board.id);
+        assert!(state.is_failed());
+        assert!(!state.is_loaded());
+        assert!(!state.is_missing());
+    }
+
+    #[test]
+    fn test_mark_failed_marks_the_archived_tier_when_cards_are_named() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let card = Card::new(board.id, column.id, "task", 0);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(
+            board.id,
+            LoadState::Loaded(vec![ArchivedCard::new(card.id, board.id)]),
+        );
+        let _ = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        let _ = m.mark_failed(EntityIds::cards([card.id]), Arc::clone(&err));
+
+        let state = m.board_archived_cards_state(board.id);
+        assert!(state.is_failed());
+        assert!(!state.is_not_loaded());
+
+        let _ = m.mark_failed(EntityIds::default(), err);
+    }
+
+    #[test]
+    fn test_load_from_snapshot_clears_the_scoped_archived_tier() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let card = Card::new(board.id, column.id, "task", 0);
+
+        let mut by_parent = HashMap::new();
+        by_parent.insert(
+            board.id,
+            LoadState::Loaded(vec![ArchivedCard::new(card.id, board.id)]),
+        );
+        let _ = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let _ = m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+
+        assert!(m.board_archived_cards_state(board.id).is_not_loaded());
+    }
+
+    #[test]
     fn test_load_from_snapshot_clears_every_new_tier() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -265,4 +265,29 @@ mod tests {
         assert!(!state.is_missing());
         assert!(m.archived_card_ids().contains(&archived_id));
     }
+
+    #[test]
+    fn test_an_unapplied_board_reads_not_loaded() {
+        let mut m = Model::default();
+        let board_a = Uuid::new_v4();
+        let board_b = Uuid::new_v4();
+        let card_id = Uuid::new_v4();
+
+        let mut by_parent = std::collections::HashMap::new();
+        by_parent.insert(
+            board_a,
+            crate::LoadState::Loaded(vec![ArchivedCard::new(card_id, board_a)]),
+        );
+        let _ = m.apply_resolved(crate::Resolved {
+            archived_cards: crate::resolved::Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let state = m.board_archived_cards_state(board_b);
+        assert!(state.is_not_loaded());
+        assert!(!state.is_loaded());
+    }
 }

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -82,6 +82,23 @@ impl Model {
     pub fn archived_card_ids(&self) -> &std::collections::HashSet<Uuid> {
         &self.archived_card_ids
     }
+
+    /// The whole-store archived-marker tier, `Loaded` exactly when a snapshot
+    /// has supplied it. Independent of `board_archived_cards_state`.
+    pub fn archived_cards_state(&self) -> LoadState<&[ArchivedCard]> {
+        match &self.archived_cards {
+            Some(markers) => LoadState::Loaded(markers.as_slice()),
+            None => LoadState::NotLoaded,
+        }
+    }
+
+    /// The parent-scoped archived-marker tier for one board. Independent of
+    /// `archived_card_ids()` and of the live/archived partition, which are
+    /// derived from a whole-store snapshot: a board-scoped marker list cannot
+    /// say which cards of other boards are archived, so it never feeds them.
+    pub fn board_archived_cards_state(&self, board_id: Uuid) -> LoadState<&[ArchivedCard]> {
+        scoped_state(&self.archived_cards_by_board, board_id)
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -35,12 +35,13 @@ pub struct Model {
     cards_by_id: HashMap<Uuid, LoadState<Card>>,
     sprints_by_id: HashMap<Uuid, LoadState<Sprint>>,
     /// The parent-scoped tier, keyed by the fixed parent id per kind
-    /// (`columns_by_board`/`sprints_by_board` by board id,
-    /// `cards_by_column` by column id). A scoped result never mutates the
-    /// flat collection or the per-id tier, and vice versa.
+    /// (`columns_by_board`/`sprints_by_board`/`archived_cards_by_board` by
+    /// board id, `cards_by_column` by column id). A scoped result never
+    /// mutates the flat collection or the per-id tier, and vice versa.
     columns_by_board: HashMap<Uuid, LoadState<Vec<Column>>>,
     cards_by_column: HashMap<Uuid, LoadState<Vec<Card>>>,
     sprints_by_board: HashMap<Uuid, LoadState<Vec<Sprint>>>,
+    archived_cards_by_board: HashMap<Uuid, LoadState<Vec<ArchivedCard>>>,
     /// Reverse index from card id to the column whose `cards_by_column`
     /// entry currently holds it. Maintained only by `set_cards_of_column`;
     /// without it, resolving a card by id through the scoped tier would scan
@@ -69,6 +70,7 @@ impl Default for Model {
             columns_by_board: HashMap::new(),
             cards_by_column: HashMap::new(),
             sprints_by_board: HashMap::new(),
+            archived_cards_by_board: HashMap::new(),
             scoped_card_index: HashMap::new(),
         }
     }
@@ -104,6 +106,7 @@ impl Model {
         self.cards_by_column.clear();
         self.scoped_card_index.clear();
         self.sprints_by_board.clear();
+        self.archived_cards_by_board.clear();
 
         self.absorb_archival_markers(
             Some(snapshot.archived_cards),

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -41,7 +41,8 @@ pub fn requestable(status: FetchStatus) -> bool {
 ///
 /// A parent-scoped accessor never returns `FetchStatus::Missing`: the scoped
 /// reads answer an unknown parent with an empty vector, so implementors must
-/// not synthesise `Missing` for them.
+/// not synthesise `Missing` for them. This includes `archived_cards_of_board`,
+/// served by `DataStore::list_archived_cards_by_board`.
 pub trait LoadedState {
     fn board_list(&self) -> FetchStatus;
     fn column_list(&self) -> FetchStatus;
@@ -54,6 +55,8 @@ pub trait LoadedState {
     fn columns_of_board(&self, board_id: Uuid) -> FetchStatus;
     fn cards_of_column(&self, column_id: Uuid) -> FetchStatus;
     fn sprints_of_board(&self, board_id: Uuid) -> FetchStatus;
+    fn archived_card_list(&self) -> FetchStatus;
+    fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus;
 }
 
 /// The `*_list` flags request a whole collection, the `*_by_*` vectors
@@ -175,6 +178,12 @@ mod tests {
             self.cards_of_column
         }
         fn sprints_of_board(&self, _board_id: Uuid) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+        fn archived_card_list(&self) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+        fn archived_cards_of_board(&self, _board_id: Uuid) -> FetchStatus {
             FetchStatus::NotLoaded
         }
     }

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -53,6 +53,14 @@ impl LoadedState for Model {
     fn sprints_of_board(&self, board_id: Uuid) -> FetchStatus {
         (&self.board_sprints_state(board_id)).into()
     }
+
+    fn archived_card_list(&self) -> FetchStatus {
+        (&self.archived_cards_state()).into()
+    }
+
+    fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus {
+        (&self.board_archived_cards_state(board_id)).into()
+    }
 }
 
 impl LoadedEntities for Model {

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -71,7 +71,10 @@ impl LoadedState for Overlay<'_> {
         }
     }
     fn archived_card_list(&self) -> FetchStatus {
-        overlay_status(&self.pass.archived_cards.all, self.base.archived_card_list())
+        overlay_status(
+            &self.pass.archived_cards.all,
+            self.base.archived_card_list(),
+        )
     }
     fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus {
         match self.pass.archived_cards.by_parent.get(&board_id) {

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -70,6 +70,15 @@ impl LoadedState for Overlay<'_> {
             None => self.base.sprints_of_board(board_id),
         }
     }
+    fn archived_card_list(&self) -> FetchStatus {
+        overlay_status(&self.pass.archived_cards.all, self.base.archived_card_list())
+    }
+    fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus {
+        match self.pass.archived_cards.by_parent.get(&board_id) {
+            Some(state) => state.into(),
+            None => self.base.archived_cards_of_board(board_id),
+        }
+    }
 }
 
 impl LoadedEntities for Overlay<'_> {

--- a/crates/kanban-service/src/resolve/tests/archived.rs
+++ b/crates/kanban-service/src/resolve/tests/archived.rs
@@ -2,7 +2,7 @@ use crate::fetch_plan::FetchRound;
 
 use super::{
     seed_archived_card, seed_board, seed_board_with_column, seed_card, seed_column, store,
-    FixedPlan, OneShotPlan, StubLoaded,
+    ArchivedByBoardPlan, FixedPlan, OneShotPlan, StubLoaded,
 };
 use crate::read_recorder::{assert_ops, ReadOp};
 use crate::resolve::resolve;
@@ -145,4 +145,27 @@ fn test_a_plan_that_repeats_an_archived_scope_fetches_it_once_and_halts() {
             .count(),
         1
     );
+}
+
+#[test]
+fn test_a_board_whose_archived_markers_are_loaded_is_not_refetched() {
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let card = seed_card(&store, &board, &column, "a");
+    seed_archived_card(&store, &board, &card);
+
+    let mut loaded = StubLoaded::default();
+    let plan = ArchivedByBoardPlan { board_id: board.id };
+
+    let resolved = resolve(&plan, &loaded, &store);
+    assert!(resolved.archived_cards.by_parent[&board.id].is_loaded());
+    loaded.apply(resolved);
+
+    store.clear_log();
+    store.fail_method("list_archived_cards_by_board");
+
+    let second = resolve(&plan, &loaded, &store);
+
+    assert_ops(&store.ops(), &[]);
+    assert!(second.archived_cards.is_untouched());
 }

--- a/crates/kanban-service/src/resolve/tests/mod.rs
+++ b/crates/kanban-service/src/resolve/tests/mod.rs
@@ -28,6 +28,7 @@ pub(super) struct StubLoaded {
     columns: Collection<Column>,
     cards: Collection<Card>,
     sprints: Collection<Sprint>,
+    archived_cards: Collection<ArchivedCard>,
     graph: LoadState<DependencyGraph>,
 }
 
@@ -89,6 +90,16 @@ impl LoadedStateTrait for StubLoaded {
             .map(FetchStatus::from)
             .unwrap_or(FetchStatus::NotLoaded)
     }
+    fn archived_card_list(&self) -> FetchStatus {
+        (&self.archived_cards.all).into()
+    }
+    fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus {
+        self.archived_cards
+            .by_parent
+            .get(&board_id)
+            .map(FetchStatus::from)
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
 }
 
 impl LoadedEntities for StubLoaded {
@@ -119,6 +130,7 @@ impl StubLoaded {
         apply_collection(&mut self.columns, resolved.columns);
         apply_collection(&mut self.cards, resolved.cards);
         apply_collection(&mut self.sprints, resolved.sprints);
+        apply_collection(&mut self.archived_cards, resolved.archived_cards);
         if !matches!(resolved.graph, LoadState::NotLoaded) {
             self.graph = resolved.graph;
         }
@@ -391,6 +403,23 @@ impl FetchPlan for CardsByIdPlan {
                 .filter(|&id| requestable(loaded.card(id)))
                 .collect(),
             ..Default::default()
+        }
+    }
+}
+
+pub(super) struct ArchivedByBoardPlan {
+    pub board_id: Uuid,
+}
+
+impl FetchPlan for ArchivedByBoardPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        if requestable(loaded.archived_cards_of_board(self.board_id)) {
+            FetchRound {
+                archived_cards_by_board: vec![self.board_id],
+                ..Default::default()
+            }
+        } else {
+            FetchRound::default()
         }
     }
 }

--- a/crates/kanban-service/src/resolve/tests/overlay.rs
+++ b/crates/kanban-service/src/resolve/tests/overlay.rs
@@ -1,4 +1,4 @@
-use kanban_domain::{LoadState, Resolved};
+use kanban_domain::{ArchivedCard, LoadState, Resolved};
 
 use crate::fetch_plan::FetchRound;
 use uuid::Uuid;
@@ -149,4 +149,29 @@ fn test_an_empty_base_and_empty_pass_project_every_dimension_as_not_loaded() {
     assert_eq!(observed.columns_of_board, FetchStatus::NotLoaded);
     assert_eq!(observed.cards_of_column, FetchStatus::NotLoaded);
     assert_eq!(observed.sprints_of_board, FetchStatus::NotLoaded);
+}
+
+#[test]
+fn test_overlay_reports_a_pass_loaded_archived_board_as_satisfied() {
+    let base = StubLoaded::default();
+    let board_id = Uuid::new_v4();
+    let mut resolved = Resolved::default();
+    resolved
+        .archived_cards
+        .by_parent
+        .insert(board_id, LoadState::Loaded(Vec::<ArchivedCard>::new()));
+    let overlay = Overlay {
+        base: &base,
+        pass: &resolved,
+    };
+
+    assert_eq!(
+        overlay.archived_cards_of_board(board_id),
+        FetchStatus::Loaded
+    );
+    assert_eq!(
+        overlay.archived_cards_of_board(Uuid::new_v4()),
+        FetchStatus::NotLoaded
+    );
+    assert_eq!(overlay.archived_card_list(), FetchStatus::NotLoaded);
 }


### PR DESCRIPTION
## Summary

- `Model` gains a board-scoped archived-card marker tier, `archived_cards_by_board`, applied from a resolve pass's `Resolved.archived_cards.by_parent`
- Two new read accessors: `Model::board_archived_cards_state(board_id)` (the scoped tier) and `Model::archived_cards_state()` (the flat whole-store tier)
- `load_from_snapshot` clears the new map; `mark_failed` marks it `Failed` when `ids.cards` is non-empty, matching every sibling scoped tier
- `LoadedState` gains two required methods with no default bodies, `archived_card_list` and `archived_cards_of_board`, implemented on `Model`, `Overlay`, and the test `StubLoaded`s
- A fetch plan that gates on `archived_cards_of_board` no longer refetches an already-loaded board's archived markers within the same resolve call

## Notes for the reviewer

- `apply_collection` was not touched. The parent-scoped tier is handled by the existing `apply_scopes` helper (added by KAN-1465), so this change is one call to it plus one loop in `mark_failed`.
- `Model::invalidate` is intentionally left alone. Dropping this tier on invalidation, together with the cross-backend parity proof, is scoped to a follow-up card (KAN-1479).
- `narrow_to_outstanding`/`Fetched` already carried the `archived_card_list`/`archived_cards_by_board` fields from KAN-1477; this PR does not touch them. Narrowing across resolve calls comes entirely from a plan consulting the new `LoadedState::archived_cards_of_board`, matching the existing behaviour for the columns/sprints scoped tiers (a `Loaded` scope is still refetched by a later `resolve` call by design; only within one call is it deduplicated).
- Tests and implementation are separate commits (a compiler-error Red commit, then Green).

## Test plan

- [x] `cargo test -p kanban-domain -p kanban-service --all-features` green
- [x] `cargo clippy --all-targets --all-features -p kanban-domain -p kanban-service -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation-checked the `mark_failed` archived loop, the `load_from_snapshot` clear, and the plan's `archived_cards_of_board` gate: each was confirmed to make its pinned test fail when reverted, then restored
