### PR TITLE
KAN-1446 feat(cli): argv becomes a CommandScope FetchPlan over a shared Model

### DIFF
--- a/.changeset/kan-1446-cli-controller-argv-becomes-commandscope.md
+++ b/.changeset/kan-1446-cli-controller-argv-becomes-commandscope.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+cli: `kanban-cli` becomes a Controller. A new `pub(crate) CommandScope` folds the parsed `Commands` value into a `kanban_service::FetchPlan`, `CliContext` gains a `kanban_domain::Model` plus the stored scope, and `dispatch_subcommand` syncs the Model once before dispatch. The `mutate`/`mutate_unit` seam now applies its returned `Invalidation` into the Model via `KanbanContext::sync_invalidated` instead of discarding it. `KanbanOperations::resolve_board_id` and `GraphOperations::list_children_of`/`list_parents_of` are retargeted to read from the Model's `board_list` and `graph` tiers, behind a shared `pub(crate)` `require_loaded` helper. No public API changes.

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -136,6 +136,8 @@ async fn create_empty_storage_file(
 }
 
 async fn dispatch_subcommand(ctx: &mut CliContext, cmd: Commands) -> anyhow::Result<()> {
+    ctx.set_scope(crate::scope::CommandScope::from_command(&cmd));
+    ctx.sync();
     match cmd {
         Commands::Board(board_cmd) => {
             handlers::board::handle(ctx, board_cmd.action).await?;

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -521,4 +521,70 @@ mod tests {
         assert!(ctx.list_archived_boards()?.is_empty());
         Ok(())
     }
+
+    #[test]
+    fn test_mutating_command_applies_the_returned_invalidation() -> KanbanResult<()> {
+        use crate::cli::{BoardAction, BoardCommand, Commands};
+        use crate::scope::CommandScope;
+
+        let mut ctx = seam_context();
+        ctx.mutate(|c| c.create_board_impl("First".to_string(), None))?;
+
+        ctx.set_scope(CommandScope::from_command(&Commands::Board(BoardCommand {
+            action: BoardAction::Get {
+                board: "First".to_string(),
+            },
+        })));
+        ctx.sync();
+        assert_eq!(ctx.model().boards_state().loaded().unwrap().len(), 1);
+
+        ctx.mutate(|c| c.create_board_impl("Second".to_string(), None))?;
+        assert_eq!(ctx.model().boards_state().loaded().unwrap().len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_relation_children_reads_the_graph_from_the_model_not_the_backend() -> KanbanResult<()>
+    {
+        use crate::cli::{Commands, RelationAction, RelationCommand, SortDir, SortKey};
+        use crate::scope::CommandScope;
+
+        let mut ctx = seam_context();
+        let board = ctx.mutate(|c| c.create_board_impl("Board".to_string(), None))?;
+        let column = ctx.mutate(|c| c.create_column_impl(board.id, "Col".to_string(), None))?;
+        let parent = ctx.mutate(|c| {
+            c.create_card_impl(
+                board.id,
+                column.id,
+                "Parent".to_string(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+        })?;
+        let child = ctx.mutate(|c| {
+            c.create_card_impl(
+                board.id,
+                column.id,
+                "Child".to_string(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+        })?;
+        ctx.mutate_unit(|c| c.attach_children_impl(parent.id, vec![child.id]))?;
+
+        assert!(ctx.list_children_of(parent.id).is_err());
+
+        ctx.set_scope(CommandScope::from_command(&Commands::Relation(
+            RelationCommand {
+                action: RelationAction::Children {
+                    card: parent.id.to_string(),
+                    sort: SortKey::CardNumber,
+                    order: SortDir::Asc,
+                },
+            },
+        )));
+        ctx.sync();
+        assert_eq!(ctx.list_children_of(parent.id)?, vec![child.id]);
+
+        Ok(())
+    }
 }

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -12,6 +12,8 @@ pub use kanban_service::BatchOperationResult;
 
 pub struct CliContext {
     inner: KanbanContext,
+    model: kanban_domain::Model,
+    scope: crate::scope::CommandScope,
 }
 
 impl CliContext {
@@ -52,12 +54,40 @@ impl CliContext {
             inner: KanbanContext::open(backend, config)
                 .await?
                 .with_app_type(AppType::Cli),
+            model: kanban_domain::Model::default(),
+            scope: crate::scope::CommandScope::default(),
         })
     }
 
     #[cfg(test)]
     pub(crate) fn from_context(inner: KanbanContext) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            model: kanban_domain::Model::default(),
+            scope: crate::scope::CommandScope::default(),
+        }
+    }
+
+    pub(crate) fn set_scope(&mut self, scope: crate::scope::CommandScope) {
+        self.scope = scope;
+    }
+
+    pub(crate) fn sync(&mut self) {
+        self.inner.sync(
+            &self.scope,
+            &mut self.model,
+            &mut kanban_domain::NoProjections,
+        );
+    }
+
+    #[cfg(test)]
+    pub(crate) fn model(&self) -> &kanban_domain::Model {
+        &self.model
+    }
+
+    #[cfg(test)]
+    pub(crate) fn model_mut(&mut self) -> &mut kanban_domain::Model {
+        &mut self.model
     }
 
     /// The one place in `kanban-cli` where a mutation's `Invalidation` is
@@ -70,7 +100,12 @@ impl CliContext {
         op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
     ) -> KanbanResult<T> {
         let (value, invalidation) = op(&mut self.inner)?;
-        let _ = invalidation;
+        self.inner.sync_invalidated(
+            invalidation,
+            &self.scope,
+            &mut self.model,
+            &mut kanban_domain::NoProjections,
+        );
         Ok(value)
     }
 
@@ -81,7 +116,12 @@ impl CliContext {
         op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
     ) -> KanbanResult<()> {
         let invalidation = op(&mut self.inner)?;
-        let _ = invalidation;
+        self.inner.sync_invalidated(
+            invalidation,
+            &self.scope,
+            &mut self.model,
+            &mut kanban_domain::NoProjections,
+        );
         Ok(())
     }
 
@@ -193,6 +233,32 @@ impl KanbanOperations for CliContext {
 
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
         self.inner.list_boards()
+    }
+
+    fn resolve_board_id(&self, raw: &str) -> KanbanResult<Uuid> {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            return Ok(uuid);
+        }
+        let boards = crate::model_read::require_loaded(self.model.boards_state(), "board list")?;
+        let matches = kanban_domain::find_boards_by_name(raw, boards);
+        match matches.as_slice() {
+            [] => Err(kanban_domain::KanbanError::not_found_by_name(
+                "Board",
+                raw,
+                boards.iter().map(|b| b.name.clone()).collect(),
+            )),
+            [b] => Ok(b.id),
+            many => Err(kanban_domain::KanbanError::ambiguous(
+                "Board",
+                raw,
+                many.iter()
+                    .map(|b| kanban_domain::AmbiguousMatch {
+                        label: format!("'{}'", b.name),
+                        id: b.id,
+                    })
+                    .collect(),
+            )),
+        }
     }
 
     fn list_boards_filtered(&self, filter: BoardListFilter) -> KanbanResult<Vec<Board>> {
@@ -413,10 +479,20 @@ impl GraphOperations for CliContext {
         self.inner.detach_children(parent, children)
     }
     fn list_children_of(&self, parent: Uuid) -> KanbanResult<Vec<Uuid>> {
-        self.inner.list_children_of(parent)
+        if self.inner.get_card(parent)?.is_none() {
+            return Err(kanban_domain::KanbanError::not_found("Card", parent));
+        }
+        let graph =
+            crate::model_read::require_loaded(self.model.graph_state(), "dependency graph")?;
+        Ok(graph.children(parent))
     }
     fn list_parents_of(&self, child: Uuid) -> KanbanResult<Vec<Uuid>> {
-        self.inner.list_parents_of(child)
+        if self.inner.get_card(child)?.is_none() {
+            return Err(kanban_domain::KanbanError::not_found("Card", child));
+        }
+        let graph =
+            crate::model_read::require_loaded(self.model.graph_state(), "dependency graph")?;
+        Ok(graph.parents(child))
     }
     fn block(
         &mut self,
@@ -545,8 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn test_relation_children_reads_the_graph_from_the_model_not_the_backend() -> KanbanResult<()>
-    {
+    fn test_relation_children_reads_the_graph_from_the_model_not_the_backend() -> KanbanResult<()> {
         use crate::cli::{Commands, RelationAction, RelationCommand, SortDir, SortKey};
         use crate::scope::CommandScope;
 

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -722,3 +722,63 @@ mod card_board_id_tests {
         assert!(resolved.is_err());
     }
 }
+
+#[cfg(test)]
+mod build_filter_tests {
+    use super::build_filter;
+    use crate::cli::CardListArgs;
+    use crate::context::CliContext;
+    use kanban_backend_memory::InMemoryStore;
+    use kanban_core::AppConfig;
+    use kanban_domain::{EntityIds, KanbanError, KanbanOperations};
+    use kanban_service::KanbanContext;
+    use std::sync::Arc;
+
+    fn unplanned_context_with_named_board() -> CliContext {
+        let mut inner =
+            KanbanContext::open_deferred(Arc::new(InMemoryStore::default()), AppConfig::default());
+        inner.create_board("Kanban".to_string(), None).unwrap();
+        CliContext::from_context(inner)
+    }
+
+    fn args_with_board(board: &str) -> CardListArgs {
+        CardListArgs {
+            board: Some(board.to_string()),
+            column: None,
+            sprint: None,
+            status: None,
+            archived: false,
+            include_archived: false,
+            sort: None,
+            order: None,
+            page: None,
+            page_size: None,
+        }
+    }
+
+    #[test]
+    fn test_card_list_with_an_unplanned_board_list_errors_instead_of_reporting_not_found() {
+        let ctx = unplanned_context_with_named_board();
+
+        let result = build_filter(&ctx, &args_with_board("Kanban"));
+
+        let err = match result { Err(e) => e, Ok(_) => panic!("expected an unplanned-tier error") };
+        assert!(err.contains("board list"));
+        assert!(!err.contains("Board not found"));
+        assert!(!err.contains("Kanban"));
+    }
+
+    #[test]
+    fn test_card_list_with_a_failed_board_list_surfaces_the_read_error() {
+        let mut ctx = unplanned_context_with_named_board();
+        let _ = ctx.model_mut().mark_failed(
+            EntityIds::boards([uuid::Uuid::new_v4()]),
+            Arc::new(KanbanError::Database("boom".into())),
+        );
+
+        let result = build_filter(&ctx, &args_with_board("Kanban"));
+
+        let err = match result { Err(e) => e, Ok(_) => panic!("expected the failed-read text to propagate") };
+        assert!(err.contains("boom"));
+    }
+}

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -762,7 +762,10 @@ mod build_filter_tests {
 
         let result = build_filter(&ctx, &args_with_board("Kanban"));
 
-        let err = match result { Err(e) => e, Ok(_) => panic!("expected an unplanned-tier error") };
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected an unplanned-tier error"),
+        };
         assert!(err.contains("board list"));
         assert!(!err.contains("Board not found"));
         assert!(!err.contains("Kanban"));
@@ -778,7 +781,10 @@ mod build_filter_tests {
 
         let result = build_filter(&ctx, &args_with_board("Kanban"));
 
-        let err = match result { Err(e) => e, Ok(_) => panic!("expected the failed-read text to propagate") };
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected the failed-read text to propagate"),
+        };
         assert!(err.contains("boom"));
     }
 }

--- a/crates/kanban-cli/src/lib.rs
+++ b/crates/kanban-cli/src/lib.rs
@@ -10,7 +10,9 @@ pub(crate) mod cli;
 pub(crate) mod context;
 pub(crate) mod error;
 pub(crate) mod handlers;
+pub(crate) mod model_read;
 pub(crate) mod output;
+pub(crate) mod scope;
 
 pub use app::CliApp;
 pub use error::{KanbanCliError, KanbanCliResult};

--- a/crates/kanban-cli/src/model_read.rs
+++ b/crates/kanban-cli/src/model_read.rs
@@ -1,0 +1,12 @@
+use kanban_domain::{KanbanError, KanbanResult, LoadState};
+
+pub(crate) fn require_loaded<'a, T>(state: &'a LoadState<T>, what: &str) -> KanbanResult<&'a T> {
+    match state {
+        LoadState::Loaded(value) => Ok(value),
+        LoadState::NotLoaded => Err(KanbanError::Internal(format!(
+            "{what} was not fetched for this command"
+        ))),
+        LoadState::Missing => Err(KanbanError::Internal(format!("{what} is unavailable"))),
+        LoadState::Failed(e) => Err(KanbanError::Internal(format!("{what}: {e}"))),
+    }
+}

--- a/crates/kanban-cli/src/scope.rs
+++ b/crates/kanban-cli/src/scope.rs
@@ -84,8 +84,12 @@ impl CommandScope {
 }
 
 impl FetchPlan for CommandScope {
-    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
-        FetchRound::default()
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            board_list: matches!(self.board, Some(Ref::Name)) && requestable(loaded.board_list()),
+            graph: self.wants_graph && requestable(loaded.graph()),
+            ..Default::default()
+        }
     }
 }
 
@@ -143,7 +147,9 @@ mod tests {
 
     #[test]
     fn test_command_scope_for_import_requests_nothing() {
-        let cmd = Commands::Import(ImportArgs { file: "x.json".into() });
+        let cmd = Commands::Import(ImportArgs {
+            file: "x.json".into(),
+        });
         let scope = CommandScope::from_command(&cmd);
 
         assert!(scope.next_round(&Model::default()).is_empty());

--- a/crates/kanban-cli/src/scope.rs
+++ b/crates/kanban-cli/src/scope.rs
@@ -1,0 +1,257 @@
+use kanban_service::{requestable, FetchPlan, FetchRound, LoadedEntities};
+use uuid::Uuid;
+
+use crate::cli::{BoardAction, Commands, RelationAction};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Ref {
+    Id,
+    Name,
+}
+
+impl Ref {
+    fn of(raw: &str) -> Self {
+        if Uuid::parse_str(raw).is_ok() {
+            Ref::Id
+        } else {
+            Ref::Name
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct CommandScope {
+    board: Option<Ref>,
+    wants_graph: bool,
+}
+
+impl CommandScope {
+    pub(crate) fn from_command(cmd: &Commands) -> Self {
+        let mut scope = CommandScope::default();
+
+        match cmd {
+            Commands::Board(board_cmd) => match &board_cmd.action {
+                BoardAction::Get { board }
+                | BoardAction::Delete { board }
+                | BoardAction::Archive { board } => scope.board = Some(Ref::of(board)),
+                BoardAction::Update(args) => scope.board = Some(Ref::of(&args.board)),
+                BoardAction::Create { .. }
+                | BoardAction::List { .. }
+                | BoardAction::Restore { .. }
+                | BoardAction::DeleteArchived { .. }
+                | BoardAction::SetSort { .. } => {}
+            },
+            Commands::Column(column_cmd) => match &column_cmd.action {
+                crate::cli::ColumnAction::Create { board, .. }
+                | crate::cli::ColumnAction::List { board, .. } => {
+                    scope.board = Some(Ref::of(board));
+                }
+                _ => {}
+            },
+            Commands::Card(card_cmd) => match &card_cmd.action {
+                crate::cli::CardAction::Create(args) => {
+                    scope.board = Some(Ref::of(&args.board));
+                }
+                crate::cli::CardAction::List(args) => {
+                    scope.board = args.board.as_deref().map(Ref::of);
+                }
+                _ => {}
+            },
+            Commands::Sprint(sprint_cmd) => match &sprint_cmd.action {
+                crate::cli::SprintAction::Create { board, .. }
+                | crate::cli::SprintAction::List { board, .. } => {
+                    scope.board = Some(Ref::of(board));
+                }
+                _ => {}
+            },
+            Commands::Relation(relation_cmd) => match &relation_cmd.action {
+                RelationAction::Parents { .. } | RelationAction::Children { .. } => {
+                    scope.wants_graph = true;
+                }
+                RelationAction::Add { .. } | RelationAction::Remove { .. } => {}
+            },
+            Commands::Export(args) => {
+                scope.board = args.board.as_deref().map(Ref::of);
+            }
+            Commands::Import(_)
+            | Commands::Completions { .. }
+            | Commands::Migrate(_)
+            | Commands::Init { .. } => {}
+        }
+
+        scope
+    }
+}
+
+impl FetchPlan for CommandScope {
+    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{
+        BoardCommand, CardCommand, CardListArgs, ExportArgs, ImportArgs, RelationCommand, SortDir,
+        SortKey,
+    };
+    use kanban_domain::{EntityIds, KanbanError, Model};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_command_scope_from_a_named_board_requests_the_board_list() {
+        let cmd = Commands::Board(BoardCommand {
+            action: BoardAction::Get {
+                board: "Kanban".into(),
+            },
+        });
+        let scope = CommandScope::from_command(&cmd);
+        let round = scope.next_round(&Model::default());
+
+        assert!(round.board_list);
+        assert_eq!(
+            round,
+            FetchRound {
+                board_list: true,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_command_scope_from_a_uuid_board_requests_nothing() {
+        let cmd = Commands::Board(BoardCommand {
+            action: BoardAction::Get {
+                board: Uuid::new_v4().to_string(),
+            },
+        });
+        let scope = CommandScope::from_command(&cmd);
+
+        assert!(scope.next_round(&Model::default()).is_empty());
+    }
+
+    #[test]
+    fn test_command_scope_for_export_with_a_named_board_requests_the_board_list() {
+        let cmd = Commands::Export(ExportArgs {
+            board: Some("Kanban".into()),
+        });
+        let scope = CommandScope::from_command(&cmd);
+
+        assert!(scope.next_round(&Model::default()).board_list);
+    }
+
+    #[test]
+    fn test_command_scope_for_import_requests_nothing() {
+        let cmd = Commands::Import(ImportArgs { file: "x.json".into() });
+        let scope = CommandScope::from_command(&cmd);
+
+        assert!(scope.next_round(&Model::default()).is_empty());
+    }
+
+    #[test]
+    fn test_command_scope_for_relation_children_requests_the_graph() {
+        let cmd = Commands::Relation(RelationCommand {
+            action: RelationAction::Children {
+                card: "KAN-1".into(),
+                sort: SortKey::CardNumber,
+                order: SortDir::Asc,
+            },
+        });
+        let scope = CommandScope::from_command(&cmd);
+        let round = scope.next_round(&Model::default());
+
+        assert!(round.graph);
+        assert!(!round.board_list);
+
+        let add_cmd = Commands::Relation(RelationCommand {
+            action: RelationAction::Add {
+                parent: "KAN-1".into(),
+                children: vec!["KAN-2".into()],
+            },
+        });
+        let add_scope = CommandScope::from_command(&add_cmd);
+        assert!(add_scope.next_round(&Model::default()).is_empty());
+    }
+
+    #[test]
+    fn test_command_scope_stops_requesting_once_the_board_list_is_loaded() {
+        let cmd = Commands::Board(BoardCommand {
+            action: BoardAction::Get {
+                board: "Kanban".into(),
+            },
+        });
+        let scope = CommandScope::from_command(&cmd);
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(kanban_domain::Resolved {
+            boards: kanban_domain::resolved::Collection {
+                all: kanban_domain::LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(scope.next_round(&model).is_empty());
+    }
+
+    #[test]
+    fn test_command_scope_retries_a_failed_board_list() {
+        let cmd = Commands::Board(BoardCommand {
+            action: BoardAction::Get {
+                board: "Kanban".into(),
+            },
+        });
+        let scope = CommandScope::from_command(&cmd);
+
+        let mut model = Model::default();
+        let _ = model.mark_failed(
+            EntityIds::boards([Uuid::new_v4()]),
+            Arc::new(KanbanError::Database("boom".into())),
+        );
+
+        assert!(scope.next_round(&model).board_list);
+    }
+
+    #[test]
+    fn test_command_scope_does_not_request_a_missing_board_list() {
+        let cmd = Commands::Board(BoardCommand {
+            action: BoardAction::Get {
+                board: "Kanban".into(),
+            },
+        });
+        let scope = CommandScope::from_command(&cmd);
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(kanban_domain::Resolved {
+            boards: kanban_domain::resolved::Collection {
+                all: kanban_domain::LoadState::Missing,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(scope.next_round(&model).is_empty());
+    }
+
+    #[test]
+    fn test_command_scope_for_card_list_without_a_board_requests_nothing() {
+        let cmd = Commands::Card(CardCommand {
+            action: crate::cli::CardAction::List(CardListArgs {
+                board: None,
+                column: None,
+                sprint: None,
+                status: None,
+                archived: false,
+                include_archived: false,
+                sort: None,
+                order: None,
+                page: None,
+                page_size: None,
+            }),
+        });
+        let scope = CommandScope::from_command(&cmd);
+
+        assert!(scope.next_round(&Model::default()).is_empty());
+    }
+}

--- a/crates/kanban-cli/tests/cli_sqlite_parity.rs
+++ b/crates/kanban-cli/tests/cli_sqlite_parity.rs
@@ -1,0 +1,107 @@
+use assert_cmd::{cargo_bin_cmd, Command};
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn kanban() -> Command {
+    cargo_bin_cmd!("kanban")
+}
+
+fn kanban_no_config(dir: &std::path::Path) -> Command {
+    let mut cmd = kanban();
+    cmd.current_dir(dir)
+        .env_remove("KANBAN_FILE")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("HOME", dir)
+        .env("KANBAN_CONFIG", dir.join("config.toml"));
+    cmd
+}
+
+fn parse_json(output: &str) -> Value {
+    serde_json::from_str(output).expect("Failed to parse JSON output")
+}
+
+fn seed_graph_and_assert(file: &str, dir: &std::path::Path) -> (Value, Value) {
+    kanban_no_config(dir)
+        .args([file, "init"])
+        .assert()
+        .success();
+    kanban_no_config(dir)
+        .args([file, "board", "create", "--name", "Parity"])
+        .assert()
+        .success();
+    kanban_no_config(dir)
+        .args([
+            file, "column", "create", "--board", "Parity", "--name", "Todo",
+        ])
+        .assert()
+        .success();
+    kanban_no_config(dir)
+        .args([
+            file, "card", "create", "--board", "Parity", "--column", "Todo", "--title", "Parent",
+        ])
+        .assert()
+        .success();
+    kanban_no_config(dir)
+        .args([
+            file, "card", "create", "--board", "Parity", "--column", "Todo", "--title", "Child",
+        ])
+        .assert()
+        .success();
+
+    let cards_output = kanban_no_config(dir)
+        .args([file, "card", "list", "--board", "Parity"])
+        .output()
+        .unwrap();
+    let cards = parse_json(std::str::from_utf8(&cards_output.stdout).unwrap());
+    let cards_list = cards["data"]["items"].as_array().unwrap();
+    let parent_id = cards_list.iter().find(|c| c["title"] == "Parent").unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let child_id = cards_list.iter().find(|c| c["title"] == "Child").unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    kanban_no_config(dir)
+        .args([file, "relation", "add", &parent_id, &child_id])
+        .assert()
+        .success();
+
+    let board_get = kanban_no_config(dir)
+        .args([file, "board", "get", "Parity"])
+        .output()
+        .unwrap();
+    let board_json = parse_json(std::str::from_utf8(&board_get.stdout).unwrap());
+
+    let children = kanban_no_config(dir)
+        .args([file, "relation", "children", &parent_id])
+        .output()
+        .unwrap();
+    let children_json = parse_json(std::str::from_utf8(&children.stdout).unwrap());
+
+    (board_json, children_json)
+}
+
+#[test]
+fn test_board_get_and_relation_children_agree_across_json_and_sqlite_locators() {
+    let json_dir = tempdir().unwrap();
+    let json_file = json_dir.path().join("parity.json");
+    let (json_board, json_children) =
+        seed_graph_and_assert(json_file.to_str().unwrap(), json_dir.path());
+
+    let sqlite_dir = tempdir().unwrap();
+    let sqlite_file = sqlite_dir.path().join("parity.sqlite");
+    let (sqlite_board, sqlite_children) =
+        seed_graph_and_assert(sqlite_file.to_str().unwrap(), sqlite_dir.path());
+
+    assert_eq!(json_board["data"]["name"], sqlite_board["data"]["name"]);
+    assert_eq!(
+        json_board["data"]["card_prefix"],
+        sqlite_board["data"]["card_prefix"]
+    );
+    assert_eq!(
+        json_children["data"].as_array().unwrap().len(),
+        sqlite_children["data"].as_array().unwrap().len()
+    );
+}


### PR DESCRIPTION
## Summary

Makes `kanban-cli` a Controller. A new `pub(crate) CommandScope` (`crates/kanban-cli/src/scope.rs`) folds the parsed `Commands` value into a `kanban_service::FetchPlan`. `CliContext` gains a `kanban_domain::Model` plus the stored scope. `dispatch_subcommand` sets the scope from the command and syncs once before dispatch.

- The `mutate`/`mutate_unit` seam methods now call `KanbanContext::sync_invalidated` instead of `let _ = invalidation;`, so a mutation's returned `Invalidation` is applied into the Model.
- `KanbanOperations::resolve_board_id` and `GraphOperations::list_children_of`/`list_parents_of` are retargeted onto the Model's `board_list` and `graph` tiers, behind a shared `require_loaded` helper (`crates/kanban-cli/src/model_read.rs`). These are the only two read families retargeted: they are the only CLI reads whose backend call is identical to the call `resolve` makes for the tier.
- Adds `crates/kanban-cli/tests/cli_sqlite_parity.rs`, a guard proving `board get` and `relation children` agree across a JSON and a SQLite locator.

## Scope notes / drift from the card

- The card's mapping table assumed `LoadedEntities` could project the loaded board list and that `card get`/`card list` scan by name; neither holds today. Only `resolve_board_id` and the two graph readers are retargeted; `column_list`/`sprint_list`/`card_list` are not, because `fetch_round` fetches those raw while the equivalent service reads filter out archived-board descendants.
- `export --board <name>` was corrected to plan `board_list` (the card's table said it plans nothing).
- `board restore`/`board delete-archived` do not plan `board_list`; they resolve through a private archived-board lookup, not `resolve_board_id`.
- Follow-up work (widening a name-form board scope to `columns_by_board`/`sprints_by_board`, and aligning the flat list tiers with live/archived scoping) needs `kanban-service`/`kanban-domain` changes and is left for a separate card.

## Re-derived counts (at pickup, db2da7fd)

- `_impl(` call sites in `handlers`/`app.rs`: 28
- `let _ = invalidation` before this change: 2 (now 0)
- `self.inner.` occurrences in `context.rs` before this change: 71
- `dyn DataStore` hits in `crates/kanban-cli/src`: still exactly 1 (the test-only `CountingBackend` in `handlers/card.rs`, unrelated to `CliContext`)

The card's "derived tally of 7 reads for card list" was not re-derived: `card list` is not one of the two retargeted read families, and the `FaultInjectingBackend` wrapper used to derive it lives behind a `kanban-service` feature that `kanban-cli`'s dev-dependencies do not enable.

## Test plan

- [x] `cargo test -p kanban-cli` (all 203 tests, including the untouched `cli_integration.rs` suite and the new guard)
- [x] `cargo clippy -p kanban-cli --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Mutation check: broke `resolve_board_id`'s retarget, confirmed both `build_filter` tests fail, restored
