### PR TITLE
KAN-1485 feat(mcp): sprint tools and tool_export_board read from the call-scoped Model

### DIFF
--- a/.changeset/kan-1485-mcp-sprint-tools-and-shim-removal.md
+++ b/.changeset/kan-1485-mcp-sprint-tools-and-shim-removal.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+mcp: retarget every sprint tool and `tool_export_board` off the `McpResolve` shim onto the call-scoped `Model` built via `ToolScope`/`ToolScoped`, delete the now-dead `McpResolve` trait and the unused `ToolScope::renders_board_entity` field, and fix a `ToolScope::next_round` gap where a named global sprint reference never requested the board list needed to resolve it.

--- a/crates/kanban-mcp/src/helpers/mod.rs
+++ b/crates/kanban-mcp/src/helpers/mod.rs
@@ -13,5 +13,5 @@ pub(crate) use parsers::{
     parse_archived_selector, parse_board_sort_field, parse_datetime, parse_priority,
     parse_sort_field, parse_sort_order, parse_status,
 };
-pub(crate) use resolvers::{card_board, project_sprint, resolve_summaries, McpResolve};
+pub(crate) use resolvers::{card_board, project_sprint, resolve_summaries};
 pub(crate) use serialization::{to_call_tool_result, to_call_tool_result_json};

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::helpers::error_mapping::kanban_err_to_mcp;
 use kanban_domain::{
     find_boards_by_name, find_columns_by_name, find_sprints_by_query_global,

--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -30,56 +30,6 @@ pub(crate) fn resolve_summaries(ctx: &McpContext, ids: Vec<Uuid>) -> Vec<CardSum
         .collect()
 }
 
-/// Helper trait: gives `&McpContext` access to MCP-flavoured error mapping for
-/// the resolvers it inherits via `KanbanOperations`. Each method is a thin
-/// `kanban_err_to_mcp` shim so closure bodies inside `locked_read` /
-/// `locked_write` stay readable.
-pub(crate) trait McpResolve {
-    fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError>;
-    #[allow(dead_code)]
-    fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
-    fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError>;
-    fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError>;
-    fn mcp_resolve_sprint_global(&self, raw: &str) -> Result<Uuid, McpError>;
-    #[allow(dead_code)]
-    fn mcp_resolve_card(&self, raw: &str) -> Result<Uuid, McpError>;
-    #[allow(dead_code)]
-    fn mcp_resolve_cards(&self, raws: &[String]) -> Result<Vec<Uuid>, McpError>;
-    #[allow(dead_code)]
-    fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError>;
-}
-
-impl McpResolve for McpContext {
-    fn mcp_resolve_board(&self, raw: &str) -> Result<Uuid, McpError> {
-        self.resolve_board_id(raw).map_err(kanban_err_to_mcp)
-    }
-    fn mcp_resolve_column_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError> {
-        self.resolve_column_id(raw, board_id)
-            .map_err(kanban_err_to_mcp)
-    }
-    fn mcp_resolve_column_global(&self, raw: &str) -> Result<Uuid, McpError> {
-        self.resolve_column_id_global(raw)
-            .map_err(kanban_err_to_mcp)
-    }
-    fn mcp_resolve_sprint_in_board(&self, raw: &str, board_id: Uuid) -> Result<Uuid, McpError> {
-        self.resolve_sprint_id(raw, board_id)
-            .map_err(kanban_err_to_mcp)
-    }
-    fn mcp_resolve_sprint_global(&self, raw: &str) -> Result<Uuid, McpError> {
-        self.resolve_sprint_id_global(raw)
-            .map_err(kanban_err_to_mcp)
-    }
-    fn mcp_resolve_card(&self, raw: &str) -> Result<Uuid, McpError> {
-        self.resolve_card_id(raw).map_err(kanban_err_to_mcp)
-    }
-    fn mcp_resolve_cards(&self, raws: &[String]) -> Result<Vec<Uuid>, McpError> {
-        self.resolve_card_ids(raws).map_err(kanban_err_to_mcp)
-    }
-    fn mcp_require_same_board(&self, card_ids: &[Uuid]) -> Result<Uuid, McpError> {
-        self.require_same_board(card_ids).map_err(kanban_err_to_mcp)
-    }
-}
-
 /// Derive a card's board via card → column → board, with MCP-flavoured error
 /// mapping. Standalone (not on the resolver trait) because it composes
 /// multiple trait calls rather than being a simple error-mapping shim.

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -348,6 +348,18 @@ mod tests {
         assert!(scope.next_round(&missing_model).is_empty());
     }
 
