### PR TITLE
KAN-1474 refactor(cli): route mutations through a CliContext::mutate seam

### DIFF
--- a/.changeset/kan-1474-cli-mutation-seam.md
+++ b/.changeset/kan-1474-cli-mutation-seam.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+cli: introduces `CliContext::mutate`/`mutate_unit`, the sole internal seam through which every mutating handler now consumes the `Invalidation` a mutation returns. No public API changes; all mutation call sites in `handlers/` and `app.rs` route through the new `pub(crate)` seam instead of the `KanbanOperations`/`GraphOperations` trait methods directly.

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -4,7 +4,6 @@ use crate::handlers;
 use crate::output;
 use clap::{CommandFactory, FromArgMatches};
 use kanban_core::AppConfig;
-use kanban_domain::KanbanOperations;
 use kanban_persistence::{StoreFactory, StoreRegistry};
 use kanban_service::StoreManager;
 #[cfg(feature = "tui")]
@@ -400,7 +399,7 @@ Provide the file path in one of these ways:
                     Some(name) => {
                         let mut ctx =
                             CliContext::load(&store_manager, &effective_file, config).await?;
-                        let created = ctx.create_board(name, None)?;
+                        let created = ctx.mutate(|c| c.create_board_impl(name, None))?;
                         ctx.save().await?;
                         output::output_success(kanban_service::api::BoardResponse::from(&created));
                     }

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -3,7 +3,7 @@ use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
     CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, FieldUpdate,
