### PR TITLE
KAN-1483 feat(mcp): card_batch tools resolve names from the call-scoped Model

### DIFF
--- a/.changeset/kan-1483-mcp-card-batch-read-model.md
+++ b/.changeset/kan-1483-mcp-card-batch-read-model.md
@@ -1,0 +1,18 @@
+---
+bump: patch
+---
+
+mcp: retarget card_batch.rs's name-resolution call sites (tool_archive_cards,
+tool_move_cards, tool_assign_cards_to_sprint, tool_assign_card_to_sprint) from
+the McpResolve shim to a call-scoped Model built through ToolScope, and fix
+resolve_cards to require the card-list tier lazily so an all-uuid batch no
+longer trips an unfetched-tier error. A failed or unfetched column/sprint
+collection read now surfaces an error naming "columns of the board" or
+"sprints of the board" instead of a raw backend error. Singular card
+identifier resolution (tool_unassign_card_from_sprint, and the card lookup
+inside tool_assign_card_to_sprint) is left on the indexed
+KanbanOperations::resolve_card_id path rather than moved to the Model, since
+that path is already an indexed lookup and migrating it would trade an
+indexed read for a full collection scan with no correctness gain.
+card_relations.rs is unchanged: it has zero McpResolve shim call sites and its
+graph reads already surface a failed read as an error.

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -525,4 +525,19 @@ mod tests {
         assert_eq!(unloaded_err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
         assert!(unloaded_err.message.contains("card list"));
     }
+
+    #[test]
+    fn test_resolve_cards_with_only_uuid_references_does_not_require_the_card_list() {
+        let a = Uuid::new_v4().to_string();
+        let b = Uuid::new_v4().to_string();
+        let ids = resolve_cards(&Model::default(), &[a.clone(), b.clone()]).unwrap();
+        assert_eq!(
+            ids,
+            vec![Uuid::parse_str(&a).unwrap(), Uuid::parse_str(&b).unwrap()]
+        );
+
+        let mixed_err = resolve_cards(&Model::default(), &[a, "KAN-5".to_string()]).unwrap_err();
+        assert_eq!(mixed_err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(mixed_err.message.contains("card list"));
+    }
 }

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -4,7 +4,7 @@ use crate::helpers::error_mapping::kanban_err_to_mcp;
 use kanban_domain::{
     find_boards_by_name, find_columns_by_name, find_sprints_by_query_global,
     find_sprints_by_query_on_board, parse_identifier, AmbiguousMatch, BatchResolutionCause,
-    BatchResolutionFailure, KanbanError, LoadState, Model, ParsedIdentifier, Prefix,
+    BatchResolutionFailure, Card, KanbanError, LoadState, Model, ParsedIdentifier, Prefix,
 };
 use rmcp::model::ErrorData as McpError;
 use uuid::Uuid;
@@ -247,15 +247,22 @@ pub(crate) fn resolve_card(model: &Model, raw: &str) -> Result<Uuid, McpError> {
 }
 
 pub(crate) fn resolve_cards(model: &Model, raws: &[String]) -> Result<Vec<Uuid>, McpError> {
-    let cards = require_loaded(model.cards_state().as_ref(), "card list")?;
-
     let mut resolved = Vec::with_capacity(raws.len());
     let mut failures = Vec::new();
+    let mut cards: Option<&Vec<Card>> = None;
     for raw in raws {
         if let Ok(uuid) = Uuid::parse_str(raw) {
             resolved.push(uuid);
             continue;
         }
+        let cards = match cards {
+            Some(cards) => cards,
+            None => {
+                let loaded = require_loaded(model.cards_state().as_ref(), "card list")?;
+                cards = Some(loaded);
+                loaded
+            }
+        };
         let matches = find_card_matches(cards, raw);
         match matches.as_slice() {
             [] => failures.push(BatchResolutionFailure {

--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -41,7 +41,9 @@ pub(crate) trait McpResolve {
     fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
     fn mcp_resolve_sprint_global(&self, raw: &str) -> Result<Uuid, McpError>;
     fn mcp_resolve_card(&self, raw: &str) -> Result<Uuid, McpError>;
+    #[allow(dead_code)]
     fn mcp_resolve_cards(&self, raws: &[String]) -> Result<Vec<Uuid>, McpError>;
+    #[allow(dead_code)]
     fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError>;
 }
 

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -101,3 +101,344 @@ impl KanbanMcpServer {
         to_call_tool_result_json(serde_json::json!({"assigned_count": count}))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::requests::board::CreateBoardRequest;
+    use crate::requests::card::CreateCardParams;
+    use crate::requests::column::CreateColumnParams;
+    use crate::requests::sprint::CreateSprintParams;
+    use crate::McpServer;
+    use kanban_backend::{KanbanBackend, KanbanBackendFactory};
+    use kanban_core::AppConfig;
+    use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
+    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_service::test_helpers::FaultInjectingBackend;
+    use rmcp::model::ErrorCode;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    struct RecordingFactory {
+        inner: Box<dyn KanbanBackendFactory>,
+        handle: Arc<Mutex<Option<Arc<FaultInjectingBackend>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl KanbanBackendFactory for RecordingFactory {
+        fn name(&self) -> &str {
+            self.inner.name()
+        }
+
+        fn matches_locator(&self, locator: &str, header: &[u8]) -> bool {
+            self.inner.matches_locator(locator, header)
+        }
+
+        async fn create(
+            &self,
+            locator: &str,
+            config: &AppConfig,
+        ) -> kanban_domain::KanbanResult<Arc<dyn KanbanBackend>> {
+            let inner = self.inner.create(locator, config).await?;
+            let wrapped = Arc::new(FaultInjectingBackend::new(inner));
+            *self.handle.lock().unwrap() = Some(Arc::clone(&wrapped));
+            Ok(wrapped as Arc<dyn KanbanBackend>)
+        }
+    }
+
+    fn text_payload(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+        let raw = &result.content[0]
+            .as_text()
+            .expect("expected text content")
+            .text;
+        serde_json::from_str(raw).expect("tool result is JSON")
+    }
+
+    struct Seeded {
+        server: KanbanMcpServer,
+        _dir: TempDir,
+        handle: Arc<FaultInjectingBackend>,
+        card_id: String,
+        sprint_id: String,
+    }
+
+    async fn seeded_server(file_name: &str) -> Seeded {
+        let sqlite_handle = Arc::new(Mutex::new(None));
+        let json_handle = Arc::new(Mutex::new(None));
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(file_name);
+
+        let server = McpServer::default()
+            .register_backend(
+                Box::new(SqliteStoreFactory),
+                Box::new(RecordingFactory {
+                    inner: Box::new(SqliteBackendFactory),
+                    handle: Arc::clone(&sqlite_handle),
+                }),
+            )
+            .register_backend(
+                Box::new(JsonStoreFactory),
+                Box::new(RecordingFactory {
+                    inner: Box::new(JsonBackendFactory),
+                    handle: Arc::clone(&json_handle),
+                }),
+            )
+            .with_data_file(path.to_string_lossy().to_string())
+            .build()
+            .await
+            .unwrap();
+
+        let board = text_payload(
+            &server
+                .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                    content: CreateBoardRequest {
+                        id: None,
+                        name: "Alpha".to_string(),
+                        description: None,
+                        sprint_prefix: None,
+                        card_prefix: None,
+                        task_sort_field: None,
+                        task_sort_order: None,
+                        sprint_duration_days: None,
+                        task_list_view: None,
+                    },
+                    with_default_columns: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let board_id = board["id"].as_str().unwrap().to_string();
+
+        let column = text_payload(
+            &server
+                .tool_create_column(Parameters(CreateColumnParams {
+                    board: board_id.clone(),
+                    content: kanban_service::api::CreateColumnRequest {
+                        id: None,
+                        name: "TODO".to_string(),
+                        wip_limit: None,
+                        default_status: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let column_id = column["id"].as_str().unwrap().to_string();
+
+        let sprint = text_payload(
+            &server
+                .tool_create_sprint(Parameters(CreateSprintParams {
+                    board: board_id.clone(),
+                    content: kanban_service::api::CreateSprintRequest {
+                        id: None,
+                        name: Some("Sprint 1".to_string()),
+                        prefix: None,
+                        card_prefix: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let sprint_id = sprint["id"].as_str().unwrap().to_string();
+
+        let card = text_payload(
+            &server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: board_id.clone(),
+                    column: column_id.clone(),
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Do the thing".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let card_id = card["id"].as_str().unwrap().to_string();
+
+        let handle = sqlite_handle
+            .lock()
+            .unwrap()
+            .clone()
+            .or_else(|| json_handle.lock().unwrap().clone())
+            .expect("a backend must have been created");
+
+        Seeded {
+            server,
+            _dir: dir,
+            handle,
+            card_id,
+            sprint_id,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_archive_cards_by_uuid_does_not_read_the_card_list_on_json() {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_archive_cards(Parameters(ArchiveCardsRequest {
+                    cards: vec![seeded.card_id.clone()],
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
+        assert_eq!(response["archived_count"], 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_archive_cards_by_uuid_does_not_read_the_card_list_on_sqlite() {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_archive_cards(Parameters(ArchiveCardsRequest {
+                    cards: vec![seeded.card_id.clone()],
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
+        assert_eq!(response["archived_count"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_archive_cards_with_an_unloadable_card_list_errors_naming_the_collection_on_json()
+    {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_all_cards");
+
+        let err = seeded
+            .server
+            .tool_archive_cards(Parameters(ArchiveCardsRequest {
+                cards: vec!["KAN-1".to_string()],
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("card list"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_archive_cards_with_an_unloadable_card_list_errors_naming_the_collection_on_sqlite(
+    ) {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_all_cards");
+
+        let err = seeded
+            .server
+            .tool_archive_cards(Parameters(ArchiveCardsRequest {
+                cards: vec!["KAN-1".to_string()],
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("card list"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_move_cards_with_an_unloadable_column_collection_errors_naming_the_collection_on_json(
+    ) {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_columns_by_board");
+
+        let err = seeded
+            .server
+            .tool_move_cards(Parameters(MoveCardsRequest {
+                cards: vec![seeded.card_id.clone()],
+                column: "TODO".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("columns of the board"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_move_cards_with_an_unloadable_column_collection_errors_naming_the_collection_on_sqlite(
+    ) {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_columns_by_board");
+
+        let err = seeded
+            .server
+            .tool_move_cards(Parameters(MoveCardsRequest {
+                cards: vec![seeded.card_id.clone()],
+                column: "TODO".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("columns of the board"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_assign_card_to_sprint_with_an_unloadable_sprint_collection_errors_naming_the_collection_on_json(
+    ) {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_sprints_by_board");
+
+        let err = seeded
+            .server
+            .tool_assign_card_to_sprint(Parameters(AssignCardToSprintRequest {
+                card: seeded.card_id.clone(),
+                sprint: "Sprint 1".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("sprints of the board"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+        let _ = &seeded.sprint_id;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_assign_card_to_sprint_with_an_unloadable_sprint_collection_errors_naming_the_collection_on_sqlite(
+    ) {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_sprints_by_board");
+
+        let err = seeded
+            .server
+            .tool_assign_card_to_sprint(Parameters(AssignCardToSprintRequest {
+                card: seeded.card_id.clone(),
+                sprint: "Sprint 1".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("sprints of the board"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+        let _ = &seeded.sprint_id;
+    }
+}

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -427,6 +427,7 @@ mod tests {
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
         assert!(err.message.contains("columns of the board"));
+        assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 
@@ -448,6 +449,7 @@ mod tests {
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
         assert!(err.message.contains("columns of the board"));
+        assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 
@@ -495,5 +497,89 @@ mod tests {
         assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
         let _ = &seeded.sprint_id;
+    }
+
+    #[tokio::test]
+    async fn test_assign_cards_to_sprint_by_uuid_assigns_the_card_on_json() {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_assign_cards_to_sprint(Parameters(AssignCardsToSprintRequest {
+                    cards: vec![seeded.card_id.clone()],
+                    sprint: "Sprint 1".to_string(),
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(response["assigned_count"], 1);
+        let _ = &seeded.sprint_id;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_assign_cards_to_sprint_by_uuid_assigns_the_card_on_sqlite() {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_assign_cards_to_sprint(Parameters(AssignCardsToSprintRequest {
+                    cards: vec![seeded.card_id.clone()],
+                    sprint: "Sprint 1".to_string(),
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(response["assigned_count"], 1);
+        let _ = &seeded.sprint_id;
+    }
+
+    #[tokio::test]
+    async fn test_assign_cards_to_sprint_with_an_unloadable_sprint_collection_errors_naming_the_collection_on_json(
+    ) {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_sprints_by_board");
+
+        let err = seeded
+            .server
+            .tool_assign_cards_to_sprint(Parameters(AssignCardsToSprintRequest {
+                cards: vec![seeded.card_id.clone()],
+                sprint: "Sprint 1".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("sprints of the board"));
+        assert!(err.message.contains("injected fault"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_assign_cards_to_sprint_with_an_unloadable_sprint_collection_errors_naming_the_collection_on_sqlite(
+    ) {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_sprints_by_board");
+
+        let err = seeded
+            .server
+            .tool_assign_cards_to_sprint(Parameters(AssignCardsToSprintRequest {
+                cards: vec![seeded.card_id.clone()],
+                sprint: "Sprint 1".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("sprints of the board"));
+        assert!(err.message.contains("injected fault"));
+        assert!(!err.message.to_lowercase().contains("not found"));
     }
 }

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -1,11 +1,12 @@
+use crate::helpers::model_read::{resolve_cards, resolve_column_in_board, resolve_sprint_in_board};
 use crate::helpers::{
     card_board, kanban_err_to_mcp, locked_write, to_call_tool_result, to_call_tool_result_json,
-    McpResolve,
 };
 use crate::requests::card::{
     ArchiveCardsRequest, AssignCardToSprintRequest, AssignCardsToSprintRequest, MoveCardsRequest,
     UnassignCardFromSprintRequest,
 };
+use crate::scope::{Ref, ToolScope, ToolScoped};
 use crate::KanbanMcpServer;
 use kanban_domain::KanbanOperations;
 use kanban_service::api::CardResponse;
@@ -14,6 +15,47 @@ use rmcp::{
     model::{CallToolResult, ErrorData as McpError},
     tool, tool_router,
 };
+
+impl ToolScoped for ArchiveCardsRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            cards: self.cards.iter().map(|r| Ref::of(r)).collect(),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for MoveCardsRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            cards: self.cards.iter().map(|r| Ref::of(r)).collect(),
+            column: Some(Ref::of(&self.column)),
+            wants_board_columns: matches!(Ref::of(&self.column), Ref::Name),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for AssignCardsToSprintRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            cards: self.cards.iter().map(|r| Ref::of(r)).collect(),
+            sprint: Some(Ref::of(&self.sprint)),
+            wants_board_sprints: matches!(Ref::of(&self.sprint), Ref::Name),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for AssignCardToSprintRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            sprint: Some(Ref::of(&self.sprint)),
+            wants_board_sprints: matches!(Ref::of(&self.sprint), Ref::Name),
+            ..Default::default()
+        }
+    }
+}
 
 #[tool_router(router = card_batch_router, vis = "pub(crate)")]
 impl KanbanMcpServer {
@@ -24,10 +66,13 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<AssignCardToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let card = locked_write(&self.ctx, |ctx| {
-            let card_id = ctx.mcp_resolve_card(&req.card)?;
+            let mut model = ctx.model_for(&scope);
+            let card_id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             let board_id = card_board(ctx, card_id)?;
-            let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
+            ctx.sync_into(&req.scope().for_board(board_id), &mut model);
+            let sprint_id = resolve_sprint_in_board(&model, &req.sprint, board_id)?;
             ctx.assign_card_to_sprint(card_id, sprint_id)
                 .map_err(kanban_err_to_mcp)
         })
@@ -41,7 +86,7 @@ impl KanbanMcpServer {
         Parameters(req): Parameters<UnassignCardFromSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
         let card = locked_write(&self.ctx, |ctx| {
-            let card_id = ctx.mcp_resolve_card(&req.card)?;
+            let card_id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             ctx.unassign_card_from_sprint(card_id)
                 .map_err(kanban_err_to_mcp)
         })
@@ -58,8 +103,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ArchiveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let count = locked_write(&self.ctx, |ctx| {
-            let ids = ctx.mcp_resolve_cards(&req.cards)?;
+            let model = ctx.model_for(&scope);
+            let ids = resolve_cards(&model, &req.cards)?;
             ctx.archive_cards(ids).map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -73,10 +120,13 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<MoveCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let count = locked_write(&self.ctx, |ctx| {
-            let ids = ctx.mcp_resolve_cards(&req.cards)?;
-            let board_id = ctx.mcp_require_same_board(&ids)?;
-            let column_id = ctx.mcp_resolve_column_in_board(&req.column, board_id)?;
+            let mut model = ctx.model_for(&scope);
+            let ids = resolve_cards(&model, &req.cards)?;
+            let board_id = ctx.require_same_board(&ids).map_err(kanban_err_to_mcp)?;
+            ctx.sync_into(&req.scope().for_board(board_id), &mut model);
+            let column_id = resolve_column_in_board(&model, &req.column, board_id)?;
             ctx.move_cards(ids, column_id).map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -90,10 +140,13 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<AssignCardsToSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let count = locked_write(&self.ctx, |ctx| {
-            let ids = ctx.mcp_resolve_cards(&req.cards)?;
-            let board_id = ctx.mcp_require_same_board(&ids)?;
-            let sprint_id = ctx.mcp_resolve_sprint_in_board(&req.sprint, board_id)?;
+            let mut model = ctx.model_for(&scope);
+            let ids = resolve_cards(&model, &req.cards)?;
+            let board_id = ctx.require_same_board(&ids).map_err(kanban_err_to_mcp)?;
+            ctx.sync_into(&req.scope().for_board(board_id), &mut model);
+            let sprint_id = resolve_sprint_in_board(&model, &req.sprint, board_id)?;
             ctx.assign_cards_to_sprint(ids, sprint_id)
                 .map_err(kanban_err_to_mcp)
         })
@@ -416,6 +469,7 @@ mod tests {
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
         assert!(err.message.contains("sprints of the board"));
+        assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
         let _ = &seeded.sprint_id;
     }
@@ -438,6 +492,7 @@ mod tests {
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
         assert!(err.message.contains("sprints of the board"));
+        assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
         let _ = &seeded.sprint_id;
     }

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -212,6 +212,7 @@ mod tests {
         _dir: TempDir,
         handle: Arc<FaultInjectingBackend>,
         card_id: String,
+        card_identifier: String,
         sprint_id: String,
     }
 
@@ -314,6 +315,11 @@ mod tests {
                 .unwrap(),
         );
         let card_id = card["id"].as_str().unwrap().to_string();
+        let card_identifier = format!(
+            "{}-{}",
+            card["prefix"].as_str().unwrap(),
+            card["card_number"].as_u64().unwrap()
+        );
 
         let handle = sqlite_handle
             .lock()
@@ -327,6 +333,7 @@ mod tests {
             _dir: dir,
             handle,
             card_id,
+            card_identifier,
             sprint_id,
         }
     }
@@ -386,6 +393,7 @@ mod tests {
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
         assert!(err.message.contains("card list"));
+        assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 
@@ -406,6 +414,7 @@ mod tests {
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
         assert!(err.message.contains("card list"));
+        assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 
@@ -537,6 +546,82 @@ mod tests {
 
         assert_eq!(response["assigned_count"], 1);
         let _ = &seeded.sprint_id;
+    }
+
+    #[tokio::test]
+    async fn test_assign_cards_to_sprint_by_name_assigns_the_card_on_json() {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_assign_cards_to_sprint(Parameters(AssignCardsToSprintRequest {
+                    cards: vec![seeded.card_identifier.clone()],
+                    sprint: "Sprint 1".to_string(),
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(response["assigned_count"], 1);
+        let _ = &seeded.sprint_id;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_assign_cards_to_sprint_by_name_assigns_the_card_on_sqlite() {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_assign_cards_to_sprint(Parameters(AssignCardsToSprintRequest {
+                    cards: vec![seeded.card_identifier.clone()],
+                    sprint: "Sprint 1".to_string(),
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(response["assigned_count"], 1);
+        let _ = &seeded.sprint_id;
+    }
+
+    #[tokio::test]
+    async fn test_archive_cards_by_name_archives_the_card_on_json() {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_archive_cards(Parameters(ArchiveCardsRequest {
+                    cards: vec![seeded.card_identifier.clone()],
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(response["archived_count"], 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_archive_cards_by_name_archives_the_card_on_sqlite() {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_archive_cards(Parameters(ArchiveCardsRequest {
+                    cards: vec![seeded.card_identifier.clone()],
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(response["archived_count"], 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Retargets the eight `mcp_resolve_*` / `mcp_require_same_board` shim call sites in `crates/kanban-mcp/src/tools/card_batch.rs` at the call-scoped `Model` (built via `ToolScope`) so batch card resolution and column/sprint-in-board resolution read a planned tier of the Model instead of hitting the backend through the `McpResolve` shim. A `NotLoaded`/`Failed` tier now produces an error that names the collection (`"card list"`, `"columns of the board"`, `"sprints of the board"`) instead of a raw backend error or a "not found" answer.

## Changes

- `tool_archive_cards`, `tool_move_cards`, `tool_assign_cards_to_sprint`, `tool_assign_card_to_sprint` build a `ToolScope`, call `ctx.model_for(&scope)`, and resolve names through `resolve_cards`/`resolve_column_in_board`/`resolve_sprint_in_board` in `helpers/model_read.rs`. The two-round tools (`move_cards`, `assign_cards_to_sprint`, `assign_card_to_sprint`) sync a second round scoped to the resolved board before resolving the column/sprint.
- `tool_unassign_card_from_sprint`, and the card lookup inside `tool_assign_card_to_sprint`, keep using `KanbanOperations::resolve_card_id` directly (dropping only the `McpResolve` shim wrapper). Singular card-identifier resolution routes to an indexed backend lookup (`list_cards_by_prefix_and_number` / `list_cards_by_number`), and moving it to the Model's `card_list` tier would trade that indexed read for a full collection scan with no correctness gain, since the indexed path already surfaces a read failure as an error.
- `card_board` and `KanbanOperations::require_same_board` are left on their existing backend paths for the same reason: neither is name resolution, and `require_same_board` cannot be served by any tier `ToolScope::next_round` can request without editing `scope.rs`, which is out of this leaf's scope.
- `crates/kanban-mcp/src/tools/card_relations.rs` is unchanged. It has zero `mcp_resolve_*` call sites already (its six `ctx.resolve_card_id` calls are direct, on the indexed path), and its graph reads (`list_parents_of` / `list_children_of`) already propagate a failed read as an error, so there is no "collapses to not found" defect to fix there.
- `helpers/model_read.rs::resolve_cards` now requires the card-list tier lazily (on first non-uuid input) instead of unconditionally up front, matching its singular sibling `resolve_card`. Without this fix, a batch call made entirely of uuids (a normal LLM call shape) would plan no `card_list` tier and then trip `NotLoaded` -> `INTERNAL_ERROR`, because `ToolScope::next_round` only requests `card_list` when at least one reference is a name.
- Two `#[allow(dead_code)]` attributes added to `McpResolve::mcp_resolve_cards` / `mcp_require_same_board` in `helpers/resolvers.rs`: after this change no call site in the crate uses either method, and without the attribute they trip `-D warnings`. The shim itself (all eight methods) is left in place for KAN-1485 to remove.

## Read-shape changes worth flagging

- The sprint tools (`tool_assign_card_to_sprint`, `tool_assign_cards_to_sprint`) now force a `board_list` read in their second round, because `resolve_sprint_in_board` reads `board_by_id_state`, which is served by the flat boards tier. Previously `resolve_sprint_id` used a per-id `get_board(board_id)`. This trades one indexed board read for a whole-collection board read; `ToolScope`'s design intentionally does not try to avoid it.
- Batch identifier resolution now reads the Model's `card_list` tier, filled from the raw `DataStore::list_all_cards()`, rather than `KanbanOperations::list_all_cards` (which excludes archived-board descendants). An identifier belonging to a card under an archived board may resolve where it previously reported not-found. The full `kanban-mcp` test suite passes with this change; no test exercises that specific edge case today. KAN-1481 shipped the identical shift for boards.

## Verification

Re-derived per-file tool/`mcp_resolve_` census against `origin/develop`, anchored at the first column-zero `#[cfg(test)]` (board.rs now carries an inline test module, so an unanchored or absent truncation undercounts):

```
board: tools=9 mcp_resolve=0
card_crud: tools=10 mcp_resolve=17
card_batch: tools=5 mcp_resolve=8
card_relations: tools=4 mcp_resolve=0
column: tools=6 mcp_resolve=6
sprint: tools=9 mcp_resolve=10
transfer: tools=4 mcp_resolve=1
```

- `git grep -c 'mcp_resolve_\|mcp_require_same_board' -- crates/kanban-mcp/src/tools/card_batch.rs crates/kanban-mcp/src/tools/card_relations.rs` returns 0 for both files, unblocking KAN-1485's shim deletion.
- `git diff --stat origin/develop -- crates/kanban-mcp/src/scope.rs crates/kanban-mcp/src/context.rs crates/kanban-mcp/src/tools/card_relations.rs crates/kanban-mcp/src/tools/transfer.rs crates/kanban-mcp/tests/` is empty.
- `nix develop --command cargo test -p kanban-mcp --all-features` is green: 81 lib unit tests, 94 integration tests (including `tool_move_cards_rejects_cross_board_batch` and `tool_assign_card_to_sprint_resolves_by_name_then_mutates`, both unmodified), 9 `mcp_server_builder` tests, 1 doctest.
- `nix develop --command cargo clippy -p kanban-mcp --all-targets --all-features -- -D warnings` and `nix develop --command cargo fmt --all -- --check` are clean.
- Nine new tests (one in `helpers/model_read.rs`, eight in `tools/card_batch.rs`) were observed failing before the implementation commit and pass after it; the four fault/zero-read scenarios each have a JSON and an SQLite twin. Mutation-checked the two-round `sync_into` call in `tool_assign_card_to_sprint`: deleting it made the fault test pass vacuously until the assertion was tightened to check the injected-fault text, then deleting the line correctly failed the test; restored.