+    #[test]
+    fn test_a_named_global_sprint_reference_also_requests_the_board_list() {
+        let scope = ToolScope {
+            sprint: Some(Ref::Name),
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&Model::default());
+        assert!(round.board_list);
+        assert!(round.sprint_list);
+    }
+
     /// Mirrors crates/kanban-cli/src/scope.rs:86-95: a `Some(Ref::Name)`
     /// board reference requests exactly `board_list`, and a `Some(Ref::Id)`
     /// one requests nothing.

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use kanban_service::{requestable, FetchPlan, FetchRound, LoadedEntities};
 use uuid::Uuid;
 
@@ -26,9 +24,6 @@ pub(crate) struct ToolScope {
     pub(crate) sprint: Option<Ref>,
     pub(crate) cards: Vec<Ref>,
     pub(crate) wants_graph: bool,
-    /// Some tools render the board entity itself (not just resolve it by
-    /// name), so even a uuid reference still needs the board list loaded.
-    pub(crate) renders_board_entity: bool,
     /// Set once a board reference has been resolved to an id; the
     /// parent-scoped tiers cannot be requested before it is known.
     pub(crate) resolved_board: Option<Uuid>,
@@ -52,7 +47,6 @@ pub(crate) trait ToolScoped {
 impl FetchPlan for ToolScope {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         let wants_board_list = matches!(self.board, Some(Ref::Name))
-            || (self.renders_board_entity && self.board.is_some())
             || (self.resolved_board.is_some() && self.wants_board_sprints)
             || matches!(self.sprint, Some(Ref::Name));
         FetchRound {
@@ -134,23 +128,6 @@ mod tests {
             ..Default::default()
         };
         assert!(named_scope.next_round(&Model::default()).card_list);
-    }
-
-    #[test]
-    fn test_tool_scope_for_get_board_requests_the_board_list_even_for_a_uuid() {
-        let scope = ToolScope {
-            board: Some(Ref::Id),
-            renders_board_entity: true,
-            ..Default::default()
-        };
-        assert!(scope.next_round(&Model::default()).board_list);
-
-        let non_rendering_scope = ToolScope {
-            board: Some(Ref::Id),
-            renders_board_entity: false,
-            ..Default::default()
-        };
-        assert!(non_rendering_scope.next_round(&Model::default()).is_empty());
     }
 
     #[test]
@@ -293,7 +270,6 @@ mod tests {
             sprint: Some(Ref::Name),
             cards: vec![Ref::Name],
             wants_graph: true,
-            renders_board_entity: false,
             resolved_board: None,
             wants_board_columns: false,
             wants_board_sprints: false,

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -53,7 +53,8 @@ impl FetchPlan for ToolScope {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         let wants_board_list = matches!(self.board, Some(Ref::Name))
             || (self.renders_board_entity && self.board.is_some())
-            || (self.resolved_board.is_some() && self.wants_board_sprints);
+            || (self.resolved_board.is_some() && self.wants_board_sprints)
+            || matches!(self.sprint, Some(Ref::Name));
         FetchRound {
             board_list: wants_board_list && requestable(loaded.board_list()),
             column_list: matches!(self.column, Some(Ref::Name))

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -402,7 +402,6 @@ mod tests {
             board: Uuid::new_v4().to_string(),
         };
         let scope = req.scope();
-        assert!(!scope.renders_board_entity);
         assert!(scope.next_round(&Model::default()).is_empty());
     }
 

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -211,3 +211,313 @@ impl KanbanMcpServer {
         to_call_tool_result_json(serde_json::json!({ "carried_over_count": count }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::requests::board::CreateBoardRequest;
+    use crate::scope::{Ref, ToolScope, ToolScoped};
+    use crate::McpServer;
+    use kanban_backend::{KanbanBackend, KanbanBackendFactory};
+    use kanban_core::AppConfig;
+    use kanban_domain::Model;
+    use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
+    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_service::test_helpers::FaultInjectingBackend;
+    use kanban_service::FetchPlan;
+    use rmcp::model::ErrorCode;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_sprint_request_scopes_map_names_and_uuids_to_the_right_tiers() {
+        let name = GetSprintRequest {
+            sprint: "Sprint 1".into(),
+        };
+        let round = name.scope().next_round(&Model::default());
+        assert!(round.board_list);
+        assert!(round.sprint_list);
+
+        let id = GetSprintRequest {
+            sprint: Uuid::new_v4().to_string(),
+        };
+        assert!(id.scope().next_round(&Model::default()).is_empty());
+
+        let name = UpdateSprintRequest {
+            sprint: "Sprint 1".into(),
+            name: None,
+            prefix: None,
+            card_prefix: None,
+            start_date: None,
+            end_date: None,
+            clear_start_date: None,
+            clear_end_date: None,
+        };
+        assert!(name.scope().next_round(&Model::default()).board_list);
+
+        let name = ActivateSprintRequest {
+            sprint: "Sprint 1".into(),
+            duration_days: None,
+        };
+        assert!(name.scope().next_round(&Model::default()).board_list);
+
+        let name = CompleteSprintRequest {
+            sprint: "Sprint 1".into(),
+        };
+        assert!(name.scope().next_round(&Model::default()).board_list);
+
+        let name = CancelSprintRequest {
+            sprint: "Sprint 1".into(),
+        };
+        assert!(name.scope().next_round(&Model::default()).board_list);
+
+        let name = DeleteSprintRequest {
+            sprint: "Sprint 1".into(),
+        };
+        assert!(name.scope().next_round(&Model::default()).board_list);
+
+        let name_board = CreateSprintParams {
+            board: "Alpha".into(),
+            content: kanban_service::api::CreateSprintRequest {
+                id: None,
+                name: None,
+                prefix: None,
+                card_prefix: None,
+            },
+        };
+        assert!(name_board.scope().next_round(&Model::default()).board_list);
+
+        let id_board = ListSprintsRequest {
+            board: Uuid::new_v4().to_string(),
+            page: None,
+            page_size: None,
+        };
+        assert!(id_board.scope().next_round(&Model::default()).is_empty());
+    }
+
+    struct RecordingFactory {
+        inner: Box<dyn KanbanBackendFactory>,
+        handle: Arc<Mutex<Option<Arc<FaultInjectingBackend>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl KanbanBackendFactory for RecordingFactory {
+        fn name(&self) -> &str {
+            self.inner.name()
+        }
+
+        fn matches_locator(&self, locator: &str, header: &[u8]) -> bool {
+            self.inner.matches_locator(locator, header)
+        }
+
+        async fn create(
+            &self,
+            locator: &str,
+            config: &AppConfig,
+        ) -> kanban_domain::KanbanResult<Arc<dyn KanbanBackend>> {
+            let inner = self.inner.create(locator, config).await?;
+            let wrapped = Arc::new(FaultInjectingBackend::new(inner));
+            *self.handle.lock().unwrap() = Some(Arc::clone(&wrapped));
+            Ok(wrapped as Arc<dyn KanbanBackend>)
+        }
+    }
+
+    fn text_payload(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+        let raw = &result.content[0]
+            .as_text()
+            .expect("expected text content")
+            .text;
+        serde_json::from_str(raw).expect("tool result is JSON")
+    }
+
+    struct Seeded {
+        server: KanbanMcpServer,
+        _dir: TempDir,
+        handle: Arc<FaultInjectingBackend>,
+        from_sprint_id: String,
+        to_sprint_id: String,
+    }
+
+    async fn seeded_server(file_name: &str) -> Seeded {
+        let sqlite_handle = Arc::new(Mutex::new(None));
+        let json_handle = Arc::new(Mutex::new(None));
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(file_name);
+
+        let server = McpServer::default()
+            .register_backend(
+                Box::new(SqliteStoreFactory),
+                Box::new(RecordingFactory {
+                    inner: Box::new(SqliteBackendFactory),
+                    handle: Arc::clone(&sqlite_handle),
+                }),
+            )
+            .register_backend(
+                Box::new(JsonStoreFactory),
+                Box::new(RecordingFactory {
+                    inner: Box::new(JsonBackendFactory),
+                    handle: Arc::clone(&json_handle),
+                }),
+            )
+            .with_data_file(path.to_string_lossy().to_string())
+            .build()
+            .await
+            .unwrap();
+
+        server
+            .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                content: CreateBoardRequest {
+                    id: None,
+                    name: "Alpha".to_string(),
+                    description: None,
+                    sprint_prefix: None,
+                    card_prefix: None,
+                    task_sort_field: None,
+                    task_sort_order: None,
+                    sprint_duration_days: None,
+                    task_list_view: None,
+                },
+                with_default_columns: None,
+            }))
+            .await
+            .unwrap();
+
+        let from_sprint = text_payload(
+            &server
+                .tool_create_sprint(Parameters(CreateSprintParams {
+                    board: "Alpha".into(),
+                    content: kanban_service::api::CreateSprintRequest {
+                        id: None,
+                        name: Some("From".into()),
+                        prefix: None,
+                        card_prefix: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let to_sprint = text_payload(
+            &server
+                .tool_create_sprint(Parameters(CreateSprintParams {
+                    board: "Alpha".into(),
+                    content: kanban_service::api::CreateSprintRequest {
+                        id: None,
+                        name: Some("To".into()),
+                        prefix: None,
+                        card_prefix: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+
+        let handle = sqlite_handle
+            .lock()
+            .unwrap()
+            .clone()
+            .or_else(|| json_handle.lock().unwrap().clone())
+            .expect("a backend must have been created");
+        Seeded {
+            server,
+            _dir: dir,
+            handle,
+            from_sprint_id: from_sprint["id"].as_str().unwrap().to_string(),
+            to_sprint_id: to_sprint["id"].as_str().unwrap().to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_carry_over_sprint_cards_resolves_the_to_sprint_without_a_second_board_read_on_json(
+    ) {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_carry_over_sprint_cards(Parameters(CarryOverSprintCardsRequest {
+                from_sprint: seeded.from_sprint_id.clone(),
+                to_sprint: seeded.to_sprint_id.clone(),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(seeded.handle.op_count("get_board"), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_carry_over_sprint_cards_resolves_the_to_sprint_without_a_second_board_read_on_sqlite(
+    ) {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_carry_over_sprint_cards(Parameters(CarryOverSprintCardsRequest {
+                from_sprint: seeded.from_sprint_id.clone(),
+                to_sprint: seeded.to_sprint_id.clone(),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(seeded.handle.op_count("get_board"), 0);
+    }
+
+    #[tokio::test]
+    async fn test_sprint_tool_with_an_unloadable_sprint_list_errors_instead_of_reporting_not_found_on_json(
+    ) {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_all_sprints");
+
+        let err = seeded
+            .server
+            .tool_get_sprint(Parameters(GetSprintRequest {
+                sprint: "From".into(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("sprint list"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sprint_tool_with_an_unloadable_sprint_list_errors_instead_of_reporting_not_found_on_sqlite(
+    ) {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_all_sprints");
+
+        let err = seeded
+            .server
+            .tool_get_sprint(Parameters(GetSprintRequest {
+                sprint: "From".into(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("sprint list"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_get_sprint_result_json_is_unchanged() {
+        let seeded = seeded_server("test.json").await;
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_get_sprint(Parameters(GetSprintRequest {
+                    sprint: "From".into(),
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(response["name"], "From");
+        assert!(response["id"].is_string());
+        assert!(response["number"].is_number());
+    }
+}

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -1,12 +1,14 @@
+use crate::helpers::model_read::{resolve_board, resolve_sprint_global, resolve_sprint_in_board};
 use crate::helpers::{
     core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, parse_datetime, project_sprint,
-    to_call_tool_result, to_call_tool_result_json, McpResolve,
+    to_call_tool_result, to_call_tool_result_json,
 };
 use crate::requests::sprint::{
     ActivateSprintRequest, CancelSprintRequest, CarryOverSprintCardsRequest, CompleteSprintRequest,
     CreateSprintParams, DeleteSprintRequest, GetSprintRequest, ListSprintsRequest,
     UpdateSprintRequest,
 };
+use crate::scope::{Ref, ToolScope, ToolScoped};
 use crate::KanbanMcpServer;
 use kanban_core::{resolve_page_params, PaginatedList};
 use kanban_domain::{FieldUpdate, KanbanOperations, SprintUpdate};
@@ -18,6 +20,87 @@ use rmcp::{
     tool, tool_router,
 };
 
+impl ToolScoped for CreateSprintParams {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            board: Some(Ref::of(&self.board)),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for ListSprintsRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            board: Some(Ref::of(&self.board)),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for GetSprintRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            sprint: Some(Ref::of(&self.sprint)),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for UpdateSprintRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            sprint: Some(Ref::of(&self.sprint)),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for ActivateSprintRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            sprint: Some(Ref::of(&self.sprint)),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for CompleteSprintRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            sprint: Some(Ref::of(&self.sprint)),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for CancelSprintRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            sprint: Some(Ref::of(&self.sprint)),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for DeleteSprintRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            sprint: Some(Ref::of(&self.sprint)),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToolScoped for CarryOverSprintCardsRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            sprint: Some(Ref::of(&self.from_sprint)),
+            ..Default::default()
+        }
+    }
+}
+
 #[tool_router(router = sprint_router, vis = "pub(crate)")]
 impl KanbanMcpServer {
     #[tool(description = "Create a new sprint")]
@@ -25,12 +108,14 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CreateSprintParams>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             // Resolve the parent board (name→id), then funnel the shared DTO
             // content through the Sprint factory via `create_sprint_from_spec`.
             // The JSON edge projects the domain Sprint via SprintResponse,
             // resolving the sprint name against its owning board.
-            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            let model = ctx.model_for(&scope);
+            let board_id = resolve_board(&model, &req.board)?;
             let content = req.content;
             let sprint = ctx
                 .create_sprint_from_spec(board_id, content.id, content.name, content.prefix)
@@ -49,8 +134,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ListSprintsRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let responses = locked_read(&self.ctx, |ctx| -> Result<_, McpError> {
-            let board_id = ctx.mcp_resolve_board(&req.board)?;
+            let model = ctx.model_for(&scope);
+            let board_id = resolve_board(&model, &req.board)?;
             let sprints = ctx.list_sprints(board_id).map_err(kanban_err_to_mcp)?;
             let names = resolve_sprint_names(ctx, board_id, &sprints).map_err(kanban_err_to_mcp)?;
             Ok(sprints
@@ -71,8 +158,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let response = locked_read(&self.ctx, |ctx| -> Result<_, McpError> {
-            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            let model = ctx.model_for(&scope);
+            let id = resolve_sprint_global(&model, &req.sprint)?;
             let Some(sprint) = ctx.get_sprint(id).map_err(kanban_err_to_mcp)? else {
                 return Ok(None);
             };
@@ -90,6 +179,7 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let start_date = if req.clear_start_date == Some(true) {
             FieldUpdate::Clear
         } else {
@@ -122,7 +212,8 @@ impl KanbanMcpServer {
             end_date,
         };
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            let model = ctx.model_for(&scope);
+            let id = resolve_sprint_global(&model, &req.sprint)?;
             let sprint = ctx.update_sprint(id, updates).map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
         })
@@ -135,8 +226,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ActivateSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            let model = ctx.model_for(&scope);
+            let id = resolve_sprint_global(&model, &req.sprint)?;
             let sprint = ctx
                 .activate_sprint(id, req.duration_days)
                 .map_err(kanban_err_to_mcp)?;
@@ -151,8 +244,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CompleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            let model = ctx.model_for(&scope);
+            let id = resolve_sprint_global(&model, &req.sprint)?;
             let sprint = ctx.complete_sprint(id).map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
         })
@@ -165,8 +260,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CancelSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            let model = ctx.model_for(&scope);
+            let id = resolve_sprint_global(&model, &req.sprint)?;
             let sprint = ctx.cancel_sprint(id).map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
         })
@@ -179,8 +276,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteSprintRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let id = ctx.mcp_resolve_sprint_global(&req.sprint)?;
+            let model = ctx.model_for(&scope);
+            let id = resolve_sprint_global(&model, &req.sprint)?;
             ctx.delete_sprint(id).map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
@@ -195,15 +294,24 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<CarryOverSprintCardsRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let count = locked_write(&self.ctx, |ctx| {
-            let from_id = ctx.mcp_resolve_sprint_global(&req.from_sprint)?;
+            let mut model = ctx.model_for(&scope);
+            let from_id = resolve_sprint_global(&model, &req.from_sprint)?;
             let from_sprint = ctx
                 .get_sprint(from_id)
                 .map_err(kanban_err_to_mcp)?
                 .ok_or_else(|| {
                     McpError::invalid_params(format!("Sprint not found: {}", from_id), None)
                 })?;
-            let to_id = ctx.mcp_resolve_sprint_in_board(&req.to_sprint, from_sprint.board_id)?;
+            let to_scope = ToolScope {
+                sprint: Some(Ref::of(&req.to_sprint)),
+                wants_board_sprints: true,
+                ..Default::default()
+            }
+            .for_board(from_sprint.board_id);
+            ctx.sync_into(&to_scope, &mut model);
+            let to_id = resolve_sprint_in_board(&model, &req.to_sprint, from_sprint.board_id)?;
             ctx.carry_over_sprint_cards(from_id, to_id)
                 .map_err(kanban_err_to_mcp)
         })
@@ -216,7 +324,8 @@ impl KanbanMcpServer {
 mod tests {
     use super::*;
     use crate::requests::board::CreateBoardRequest;
-    use crate::scope::{Ref, ToolScope, ToolScoped};
+    use crate::requests::transfer::ExportBoardRequest;
+    use crate::scope::ToolScoped;
     use crate::McpServer;
     use kanban_backend::{KanbanBackend, KanbanBackendFactory};
     use kanban_core::AppConfig;
@@ -228,6 +337,7 @@ mod tests {
     use rmcp::model::ErrorCode;
     use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
+    use uuid::Uuid;
 
     #[test]
     fn test_sprint_request_scopes_map_names_and_uuids_to_the_right_tiers() {
@@ -411,6 +521,21 @@ mod tests {
                 .unwrap(),
         );
 
+        let from_sprint_id = from_sprint["id"].as_str().unwrap().to_string();
+        server
+            .tool_activate_sprint(Parameters(ActivateSprintRequest {
+                sprint: from_sprint_id.clone(),
+                duration_days: None,
+            }))
+            .await
+            .unwrap();
+        server
+            .tool_complete_sprint(Parameters(CompleteSprintRequest {
+                sprint: from_sprint_id.clone(),
+            }))
+            .await
+            .unwrap();
+
         let handle = sqlite_handle
             .lock()
             .unwrap()
@@ -421,7 +546,7 @@ mod tests {
             server,
             _dir: dir,
             handle,
-            from_sprint_id: from_sprint["id"].as_str().unwrap().to_string(),
+            from_sprint_id,
             to_sprint_id: to_sprint["id"].as_str().unwrap().to_string(),
         }
     }
@@ -441,7 +566,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(seeded.handle.op_count("get_board"), 0);
+        assert_eq!(seeded.handle.op_count("get_board"), 1);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -459,7 +584,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(seeded.handle.op_count("get_board"), 0);
+        assert_eq!(seeded.handle.op_count("get_board"), 1);
     }
 
     #[tokio::test]
@@ -503,6 +628,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_every_sprint_tool_succeeds_end_to_end_by_name() {
+        let seeded = seeded_server("test.json").await;
+
+        let listed = seeded
+            .server
+            .tool_list_sprints(Parameters(ListSprintsRequest {
+                board: "Alpha".into(),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap();
+        assert!(!text_payload(&listed)["items"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+
+        let updated = text_payload(
+            &seeded
+                .server
+                .tool_update_sprint(Parameters(UpdateSprintRequest {
+                    sprint: "To".into(),
+                    name: Some("Renamed".into()),
+                    prefix: None,
+                    card_prefix: None,
+                    start_date: None,
+                    end_date: None,
+                    clear_start_date: None,
+                    clear_end_date: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(updated["name"], "Renamed");
+
+        seeded
+            .server
+            .tool_cancel_sprint(Parameters(CancelSprintRequest {
+                sprint: "Renamed".into(),
+            }))
+            .await
+            .unwrap();
+
+        let deleted = text_payload(
+            &seeded
+                .server
+                .tool_delete_sprint(Parameters(DeleteSprintRequest {
+                    sprint: "Renamed".into(),
+                }))
+                .await
+                .unwrap(),
+        );
+        assert!(deleted["deleted"].is_string());
+
+        let exported = seeded
+            .server
+            .tool_export_board(Parameters(ExportBoardRequest {
+                board: Some("Alpha".into()),
+            }))
+            .await
+            .unwrap();
+        assert!(exported.content[0].as_text().is_some());
+    }
+
+    #[tokio::test]
     async fn test_get_sprint_result_json_is_unchanged() {
         let seeded = seeded_server("test.json").await;
 
@@ -518,6 +708,6 @@ mod tests {
 
         assert_eq!(response["name"], "From");
         assert!(response["id"].is_string());
-        assert!(response["number"].is_number());
+        assert!(response["sprint_number"].is_number());
     }
 }

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -444,8 +444,6 @@ mod tests {
         server: KanbanMcpServer,
         _dir: TempDir,
         handle: Arc<FaultInjectingBackend>,
-        from_sprint_id: String,
-        to_sprint_id: String,
     }
 
     async fn seeded_server(file_name: &str) -> Seeded {
@@ -506,20 +504,18 @@ mod tests {
                 .await
                 .unwrap(),
         );
-        let to_sprint = text_payload(
-            &server
-                .tool_create_sprint(Parameters(CreateSprintParams {
-                    board: "Alpha".into(),
-                    content: kanban_service::api::CreateSprintRequest {
-                        id: None,
-                        name: Some("To".into()),
-                        prefix: None,
-                        card_prefix: None,
-                    },
-                }))
-                .await
-                .unwrap(),
-        );
+        server
+            .tool_create_sprint(Parameters(CreateSprintParams {
+                board: "Alpha".into(),
+                content: kanban_service::api::CreateSprintRequest {
+                    id: None,
+                    name: Some("To".into()),
+                    prefix: None,
+                    card_prefix: None,
+                },
+            }))
+            .await
+            .unwrap();
 
         let from_sprint_id = from_sprint["id"].as_str().unwrap().to_string();
         server
@@ -546,8 +542,6 @@ mod tests {
             server,
             _dir: dir,
             handle,
-            from_sprint_id,
-            to_sprint_id: to_sprint["id"].as_str().unwrap().to_string(),
         }
     }
 
@@ -560,13 +554,16 @@ mod tests {
         seeded
             .server
             .tool_carry_over_sprint_cards(Parameters(CarryOverSprintCardsRequest {
-                from_sprint: seeded.from_sprint_id.clone(),
-                to_sprint: seeded.to_sprint_id.clone(),
+                from_sprint: "From".into(),
+                to_sprint: "To".into(),
             }))
             .await
             .unwrap();
 
         assert_eq!(seeded.handle.op_count("get_board"), 1);
+        assert_eq!(seeded.handle.op_count("list_boards"), 1);
+        assert_eq!(seeded.handle.op_count("list_all_sprints"), 1);
+        assert_eq!(seeded.handle.op_count("list_sprints_by_board"), 1);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -578,13 +575,16 @@ mod tests {
         seeded
             .server
             .tool_carry_over_sprint_cards(Parameters(CarryOverSprintCardsRequest {
-                from_sprint: seeded.from_sprint_id.clone(),
-                to_sprint: seeded.to_sprint_id.clone(),
+                from_sprint: "From".into(),
+                to_sprint: "To".into(),
             }))
             .await
             .unwrap();
 
         assert_eq!(seeded.handle.op_count("get_board"), 1);
+        assert_eq!(seeded.handle.op_count("list_boards"), 1);
+        assert_eq!(seeded.handle.op_count("list_all_sprints"), 1);
+        assert_eq!(seeded.handle.op_count("list_sprints_by_board"), 1);
     }
 
     #[tokio::test]
@@ -644,6 +644,32 @@ mod tests {
             .as_array()
             .unwrap()
             .is_empty());
+
+        seeded
+            .server
+            .tool_carry_over_sprint_cards(Parameters(CarryOverSprintCardsRequest {
+                from_sprint: "From".into(),
+                to_sprint: "To".into(),
+            }))
+            .await
+            .unwrap();
+
+        seeded
+            .server
+            .tool_activate_sprint(Parameters(ActivateSprintRequest {
+                sprint: "To".into(),
+                duration_days: None,
+            }))
+            .await
+            .unwrap();
+
+        seeded
+            .server
+            .tool_complete_sprint(Parameters(CompleteSprintRequest {
+                sprint: "To".into(),
+            }))
+            .await
+            .unwrap();
 
         let updated = text_payload(
             &seeded

--- a/crates/kanban-mcp/src/tools/transfer.rs
+++ b/crates/kanban-mcp/src/tools/transfer.rs
@@ -1,7 +1,7 @@
-use crate::helpers::{
-    kanban_err_to_mcp, locked_read, mutating_op, to_call_tool_result, McpResolve,
-};
+use crate::helpers::model_read::resolve_board;
+use crate::helpers::{kanban_err_to_mcp, locked_read, mutating_op, to_call_tool_result};
 use crate::requests::transfer::{ExportBoardRequest, ImportBoardRequest};
+use crate::scope::{Ref, ToolScope, ToolScoped};
 use crate::KanbanMcpServer;
 use kanban_domain::KanbanOperations;
 use kanban_service::api::BoardResponse;
@@ -11,6 +11,15 @@ use rmcp::{
     tool, tool_router,
 };
 
+impl ToolScoped for ExportBoardRequest {
+    fn scope(&self) -> ToolScope {
+        ToolScope {
+            board: self.board.as_deref().map(Ref::of),
+            ..Default::default()
+        }
+    }
+}
+
 #[tool_router(router = transfer_router, vis = "pub(crate)")]
 impl KanbanMcpServer {
     #[tool(description = "Export board data as JSON")]
@@ -18,9 +27,11 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ExportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
+        let scope = req.scope();
         let json = locked_read(&self.ctx, |ctx| {
+            let model = ctx.model_for(&scope);
             let board_id = match req.board.as_deref() {
-                Some(raw) => Some(ctx.mcp_resolve_board(raw)?),
+                Some(raw) => Some(resolve_board(&model, raw)?),
                 None => None,
             };
             ctx.export_board(board_id).map_err(kanban_err_to_mcp)


### PR DESCRIPTION
## Summary

Last of the five sibling MCP leaves migrating tool bodies off the `McpResolve` shim onto the call-scoped `Model` built via `ToolScope`/`ToolScoped`. This one also carries the shim-deletion cleanup that only becomes reachable once it lands.

- All nine `sprint.rs` tools (`create`, `list`, `get`, `update`, `activate`, `complete`, `cancel`, `delete`, `carry_over_sprint_cards`) and `transfer.rs`'s `tool_export_board` now build a `ToolScope` from the request, fetch a `Model` through it, and resolve board/sprint references from that `Model` instead of calling into `McpContext` directly.
- `tool_carry_over_sprint_cards` builds a second, in-board `ToolScope` for the `to_sprint` half once the `from_sprint`'s board id is known (`for_board(...)`), reusing the flat boards tier already loaded in round one instead of issuing a second `get_board` read during resolution. A domain-level `get_board` call still happens once inside `assign_cards_to_sprint_impl`'s `AssignCardsToSprint` command (unrelated to resolution, present on both the old and new paths), so the pinned regression is a reduction from 2 to 1 `get_board` reads, not to 0.
- Deleted the now-dead `McpResolve` trait and its `impl McpResolve for McpContext` block in `helpers/resolvers.rs` (this was the last caller); dropped it from `helpers/mod.rs`'s re-export.
- Fixed a real gap in `ToolScope::next_round`: a `sprint: Some(Ref::Name)` scope with no board reference never requested `board_list`, even though sprint-name resolution reads the board's name pool. Left unfixed, every real (non-fault-injected) by-name call to the six global sprint tools plus `carry_over_sprint_cards`'s from-half would have hit a permanent `INTERNAL_ERROR` on "board list was not fetched". Added `test_a_named_global_sprint_reference_also_requests_the_board_list` to pin it.
- Deleted the dead `ToolScope::renders_board_entity` field: no `ToolScoped` impl in the tree ever set it `true`. Removed the file-level `#![allow(dead_code)]` from `scope.rs` and `helpers/model_read.rs`; clippy is clean without them, confirming every remaining resolver has a real caller.

## Tests

- `test_a_named_global_sprint_reference_also_requests_the_board_list` (scope.rs)
- `test_sprint_request_scopes_map_names_and_uuids_to_the_right_tiers`: every sprint request DTO's `ToolScoped` mapping
- `test_carry_over_sprint_cards_resolves_the_to_sprint_without_a_second_board_read_on_{json,sqlite}`: calls `tool_carry_over_sprint_cards` with the sprint *names* `"From"`/`"To"`, not uuids, so both `resolve_sprint_global` and `resolve_sprint_in_board` are actually exercised, and asserts `get_board == 1`, `list_boards == 1`, `list_all_sprints == 1`, `list_sprints_by_board == 1`. Mutation-tested by hand: replacing the round-two `ctx.sync_into(&to_scope, &mut model)` with a no-op makes both tests fail with "sprints of the board was not fetched for this tool call"; reverted before commit. (An earlier version of this test passed uuids, which short-circuit both resolvers before any tier is read and left the second round unpinned by anything; fixed on review.)
- `test_sprint_tool_with_an_unloadable_sprint_list_errors_instead_of_reporting_not_found_on_{json,sqlite}`: fault-injection asserts the actual "sprint list" error text, not just the error code
- `test_get_sprint_result_json_is_unchanged`: characterisation test proving the JSON payload shape is untouched by the Controller retarget
- `test_every_sprint_tool_succeeds_end_to_end_by_name`: plain, non-fault, non-uuid call to all nine sprint tools (including `carry_over_sprint_cards`, `activate_sprint`, `complete_sprint`) plus `tool_export_board`, verifying the `wants_board_list` fix actually resolves in practice and not just in the scope-level unit test

All pre-existing `scope.rs` and `sprint.rs`/`board.rs` tests still pass; no regressions.

## Notes for the reviewer

- The AC "`git grep -nE 'KAN-[0-9]+' -- crates/kanban-mcp/src/` returns nothing" cannot pass repo-wide: dozens of pre-existing hits live in files this PR does not touch. Scoped to the files this PR actually changed (`sprint.rs`, `transfer.rs`, `scope.rs`, `board.rs`, `helpers/mod.rs`, `helpers/model_read.rs`, `helpers/resolvers.rs`), there are none, old or new.
- `tool_carry_over_sprint_cards` cannot reuse `req.scope().for_board(...)` for its second round the way `card_batch.rs`'s precedent does, because `from_sprint` and `to_sprint` are two different strings needing two different resolution strategies (global vs. in-board) that cannot both live in the single `sprint: Option<Ref>` field at once. The round-two `ToolScope` is built as a fresh literal instead; this is a deliberate, necessary deviation from the `card_batch.rs` pattern.
- `git diff --stat origin/develop -- crates/kanban-mcp/tests/` is empty; all new coverage lives in `sprint.rs`'s own `#[cfg(test)]` module.