-    GraphOperations, KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
+    GraphOperations, Invalidation, KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;
@@ -58,6 +58,31 @@ impl CliContext {
     #[cfg(test)]
     pub(crate) fn from_context(inner: KanbanContext) -> Self {
         Self { inner }
+    }
+
+    /// The one place in `kanban-cli` where a mutation's `Invalidation` is
+    /// handled. Every mutating handler goes through here; nothing in
+    /// `handlers/` calls a `KanbanOperations` or `GraphOperations` mutator
+    /// directly. The operation runs once; an `Err` propagates unchanged and
+    /// invalidates nothing.
+    pub(crate) fn mutate<T>(
+        &mut self,
+        op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
+    ) -> KanbanResult<T> {
+        let (value, invalidation) = op(&mut self.inner)?;
+        let _ = invalidation;
+        Ok(value)
+    }
+
+    /// [`mutate`](Self::mutate) for the operations whose only result is the
+    /// `Invalidation`.
+    pub(crate) fn mutate_unit(
+        &mut self,
+        op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
+    ) -> KanbanResult<()> {
+        let invalidation = op(&mut self.inner)?;
+        let _ = invalidation;
+        Ok(())
     }
 
     pub async fn save(&self) -> KanbanResult<()> {
@@ -475,8 +500,7 @@ mod tests {
     fn test_mutate_unit_returns_unit_and_commits_the_operation() -> KanbanResult<()> {
         let mut ctx = seam_context();
         let board = ctx.mutate(|c| c.create_board_impl("Seam".to_string(), None))?;
-        let result = ctx.mutate_unit(|c| c.archive_board_impl(board.id))?;
-        assert_eq!(result, ());
+        ctx.mutate_unit(|c| c.archive_board_impl(board.id))?;
         assert!(ctx.list_boards()?.is_empty());
         assert_eq!(ctx.list_archived_boards()?.len(), 1);
         Ok(())

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -420,3 +420,81 @@ impl GraphOperations for CliContext {
         self.inner.list_related_to(card)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::{DomainError, KanbanError};
+
+    fn seam_context() -> CliContext {
+        CliContext::from_context(KanbanContext::open_deferred(
+            std::sync::Arc::new(kanban_backend_memory::InMemoryStore::default()),
+            AppConfig::default(),
+        ))
+    }
+
+    #[test]
+    fn test_mutate_returns_the_operations_value() -> KanbanResult<()> {
+        let mut ctx = seam_context();
+        let board = ctx.mutate(|c| c.create_board_impl("Seam".to_string(), None))?;
+        assert_eq!(board.name, "Seam");
+        assert_eq!(ctx.list_boards()?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_mutate_propagates_the_error_and_invalidates_nothing() -> KanbanResult<()> {
+        let mut ctx = seam_context();
+        let missing_id = Uuid::new_v4();
+        let result = ctx.mutate(|c| c.update_board_impl(missing_id, BoardUpdate::default()));
+        match result {
+            Err(KanbanError::Domain(DomainError::NotFound { entity, id })) => {
+                assert_eq!(entity, "Board");
+                assert_eq!(id, missing_id);
+            }
+            other => panic!("expected NotFound error, got {other:?}"),
+        }
+        assert!(ctx.list_boards()?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_mutate_runs_the_operation_exactly_once() -> KanbanResult<()> {
+        let mut ctx = seam_context();
+        let calls = std::cell::Cell::new(0usize);
+        ctx.mutate(|c| {
+            calls.set(calls.get() + 1);
+            c.create_board_impl("Seam".to_string(), None)
+        })?;
+        assert_eq!(calls.get(), 1);
+        assert_eq!(ctx.list_boards()?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_mutate_unit_returns_unit_and_commits_the_operation() -> KanbanResult<()> {
+        let mut ctx = seam_context();
+        let board = ctx.mutate(|c| c.create_board_impl("Seam".to_string(), None))?;
+        let result = ctx.mutate_unit(|c| c.archive_board_impl(board.id))?;
+        assert_eq!(result, ());
+        assert!(ctx.list_boards()?.is_empty());
+        assert_eq!(ctx.list_archived_boards()?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_mutate_unit_propagates_the_error_and_invalidates_nothing() -> KanbanResult<()> {
+        let mut ctx = seam_context();
+        let missing_id = Uuid::new_v4();
+        let result = ctx.mutate_unit(|c| c.archive_board_impl(missing_id));
+        match result {
+            Err(KanbanError::Domain(DomainError::NotFound { entity, id })) => {
+                assert_eq!(entity, "Board");
+                assert_eq!(id, missing_id);
+            }
+            other => panic!("expected NotFound error, got {other:?}"),
+        }
+        assert!(ctx.list_archived_boards()?.is_empty());
+        Ok(())
+    }
+}

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -26,7 +26,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                     anyhow::anyhow!("board not found after creating it with default columns")
                 })?
             } else {
-                ctx.create_board(name, card_prefix)?
+                ctx.mutate(|c| c.create_board_impl(name, card_prefix))?
             };
             ctx.save().await?;
             output::output_success(BoardResponse::from(&board));
@@ -88,7 +88,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            ctx.delete_board(uuid)?;
+            ctx.mutate_unit(|c| c.delete_board_impl(uuid))?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
@@ -98,7 +98,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            ctx.archive_board(uuid)?;
+            ctx.mutate_unit(|c| c.archive_board_impl(uuid))?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"archived": uuid.to_string()}));
         }
@@ -109,7 +109,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
-            ctx.restore_board(uuid)?;
+            ctx.mutate_unit(|c| c.restore_board_impl(uuid))?;
             ctx.save().await?;
             match ctx.get_board(uuid)? {
                 Some(b) => output::output_success(BoardResponse::from(&b)),
@@ -123,7 +123,7 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
-            ctx.delete_board(uuid)?;
+            ctx.mutate_unit(|c| c.delete_board_impl(uuid))?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
@@ -238,7 +238,7 @@ async fn handle_update(
         task_sort_order: args.sort_order.map(|o| o.to_sort_order()),
         ..Default::default()
     };
-    let board = ctx.update_board(uuid, updates)?;
+    let board = ctx.mutate(|c| c.update_board_impl(uuid, updates))?;
     ctx.save().await?;
     Ok(board)
 }

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -30,9 +30,8 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Err(e) => return output::output_error(&e),
             };
             options.sprint_id = sprint_uuid;
-            // Funnels through the Card factory via the create command (KAN-796);
-            // the JSON edge projects the domain Card via CardResponse.
-            let card = ctx.create_card(board_uuid, column_uuid, args.title, options)?;
+            let card =
+                ctx.mutate(|c| c.create_card_impl(board_uuid, column_uuid, args.title, options))?;
             ctx.save().await?;
             output::output_success(CardResponse::from(&card));
         }
@@ -89,7 +88,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
-            let card = ctx.update_card(uuid, updates)?;
+            let card = ctx.mutate(|c| c.update_card_impl(uuid, updates))?;
             ctx.save().await?;
             output::output_success(CardResponse::from(&card));
         }
@@ -106,7 +105,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
-            let moved = ctx.move_card(uuid, column_uuid, position)?;
+            let moved = ctx.mutate(|c| c.move_card_impl(uuid, column_uuid, position))?;
             ctx.save().await?;
             output::output_success(CardResponse::from(&moved));
         }
@@ -115,7 +114,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            ctx.archive_card(uuid)?;
+            ctx.mutate(|c| c.archive_card_impl(uuid))?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"archived": uuid.to_string()}));
         }
@@ -131,7 +130,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 },
                 None => None,
             };
-            let restored = ctx.restore_card(uuid, column_uuid)?;
+            let restored = ctx.mutate(|c| c.restore_card_impl(uuid, column_uuid))?;
             ctx.save().await?;
             output::output_success(CardResponse::from(&restored));
         }
