### PR TITLE
KAN-1480 feat(mcp): add ToolScope FetchPlan, a call-scoped Model, and Model-reading resolvers

### DIFF
--- a/.changeset/kan-1480-mcp-tool-scope-and-model-resolvers.md
+++ b/.changeset/kan-1480-mcp-tool-scope-and-model-resolvers.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+mcp: adds `McpContext::model_for`, `sync_into` and `sync_invalidated`, three new public methods for building and refreshing a call-scoped `Model` over the shared `KanbanContext::sync`/`sync_invalidated` seam. No tool body changes; leaves the seven `mcp_resolve_*` shims and every tool untouched.

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -191,6 +191,7 @@ impl McpContext {
     /// it, so the next call starts from `Model::default()` again.
     pub fn model_for(&self, plan: &dyn kanban_service::FetchPlan) -> kanban_domain::Model {
         let mut model = kanban_domain::Model::default();
+        self.sync_into(plan, &mut model);
         model
     }
 
@@ -199,7 +200,8 @@ impl McpContext {
         plan: &dyn kanban_service::FetchPlan,
         model: &mut kanban_domain::Model,
     ) {
-        let _ = (plan, model);
+        self.inner
+            .sync(plan, model, &mut kanban_domain::NoProjections);
     }
 
     pub fn sync_invalidated(
@@ -208,49 +210,8 @@ impl McpContext {
         plan: &dyn kanban_service::FetchPlan,
         model: &mut kanban_domain::Model,
     ) {
-        let _ = (inv, plan, model);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::scope::ToolScope;
-    use kanban_core::AppConfig;
-    use kanban_service::StoreManager;
-
-    fn test_store_manager() -> StoreManager {
-        let mut registry = kanban_persistence::StoreRegistry::new();
-        let mut backends = kanban_backend::KanbanBackendRegistry::new();
-        registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
-        backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
-        registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
-        backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
-        StoreManager::new(registry, backends)
-    }
-
-    #[tokio::test]
-    async fn test_model_for_builds_a_model_and_does_not_retain_it() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let path = dir.path().join("test.json");
-        let store_manager = test_store_manager();
-        let mut ctx = McpContext::new(&store_manager, &path.to_string_lossy(), AppConfig::default())
-            .await
-            .unwrap();
-
-        ctx.create_board("Kanban".into(), Some("KAN".into()))
-            .unwrap();
-
-        let scope = ToolScope {
-            board: Some(crate::scope::Ref::Name),
-            ..Default::default()
-        };
-        let model = ctx.model_for(&scope);
-        assert!(model.boards_state().is_loaded());
-
-        let empty_scope = ToolScope::default();
-        let second_model = ctx.model_for(&empty_scope);
-        assert!(second_model.boards_state().is_not_loaded());
+        self.inner
+            .sync_invalidated(inv, plan, model, &mut kanban_domain::NoProjections);
     }
 }
 
@@ -543,5 +504,51 @@ impl GraphOperations for McpContext {
     }
     fn list_related_to(&self, card: Uuid) -> KanbanResult<Vec<Uuid>> {
         self.inner.list_related_to(card)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scope::ToolScope;
+    use kanban_core::AppConfig;
+    use kanban_service::StoreManager;
+
+    fn test_store_manager() -> StoreManager {
+        let mut registry = kanban_persistence::StoreRegistry::new();
+        let mut backends = kanban_backend::KanbanBackendRegistry::new();
+        registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
+        backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+        registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+        backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+        StoreManager::new(registry, backends)
+    }
+
+    #[tokio::test]
+    async fn test_model_for_builds_a_model_and_does_not_retain_it() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.json");
+        let store_manager = test_store_manager();
+        let mut ctx = McpContext::new(
+            &store_manager,
+            &path.to_string_lossy(),
+            AppConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        ctx.create_board("Kanban".into(), Some("KAN".into()))
+            .unwrap();
+
+        let scope = ToolScope {
+            board: Some(crate::scope::Ref::Name),
+            ..Default::default()
+        };
+        let model = ctx.model_for(&scope);
+        assert!(model.boards_state().is_loaded());
+
+        let empty_scope = ToolScope::default();
+        let second_model = ctx.model_for(&empty_scope);
+        assert!(second_model.boards_state().is_not_loaded());
     }
 }

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -185,6 +185,73 @@ impl McpContext {
         let cards = self.inner.list_cards(filter)?;
         Ok(PaginatedList::paginate(cards, page, page_size)?)
     }
+
+    /// Builds a fresh `Model`, syncs `plan` into it, and hands it back. The
+    /// Model is scoped to a single tool call: nothing on `McpContext` retains
+    /// it, so the next call starts from `Model::default()` again.
+    pub fn model_for(&self, plan: &dyn kanban_service::FetchPlan) -> kanban_domain::Model {
+        let mut model = kanban_domain::Model::default();
+        model
+    }
+
+    pub fn sync_into(
+        &self,
+        plan: &dyn kanban_service::FetchPlan,
+        model: &mut kanban_domain::Model,
+    ) {
+        let _ = (plan, model);
+    }
+
+    pub fn sync_invalidated(
+        &self,
+        inv: kanban_domain::Invalidation,
+        plan: &dyn kanban_service::FetchPlan,
+        model: &mut kanban_domain::Model,
+    ) {
+        let _ = (inv, plan, model);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scope::ToolScope;
+    use kanban_core::AppConfig;
+    use kanban_service::StoreManager;
+
+    fn test_store_manager() -> StoreManager {
+        let mut registry = kanban_persistence::StoreRegistry::new();
+        let mut backends = kanban_backend::KanbanBackendRegistry::new();
+        registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
+        backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+        registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+        backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+        StoreManager::new(registry, backends)
+    }
+
+    #[tokio::test]
+    async fn test_model_for_builds_a_model_and_does_not_retain_it() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.json");
+        let store_manager = test_store_manager();
+        let mut ctx = McpContext::new(&store_manager, &path.to_string_lossy(), AppConfig::default())
+            .await
+            .unwrap();
+
+        ctx.create_board("Kanban".into(), Some("KAN".into()))
+            .unwrap();
+
+        let scope = ToolScope {
+            board: Some(crate::scope::Ref::Name),
+            ..Default::default()
+        };
+        let model = ctx.model_for(&scope);
+        assert!(model.boards_state().is_loaded());
+
+        let empty_scope = ToolScope::default();
+        let second_model = ctx.model_for(&empty_scope);
+        assert!(second_model.boards_state().is_not_loaded());
+    }
 }
 
 impl KanbanOperations for McpContext {

--- a/crates/kanban-mcp/src/helpers/mod.rs
+++ b/crates/kanban-mcp/src/helpers/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod error_mapping;
 pub(crate) mod macros;
+pub(crate) mod model_read;
 pub(crate) mod parsers;
 pub(crate) mod resolvers;
 pub(crate) mod serialization;

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -1,0 +1,334 @@
+#![allow(dead_code)]
+
+use crate::helpers::error_mapping::kanban_err_to_mcp;
+use kanban_domain::{KanbanError, LoadState, Model};
+use rmcp::model::ErrorData as McpError;
+use uuid::Uuid;
+
+pub(crate) fn require_loaded<T>(state: LoadState<T>, what: &str) -> Result<T, McpError> {
+    match state {
+        LoadState::Loaded(value) => Ok(value),
+        LoadState::NotLoaded => Err(kanban_err_to_mcp(KanbanError::Internal(format!(
+            "{what} was not fetched for this tool call"
+        )))),
+        LoadState::Missing => Err(kanban_err_to_mcp(KanbanError::Internal(format!(
+            "{what} is unavailable"
+        )))),
+        LoadState::Failed(e) => Err(kanban_err_to_mcp(KanbanError::Internal(format!(
+            "{what}: {e}"
+        )))),
+    }
+}
+
+pub(crate) fn resolve_board(model: &Model, raw: &str) -> Result<Uuid, McpError> {
+    let _ = model;
+    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+        "Board",
+        raw,
+        Vec::new(),
+    )))
+}
+
+pub(crate) fn resolve_column_in_board(
+    model: &Model,
+    raw: &str,
+    board_id: Uuid,
+) -> Result<Uuid, McpError> {
+    let _ = (model, board_id);
+    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+        "Column",
+        raw,
+        Vec::new(),
+    )))
+}
+
+pub(crate) fn resolve_column_global(model: &Model, raw: &str) -> Result<Uuid, McpError> {
+    let _ = model;
+    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+        "Column",
+        raw,
+        Vec::new(),
+    )))
+}
+
+pub(crate) fn resolve_sprint_in_board(
+    model: &Model,
+    raw: &str,
+    board_id: Uuid,
+) -> Result<Uuid, McpError> {
+    let _ = (model, board_id);
+    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+        "Sprint",
+        raw,
+        Vec::new(),
+    )))
+}
+
+pub(crate) fn resolve_sprint_global(model: &Model, raw: &str) -> Result<Uuid, McpError> {
+    let _ = model;
+    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+        "Sprint",
+        raw,
+        Vec::new(),
+    )))
+}
+
+pub(crate) fn resolve_card(model: &Model, raw: &str) -> Result<Uuid, McpError> {
+    let _ = model;
+    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+        "Card",
+        raw,
+        Vec::new(),
+    )))
+}
+
+pub(crate) fn resolve_cards(model: &Model, raws: &[String]) -> Result<Vec<Uuid>, McpError> {
+    let _ = model;
+    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+        "Card",
+        raws.first().map(String::as_str).unwrap_or(""),
+        Vec::new(),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::{resolved::Collection, Board, Card, Column, EntityIds, KanbanError, Resolved, Sprint};
+    use std::sync::Arc;
+
+    fn loaded_boards(boards: Vec<Board>) -> Model {
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(boards),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        model
+    }
+
+    #[test]
+    fn test_a_not_loaded_board_list_errors_instead_of_reporting_not_found() {
+        let err = resolve_board(&Model::default(), "Kanban").unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("board list"));
+        assert!(!err.message.contains("not found"));
+    }
+
+    #[test]
+    fn test_a_failed_board_list_errors_naming_the_collection() {
+        let mut model = Model::default();
+        let _ = model.mark_failed(
+            EntityIds::boards([Uuid::new_v4()]),
+            Arc::new(KanbanError::Database("boom".into())),
+        );
+
+        let err = resolve_board(&model, "Kanban").unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("board list"));
+        assert!(err.message.contains("boom"));
+
+        let not_loaded_err = resolve_board(&Model::default(), "Kanban").unwrap_err();
+        assert_ne!(err.message, not_loaded_err.message);
+    }
+
+    #[test]
+    fn test_resolve_board_by_name_from_the_model_returns_its_id() {
+        let board = Board::new("Kanban", None::<String>);
+        let board_id = board.id;
+        let model = loaded_boards(vec![board]);
+
+        assert_eq!(resolve_board(&model, "Kanban").unwrap(), board_id);
+
+        let uuid_raw = Uuid::new_v4().to_string();
+        assert_eq!(
+            resolve_board(&Model::default(), &uuid_raw).unwrap(),
+            Uuid::parse_str(&uuid_raw).unwrap()
+        );
+
+        assert!(resolve_board(&model, "Nope").is_err());
+
+        let dup_model = loaded_boards(vec![
+            Board::new("Kanban", None::<String>),
+            Board::new("Kanban", None::<String>),
+        ]);
+        assert!(resolve_board(&dup_model, "Kanban").is_err());
+    }
+
+    #[test]
+    fn test_resolve_column_in_board_reads_the_parent_scoped_tier() {
+        let board_id = Uuid::new_v4();
+        let column = Column::new(board_id, "TODO", 0);
+        let column_id = column.id;
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: [(board_id, LoadState::Loaded(vec![column]))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            resolve_column_in_board(&model, "TODO", board_id).unwrap(),
+            column_id
+        );
+
+        let err = resolve_column_in_board(&Model::default(), "TODO", board_id).unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(!err.message.contains("not found"));
+    }
+
+    #[test]
+    fn test_resolve_column_global_reads_the_flat_tier() {
+        let board_id = Uuid::new_v4();
+        let column = Column::new(board_id, "TODO", 0);
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            columns: Collection {
+                all: LoadState::Loaded(vec![column]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(resolve_column_global(&model, "TODO").is_ok());
+
+        let err = resolve_column_global(&Model::default(), "TODO").unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("column list"));
+
+        let board_a = Uuid::new_v4();
+        let board_b = Uuid::new_v4();
+        let mut dup_model = Model::default();
+        let _ = dup_model.apply_resolved(Resolved {
+            columns: Collection {
+                all: LoadState::Loaded(vec![
+                    Column::new(board_a, "TODO", 0),
+                    Column::new(board_b, "TODO", 0),
+                ]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        assert!(resolve_column_global(&dup_model, "TODO").is_err());
+    }
+
+    #[test]
+    fn test_resolve_sprint_in_board_reads_the_scoped_tier_and_the_board() {
+        let board = Board::new("Kanban", None::<String>);
+        let board_id = board.id;
+        let sprint = Sprint::new(board_id, 1, None, None::<String>);
+        let sprint_id = sprint.id;
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board]),
+                ..Default::default()
+            },
+            sprints: Collection {
+                by_parent: [(board_id, LoadState::Loaded(vec![sprint]))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            resolve_sprint_in_board(&model, "1", board_id).unwrap(),
+            sprint_id
+        );
+
+        let err =
+            resolve_sprint_in_board(&Model::default(), "1", board_id).unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(!err.message.contains("not found"));
+    }
+
+    #[test]
+    fn test_resolve_sprint_global_reads_the_flat_sprint_and_board_tiers() {
+        let board = Board::new("Kanban", None::<String>);
+        let board_id = board.id;
+        let sprint = Sprint::new(board_id, 1, None, None::<String>);
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board]),
+                ..Default::default()
+            },
+            sprints: Collection {
+                all: LoadState::Loaded(vec![sprint]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(resolve_sprint_global(&model, "1").is_ok());
+
+        let err = resolve_sprint_global(&Model::default(), "1").unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn test_resolve_card_by_identifier_reads_the_card_list() {
+        let mut card = Card::new(Uuid::new_v4(), Uuid::new_v4(), "Title", 0);
+        card.prefix = "KAN".into();
+        card.card_number = 5;
+        let card_id = card.id;
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![card]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(resolve_card(&model, "KAN-5").unwrap(), card_id);
+        assert_eq!(resolve_card(&model, "5").unwrap(), card_id);
+
+        let err = resolve_card(&Model::default(), "KAN-5").unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("card list"));
+
+        assert!(resolve_card(&model, "KAN-999").is_err());
+    }
+
+    #[test]
+    fn test_resolve_cards_reports_per_input_failures_and_distinguishes_an_unloaded_tier() {
+        let mut card = Card::new(Uuid::new_v4(), Uuid::new_v4(), "Title", 0);
+        card.prefix = "KAN".into();
+        card.card_number = 5;
+        let card_id = card.id;
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![card]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let ids = resolve_cards(&model, &["KAN-5".to_string(), "KAN-999".to_string()]);
+        assert!(ids.is_err());
+        let err = ids.unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("KAN-999"));
+        let _ = card_id;
+
+        let unloaded_err = resolve_cards(
+            &Model::default(),
+            &["KAN-5".to_string(), "KAN-999".to_string()],
+        )
+        .unwrap_err();
+        assert_eq!(unloaded_err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(unloaded_err.message.contains("card list"));
+    }
+}

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -1,7 +1,11 @@
 #![allow(dead_code)]
 
 use crate::helpers::error_mapping::kanban_err_to_mcp;
-use kanban_domain::{KanbanError, LoadState, Model};
+use kanban_domain::{
+    find_boards_by_name, find_columns_by_name, find_sprints_by_query_global,
+    find_sprints_by_query_on_board, parse_identifier, AmbiguousMatch, BatchResolutionCause,
+    BatchResolutionFailure, KanbanError, LoadState, Model, ParsedIdentifier, Prefix,
+};
 use rmcp::model::ErrorData as McpError;
 use uuid::Uuid;
 
@@ -21,12 +25,29 @@ pub(crate) fn require_loaded<T>(state: LoadState<T>, what: &str) -> Result<T, Mc
 }
 
 pub(crate) fn resolve_board(model: &Model, raw: &str) -> Result<Uuid, McpError> {
-    let _ = model;
-    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
-        "Board",
-        raw,
-        Vec::new(),
-    )))
+    if let Ok(uuid) = Uuid::parse_str(raw) {
+        return Ok(uuid);
+    }
+    let boards = require_loaded(model.boards_state().as_ref(), "board list")?;
+    let matches = find_boards_by_name(raw, boards);
+    match matches.as_slice() {
+        [] => Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+            "Board",
+            raw,
+            boards.iter().map(|b| b.name.clone()).collect(),
+        ))),
+        [b] => Ok(b.id),
+        many => Err(kanban_err_to_mcp(KanbanError::ambiguous(
+            "Board",
+            raw,
+            many.iter()
+                .map(|b| AmbiguousMatch {
+                    label: format!("'{}'", b.name),
+                    id: b.id,
+                })
+                .collect(),
+        ))),
+    }
 }
 
 pub(crate) fn resolve_column_in_board(
@@ -34,21 +55,64 @@ pub(crate) fn resolve_column_in_board(
     raw: &str,
     board_id: Uuid,
 ) -> Result<Uuid, McpError> {
-    let _ = (model, board_id);
-    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
-        "Column",
-        raw,
-        Vec::new(),
-    )))
+    if let Ok(uuid) = Uuid::parse_str(raw) {
+        return Ok(uuid);
+    }
+    let columns = require_loaded(model.board_columns_state(board_id), "columns of the board")?;
+    let matches = find_columns_by_name(raw, columns);
+    match matches.as_slice() {
+        [] => Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+            "Column",
+            raw,
+            columns.iter().map(|c| c.name.clone()).collect(),
+        ))),
+        [c] => Ok(c.id),
+        many => Err(kanban_err_to_mcp(KanbanError::ambiguous(
+            "Column",
+            raw,
+            many.iter()
+                .map(|c| AmbiguousMatch {
+                    label: format!("'{}'", c.name),
+                    id: c.id,
+                })
+                .collect(),
+        ))),
+    }
 }
 
 pub(crate) fn resolve_column_global(model: &Model, raw: &str) -> Result<Uuid, McpError> {
-    let _ = model;
-    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
-        "Column",
-        raw,
-        Vec::new(),
-    )))
+    if let Ok(uuid) = Uuid::parse_str(raw) {
+        return Ok(uuid);
+    }
+    let columns = require_loaded(model.columns_state().as_ref(), "column list")?;
+    let matches = find_columns_by_name(raw, columns);
+    match matches.as_slice() {
+        [] => Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+            "Column",
+            raw,
+            columns.iter().map(|c| c.name.clone()).collect(),
+        ))),
+        [c] => Ok(c.id),
+        many => {
+            let boards = model.boards_state().loaded();
+            let matches: Vec<AmbiguousMatch> = many
+                .iter()
+                .map(|c| {
+                    let board_name = boards
+                        .and_then(|bs| bs.iter().find(|b| b.id == c.board_id))
+                        .map(|b| b.name.as_str())
+                        .unwrap_or("(unknown)");
+                    AmbiguousMatch {
+                        label: format!("on board '{}'", board_name),
+                        id: c.id,
+                    }
+                })
+                .collect();
+            Err(kanban_err_to_mcp(KanbanError::ambiguous(
+                "Column", raw, matches,
+            )))
+        }
+    }
 }
 
 pub(crate) fn resolve_sprint_in_board(
@@ -56,45 +120,176 @@ pub(crate) fn resolve_sprint_in_board(
     raw: &str,
     board_id: Uuid,
 ) -> Result<Uuid, McpError> {
-    let _ = (model, board_id);
-    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
-        "Sprint",
-        raw,
-        Vec::new(),
-    )))
+    if let Ok(uuid) = Uuid::parse_str(raw) {
+        return Ok(uuid);
+    }
+    let sprints = require_loaded(model.board_sprints_state(board_id), "sprints of the board")?;
+    let board = require_loaded(model.board_by_id_state(board_id), "board")?;
+    let matches = find_sprints_by_query_on_board(raw, sprints, board);
+    match matches.as_slice() {
+        [] => {
+            let available = sprints
+                .iter()
+                .map(|s| {
+                    let label = s.get_name(board).unwrap_or("(unnamed)");
+                    format!("#{} {}", s.sprint_number, label)
+                })
+                .collect();
+            Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+                "Sprint", raw, available,
+            )))
+        }
+        [s] => Ok(s.id),
+        many => Err(kanban_err_to_mcp(KanbanError::ambiguous(
+            "Sprint",
+            raw,
+            many.iter()
+                .map(|s| {
+                    let name = s.get_name(board).unwrap_or("(unnamed)");
+                    AmbiguousMatch {
+                        label: format!("#{} '{}'", s.sprint_number, name),
+                        id: s.id,
+                    }
+                })
+                .collect(),
+        ))),
+    }
 }
 
 pub(crate) fn resolve_sprint_global(model: &Model, raw: &str) -> Result<Uuid, McpError> {
-    let _ = model;
-    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
-        "Sprint",
-        raw,
-        Vec::new(),
-    )))
+    if let Ok(uuid) = Uuid::parse_str(raw) {
+        return Ok(uuid);
+    }
+    let all_sprints = require_loaded(model.sprints_state().as_ref(), "sprint list")?;
+    let boards = require_loaded(model.boards_state().as_ref(), "board list")?;
+    let matches = find_sprints_by_query_global(raw, all_sprints, boards);
+    match matches.as_slice() {
+        [] => {
+            let available = all_sprints
+                .iter()
+                .map(|s| {
+                    let label = boards
+                        .iter()
+                        .find(|b| b.id == s.board_id)
+                        .and_then(|b| s.get_name(b))
+                        .unwrap_or("(unnamed)");
+                    format!("#{} {}", s.sprint_number, label)
+                })
+                .collect();
+            Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+                "Sprint", raw, available,
+            )))
+        }
+        [s] => Ok(s.id),
+        many => {
+            let matches: Vec<AmbiguousMatch> = many
+                .iter()
+                .map(|s| {
+                    let board = boards.iter().find(|b| b.id == s.board_id);
+                    let board_name = board.map(|b| b.name.as_str()).unwrap_or("(unknown)");
+                    let sprint_name = board.and_then(|b| s.get_name(b)).unwrap_or("(unnamed)");
+                    AmbiguousMatch {
+                        label: format!(
+                            "#{} '{}' on board '{}'",
+                            s.sprint_number, sprint_name, board_name
+                        ),
+                        id: s.id,
+                    }
+                })
+                .collect();
+            Err(kanban_err_to_mcp(KanbanError::ambiguous(
+                "Sprint", raw, matches,
+            )))
+        }
+    }
+}
+
+fn find_card_matches<'a>(
+    cards: &'a [kanban_domain::Card],
+    raw: &str,
+) -> Vec<&'a kanban_domain::Card> {
+    match parse_identifier(raw) {
+        Some(ParsedIdentifier::PrefixAndNumber { prefix, number }) => cards
+            .iter()
+            .filter(|c| c.card_number == number && Prefix::normalize(&c.prefix) == prefix)
+            .collect(),
+        Some(ParsedIdentifier::NumberOnly(number)) => {
+            cards.iter().filter(|c| c.card_number == number).collect()
+        }
+        None => Vec::new(),
+    }
 }
 
 pub(crate) fn resolve_card(model: &Model, raw: &str) -> Result<Uuid, McpError> {
-    let _ = model;
-    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
-        "Card",
-        raw,
-        Vec::new(),
-    )))
+    if let Ok(uuid) = Uuid::parse_str(raw) {
+        return Ok(uuid);
+    }
+    let cards = require_loaded(model.cards_state().as_ref(), "card list")?;
+    let matches = find_card_matches(cards, raw);
+    match matches.as_slice() {
+        [] => Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
+            "Card",
+            raw,
+            Vec::new(),
+        ))),
+        [c] => Ok(c.id),
+        many => Err(kanban_err_to_mcp(KanbanError::ambiguous(
+            "Card",
+            raw,
+            many.iter()
+                .map(|c| AmbiguousMatch {
+                    label: format!("'{}'", c.title),
+                    id: c.id,
+                })
+                .collect(),
+        ))),
+    }
 }
 
 pub(crate) fn resolve_cards(model: &Model, raws: &[String]) -> Result<Vec<Uuid>, McpError> {
-    let _ = model;
-    Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
-        "Card",
-        raws.first().map(String::as_str).unwrap_or(""),
-        Vec::new(),
-    )))
+    let cards = require_loaded(model.cards_state().as_ref(), "card list")?;
+
+    let mut resolved = Vec::with_capacity(raws.len());
+    let mut failures = Vec::new();
+    for raw in raws {
+        if let Ok(uuid) = Uuid::parse_str(raw) {
+            resolved.push(uuid);
+            continue;
+        }
+        let matches = find_card_matches(cards, raw);
+        match matches.as_slice() {
+            [] => failures.push(BatchResolutionFailure {
+                raw_input: raw.clone(),
+                cause: BatchResolutionCause::NotFound,
+            }),
+            [c] => resolved.push(c.id),
+            many => failures.push(BatchResolutionFailure {
+                raw_input: raw.clone(),
+                cause: BatchResolutionCause::Ambiguous(
+                    many.iter()
+                        .map(|c| AmbiguousMatch {
+                            label: format!("'{}'", c.title),
+                            id: c.id,
+                        })
+                        .collect(),
+                ),
+            }),
+        }
+    }
+    if !failures.is_empty() {
+        return Err(kanban_err_to_mcp(KanbanError::batch_resolution_failed(
+            "Card", failures,
+        )));
+    }
+    Ok(resolved)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kanban_domain::{resolved::Collection, Board, Card, Column, EntityIds, KanbanError, Resolved, Sprint};
+    use kanban_domain::{
+        resolved::Collection, Board, Card, Column, EntityIds, KanbanError, Resolved, Sprint,
+    };
     use std::sync::Arc;
 
     fn loaded_boards(boards: Vec<Board>) -> Model {
@@ -243,8 +438,7 @@ mod tests {
             sprint_id
         );
 
-        let err =
-            resolve_sprint_in_board(&Model::default(), "1", board_id).unwrap_err();
+        let err = resolve_sprint_in_board(&Model::default(), "1", board_id).unwrap_err();
         assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
         assert!(!err.message.contains("not found"));
     }

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -4,6 +4,7 @@ pub mod server;
 
 pub(crate) mod helpers;
 pub mod requests;
