### PR TITLE
KAN-1445 feat(service): KanbanContext::sync and sync_invalidated

### DIFF
--- a/.changeset/kan-1445-kanbancontext-sync.md
+++ b/.changeset/kan-1445-kanbancontext-sync.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: `KanbanContext::sync` and `KanbanContext::sync_invalidated` are new inherent methods that run a `FetchPlan` against a `Model` and fold the resolved entities back in, resyncing the caller's `DerivedProjections` with the `ModelChanged` receipt. `sync_invalidated` applies its `Invalidation` before the plan is consulted, so a tier a mutation touched is refetched instead of being left `Loaded` and skipped. Every application now shares one resolve-application step and none of them needs a `&dyn DataStore`.

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -24,6 +24,7 @@ pub use graph::BoardRelations;
 mod persistence;
 mod sprints;
 pub use sprints::SprintCreateOutcome;
+mod sync;
 mod undo;
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/kanban-service/src/context/sync.rs
+++ b/crates/kanban-service/src/context/sync.rs
@@ -1,0 +1,210 @@
+#[cfg(test)]
+mod tests {
+    use super::super::KanbanContext;
+    use crate::fetch_plan::{requestable, FetchPlan, FetchRound, LoadedEntities};
+    use kanban_backend_memory::InMemoryStore;
+    use kanban_core::AppConfig;
+    use kanban_domain::data_store::DataStore;
+    use kanban_domain::{
+        Board, CardUpdate, DerivedProjections, Invalidation, KanbanOperations, Model,
+        ModelChanged, NoProjections,
+    };
+    use std::sync::Arc;
+
+    struct BoardListPlan;
+    impl FetchPlan for BoardListPlan {
+        fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+            FetchRound {
+                board_list: requestable(loaded.board_list()),
+                ..Default::default()
+            }
+        }
+    }
+
+    struct CardListPlan;
+    impl FetchPlan for CardListPlan {
+        fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+            FetchRound {
+                card_list: requestable(loaded.card_list()),
+                ..Default::default()
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingProjections {
+        resyncs: usize,
+    }
+
+    impl DerivedProjections for CountingProjections {
+        fn resync(&mut self, _model: &Model, _changed: ModelChanged) {
+            self.resyncs += 1;
+        }
+    }
+
+    fn ctx_with_seeded_board() -> (KanbanContext, Board) {
+        let store = InMemoryStore::new();
+        let board = Board::new("Seeded", None::<String>);
+        store.upsert_board(board.clone()).unwrap();
+        (
+            KanbanContext::open_deferred(Arc::new(store), AppConfig::default()),
+            board,
+        )
+    }
+
+    #[test]
+    fn test_sync_applies_a_resolved_pass_into_the_model() {
+        let (ctx, board) = ctx_with_seeded_board();
+        let mut model = Model::default();
+        assert!(model.boards_state().is_not_loaded());
+
+        ctx.sync(&BoardListPlan, &mut model, &mut NoProjections);
+
+        assert!(model.boards_state().is_loaded());
+        assert!(model
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .any(|b| b.id == board.id));
+    }
+
+    #[test]
+    fn test_sync_invalidated_refetches_the_invalidated_card_before_planning() {
+        let mut ctx_a = KanbanContext::open_deferred(
+            Arc::new(InMemoryStore::new()),
+            AppConfig::default(),
+        );
+        let board = ctx_a.create_board("Board".into(), Some("BRD".into())).unwrap();
+        let column = ctx_a.create_column(board.id, "Col".into(), None).unwrap();
+        let card = ctx_a
+            .create_card(
+                board.id,
+                column.id,
+                "before".into(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+            .unwrap();
+
+        let mut model_a = Model::default();
+        ctx_a.sync(&CardListPlan, &mut model_a, &mut NoProjections);
+        assert_eq!(
+            model_a.card_by_id_state(card.id).loaded().unwrap().title,
+            "before"
+        );
+
+        let (_card, inv) = ctx_a
+            .update_card_impl(
+                card.id,
+                CardUpdate {
+                    title: Some("after".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        ctx_a.sync_invalidated(inv, &CardListPlan, &mut model_a, &mut NoProjections);
+        assert_eq!(
+            model_a.card_by_id_state(card.id).loaded().unwrap().title,
+            "after"
+        );
+
+        let mut ctx_b = KanbanContext::open_deferred(
+            Arc::new(InMemoryStore::new()),
+            AppConfig::default(),
+        );
+        let board_b = ctx_b.create_board("Board".into(), Some("BRD".into())).unwrap();
+        let column_b = ctx_b.create_column(board_b.id, "Col".into(), None).unwrap();
+        let card_b = ctx_b
+            .create_card(
+                board_b.id,
+                column_b.id,
+                "before".into(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+            .unwrap();
+
+        let mut model_b = Model::default();
+        ctx_b.sync(&CardListPlan, &mut model_b, &mut NoProjections);
+        assert_eq!(
+            model_b.card_by_id_state(card_b.id).loaded().unwrap().title,
+            "before"
+        );
+
+        let (_card_b, inv_b) = ctx_b
+            .update_card_impl(
+                card_b.id,
+                CardUpdate {
+                    title: Some("after".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let _ = inv_b;
+
+        ctx_b.sync(&CardListPlan, &mut model_b, &mut NoProjections);
+        assert_eq!(
+            model_b.card_by_id_state(card_b.id).loaded().unwrap().title,
+            "before"
+        );
+    }
+
+    #[test]
+    fn test_sync_leaves_untouched_tiers_alone() {
+        let mut ctx = KanbanContext::open_deferred(
+            Arc::new(InMemoryStore::new()),
+            AppConfig::default(),
+        );
+        let board = ctx.create_board("Board".into(), Some("BRD".into())).unwrap();
+        let column = ctx.create_column(board.id, "Col".into(), None).unwrap();
+        let _card = ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Card".into(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+            .unwrap();
+
+        let mut model = Model::default();
+        ctx.sync(&BoardListPlan, &mut model, &mut NoProjections);
+
+        assert!(model.boards_state().is_loaded());
+        assert!(model.cards_state().is_not_loaded());
+        assert!(!model.cards_state().is_loaded());
+        assert!(model.columns_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_sync_hands_the_projections_a_resync() {
+        let (ctx, _board) = ctx_with_seeded_board();
+        let mut model = Model::default();
+        let mut proj = CountingProjections::default();
+
+        ctx.sync(&BoardListPlan, &mut model, &mut proj);
+        assert_eq!(proj.resyncs, 1);
+
+        ctx.sync_invalidated(Invalidation::All, &BoardListPlan, &mut model, &mut proj);
+        assert_eq!(proj.resyncs, 2);
+    }
+
+    #[cfg(feature = "test-helpers")]
+    #[test]
+    fn test_sync_records_a_failed_read_as_failed_not_empty() {
+        use crate::test_helpers::FaultInjectingBackend;
+        use crate::KanbanBackend;
+
+        let store = InMemoryStore::new();
+        let board = Board::new("Seeded", None::<String>);
+        store.upsert_board(board).unwrap();
+        let backend = FaultInjectingBackend::new(Arc::new(store) as Arc<dyn KanbanBackend>);
+        backend.fail("list_boards");
+
+        let ctx = KanbanContext::open_deferred(Arc::new(backend), AppConfig::default());
+        let mut model = Model::default();
+
+        ctx.sync(&BoardListPlan, &mut model, &mut NoProjections);
+
+        assert!(model.boards_state().is_failed());
+        assert!(!model.boards_state().is_loaded());
+    }
+}

--- a/crates/kanban-service/src/context/sync.rs
+++ b/crates/kanban-service/src/context/sync.rs
@@ -1,3 +1,43 @@
+use super::KanbanContext;
+use crate::fetch_plan::FetchPlan;
+use kanban_domain::{DerivedProjections, Invalidation, Model, ModelChanged};
+
+impl KanbanContext {
+    fn resolve_into(&self, plan: &dyn FetchPlan, model: &mut Model) -> ModelChanged {
+        let resolved = self.resolve(plan, &*model);
+        model.apply_resolved(resolved)
+    }
+
+    /// Runs `plan` against `model`, folds the result in, and resyncs `proj`.
+    /// A failed read is recorded as `LoadState::Failed` on the affected tier
+    /// rather than returned, so a partial failure is visible per tier
+    /// instead of collapsing the sync.
+    pub fn sync(
+        &self,
+        plan: &dyn FetchPlan,
+        model: &mut Model,
+        proj: &mut impl DerivedProjections,
+    ) {
+        let changed = self.resolve_into(plan, model);
+        proj.resync(model, changed);
+    }
+
+    /// Applies `inv` to `model` before the plan is consulted, so the
+    /// mutated entity is refetched instead of being left `Loaded` and
+    /// skipped by the plan's `requestable` gate.
+    pub fn sync_invalidated(
+        &self,
+        inv: Invalidation,
+        plan: &dyn FetchPlan,
+        model: &mut Model,
+        proj: &mut impl DerivedProjections,
+    ) {
+        let invalidated = model.invalidate(inv);
+        let changed = invalidated.merge(self.resolve_into(plan, model));
+        proj.resync(model, changed);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::KanbanContext;
@@ -6,8 +46,8 @@ mod tests {
     use kanban_core::AppConfig;
     use kanban_domain::data_store::DataStore;
     use kanban_domain::{
-        Board, CardUpdate, DerivedProjections, Invalidation, KanbanOperations, Model,
-        ModelChanged, NoProjections,
+        Board, CardUpdate, DerivedProjections, Invalidation, KanbanOperations, Model, ModelChanged,
+        NoProjections,
     };
     use std::sync::Arc;
 
@@ -70,11 +110,11 @@ mod tests {
 
     #[test]
     fn test_sync_invalidated_refetches_the_invalidated_card_before_planning() {
-        let mut ctx_a = KanbanContext::open_deferred(
-            Arc::new(InMemoryStore::new()),
-            AppConfig::default(),
-        );
-        let board = ctx_a.create_board("Board".into(), Some("BRD".into())).unwrap();
+        let mut ctx_a =
+            KanbanContext::open_deferred(Arc::new(InMemoryStore::new()), AppConfig::default());
+        let board = ctx_a
+            .create_board("Board".into(), Some("BRD".into()))
+            .unwrap();
         let column = ctx_a.create_column(board.id, "Col".into(), None).unwrap();
         let card = ctx_a
             .create_card(
@@ -108,11 +148,11 @@ mod tests {
             "after"
         );
 
-        let mut ctx_b = KanbanContext::open_deferred(
-            Arc::new(InMemoryStore::new()),
-            AppConfig::default(),
-        );
-        let board_b = ctx_b.create_board("Board".into(), Some("BRD".into())).unwrap();
+        let mut ctx_b =
+            KanbanContext::open_deferred(Arc::new(InMemoryStore::new()), AppConfig::default());
+        let board_b = ctx_b
+            .create_board("Board".into(), Some("BRD".into()))
+            .unwrap();
         let column_b = ctx_b.create_column(board_b.id, "Col".into(), None).unwrap();
         let card_b = ctx_b
             .create_card(
@@ -150,11 +190,11 @@ mod tests {
 
     #[test]
     fn test_sync_leaves_untouched_tiers_alone() {
-        let mut ctx = KanbanContext::open_deferred(
-            Arc::new(InMemoryStore::new()),
-            AppConfig::default(),
-        );
-        let board = ctx.create_board("Board".into(), Some("BRD".into())).unwrap();
+        let mut ctx =
+            KanbanContext::open_deferred(Arc::new(InMemoryStore::new()), AppConfig::default());
+        let board = ctx
+            .create_board("Board".into(), Some("BRD".into()))
+            .unwrap();
         let column = ctx.create_column(board.id, "Col".into(), None).unwrap();
         let _card = ctx
             .create_card(


### PR DESCRIPTION
## Summary

- Adds `KanbanContext::sync` and `KanbanContext::sync_invalidated` in a new `crates/kanban-service/src/context/sync.rs`.
- `sync` resolves a `FetchPlan` against a `&mut Model`, folds the `Resolved` back in via `Model::apply_resolved`, and resyncs the caller's `DerivedProjections` with the resulting `ModelChanged` receipt.
- `sync_invalidated` applies an `Invalidation` to the `Model` first, then runs `sync`, so a mutated tier is refetched instead of being skipped by the plan's `requestable` gate. The two receipts are folded with `ModelChanged::merge` so projections resync exactly once.
- This is the one Controller-style step all four applications (TUI, CLI, MCP, server) can share, keeping `&dyn DataStore` inside `kanban-service`.
- No application crate is touched; the methods are unused until KAN-1446/1447/1448 wire them in.

## Test plan

- [x] `cargo test -p kanban-service --features test-helpers` green (includes the new `context::sync::tests` module)
- [x] `cargo clippy -p kanban-service --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: reversed the invalidate-then-resolve order in `sync_invalidated`, confirmed `test_sync_invalidated_refetches_the_invalidated_card_before_planning` fails, reverted
