### PR TITLE
KAN-1473 feat(service,mcp,server): graph and board-spec mutators return their invalidation

### DIFF
--- a/.changeset/kan-1473-graph-and-board-spec-mutations-return-invalidation.md
+++ b/.changeset/kan-1473-graph-and-board-spec-mutations-return-invalidation.md
@@ -1,0 +1,11 @@
+---
+bump: minor
+---
+
+service: `KanbanContext` gains six `pub` inherent graph mutators
+(`attach_children_impl`, `detach_children_impl`, `block_impl`, `unblock_impl`,
+`relate_impl`, `dissociate_impl`) returning `KanbanResult<Invalidation>`, with
+the `GraphOperations` trait impl reduced to thin discards over them.
+`create_board_from_spec` now returns `(Board, Invalidation)` and
+`create_or_replace_board` now returns `(BoardCreateOutcome, Invalidation)`;
+the internal `create_board_from_spec_returning` helper is removed.

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -105,7 +105,7 @@ impl McpContext {
         id: Option<Uuid>,
         spec: kanban_domain::NewBoard,
     ) -> KanbanResult<Board> {
-        self.inner.create_board_from_spec(id, spec)
+        Ok(self.inner.create_board_from_spec(id, spec)?.0)
     }
 
     /// Create a column from a full spec + optional client id, funneling through

