### PR TITLE
KAN-1486 fix(mcp): ToolScope requests the by-parent tiers once a board id is known

### DIFF
--- a/.changeset/kan-1486-tool-scope-by-parent-second-round.md
+++ b/.changeset/kan-1486-tool-scope-by-parent-second-round.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+mcp: `ToolScope` gains `resolved_board`, `wants_board_columns`, `wants_board_sprints` and a `for_board` builder so a second sync round can request `columns_by_board`/`sprints_by_board` once a board reference is resolved, fixing `resolve_column_in_board` and `resolve_sprint_in_board` so they actually resolve a name reference. No public API added; `scope` stays `pub(crate)`.

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -551,4 +551,50 @@ mod tests {
         let second_model = ctx.model_for(&empty_scope);
         assert!(second_model.boards_state().is_not_loaded());
     }
+
+    #[tokio::test]
+    async fn test_a_named_column_resolves_end_to_end_after_the_second_round() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.json");
+        let store_manager = test_store_manager();
+        let mut ctx = McpContext::new(
+            &store_manager,
+            &path.to_string_lossy(),
+            AppConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        let board = ctx
+            .create_board("Kanban".into(), Some("KAN".into()))
+            .unwrap();
+        let column = ctx.create_column(board.id, "TODO".into(), None).unwrap();
+        let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+
+        let scope = ToolScope {
+            board: Some(crate::scope::Ref::Name),
+            column: Some(crate::scope::Ref::Name),
+            sprint: Some(crate::scope::Ref::Name),
+            wants_board_columns: true,
+            wants_board_sprints: true,
+            ..Default::default()
+        };
+        let mut model = ctx.model_for(&scope);
+        let board_id = crate::helpers::model_read::resolve_board(&model, "Kanban").unwrap();
+        ctx.sync_into(&scope.for_board(board_id), &mut model);
+
+        assert_eq!(
+            crate::helpers::model_read::resolve_column_in_board(&model, "TODO", board_id).unwrap(),
+            column.id
+        );
+        assert_eq!(
+            crate::helpers::model_read::resolve_sprint_in_board(
+                &model,
+                &sprint.sprint_number.to_string(),
+                board_id
+            )
+            .unwrap(),
+            sprint.id
+        );
+    }
 }

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -124,6 +124,138 @@ mod tests {
     }
 
     #[test]
