### PR TITLE
KAN-1479 fix(domain): invalidate drops the board-scoped archived-card tier

### DIFF
--- a/.changeset/kan-1479-invalidate-drops-archived-tier.md
+++ b/.changeset/kan-1479-invalidate-drops-archived-tier.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain,service: `Model::invalidate` now drops the board-scoped `archived_cards_by_board` tier alongside the sibling `columns_by_board`/`sprints_by_board`/`cards_by_column` tiers, since a `cards` or `boards` id in `EntityIds` previously left it stale and could serve a just-restored card as still archived until the whole model was reset. `kanban_service::test_helpers::contract::cache` gains a new public `ArchivedByBoardPlan` and two contract functions, registered in `cache_contract_tests!`, that hold the fix and the board-scoping of `list_archived_cards_by_board` to one spec across the in-memory, JSON and SQLite backends. This is `minor`, not `patch`, because it adds new public surface (`ArchivedByBoardPlan`, two `pub async fn` contract functions, two macro arms) on a crate published to crates.io, following the precedent set by KAN-1426.

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -143,6 +143,18 @@ mod tests {
         NoProjections.resync(m, changed);
         m.set_cards_of_column(col_a.id, LoadState::Loaded(vec![c1.clone()]));
         m.set_cards_of_column(col_b.id, LoadState::Loaded(vec![c2.clone()]));
+        let changed = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent: [(
+                    board.id,
+                    LoadState::Loaded(vec![ArchivedCard::new(c1.id, board.id)]),
+                )]
+                .into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        NoProjections.resync(m, changed);
     }
 
     fn assert_every_tier_not_loaded(
@@ -172,6 +184,7 @@ mod tests {
         assert!(m.scoped_card_index.is_empty());
         assert!(m.card_index.is_empty());
         assert!(m.board_index.is_empty());
+        assert!(m.board_archived_cards_state(board.id).is_not_loaded());
     }
 
     #[test]
@@ -784,5 +797,74 @@ mod tests {
         let _ = m.invalidate(Invalidation::Entities(EntityIds::default()));
 
         assert_every_tier_not_loaded(&m, &board, &col_a, &col_b, &c1, &c2, &sprint);
+    }
+
+    #[test]
+    fn test_invalidating_a_card_drops_every_boards_archived_card_scope() {
+        let b1 = Board::new("B1", None::<String>);
+        let b2 = Board::new("B2", None::<String>);
+        let c1 = Card::new(b1.id, Uuid::new_v4(), "one", 0);
+        let c2 = Card::new(b2.id, Uuid::new_v4(), "two", 0);
+
+        let mut m = Model::default();
+        let changed = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent: [
+                    (
+                        b1.id,
+                        LoadState::Loaded(vec![ArchivedCard::new(c1.id, b1.id)]),
+                    ),
+                    (
+                        b2.id,
+                        LoadState::Loaded(vec![ArchivedCard::new(c2.id, b2.id)]),
+                    ),
+                ]
+                .into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        NoProjections.resync(&m, changed);
+
+        assert!(m.board_archived_cards_state(b1.id).is_loaded());
+        assert!(m.board_archived_cards_state(b2.id).is_loaded());
+
+        let _ = m.invalidate(Invalidation::Entities(EntityIds::cards([c1.id])));
+
+        assert!(m.board_archived_cards_state(b1.id).is_not_loaded());
+        assert!(m.board_archived_cards_state(b2.id).is_not_loaded());
+    }
+
+    #[test]
+    fn test_invalidating_a_board_drops_only_that_boards_archived_scope() {
+        let b1 = Board::new("B1", None::<String>);
+        let b2 = Board::new("B2", None::<String>);
+        let c1 = Card::new(b1.id, Uuid::new_v4(), "one", 0);
+        let c2 = Card::new(b2.id, Uuid::new_v4(), "two", 0);
+
+        let mut m = Model::default();
+        let changed = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent: [
+                    (
+                        b1.id,
+                        LoadState::Loaded(vec![ArchivedCard::new(c1.id, b1.id)]),
+                    ),
+                    (
+                        b2.id,
+                        LoadState::Loaded(vec![ArchivedCard::new(c2.id, b2.id)]),
+                    ),
+                ]
+                .into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        NoProjections.resync(&m, changed);
+
+        let _ = m.invalidate(Invalidation::Entities(EntityIds::boards([b1.id])));
+
+        assert!(m.board_archived_cards_state(b1.id).is_not_loaded());
+        assert!(m.board_archived_cards_state(b2.id).is_loaded());
     }
 }

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -8,11 +8,12 @@ impl Model {
     ///
     /// `EntityIds` names child ids, not the parent key a scoped tier is keyed
     /// on, so a `cards`, `columns` or `sprints` id drops the WHOLE affected
-    /// parent-scoped tier (`cards_by_column`, `columns_by_board` and
-    /// `sprints_by_board` respectively) rather than one guessed scope. Where
-    /// the named id is itself a parent key the drop is exact instead: a
-    /// `columns` id drops only its own `cards_by_column` entry, and a
-    /// `boards` id drops only its own `columns_by_board`/`sprints_by_board`
+    /// parent-scoped tier (`cards_by_column`, `columns_by_board`,
+    /// `sprints_by_board` and `archived_cards_by_board` respectively) rather
+    /// than one guessed scope. Where the named id is itself a parent key the
+    /// drop is exact instead: a `columns` id drops only its own
+    /// `cards_by_column` entry, and a `boards` id drops only its own
+    /// `columns_by_board`/`sprints_by_board`/`archived_cards_by_board`
     /// entries.
     ///
     /// `scoped_card_index` is a reverse index over `cards_by_column`; every
@@ -43,6 +44,7 @@ impl Model {
         for id in &ids.boards {
             self.columns_by_board.remove(id);
             self.sprints_by_board.remove(id);
+            self.archived_cards_by_board.remove(id);
         }
 
         if !ids.columns.is_empty() {
@@ -63,6 +65,7 @@ impl Model {
             }
             self.cards_by_column.clear();
             self.scoped_card_index.clear();
+            self.archived_cards_by_board.clear();
         }
 
         if !ids.sprints.is_empty() {

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -459,3 +459,147 @@ pub async fn test_a_card_moved_between_columns_reads_correctly_after_invalidatio
         .unwrap();
     assert!(!in_source.iter().any(|c| c.id == card.id));
 }
+
+/// Gated on the loaded scope so a still-`Loaded` tier stops the refetch.
+/// `resolve` narrows a scoped round only against what the current call
+/// already fetched, never against `loaded`, so an ungated plan would
+/// refetch unconditionally and hide a missed invalidation.
+pub struct ArchivedByBoardPlan(pub Uuid);
+
+impl FetchPlan for ArchivedByBoardPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        if requestable(loaded.archived_cards_of_board(self.0)) {
+            FetchRound {
+                archived_cards_by_board: vec![self.0],
+                ..Default::default()
+            }
+        } else {
+            FetchRound::default()
+        }
+    }
+}
+
+pub async fn test_a_boards_archived_cards_are_scoped_to_that_board_on_every_backend(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let a = ctx.create_board("A".into(), Some("A".into())).unwrap();
+    let b = ctx.create_board("B".into(), Some("B".into())).unwrap();
+    let col_a = ctx.create_column(a.id, "Col".into(), None).unwrap();
+    let col_b = ctx.create_column(b.id, "Col".into(), None).unwrap();
+    let card_a = ctx
+        .create_card(
+            a.id,
+            col_a.id,
+            "Card A".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_b = ctx
+        .create_card(
+            b.id,
+            col_b.id,
+            "Card B".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let _ = ctx.archive_card_impl(card_a.id).unwrap();
+    let _ = ctx.archive_card_impl(card_b.id).unwrap();
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            archived_cards_by_board: vec![a.id],
+            ..Default::default()
+        }),
+        &Model::default(),
+    );
+
+    let scope = resolved
+        .archived_cards
+        .by_parent
+        .get(&a.id)
+        .expect("board a's scope requested");
+    let markers = scope.loaded().expect("board a's scope loaded");
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0].entity_id, card_a.id);
+    assert!(!resolved.archived_cards.by_parent.contains_key(&b.id));
+
+    let mut model = Model::default();
+    apply(&mut model, resolved);
+
+    let loaded_a = model
+        .board_archived_cards_state(a.id)
+        .loaded()
+        .copied()
+        .unwrap();
+    assert_eq!(loaded_a.len(), 1);
+    assert!(model.board_archived_cards_state(b.id).is_not_loaded());
+}
+
+pub async fn test_an_archived_card_restored_then_reread_is_absent_on_every_backend(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+    let mut model = Model::default();
+
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Card".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let plan = ArchivedByBoardPlan(board.id);
+    let resolved = ctx.resolve(&plan, &model);
+    apply(&mut model, resolved);
+    assert!(model
+        .board_archived_cards_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap()
+        .is_empty());
+
+    let ((), inv) = ctx.archive_card_impl(card.id).unwrap();
+    let changed = model.invalidate(inv);
+    NoProjections.resync(&model, changed);
+
+    let resolved = ctx.resolve(&plan, &model);
+    apply(&mut model, resolved);
+    let markers = model
+        .board_archived_cards_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap();
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0].entity_id, card.id);
+
+    let (_card, inv) = ctx.restore_card_impl(card.id, None).unwrap();
+    let changed = model.invalidate(inv);
+    NoProjections.resync(&model, changed);
+
+    assert!(model.board_archived_cards_state(board.id).is_not_loaded());
+
+    let resolved = ctx.resolve(&plan, &model);
+    apply(&mut model, resolved);
+    let markers = model
+        .board_archived_cards_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap();
+    assert!(markers.is_empty());
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -484,5 +484,13 @@ macro_rules! cache_contract_tests {
         async fn test_a_card_moved_between_columns_reads_correctly_after_invalidation_on_every_backend() {
             $crate::test_helpers::contract::cache::test_a_card_moved_between_columns_reads_correctly_after_invalidation_on_every_backend(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_boards_archived_cards_are_scoped_to_that_board_on_every_backend() {
+            $crate::test_helpers::contract::cache::test_a_boards_archived_cards_are_scoped_to_that_board_on_every_backend(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_an_archived_card_restored_then_reread_is_absent_on_every_backend() {
+            $crate::test_helpers::contract::cache::test_an_archived_card_restored_then_reread_is_absent_on_every_backend(&$factory_fn()).await;
+        }
     };
 }


### PR DESCRIPTION
## Summary

- `Model::invalidate` left `archived_cards_by_board` stale on a `cards` or `boards` invalidation, so a card restored via `restore_card_impl` (which returns `Invalidation::Entities{cards, graph}`) could still be served as archived until the whole model was reset.
- Fix: a `boards` id now removes its own `archived_cards_by_board` entry alongside `columns_by_board`/`sprints_by_board`; a nonempty `cards` id clears the whole tier alongside `cards_by_column`/`scoped_card_index`, since `EntityIds` names the child id rather than the board key the tier is keyed on.
- Added two domain unit tests covering both invalidation shapes, and extended the existing `invalidate_all`/empty-entity-ids suite to cover the tier non-vacuously.
- Added `ArchivedByBoardPlan` (gated on `requestable`) and two new cross-backend contract functions in `kanban_service::test_helpers::contract::cache`, registered in `cache_contract_tests!`: a board-scoping parity check and a restore-then-reread check, both run on in-memory, JSON and SQLite.

## Verification

- `grep -c '^pub async fn test_' crates/kanban-service/src/test_helpers/contract/cache.rs` = 13, matching the `cache_contract_tests!` arm count (also 13).
- Mutation check: temporarily removed SQLite's `WHERE board_id = ?` from `list_archived_cards_by_board`. Result: `sqlite::test_a_boards_archived_cards_are_scoped_to_that_board_on_every_backend` FAILED (2 markers where 1 was asserted) while `in_memory::` and `json::` PASSED (their overrides filter in Rust). Reverted; `git diff origin/develop --stat -- crates/kanban-persistence-sqlite` is empty on the final branch.
- Red before fix: the two domain tests failed, and `test_an_archived_card_restored_then_reread_is_absent_on_every_backend` failed on all three backends (in_memory, json, sqlite), since the defect is in `Model::invalidate`, not any store.
- Green after fix: all of the above pass.

```
cargo fmt --all -- --check                                                    -> clean
cargo clippy -p kanban-domain -p kanban-service --all-targets --all-features -- -D warnings -> clean
cargo test -p kanban-domain                                                    -> 722+ passed, 0 failed
cargo test -p kanban-service --all-features                                    -> all passed, 0 failed
cargo test -p kanban-persistence-json                                          -> all passed, 0 failed
```

## Changeset

`bump: minor`, not `patch`: the diff adds new public surface (`ArchivedByBoardPlan`, two `pub async fn` contract functions, two macro arms) to `kanban-service`, a crate published to crates.io, following the precedent set by KAN-1426.

## Not touched

No renderer, panel, `HttpBackend::list_archived_cards_by_board`, `archived_card_ids`, or live/archived partition code.