@@ -140,7 +139,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            ctx.delete_card(uuid)?;
+            ctx.mutate_unit(|c| c.delete_card_impl(uuid))?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
@@ -153,7 +152,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e),
             };
-            let assigned = ctx.assign_card_to_sprint(uuid, sprint_uuid)?;
+            let assigned = ctx.mutate(|c| c.assign_card_to_sprint_impl(uuid, sprint_uuid))?;
             ctx.save().await?;
             output::output_success(CardResponse::from(&assigned));
         }
@@ -162,7 +161,7 @@ pub async fn handle(ctx: &mut CliContext, action: CardAction) -> anyhow::Result<
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let unassigned = ctx.unassign_card_from_sprint(uuid)?;
+            let unassigned = ctx.mutate(|c| c.unassign_card_from_sprint_impl(uuid))?;
             ctx.save().await?;
             output::output_success(CardResponse::from(&unassigned));
         }

--- a/crates/kanban-cli/src/handlers/column.rs
+++ b/crates/kanban-cli/src/handlers/column.rs
@@ -63,7 +63,7 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            ctx.delete_column(uuid)?;
+            ctx.mutate_unit(|c| c.delete_column_impl(uuid))?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
@@ -72,7 +72,7 @@ pub async fn handle(ctx: &mut CliContext, action: ColumnAction) -> anyhow::Resul
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let c = ctx.reorder_column(uuid, position)?;
+            let c = ctx.mutate(|c| c.reorder_column_impl(uuid, position))?;
             ctx.save().await?;
             output::output_success(ColumnResponse::from(&c));
         }
@@ -110,7 +110,7 @@ async fn handle_update(
         },
         default_status,
     };
-    let column = ctx.update_column(uuid, updates)?;
+    let column = ctx.mutate(|c| c.update_column_impl(uuid, updates))?;
     ctx.save().await?;
     Ok(column)
 }

--- a/crates/kanban-cli/src/handlers/export.rs
+++ b/crates/kanban-cli/src/handlers/export.rs
@@ -20,7 +20,7 @@ pub async fn handle_export(ctx: &CliContext, args: ExportArgs) -> anyhow::Result
 pub async fn handle_import(ctx: &mut CliContext, args: ImportArgs) -> anyhow::Result<()> {
     let data = std::fs::read_to_string(&args.file)
         .map_err(|e| anyhow::anyhow!("Failed to read file {}: {}", args.file, e))?;
-    let board = ctx.import_board(&data)?;
+    let board = ctx.mutate(|c| c.import_board_impl(&data))?;
     ctx.save().await?;
     output::output_success(BoardResponse::from(&board));
     Ok(())

--- a/crates/kanban-cli/src/handlers/relation.rs
+++ b/crates/kanban-cli/src/handlers/relation.rs
@@ -142,7 +142,7 @@ async fn run(ctx: &mut CliContext, action: RelationAction) -> KanbanCliResult<se
                 "parent":   parent_uuid.to_string(),
                 "children": serde_json::to_value(&child_uuids)?,
             });
-            ctx.attach_children(parent_uuid, child_uuids)
+            ctx.mutate_unit(|c| c.attach_children_impl(parent_uuid, child_uuids))
                 .map_err(|e| enrich_add_error_for_batch(e, &parent, &children))?;
             ctx.save().await?;
             Ok(response)
@@ -154,7 +154,7 @@ async fn run(ctx: &mut CliContext, action: RelationAction) -> KanbanCliResult<se
                 "parent":   parent_uuid.to_string(),
                 "children": serde_json::to_value(&child_uuids)?,
             });
-            ctx.detach_children(parent_uuid, child_uuids)
+            ctx.mutate_unit(|c| c.detach_children_impl(parent_uuid, child_uuids))
                 .map_err(|e| enrich_remove_error_for_batch(e, &parent, &children))?;
             ctx.save().await?;
             Ok(response)

--- a/crates/kanban-cli/src/handlers/sprint.rs
+++ b/crates/kanban-cli/src/handlers/sprint.rs
@@ -25,10 +25,7 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            // Funnels through the Sprint factory via the create command
-            // (KAN-798); the JSON edge projects the domain Sprint via
-            // SprintResponse, resolving the sprint name against its owning board.
-            let sprint = ctx.create_sprint(board_uuid, prefix, name)?;
+            let sprint = ctx.mutate(|c| c.create_sprint_impl(board_uuid, prefix, name))?;
             ctx.save().await?;
             output::output_success(sprint_response(ctx, &sprint)?);
         }
@@ -76,7 +73,7 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let activated = ctx.activate_sprint(uuid, duration_days)?;
+            let activated = ctx.mutate(|c| c.activate_sprint_impl(uuid, duration_days))?;
             ctx.save().await?;
             output::output_success(sprint_response(ctx, &activated)?);
         }
