### PR TITLE
KAN-1494 feat(mcp): card_relations tools read from the call-scoped Model

### DIFF
--- a/.changeset/kan-1494-mcp-card-relations-read-model.md
+++ b/.changeset/kan-1494-mcp-card-relations-read-model.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+mcp: retarget the four card_relations tools (set/remove card parent, list card parents/children) at the call-scoped Model instead of the raw KanbanContext. Card identifier resolution now goes through helpers::model_read::resolve_card, and the parent/child edge read goes through Model::graph_state() via require_loaded instead of ctx.list_parents_of/list_children_of. A NotLoaded or Failed card list or dependency graph tier now surfaces as an error naming the collection instead of the tool reporting a false "not found" or silently returning an empty relation list.

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -1,4 +1,4 @@
-use crate::error::KanbanMcpResult;
+use crate::helpers::model_read::{require_loaded, resolve_card};
 use crate::helpers::{
     core_err_to_mcp, locked_read, locked_write, mcp_enrich_add_error, mcp_enrich_remove_error,
     resolve_summaries, to_call_tool_result, to_call_tool_result_json,
@@ -6,14 +6,66 @@ use crate::helpers::{
 use crate::requests::card::{
     ListCardChildrenRequest, ListCardParentsRequest, RemoveCardParentRequest, SetCardParentRequest,
 };
+use crate::scope::{Ref, ToolScope, ToolScoped};
 use crate::KanbanMcpServer;
 use kanban_core::{resolve_page_params, PaginatedList};
-use kanban_domain::{GraphOperations, KanbanOperations};
+use kanban_domain::{GraphOperations, Model};
 use rmcp::{
     handler::server::wrapper::Parameters,
     model::{CallToolResult, ErrorData as McpError},
     tool, tool_router,
 };
+use uuid::Uuid;
+
+impl ToolScoped for SetCardParentRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            cards: vec![Ref::of(&self.parent), Ref::of(&self.child)],
+            wants_graph: true,
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for RemoveCardParentRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            cards: vec![Ref::of(&self.parent), Ref::of(&self.child)],
+            wants_graph: true,
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for ListCardParentsRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            cards: vec![Ref::of(&self.card)],
+            wants_graph: true,
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for ListCardChildrenRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            cards: vec![Ref::of(&self.card)],
+            wants_graph: true,
+            ..Default::default()
+        }
+    }
+}
+
+fn list_parents_in_model(model: &Model, child: Uuid) -> Result<Vec<Uuid>, McpError> {
+    let graph = require_loaded(model.graph_state().as_ref(), "dependency graph")?;
+    Ok(graph.parents(child))
+}
+
+fn list_children_in_model(model: &Model, parent: Uuid) -> Result<Vec<Uuid>, McpError> {
+    let graph = require_loaded(model.graph_state().as_ref(), "dependency graph")?;
+    Ok(graph.children(parent))
+}
 
 #[tool_router(router = card_relations_router, vis = "pub(crate)")]
 impl KanbanMcpServer {
@@ -26,9 +78,11 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let parent_raw = req.parent.clone();
         let child_raw = req.child.clone();
-        let (child_id, parent_id) = locked_write(&self.ctx, |ctx| -> KanbanMcpResult<_> {
-            let child_id = ctx.resolve_card_id(&req.child)?;
-            let parent_id = ctx.resolve_card_id(&req.parent)?;
+        let scope = req.scope();
+        let (child_id, parent_id) = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
+            let model = ctx.model_for(&scope);
+            let child_id = resolve_card(&model, &req.child)?;
+            let parent_id = resolve_card(&model, &req.parent)?;
             ctx.attach_child(parent_id, child_id)
                 .map_err(|e| mcp_enrich_add_error(e, &parent_raw, &child_raw))?;
             Ok((child_id, parent_id))
@@ -47,9 +101,11 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let parent_raw = req.parent.clone();
         let child_raw = req.child.clone();
-        let (child_id, parent_id) = locked_write(&self.ctx, |ctx| -> KanbanMcpResult<_> {
-            let child_id = ctx.resolve_card_id(&req.child)?;
-            let parent_id = ctx.resolve_card_id(&req.parent)?;
+        let scope = req.scope();
+        let (child_id, parent_id) = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
+            let model = ctx.model_for(&scope);
+            let child_id = resolve_card(&model, &req.child)?;
+            let parent_id = resolve_card(&model, &req.parent)?;
             ctx.detach_child(parent_id, child_id)
                 .map_err(|e| mcp_enrich_remove_error(e, &parent_raw, &child_raw))?;
             Ok((child_id, parent_id))
@@ -68,9 +124,11 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListCardParentsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let parents = locked_read(&self.ctx, |ctx| -> KanbanMcpResult<_> {
-            let id = ctx.resolve_card_id(&req.card)?;
-            let ids = ctx.list_parents_of(id)?;
+        let scope = req.scope();
+        let parents = locked_read(&self.ctx, |ctx| -> Result<_, McpError> {
+            let model = ctx.model_for(&scope);
+            let id = resolve_card(&model, &req.card)?;
+            let ids = list_parents_in_model(&model, id)?;
             Ok(resolve_summaries(ctx, ids))
         })
         .await?;
@@ -87,9 +145,11 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListCardChildrenRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let children = locked_read(&self.ctx, |ctx| -> KanbanMcpResult<_> {
-            let id = ctx.resolve_card_id(&req.card)?;
-            let ids = ctx.list_children_of(id)?;
+        let scope = req.scope();
+        let children = locked_read(&self.ctx, |ctx| -> Result<_, McpError> {
+            let model = ctx.model_for(&scope);
+            let id = resolve_card(&model, &req.card)?;
+            let ids = list_children_in_model(&model, id)?;
             Ok(resolve_summaries(ctx, ids))
         })
         .await?;
@@ -99,6 +159,7 @@ impl KanbanMcpServer {
         to_call_tool_result(&paged)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -99,3 +99,317 @@ impl KanbanMcpServer {
         to_call_tool_result(&paged)
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::requests::board::CreateBoardRequest;
+    use crate::requests::card::CreateCardParams;
+    use crate::requests::column::CreateColumnParams;
+    use crate::McpServer;
+    use kanban_backend::{KanbanBackend, KanbanBackendFactory};
+    use kanban_core::AppConfig;
+    use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
+    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_service::test_helpers::FaultInjectingBackend;
+    use rmcp::model::ErrorCode;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    struct RecordingFactory {
+        inner: Box<dyn KanbanBackendFactory>,
+        handle: Arc<Mutex<Option<Arc<FaultInjectingBackend>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl KanbanBackendFactory for RecordingFactory {
+        fn name(&self) -> &str {
+            self.inner.name()
+        }
+
+        fn matches_locator(&self, locator: &str, header: &[u8]) -> bool {
+            self.inner.matches_locator(locator, header)
+        }
+
+        async fn create(
+            &self,
+            locator: &str,
+            config: &AppConfig,
+        ) -> kanban_domain::KanbanResult<Arc<dyn KanbanBackend>> {
+            let inner = self.inner.create(locator, config).await?;
+            let wrapped = Arc::new(FaultInjectingBackend::new(inner));
+            *self.handle.lock().unwrap() = Some(Arc::clone(&wrapped));
+            Ok(wrapped as Arc<dyn KanbanBackend>)
+        }
+    }
+
+    fn text_payload(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+        let raw = &result.content[0]
+            .as_text()
+            .expect("expected text content")
+            .text;
+        serde_json::from_str(raw).expect("tool result is JSON")
+    }
+
+    struct Seeded {
+        server: KanbanMcpServer,
+        _dir: TempDir,
+        handle: Arc<FaultInjectingBackend>,
+        card_a_id: String,
+        card_a_identifier: String,
+        card_b_id: String,
+        card_b_identifier: String,
+    }
+
+    async fn seeded_server(file_name: &str) -> Seeded {
+        let sqlite_handle = Arc::new(Mutex::new(None));
+        let json_handle = Arc::new(Mutex::new(None));
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(file_name);
+
+        let server = McpServer::default()
+            .register_backend(
+                Box::new(SqliteStoreFactory),
+                Box::new(RecordingFactory {
+                    inner: Box::new(SqliteBackendFactory),
+                    handle: Arc::clone(&sqlite_handle),
+                }),
+            )
+            .register_backend(
+                Box::new(JsonStoreFactory),
+                Box::new(RecordingFactory {
+                    inner: Box::new(JsonBackendFactory),
+                    handle: Arc::clone(&json_handle),
+                }),
+            )
+            .with_data_file(path.to_string_lossy().to_string())
+            .build()
+            .await
+            .unwrap();
+
+        let board = text_payload(
+            &server
+                .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                    content: CreateBoardRequest {
+                        id: None,
+                        name: "Alpha".to_string(),
+                        description: None,
+                        sprint_prefix: None,
+                        card_prefix: None,
+                        task_sort_field: None,
+                        task_sort_order: None,
+                        sprint_duration_days: None,
+                        task_list_view: None,
+                    },
+                    with_default_columns: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let board_id = board["id"].as_str().unwrap().to_string();
+
+        let column = text_payload(
+            &server
+                .tool_create_column(Parameters(CreateColumnParams {
+                    board: board_id.clone(),
+                    content: kanban_service::api::CreateColumnRequest {
+                        id: None,
+                        name: "TODO".to_string(),
+                        wip_limit: None,
+                        default_status: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let column_id = column["id"].as_str().unwrap().to_string();
+
+        let card_a = text_payload(
+            &server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: board_id.clone(),
+                    column: column_id.clone(),
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Card A".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let card_a_id = card_a["id"].as_str().unwrap().to_string();
+        let card_a_identifier = format!(
+            "{}-{}",
+            card_a["prefix"].as_str().unwrap(),
+            card_a["card_number"].as_u64().unwrap()
+        );
+
+        let card_b = text_payload(
+            &server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: board_id.clone(),
+                    column: column_id.clone(),
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Card B".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let card_b_id = card_b["id"].as_str().unwrap().to_string();
+        let card_b_identifier = format!(
+            "{}-{}",
+            card_b["prefix"].as_str().unwrap(),
+            card_b["card_number"].as_u64().unwrap()
+        );
+
+        let handle = sqlite_handle
+            .lock()
+            .unwrap()
+            .clone()
+            .or_else(|| json_handle.lock().unwrap().clone())
+            .expect("a backend must have been created");
+
+        Seeded {
+            server,
+            _dir: dir,
+            handle,
+            card_a_id,
+            card_a_identifier,
+            card_b_id,
+            card_b_identifier,
+        }
+    }
+
+    #[test]
+    fn test_a_relation_tool_with_a_not_loaded_graph_errors_instead_of_reporting_no_edges() {
+        let err = list_parents_in_model(&Model::default(), Uuid::new_v4()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("graph"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_set_card_parent_with_an_unloadable_card_list_errors_naming_the_collection_on_json(
+    ) {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_all_cards");
+
+        let err = seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("card list"));
+        assert!(err.message.contains("injected fault"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_set_card_parent_with_an_unloadable_card_list_errors_naming_the_collection_on_sqlite(
+    ) {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_all_cards");
+
+        let err = seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("card list"));
+        assert!(err.message.contains("injected fault"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_list_card_children_resolves_the_card_by_name_from_the_model() {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_list_card_children(Parameters(ListCardChildrenRequest {
+                    card: seeded.card_a_identifier.clone(),
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+
+        let items = response["items"].as_array().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["id"], seeded.card_b_id);
+    }
+
+    #[tokio::test]
+    async fn test_remove_card_parent_distinguishes_a_missing_card_from_a_not_loaded_one() {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+
+        let not_found_err = seeded
+            .server
+            .tool_remove_card_parent(Parameters(RemoveCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: "KAN-999".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(not_found_err.code, ErrorCode::INVALID_PARAMS);
+        assert!(not_found_err.message.to_lowercase().contains("not found"));
+
+        seeded.handle.fail("list_all_cards");
+
+        let fault_err = seeded
+            .server
+            .tool_remove_card_parent(Parameters(RemoveCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: "KAN-999".to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(fault_err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(fault_err.message.contains("card list"));
+        assert!(fault_err.message.contains("injected fault"));
+
+        assert_ne!(not_found_err.code, fault_err.code);
+        assert_ne!(not_found_err.message, fault_err.message);
+        let _ = (&seeded.card_a_id, &seeded.card_b_id);
+    }
+}


### PR DESCRIPTION
## Summary

- Retarget the four `card_relations.rs` MCP tools (`tool_set_card_parent`, `tool_remove_card_parent`, `tool_list_card_parents`, `tool_list_card_children`) at the call-scoped `Model`, mirroring the merged `card_batch.rs` (KAN-1483) and `board.rs` (KAN-1481) precedent.
- Card identifier resolution moves from `ctx.resolve_card_id` to `helpers::model_read::resolve_card(&model, ...)`.
- The parent/child edge read moves from `ctx.list_parents_of`/`ctx.list_children_of` to two small local helpers that read `Model::graph_state()` through `require_loaded`, calling the infallible `DependencyGraph::parents`/`children`.
- A `NotLoaded` or `Failed` card list or dependency graph tier now surfaces as an error naming the collection (e.g. "card list", "dependency graph") instead of the tool silently reporting not-found or an empty relation list.
- `attach_child`/`detach_child` still mutate through `ctx` directly; only the two id resolutions feeding them move to the Model.
- No JSON tool schema, name, or description changed for any of the four tools.

## Test plan

- [x] `cargo test -p kanban-mcp --all-features`
- [x] `cargo clippy -p kanban-mcp --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New tests use a card name, never a bare uuid, for the identifier being resolved
- [x] Red tests shown failing to compile against pre-fix production code before the Green commit
- [x] Mutation check: reverting the graph-read fix to a silent-empty fallback fails the new NotLoaded test