+pub(crate) mod scope;
 pub(crate) mod tools;
 
 pub use error::{KanbanMcpError, KanbanMcpResult};

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -1,0 +1,198 @@
+#![allow(dead_code)]
+
+use kanban_service::{requestable, FetchPlan, FetchRound, LoadedEntities};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Ref {
+    Id,
+    Name,
+}
+
+impl Ref {
+    pub(crate) fn of(raw: &str) -> Self {
+        if Uuid::parse_str(raw).is_ok() {
+            Ref::Id
+        } else {
+            Ref::Name
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ToolScope {
+    pub(crate) board: Option<Ref>,
+    pub(crate) column: Option<Ref>,
+    pub(crate) sprint: Option<Ref>,
+    pub(crate) cards: Vec<Ref>,
+    pub(crate) wants_graph: bool,
+    /// Some tools render the board entity itself (not just resolve it by
+    /// name), so even a uuid reference still needs the board list loaded.
+    pub(crate) renders_board_entity: bool,
+}
+
+pub(crate) trait ToolScoped {
+    fn scope(&self) -> ToolScope;
+}
+
+impl FetchPlan for ToolScope {
+    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::{EntityIds, KanbanError, LoadState, Model, Resolved};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_tool_scope_from_named_board_requests_the_board_list() {
+        let scope = ToolScope {
+            board: Some(Ref::Name),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            scope.next_round(&Model::default()),
+            FetchRound {
+                board_list: true,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_tool_scope_from_uuid_board_requests_no_board_tier() {
+        let scope = ToolScope {
+            board: Some(Ref::Id),
+            ..Default::default()
+        };
+
+        assert!(scope.next_round(&Model::default()).is_empty());
+        assert_eq!(Ref::of(&Uuid::new_v4().to_string()), Ref::Id);
+        assert_eq!(Ref::of("Kanban"), Ref::Name);
+    }
+
+    #[test]
+    fn test_tool_scope_from_uuid_card_requests_no_card_tier() {
+        let scope = ToolScope {
+            cards: vec![Ref::Id],
+            ..Default::default()
+        };
+        let round = scope.next_round(&Model::default());
+
+        assert!(!round.card_list);
+        assert!(round.cards.is_empty());
+        assert!(round.is_empty());
+
+        let named_scope = ToolScope {
+            cards: vec![Ref::Name],
+            ..Default::default()
+        };
+        assert!(named_scope.next_round(&Model::default()).card_list);
+    }
+
+    #[test]
+    fn test_tool_scope_for_get_board_requests_the_board_list_even_for_a_uuid() {
+        let scope = ToolScope {
+            board: Some(Ref::Id),
+            renders_board_entity: true,
+            ..Default::default()
+        };
+        assert!(scope.next_round(&Model::default()).board_list);
+
+        let non_rendering_scope = ToolScope {
+            board: Some(Ref::Id),
+            renders_board_entity: false,
+            ..Default::default()
+        };
+        assert!(non_rendering_scope.next_round(&Model::default()).is_empty());
+    }
+
+    #[test]
+    fn test_tool_scope_stops_requesting_once_everything_is_loaded() {
+        let scope = ToolScope {
+            board: Some(Ref::Name),
+            column: Some(Ref::Name),
+            sprint: Some(Ref::Name),
+            cards: vec![Ref::Name],
+            wants_graph: true,
+            renders_board_entity: false,
+        };
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: kanban_domain::resolved::Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            columns: kanban_domain::resolved::Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            cards: kanban_domain::resolved::Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            sprints: kanban_domain::resolved::Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            graph: LoadState::Loaded(Default::default()),
+            ..Default::default()
+        });
+
+        assert!(scope.next_round(&model).is_empty());
+    }
+
+    #[test]
+    fn test_tool_scope_retries_a_failed_tier_but_not_a_missing_one() {
+        let scope = ToolScope {
+            board: Some(Ref::Name),
+            ..Default::default()
+        };
+
+        let mut failed_model = Model::default();
+        let _ = failed_model.mark_failed(
+            EntityIds::boards([Uuid::new_v4()]),
+            Arc::new(KanbanError::Database("boom".into())),
+        );
+        assert!(scope.next_round(&failed_model).board_list);
+
+        let mut missing_model = Model::default();
+        let _ = missing_model.apply_resolved(Resolved {
+            boards: kanban_domain::resolved::Collection {
+                all: LoadState::Missing,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        assert!(scope.next_round(&missing_model).is_empty());
+    }
+
+    /// Mirrors crates/kanban-cli/src/scope.rs:86-95: a `Some(Ref::Name)`
+    /// board reference requests exactly `board_list`, and a `Some(Ref::Id)`
+    /// one requests nothing.
+    #[test]
+    fn test_tool_scope_matches_command_scope_for_the_same_reference_shape() {
+        let named = ToolScope {
+            board: Some(Ref::Name),
+            ..Default::default()
+        };
+        assert_eq!(
+            named.next_round(&Model::default()),
+            FetchRound {
+                board_list: true,
+                ..Default::default()
+            }
+        );
+
+        let by_id = ToolScope {
+            board: Some(Ref::Id),
+            ..Default::default()
+        };
+        assert!(by_id.next_round(&Model::default()).is_empty());
+    }
+}

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -36,8 +36,20 @@ pub(crate) trait ToolScoped {
 }
 
 impl FetchPlan for ToolScope {
-    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
-        FetchRound::default()
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        let wants_board_list = matches!(self.board, Some(Ref::Name))
+            || (self.renders_board_entity && self.board.is_some());
+        FetchRound {
+            board_list: wants_board_list && requestable(loaded.board_list()),
+            column_list: matches!(self.column, Some(Ref::Name))
+                && requestable(loaded.column_list()),
+            card_list: self.cards.iter().any(|r| matches!(r, Ref::Name))
+                && requestable(loaded.card_list()),
+            sprint_list: matches!(self.sprint, Some(Ref::Name))
+                && requestable(loaded.sprint_list()),
+            graph: self.wants_graph && requestable(loaded.graph()),
+            ..Default::default()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the MCP Controller mechanism without touching a single tool body:

- `crates/kanban-mcp/src/scope.rs` (new): fieldless `Ref { Id, Name }`, a `ToolScope` implementing `kanban_service::FetchPlan`, and a `ToolScoped` trait with no implementors yet.
- `McpContext` gains three `&self` methods threading `NoProjections` into `KanbanContext::sync`/`sync_invalidated`: `model_for` (builds and syncs a fresh `Model`, does not retain it), `sync_into`, `sync_invalidated`.
- `crates/kanban-mcp/src/helpers/model_read.rs` (new): `require_loaded` plus seven Model-reading counterparts to the existing `mcp_resolve_*` shims (`resolve_board`, `resolve_column_in_board`, `resolve_column_global`, `resolve_sprint_in_board`, `resolve_sprint_global`, `resolve_card`, `resolve_cards`). These turn a `NotLoaded`/`Missing`/`Failed` tier into an INTERNAL_ERROR naming the collection instead of an INVALID_PARAMS "not found" answer to an LLM.

The seven existing `mcp_resolve_*` shims and all 43 in-scope tool bodies are untouched; leaves KAN-1481..1485 consume this.

## Deviations from the card

- `ToolScope::Ref` is fieldless per AC #7, so it can never populate a uuid-keyed `FetchRound` tier. Renamed `test_tool_scope_from_uuid_card_requests_only_the_per_id_tier` to `test_tool_scope_from_uuid_card_requests_no_card_tier` to match what the code actually does.
- `test_tool_scope_matches_command_scope_for_the_same_reference_shape` cannot import `kanban-cli`'s `CommandScope` across the crate boundary; it instead asserts the literal `FetchRound` values the CLI's mapping produces, with a doc comment pointing at the mirrored code.
- The Model-reading resolvers live in a new `helpers/model_read.rs`, mirroring `crates/kanban-cli/src/model_read.rs`, rather than being folded into `helpers/resolvers.rs`.
- `#![allow(dead_code)]` is on both new module files: every new item is `pub(crate)` with zero production callers until KAN-1481/1485 wire them in, so `-D warnings` would otherwise fail the non-test lib build.
- Both new `McpContext` methods add `pub fn` API to a crate that publishes to crates.io, so the changeset bump is `minor`, not the `patch` a sibling card in this epic used.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p kanban-mcp --all-targets --all-features -- -D warnings`
- `cargo test -p kanban-mcp --all-features` (57 lib tests including the 15 red-then-green tests, plus the existing integration suites)
- Mutation check: reverted `board_list`'s mapping to `false` in `next_round`, confirmed 4 scope tests failed, then restored.

No tool bodies, tests directory, or Cargo.toml files were touched.