+    fn test_a_named_column_in_board_resolves_after_a_second_round() {
+        let scope = ToolScope {
+            board: Some(Ref::Name),
+            column: Some(Ref::Name),
+            wants_board_columns: true,
+            ..Default::default()
+        };
+
+        let round1 = scope.next_round(&Model::default());
+        assert!(round1.board_list);
+        assert!(round1.columns_by_board.is_empty());
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: kanban_domain::resolved::Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let board_id = Uuid::new_v4();
+        let round = scope.for_board(board_id).next_round(&model);
+        assert_eq!(round.columns_by_board, vec![board_id]);
+        assert!(!round.column_list);
+        assert!(!round.board_list);
+    }
+
+    #[test]
+    fn test_a_named_sprint_in_board_resolves_after_a_second_round() {
+        let scope = ToolScope {
+            board: Some(Ref::Id),
+            sprint: Some(Ref::Name),
+            wants_board_sprints: true,
+            ..Default::default()
+        };
+
+        let board_id = Uuid::new_v4();
+        let round = scope.for_board(board_id).next_round(&Model::default());
+        assert_eq!(round.sprints_by_board, vec![board_id]);
+        assert!(!round.sprint_list);
+        assert!(round.board_list);
+    }
+
+    #[test]
+    fn test_tool_scope_stops_requesting_once_the_by_parent_tiers_are_loaded() {
+        let board_id = Uuid::new_v4();
+        let scope = ToolScope {
+            board: Some(Ref::Name),
+            column: Some(Ref::Name),
+            sprint: Some(Ref::Name),
+            wants_board_columns: true,
+            wants_board_sprints: true,
+            ..Default::default()
+        }
+        .for_board(board_id);
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: kanban_domain::resolved::Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            columns: kanban_domain::resolved::Collection {
+                by_parent: [(board_id, LoadState::Loaded(vec![]))].into(),
+                ..Default::default()
+            },
+            sprints: kanban_domain::resolved::Collection {
+                by_parent: [(board_id, LoadState::Loaded(vec![]))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(scope.next_round(&model).is_empty());
+    }
+
+    #[test]
+    fn test_a_by_parent_tier_is_not_requested_when_the_tool_does_not_want_it() {
+        let board_id = Uuid::new_v4();
+        let scope = ToolScope {
+            board: Some(Ref::Id),
+            column: Some(Ref::Name),
+            ..Default::default()
+        }
+        .for_board(board_id);
+
+        let round = scope.next_round(&Model::default());
+        assert!(round.columns_by_board.is_empty());
+        assert!(round.column_list);
+    }
+
+    #[test]
+    fn test_by_parent_tiers_are_not_requested_before_the_board_is_resolved() {
+        let scope = ToolScope {
+            board: Some(Ref::Name),
+            column: Some(Ref::Name),
+            wants_board_columns: true,
+            wants_board_sprints: true,
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&Model::default());
+        assert!(round.columns_by_board.is_empty());
+        assert!(round.sprints_by_board.is_empty());
+        assert!(round.board_list);
+    }
+
+    #[test]
+    fn test_a_wanted_by_parent_tier_suppresses_its_flat_tier() {
+        let scope = ToolScope {
+            column: Some(Ref::Name),
+            sprint: Some(Ref::Name),
+            wants_board_columns: true,
+            wants_board_sprints: true,
+            ..Default::default()
+        };
+        let round = scope.next_round(&Model::default());
+        assert!(!round.column_list);
+        assert!(!round.sprint_list);
+
+        let control = ToolScope {
+            column: Some(Ref::Name),
+            sprint: Some(Ref::Name),
+            ..Default::default()
+        };
+        let control_round = control.next_round(&Model::default());
+        assert!(control_round.column_list);
+        assert!(control_round.sprint_list);
+    }
+
+    #[test]
     fn test_tool_scope_stops_requesting_once_everything_is_loaded() {
         let scope = ToolScope {
             board: Some(Ref::Name),
@@ -132,6 +264,9 @@ mod tests {
             cards: vec![Ref::Name],
             wants_graph: true,
             renders_board_entity: false,
+            resolved_board: None,
+            wants_board_columns: false,
+            wants_board_sprints: false,
         };
 
         let mut model = Model::default();

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -29,6 +29,20 @@ pub(crate) struct ToolScope {
     /// Some tools render the board entity itself (not just resolve it by
     /// name), so even a uuid reference still needs the board list loaded.
     pub(crate) renders_board_entity: bool,
+    /// Set once a board reference has been resolved to an id; the
+    /// parent-scoped tiers cannot be requested before it is known.
+    pub(crate) resolved_board: Option<Uuid>,
+    /// Requests the board's columns independently of how, or whether, a
+    /// column reference is written.
+    pub(crate) wants_board_columns: bool,
+    pub(crate) wants_board_sprints: bool,
+}
+
+impl ToolScope {
+    pub(crate) fn for_board(mut self, board_id: Uuid) -> Self {
+        self.resolved_board = Some(board_id);
+        self
+    }
 }
 
 pub(crate) trait ToolScoped {
@@ -38,16 +52,31 @@ pub(crate) trait ToolScoped {
 impl FetchPlan for ToolScope {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         let wants_board_list = matches!(self.board, Some(Ref::Name))
-            || (self.renders_board_entity && self.board.is_some());
+            || (self.renders_board_entity && self.board.is_some())
+            || (self.resolved_board.is_some() && self.wants_board_sprints);
         FetchRound {
             board_list: wants_board_list && requestable(loaded.board_list()),
             column_list: matches!(self.column, Some(Ref::Name))
+                && !self.wants_board_columns
                 && requestable(loaded.column_list()),
             card_list: self.cards.iter().any(|r| matches!(r, Ref::Name))
                 && requestable(loaded.card_list()),
             sprint_list: matches!(self.sprint, Some(Ref::Name))
+                && !self.wants_board_sprints
                 && requestable(loaded.sprint_list()),
             graph: self.wants_graph && requestable(loaded.graph()),
+            columns_by_board: self
+                .resolved_board
+                .filter(|_| self.wants_board_columns)
+                .filter(|id| requestable(loaded.columns_of_board(*id)))
+                .into_iter()
+                .collect(),
+            sprints_by_board: self
+                .resolved_board
+                .filter(|_| self.wants_board_sprints)
+                .filter(|id| requestable(loaded.sprints_of_board(*id)))
+                .into_iter()
+                .collect(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Summary

`resolve_column_in_board` and `resolve_sprint_in_board` (added in KAN-1480) read `board_columns_state`/`board_sprints_state`, which are populated only by a by-parent fetch tied to a resolved board id. `ToolScope::next_round` never requested those tiers, so a name reference to a column or sprint inside a board always resolved to an internal error, while a uuid reference passed vacuously.

- `ToolScope` gains `resolved_board: Option<Uuid>`, `wants_board_columns: bool`, `wants_board_sprints: bool`, and a `for_board(self, Uuid) -> Self` consuming builder.
- `next_round` now emits `columns_by_board`/`sprints_by_board` once `resolved_board` is set and the corresponding `wants_board_*` flag is on, gated by `requestable(...)` so a `Loaded` tier is never re-requested.
- A wanted by-parent tier suppresses its flat tier (`column_list`/`sprint_list`), matching the two-round consumer shape: round 1 resolves the board name, round 2 (built via `.for_board(id)`) fetches the by-parent tier.
- `wants_board_sprints` (not `wants_board_columns`) also forces `board_list` to stay requested, because `resolve_sprint_in_board` additionally reads `board_by_id_state`, which comes off the flat boards tier; `resolve_column_in_board` does not touch it.
- No `kanban-domain` or `kanban-service` file is touched; the fetch-planning primitives this relies on (`columns_by_board`/`sprints_by_board` on `FetchRound`, `columns_of_board`/`sprints_of_board` on `LoadedState`) already existed.

## Footgun for future tool leaves

Setting `wants_board_columns`/`wants_board_sprints` without calling `.for_board(id)` suppresses the flat tier and requests nothing, so the resolver returns an internal error rather than falling back. Pinned by `test_by_parent_tiers_are_not_requested_before_the_board_is_resolved`.

## Changeset

`patch`. `scope` is `pub(crate) mod` (`lib.rs:7`) and every new item (`resolved_board`, `wants_board_columns`, `wants_board_sprints`, `for_board`) is `pub(crate)`, so this diff adds no public API and removes/renames/resignatures nothing public.

## Guards re-derived at HEAD

- `git diff --stat origin/develop -- crates/kanban-mcp/src/tools crates/kanban-domain crates/kanban-service` → empty
- `git diff --stat origin/develop -- crates/kanban-mcp/src/helpers/model_read.rs` → empty
- `git grep -c 'impl ToolScoped' -- crates/kanban-mcp/src` → 0 hits
- `git grep -c 'fn mcp_resolve' -- crates/kanban-mcp/src/helpers/resolvers.rs` → 14
- `#![allow(dead_code)]` still at `crates/kanban-mcp/src/scope.rs:1`
- `Ref` unchanged: fieldless `Id | Name`

## Test plan

- [x] Red: 6 new tests in `scope.rs` plus 1 end-to-end test in `context.rs` fail to compile (E0560/E0599) with the impl reverted; the end-to-end test isolated separately fails at runtime with an `Err`-unwrap panic (`resolve_column_in_board`/`resolve_sprint_in_board` returning INTERNAL_ERROR).
- [x] Green: all 8 named tests pass, plus the full `kanban-mcp` suite (`cargo test -p kanban-mcp --all-features`).
- [x] Mutation check: reverted `columns_by_board`/`sprints_by_board` to `Vec::new()`, confirmed the two round-2 tests fail, restored.
- [x] `cargo fmt --all -- --check`, `cargo clippy -p kanban-mcp --all-targets --all-features -- -D warnings` both clean.