--- a/crates/kanban-server/src/handlers/boards.rs
+++ b/crates/kanban-server/src/handlers/boards.rs
@@ -18,7 +18,7 @@ pub fn create_board(
     req: CreateBoardRequest,
 ) -> Result<BoardResponse, ApiError> {
     let (id, spec) = req.into_new_board();
-    let board = ctx
+    let (board, _inv) = ctx
         .create_board_from_spec(id, spec)
         .map_err(|e| ApiError::from(&e))?;
     Ok(BoardResponse::from(&board))
@@ -33,7 +33,7 @@ pub fn create_or_replace_board(
     req: ReplaceBoardRequest,
 ) -> Result<(BoardResponse, bool), ApiError> {
     let spec = req.into_new_board();
-    let outcome = ctx
+    let (outcome, _inv) = ctx
         .create_or_replace_board(id, spec)
         .map_err(|e| ApiError::from(&e))?;
     Ok((BoardResponse::from(&outcome.board), outcome.created))

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -28,15 +28,8 @@ impl KanbanContext {
     /// and applies the server-managed `position`. Inherent on `KanbanContext`
     /// (not a `KanbanOperations` trait method) — the trait is dual-impl by
     /// TUI+CLI and would force churn there.
+    /// Returns the created board and the invalidation the create batch implies.
     pub fn create_board_from_spec(
-        &mut self,
-        id: Option<Uuid>,
-        spec: NewBoard,
-    ) -> KanbanResult<Board> {
-        Ok(self.create_board_from_spec_returning(id, spec)?.0)
-    }
-
-    pub(super) fn create_board_from_spec_returning(
         &mut self,
         id: Option<Uuid>,
         spec: NewBoard,
@@ -70,23 +63,30 @@ impl KanbanContext {
     /// counters, `active_sprint_id`) is preserved across the replace arm — only
     /// client-settable content is overwritten, wholesale (an absent nullable
     /// field clears). The HTTP binding stays in the server seam.
+    /// The returned invalidation belongs to whichever arm ran.
     pub fn create_or_replace_board(
         &mut self,
         id: Uuid,
         spec: NewBoard,
-    ) -> KanbanResult<BoardCreateOutcome> {
+    ) -> KanbanResult<(BoardCreateOutcome, Invalidation)> {
         if self.backend.get_board(id)?.is_none() {
-            let board = self.create_board_from_spec(Some(id), spec)?;
-            return Ok(BoardCreateOutcome {
-                board,
-                created: true,
-            });
+            let (board, inv) = self.create_board_from_spec(Some(id), spec)?;
+            return Ok((
+                BoardCreateOutcome {
+                    board,
+                    created: true,
+                },
+                inv,
+            ));
         }
-        let (board, _inv) = self.update_board_impl(id, replace_update_from_spec(spec))?;
-        Ok(BoardCreateOutcome {
-            board,
-            created: false,
-        })
+        let (board, inv) = self.update_board_impl(id, replace_update_from_spec(spec))?;
+        Ok((
+            BoardCreateOutcome {
+                board,
+                created: false,
+            },
+            inv,
+        ))
     }
 
     /// Thin shim over [`create_board_from_spec`](Self::create_board_from_spec)
@@ -107,7 +107,7 @@ impl KanbanContext {
             sprint_duration_days: None,
             task_list_view: None,
         };
-        self.create_board_from_spec_returning(None, spec)
+        self.create_board_from_spec(None, spec)
     }
 
     pub(super) fn list_boards_impl(&self) -> KanbanResult<Vec<Board>> {

--- a/crates/kanban-service/src/context/graph.rs
+++ b/crates/kanban-service/src/context/graph.rs
@@ -5,8 +5,8 @@ use kanban_domain::commands::{
     RemoveSpawns,
 };
 use kanban_domain::{
-    BlocksEdge, GraphOperations, KanbanError, KanbanResult, RelatesEdge, RelatesKind, Severity,
-    SpawnsEdge,
+    BlocksEdge, GraphOperations, Invalidation, KanbanError, KanbanResult, RelatesEdge, RelatesKind,
+    Severity, SpawnsEdge,
 };
 use std::collections::HashSet;
 use uuid::Uuid;
@@ -97,10 +97,15 @@ impl KanbanContext {
         Ok(self.backend.get_archived_card(a)?.is_some()
             || self.backend.get_archived_card(b)?.is_some())
     }
-}
 
-impl GraphOperations for KanbanContext {
-    fn attach_children(&mut self, parent: Uuid, children: Vec<Uuid>) -> KanbanResult<()> {
+    /// Attach `children` as spawned cards of `parent` and return the
+    /// invalidation the batch implies. Passing an empty `children` builds an
+    /// empty command batch, whose empty inverse maps to `Invalidation::All`.
+    pub fn attach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<Invalidation> {
         self.require_card_exists(parent)?;
         for child in &children {
             self.require_card_exists(*child)?;
@@ -116,10 +121,14 @@ impl GraphOperations for KanbanContext {
                 },
             )));
         }
-        self.execute(commands).map(|_| ())
+        self.execute(commands)
     }
 
-    fn detach_children(&mut self, parent: Uuid, children: Vec<Uuid>) -> KanbanResult<()> {
+    pub fn detach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<Invalidation> {
         self.require_card_exists(parent)?;
         for child in &children {
             self.require_card_exists(*child)?;
@@ -135,7 +144,86 @@ impl GraphOperations for KanbanContext {
                 }))
             })
             .collect();
-        self.execute(commands).map(|_| ())
+        self.execute(commands)
+    }
+
+    pub fn block_impl(
+        &mut self,
+        blocker: Uuid,
+        blocked: Uuid,
+        severity: Severity,
+    ) -> KanbanResult<Invalidation> {
+        self.require_card_exists(blocker)?;
+        self.require_card_exists(blocked)?;
+        let as_archived = self.edge_born_archived(blocker, blocked)?;
+        self.execute(vec![Command::Dependency(DependencyCommand::AddBlocks(
+            AddBlocks {
+                source: blocker,
+                target: blocked,
+                severity,
+                as_archived,
+            },
+        ))])
+    }
+
+    pub fn unblock_impl(&mut self, blocker: Uuid, blocked: Uuid) -> KanbanResult<Invalidation> {
+        self.require_card_exists(blocker)?;
+        self.require_card_exists(blocked)?;
+        self.execute(vec![Command::Dependency(DependencyCommand::RemoveBlocks(
+            RemoveBlocks {
+                source: blocker,
+                target: blocked,
+                tolerate_missing: false,
+                as_archived: false,
+            },
+        ))])
+    }
+
+    pub fn relate_impl(
+        &mut self,
+        a: Uuid,
+        b: Uuid,
+        kind: RelatesKind,
+    ) -> KanbanResult<Invalidation> {
+        self.require_card_exists(a)?;
+        self.require_card_exists(b)?;
+        let as_archived = self.edge_born_archived(a, b)?;
+        self.execute(vec![Command::Dependency(DependencyCommand::AddRelates(
+            AddRelates {
+                source: a,
+                target: b,
+                kind,
+                as_archived,
+            },
+        ))])
+    }
+
+    pub fn dissociate_impl(&mut self, a: Uuid, b: Uuid) -> KanbanResult<Invalidation> {
+        self.require_card_exists(a)?;
+        self.require_card_exists(b)?;
+        self.execute(vec![Command::Dependency(DependencyCommand::RemoveRelates(
+            RemoveRelates {
+                source: a,
+                target: b,
+                tolerate_missing: false,
+                as_archived: false,
+            },
+        ))])
+    }
+}
+
+/// The only place a graph-mutation `Invalidation` is discarded: the
+/// `GraphOperations` trait is frozen at `KanbanResult<()>` for its four other
+/// implementors (kanban-cli, kanban-mcp, kanban-tui, and the domain-side test
+/// doubles), so each mutator here forwards to its `*_impl` twin and drops the
+/// value.
+impl GraphOperations for KanbanContext {
+    fn attach_children(&mut self, parent: Uuid, children: Vec<Uuid>) -> KanbanResult<()> {
+        self.attach_children_impl(parent, children).map(|_| ())
+    }
+
+    fn detach_children(&mut self, parent: Uuid, children: Vec<Uuid>) -> KanbanResult<()> {
+        self.detach_children_impl(parent, children).map(|_| ())
     }
 
     fn list_children_of(&self, parent: Uuid) -> KanbanResult<Vec<Uuid>> {
@@ -149,32 +237,11 @@ impl GraphOperations for KanbanContext {
     }
 
     fn block(&mut self, blocker: Uuid, blocked: Uuid, severity: Severity) -> KanbanResult<()> {
-        self.require_card_exists(blocker)?;
-        self.require_card_exists(blocked)?;
-        let as_archived = self.edge_born_archived(blocker, blocked)?;
-        self.execute(vec![Command::Dependency(DependencyCommand::AddBlocks(
-            AddBlocks {
-                source: blocker,
-                target: blocked,
-                severity,
-                as_archived,
-            },
-        ))])
-        .map(|_| ())
+        self.block_impl(blocker, blocked, severity).map(|_| ())
     }
 
     fn unblock(&mut self, blocker: Uuid, blocked: Uuid) -> KanbanResult<()> {
-        self.require_card_exists(blocker)?;
-        self.require_card_exists(blocked)?;
-        self.execute(vec![Command::Dependency(DependencyCommand::RemoveBlocks(
-            RemoveBlocks {
-                source: blocker,
-                target: blocked,
-                tolerate_missing: false,
-                as_archived: false,
-            },
-        ))])
-        .map(|_| ())
+        self.unblock_impl(blocker, blocked).map(|_| ())
     }
 
     fn list_blocked_by(&self, blocker: Uuid) -> KanbanResult<Vec<Uuid>> {
@@ -188,32 +255,11 @@ impl GraphOperations for KanbanContext {
     }
 
     fn relate(&mut self, a: Uuid, b: Uuid, kind: RelatesKind) -> KanbanResult<()> {
-        self.require_card_exists(a)?;
-        self.require_card_exists(b)?;
-        let as_archived = self.edge_born_archived(a, b)?;
-        self.execute(vec![Command::Dependency(DependencyCommand::AddRelates(
-            AddRelates {
-                source: a,
-                target: b,
-                kind,
-                as_archived,
-            },
-        ))])
-        .map(|_| ())
+        self.relate_impl(a, b, kind).map(|_| ())
     }
 
     fn dissociate(&mut self, a: Uuid, b: Uuid) -> KanbanResult<()> {
-        self.require_card_exists(a)?;
-        self.require_card_exists(b)?;
-        self.execute(vec![Command::Dependency(DependencyCommand::RemoveRelates(
-            RemoveRelates {
-                source: a,
-                target: b,
-                tolerate_missing: false,
-                as_archived: false,
-            },
-        ))])
-        .map(|_| ())
+        self.dissociate_impl(a, b).map(|_| ())
     }
 
     fn list_related_to(&self, card: Uuid) -> KanbanResult<Vec<Uuid>> {

--- a/crates/kanban-service/src/test_helpers/contract/board.rs
+++ b/crates/kanban-service/src/test_helpers/contract/board.rs
@@ -3,8 +3,36 @@ use crate::KanbanContext;
 use kanban_core::AppConfig;
 use kanban_domain::board::{SortField, SortOrder};
 use kanban_domain::task_list_view::TaskListView;
-use kanban_domain::{BoardUpdate, FieldUpdate, KanbanOperations};
+use kanban_domain::{BoardUpdate, EntityIds, FieldUpdate, Invalidation, KanbanOperations, NewBoard};
 use tempfile::TempDir;
+
+pub async fn test_create_board_from_spec_returns_an_invalidation_naming_the_board_on_every_backend(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let spec = NewBoard {
+        name: "Roadmap".into(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: Some("KAN".into()),
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    };
+    let (board, inv) = ctx.create_board_from_spec(None, spec).unwrap();
+
+    assert_eq!(inv, Invalidation::Entities(EntityIds::boards([board.id])));
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+    assert_eq!(ctx.get_board(board.id).unwrap().unwrap().name, "Roadmap");
+}
 
 pub async fn test_board_basic_fields_roundtrip(factory: &BackendFactory) {
     let dir = TempDir::new().unwrap();

--- a/crates/kanban-service/src/test_helpers/contract/board.rs
+++ b/crates/kanban-service/src/test_helpers/contract/board.rs
@@ -3,7 +3,9 @@ use crate::KanbanContext;
 use kanban_core::AppConfig;
 use kanban_domain::board::{SortField, SortOrder};
 use kanban_domain::task_list_view::TaskListView;
-use kanban_domain::{BoardUpdate, EntityIds, FieldUpdate, Invalidation, KanbanOperations, NewBoard};
+use kanban_domain::{
+    BoardUpdate, EntityIds, FieldUpdate, Invalidation, KanbanOperations, NewBoard,
+};
 use tempfile::TempDir;
 
 pub async fn test_create_board_from_spec_returns_an_invalidation_naming_the_board_on_every_backend(

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -84,6 +84,10 @@ macro_rules! context_contract_tests {
             $crate::test_helpers::contract::board::test_board_basic_fields_roundtrip(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
+        async fn test_create_board_from_spec_returns_an_invalidation_naming_the_board_on_every_backend() {
+            $crate::test_helpers::contract::board::test_create_board_from_spec_returns_an_invalidation_naming_the_board_on_every_backend(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
         async fn test_board_update_all_optional_fields_roundtrip() {
             $crate::test_helpers::contract::board::test_board_update_all_optional_fields_roundtrip(&$factory_fn()).await;
         }

--- a/crates/kanban-service/tests/create_board_from_spec.rs
+++ b/crates/kanban-service/tests/create_board_from_spec.rs
@@ -35,7 +35,7 @@ async fn test_create_board_from_spec_applies_all_content_fields() {
     let path = dir.path().join("spec.json");
     let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
 
-    let board = ctx
+    let (board, _inv) = ctx
         .create_board_from_spec(None, full_spec("Roadmap"))
         .unwrap();
 
@@ -59,10 +59,10 @@ async fn test_create_board_from_spec_position_is_prior_list_len() {
     let path = dir.path().join("pos.json");
     let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
 
-    let first = ctx
+    let (first, _inv) = ctx
         .create_board_from_spec(None, full_spec("First"))
         .unwrap();
-    let second = ctx
+    let (second, _inv) = ctx
         .create_board_from_spec(None, full_spec("Second"))
         .unwrap();
 
@@ -76,7 +76,7 @@ async fn test_create_board_from_spec_mints_id_when_absent() {
     let path = dir.path().join("mint.json");
     let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
 
-    let board = ctx
+    let (board, _inv) = ctx
         .create_board_from_spec(None, full_spec("Minted"))
         .unwrap();
 
@@ -91,7 +91,7 @@ async fn test_create_board_from_spec_uses_client_supplied_id() {
     let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
 
     let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-    let board = ctx
+    let (board, _inv) = ctx
         .create_board_from_spec(Some(id), full_spec("Pinned"))
         .unwrap();
 
@@ -106,7 +106,8 @@ async fn test_create_board_with_duplicate_client_id_returns_conflict() {
     let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
 
     let id = Uuid::new_v4();
-    ctx.create_board_from_spec(Some(id), full_spec("Original"))
+    let (_board, _inv) = ctx
+        .create_board_from_spec(Some(id), full_spec("Original"))
         .unwrap();
 
     let err = ctx
@@ -131,7 +132,7 @@ async fn test_create_or_replace_board_creates_when_absent_reports_created() {
     let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
 
     let id = Uuid::new_v4();
-    let outcome = ctx.create_or_replace_board(id, full_spec("Fresh")).unwrap();
+    let (outcome, _inv) = ctx.create_or_replace_board(id, full_spec("Fresh")).unwrap();
 
     assert!(outcome.created, "absent id must report created");
     assert_eq!(outcome.board.id, id);
@@ -147,7 +148,8 @@ async fn test_create_or_replace_board_replaces_when_present_reports_not_created(
     let mut ctx = KanbanContext::open_deferred(make_json_backend(&path), AppConfig::default());
 
     let id = Uuid::new_v4();
-    ctx.create_or_replace_board(id, full_spec("Original"))
+    let (_outcome, _inv) = ctx
+        .create_or_replace_board(id, full_spec("Original"))
         .unwrap();
 
     let replacement = NewBoard {
@@ -160,7 +162,7 @@ async fn test_create_or_replace_board_replaces_when_present_reports_not_created(
         sprint_duration_days: None,
         task_list_view: Some(TaskListView::Flat),
     };
-    let outcome = ctx.create_or_replace_board(id, replacement).unwrap();
+    let (outcome, _inv) = ctx.create_or_replace_board(id, replacement).unwrap();
 
     assert!(
         !outcome.created,
@@ -189,11 +191,12 @@ async fn test_create_or_replace_board_preserves_server_managed_counters_on_repla
     let created = ctx
         .create_or_replace_board(id, full_spec("WithCards"))
         .unwrap()
+        .0
         .board;
     let position = created.position;
 
     // Replace content; server-managed position must not be disturbed.
-    let outcome = ctx
+    let (outcome, _inv) = ctx
         .create_or_replace_board(id, full_spec("StillThere"))
         .unwrap();
     assert!(!outcome.created);

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -334,8 +334,7 @@ fn test_kanban_context_is_send_and_sync() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_attach_children_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()>
-{
+async fn test_attach_children_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let (parent, child) = two_cards(&mut ctx).await;
 
@@ -349,11 +348,10 @@ async fn test_attach_children_impl_returns_an_invalidation_naming_both_cards() -
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_detach_children_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()>
-{
+async fn test_detach_children_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let (parent, child) = two_cards(&mut ctx).await;
-    ctx.attach_children_impl(parent.id, vec![child.id])?;
+    let _ = ctx.attach_children_impl(parent.id, vec![child.id])?;
 
     let inv = ctx.detach_children_impl(parent.id, vec![child.id])?;
 
@@ -369,7 +367,7 @@ async fn test_block_impl_returns_an_invalidation_naming_both_cards() -> KanbanRe
     let mut ctx = make_ctx().await;
     let (a, b) = two_cards(&mut ctx).await;
 
-    let inv = ctx.block_impl(a.id, b.id, Severity::Hard)?;
+    let inv = ctx.block_impl(a.id, b.id, Severity::High)?;
 
     assert_eq!(
         inv,
@@ -382,7 +380,7 @@ async fn test_block_impl_returns_an_invalidation_naming_both_cards() -> KanbanRe
 async fn test_unblock_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let (a, b) = two_cards(&mut ctx).await;
-    ctx.block_impl(a.id, b.id, Severity::Hard)?;
+    let _ = ctx.block_impl(a.id, b.id, Severity::High)?;
 
     let inv = ctx.unblock_impl(a.id, b.id)?;
 
@@ -411,7 +409,7 @@ async fn test_relate_impl_returns_an_invalidation_naming_both_cards() -> KanbanR
 async fn test_dissociate_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let (a, b) = two_cards(&mut ctx).await;
-    ctx.relate_impl(a.id, b.id, RelatesKind::default())?;
+    let _ = ctx.relate_impl(a.id, b.id, RelatesKind::default())?;
 
     let inv = ctx.dissociate_impl(a.id, b.id)?;
 
@@ -439,10 +437,10 @@ async fn test_a_failed_graph_mutation_returns_an_error_and_leaves_the_graph_unch
     let mut ctx = make_ctx().await;
     let (real_card, _other) = two_cards(&mut ctx).await;
 
-    let result = ctx.block_impl(real_card.id, Uuid::new_v4(), Severity::Hard);
+    let result = ctx.block_impl(real_card.id, Uuid::new_v4(), Severity::High);
 
     assert!(result.is_err());
-    assert!(ctx.get_graph()?.blocked(real_card.id).is_empty());
+    assert!(ctx.graph()?.blocked(real_card.id).is_empty());
     Ok(())
 }
 
@@ -486,7 +484,7 @@ async fn test_create_or_replace_board_returns_the_update_invalidation_on_the_rep
 ) -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
     let id = Uuid::new_v4();
-    ctx.create_or_replace_board(id, spec("Original"))?;
+    let _ = ctx.create_or_replace_board(id, spec("Original"))?;
 
     let (outcome, inv) = ctx.create_or_replace_board(id, spec("Replaced"))?;
 

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -1,11 +1,12 @@
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
-    BoardUpdate, Card, CardUpdate, DataStore, EntityIds, Invalidation, KanbanOperations,
-    KanbanResult, Model, Prefix, Sprint,
+    BoardUpdate, Card, CardUpdate, DataStore, EntityIds, GraphOperations, Invalidation,
+    KanbanOperations, KanbanResult, Model, NewBoard, Prefix, RelatesKind, Severity, Sprint,
 };
 use kanban_service::{FetchPlan, FetchRound, KanbanContext, LoadedEntities};
 use std::collections::HashSet;
 use std::sync::Arc;
+use uuid::Uuid;
 
 async fn make_ctx() -> KanbanContext {
     KanbanContext::open(
@@ -14,6 +15,31 @@ async fn make_ctx() -> KanbanContext {
     )
     .await
     .unwrap()
+}
+
+fn spec(name: &str) -> NewBoard {
+    NewBoard {
+        name: name.to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: Some("KAN".into()),
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    }
+}
+
+async fn two_cards(ctx: &mut KanbanContext) -> (Card, Card) {
+    let board = ctx.create_board("B".into(), Some("KAN".into())).unwrap();
+    let col = ctx.create_column(board.id, "C".into(), None).unwrap();
+    let a = ctx
+        .create_card(board.id, col.id, "A".into(), Default::default())
+        .unwrap();
+    let b = ctx
+        .create_card(board.id, col.id, "B".into(), Default::default())
+        .unwrap();
+    (a, b)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -305,4 +331,166 @@ async fn test_redo_with_nothing_to_redo_returns_none() -> KanbanResult<()> {
 fn test_kanban_context_is_send_and_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<KanbanContext>();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_attach_children_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()>
+{
+    let mut ctx = make_ctx().await;
+    let (parent, child) = two_cards(&mut ctx).await;
+
+    let inv = ctx.attach_children_impl(parent.id, vec![child.id])?;
+
+    assert_eq!(
+        inv,
+        Invalidation::Entities(EntityIds::cards([parent.id, child.id]).with_graph())
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_detach_children_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()>
+{
+    let mut ctx = make_ctx().await;
+    let (parent, child) = two_cards(&mut ctx).await;
+    ctx.attach_children_impl(parent.id, vec![child.id])?;
+
+    let inv = ctx.detach_children_impl(parent.id, vec![child.id])?;
+
+    assert_eq!(
+        inv,
+        Invalidation::Entities(EntityIds::cards([parent.id, child.id]).with_graph())
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let (a, b) = two_cards(&mut ctx).await;
+
+    let inv = ctx.block_impl(a.id, b.id, Severity::Hard)?;
+
+    assert_eq!(
+        inv,
+        Invalidation::Entities(EntityIds::cards([a.id, b.id]).with_graph())
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unblock_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let (a, b) = two_cards(&mut ctx).await;
+    ctx.block_impl(a.id, b.id, Severity::Hard)?;
+
+    let inv = ctx.unblock_impl(a.id, b.id)?;
+
+    assert_eq!(
+        inv,
+        Invalidation::Entities(EntityIds::cards([a.id, b.id]).with_graph())
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_relate_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let (a, b) = two_cards(&mut ctx).await;
+
+    let inv = ctx.relate_impl(a.id, b.id, RelatesKind::default())?;
+
+    assert_eq!(
+        inv,
+        Invalidation::Entities(EntityIds::cards([a.id, b.id]).with_graph())
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dissociate_impl_returns_an_invalidation_naming_both_cards() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let (a, b) = two_cards(&mut ctx).await;
+    ctx.relate_impl(a.id, b.id, RelatesKind::default())?;
+
+    let inv = ctx.dissociate_impl(a.id, b.id)?;
+
+    assert_eq!(
+        inv,
+        Invalidation::Entities(EntityIds::cards([a.id, b.id]).with_graph())
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_attach_children_impl_with_no_children_returns_all() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let (parent, _child) = two_cards(&mut ctx).await;
+
+    let inv = ctx.attach_children_impl(parent.id, vec![])?;
+
+    assert_eq!(inv, Invalidation::All);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_a_failed_graph_mutation_returns_an_error_and_leaves_the_graph_unchanged(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let (real_card, _other) = two_cards(&mut ctx).await;
+
+    let result = ctx.block_impl(real_card.id, Uuid::new_v4(), Severity::Hard);
+
+    assert!(result.is_err());
+    assert!(ctx.get_graph()?.blocked(real_card.id).is_empty());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_the_graph_operations_facade_still_returns_unit() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let (parent, child) = two_cards(&mut ctx).await;
+
+    let unit: () = GraphOperations::attach_children(&mut ctx, parent.id, vec![child.id])?;
+
+    assert_eq!(unit, ());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_board_from_spec_returns_an_invalidation_naming_the_board() -> KanbanResult<()>
+{
+    let mut ctx = make_ctx().await;
+
+    let (board, inv) = ctx.create_board_from_spec(None, spec("Roadmap"))?;
+
+    assert_eq!(inv, Invalidation::Entities(EntityIds::boards([board.id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_board_returns_the_create_invalidation_on_the_create_path(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let id = Uuid::new_v4();
+
+    let (outcome, inv) = ctx.create_or_replace_board(id, spec("Fresh"))?;
+
+    assert!(outcome.created);
+    assert_eq!(inv, Invalidation::Entities(EntityIds::boards([id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_board_returns_the_update_invalidation_on_the_replace_path(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let id = Uuid::new_v4();
+    ctx.create_or_replace_board(id, spec("Original"))?;
+
+    let (outcome, inv) = ctx.create_or_replace_board(id, spec("Replaced"))?;
+
+    assert!(!outcome.created);
+    assert_eq!(inv, Invalidation::Entities(EntityIds::boards([id])));
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Add six `pub` inherent `KanbanContext` graph mutators (`attach_children_impl`, `detach_children_impl`, `block_impl`, `unblock_impl`, `relate_impl`, `dissociate_impl`), each returning `KanbanResult<Invalidation>`. The `GraphOperations` trait impl is reduced to six one-line `.map(|_| ())` forwards over these, since the trait signature is frozen across its four production implementors (kanban-cli, kanban-mcp, kanban-service, kanban-tui).
- Fold the `pub(super) create_board_from_spec_returning` helper back into `create_board_from_spec`, which now returns `(Board, Invalidation)`.
- Retype `create_or_replace_board` to return `(BoardCreateOutcome, Invalidation)`, propagating whichever arm ran (create vs replace) instead of discarding it.
- Repair the three downstream call sites that only needed the value half: `kanban-mcp/src/context.rs` (`McpContext::create_board_from_spec` forwarder), and both handlers in `kanban-server/src/handlers/boards.rs`.
- Repair the twelve call sites in `crates/kanban-service/tests/create_board_from_spec.rs` for the new tuple return types.

## Empirical answer

`Command::Dependency(..).touched_entities()` returns `Some(EntityIds::cards([source, target]).with_graph())` for all six `Add*`/`Remove*` dependency commands, so a graph mutation's invalidation is `Invalidation::Entities` naming both cards with `graph = true`, never `All`, except for an empty `children` vec on `attach_children_impl`/`detach_children_impl`, where the empty inverse makes `invalidation_from_inverse` return `All`.

## Scope note

The three mcp/server repairs are compile-only (destructuring the new tuple returns); they do not introduce a `mutate` seam or touch any mutation call site logic. That work remains scoped to KAN-1474/1475/1476.

## Testing

- New tests in `crates/kanban-service/tests/mutation_invalidation.rs` cover all six graph mutators, the empty-children All case, a failed-mutation no-op case, the `GraphOperations` facade unit-return regression guard, and the three board-spec invalidation cases.
- New cross-backend contract test `test_create_board_from_spec_returns_an_invalidation_naming_the_board_on_every_backend`, registered in `context_contract_tests!`, passing under in-memory, JSON and SQLite.