@@ -85,7 +82,7 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let completed = ctx.complete_sprint(uuid)?;
+            let completed = ctx.mutate(|c| c.complete_sprint_impl(uuid))?;
             ctx.save().await?;
             output::output_success(sprint_response(ctx, &completed)?);
         }
@@ -94,7 +91,7 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let cancelled = ctx.cancel_sprint(uuid)?;
+            let cancelled = ctx.mutate(|c| c.cancel_sprint_impl(uuid))?;
             ctx.save().await?;
             output::output_success(sprint_response(ctx, &cancelled)?);
         }
@@ -103,7 +100,7 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            ctx.delete_sprint(uuid)?;
+            ctx.mutate_unit(|c| c.delete_sprint_impl(uuid))?;
             ctx.save().await?;
             output::output_success(serde_json::json!({"deleted": uuid.to_string()}));
         }
@@ -120,7 +117,7 @@ pub async fn handle(ctx: &mut CliContext, action: SprintAction) -> anyhow::Resul
                 Ok(u) => u,
                 Err(e) => return output::output_error(&e.to_string()),
             };
-            let count = ctx.carry_over_sprint_cards(from_uuid, to_uuid)?;
+            let count = ctx.mutate(|c| c.carry_over_sprint_cards_impl(from_uuid, to_uuid))?;
             ctx.save().await?;
             output::output_success(serde_json::json!({ "carried_over": count }));
         }
@@ -168,7 +165,7 @@ async fn handle_update(
         start_date,
         end_date,
     };
-    let sprint = ctx.update_sprint(uuid, updates)?;
+    let sprint = ctx.mutate(|c| c.update_sprint_impl(uuid, updates))?;
     ctx.save().await?;
     Ok(sprint)
 }


### PR DESCRIPTION
## Summary

- Adds `CliContext::mutate` and `CliContext::mutate_unit`, the single `pub(crate)` seam in `kanban-cli` that consumes a mutation's `Invalidation`. Both are documented, run the operation exactly once, and let an `Err` propagate unchanged (nothing commits and nothing invalidates on the error path, since `KanbanContext::execute_with_extra` rolls the whole batch back).
- Rewires all 28 handler/app mutation sites off the `KanbanOperations`/`GraphOperations` facade onto the `pub` `*_impl` methods, routed through the new seam.
- KAN-1424 shipped both `*_impl` return forms across these 28 sites: 19 return `KanbanResult<(T, Invalidation)>` and go through `mutate`; 9 return the bare `KanbanResult<Invalidation>` and go through `mutate_unit` (`delete_board_impl`, `archive_board_impl`, `restore_board_impl`, `delete_card_impl`, `delete_column_impl`, `delete_sprint_impl`, `attach_children_impl`, `detach_children_impl`). `archive_card_impl` is the one unit-valued method in the pair form (`KanbanResult<((), Invalidation)>`), so it goes through `mutate`, not `mutate_unit`.
- Removes the now-dead `use kanban_domain::KanbanOperations;` import from `crates/kanban-cli/src/app.rs`.

## Verification

- Re-derived the site census against this branch with the column-zero `^#[cfg(test)]`-truncated grep over every mutating method name: went from 28 hits to 0.
- `crates/kanban-cli/tests/` is untouched; the full integration suite (`cargo test -p kanban-cli --all-features`) is green, including migrate tests that exercise a real JSON locator and a real SQLite locator.
- Added five new `#[cfg(test)]` tests in `crates/kanban-cli/src/context.rs` pinning the seam: success + error-propagation + exactly-once for `mutate`, and success + error-propagation for `mutate_unit`.
- Mutation-checked the pinning test by temporarily swapping `?` for `.unwrap()` in `mutate`, confirmed `test_mutate_propagates_the_error_and_invalidates_nothing` panics, then reverted.
- `cargo fmt --all -- --check`, `cargo clippy -p kanban-cli --all-targets --all-features -- -D warnings`, and `cargo test -p kanban-cli --all-features` are all green.

## Out of scope (reported, not fixed)

Three mutating paths route through `context.rs` but are not census matches and are left untouched:
- `ctx.execute_commands(build_create_board_batch(..))` in `handlers/board.rs` (its `CliContext` forwarder drops the returned `Invalidation` today).
- The three `*_detailed` batch calls in `handlers/card.rs` (the service returns `BatchOperationResult`, no `Invalidation`).
- `ctx.create_column_with_default_status(..)` in `handlers/column.rs` (a composite defined inside `context.rs`).

All three still funnel through `context.rs`, so a future pass can reach them from one file.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p kanban-cli --all-targets --all-features -- -D warnings`
- [x] `cargo test -p kanban-cli --all-features`
