### PR TITLE
KAN-1489 fix(tui): decline on flat load tiers and use a headless terminal in tests

### DIFF
--- a/.changeset/kan-1489-detail-view-handlers-decline-on-unloaded-tiers.md
+++ b/.changeset/kan-1489-detail-view-handlers-decline-on-unloaded-tiers.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: board detail, card detail, sprint detail and manage-parents/children handlers now decline with an error banner when the columns or sprints tier they need is not loaded, instead of silently treating an unloaded tier as empty.

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -8,7 +8,7 @@ use kanban_core::Editable;
 use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::Model;
 use kanban_domain::{
-    BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, LoadState, Searcher, Sprint,
+    BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, LoadState, Searcher,
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
@@ -271,39 +271,7 @@ impl App {
                 self.focus.card_focus = CardFocus::Title;
             }
             KeyCode::Char('a') => {
-                if let Some(board) = self.active_board().cloned() {
-                    match self
-                        .model
-                        .board_sprints_state(board.id)
-                        .map(<[Sprint]>::len)
-                    {
-                        LoadState::Loaded(sprint_count) if sprint_count > 0 => {
-                            match self.model.sprints_state() {
-                                LoadState::Loaded(all_sprints) => {
-                                    let current_sprint_id = self
-                                        .selection
-                                        .active_card_id
-                                        .and_then(|id| {
-                                            self.model.card_by_id_state(id).loaded().copied()
-                                        })
-                                        .and_then(|c| c.sprint_id);
-                                    self.dialog_input
-                                        .assign_sprint_picker
-                                        .reset_for_card_assignment(
-                                            current_sprint_id,
-                                            all_sprints,
-                                            &board,
-                                            chrono::Utc::now(),
-                                        );
-                                    self.open_dialog(DialogMode::AssignCardToSprint);
-                                }
-                                _ => self.set_error("Sprints are not loaded yet"),
-                            }
-                        }
-                        LoadState::Loaded(_) => {}
-                        _ => self.set_error("Sprints are not loaded yet"),
-                    }
-                }
+                self.handle_assign_sprint_shortcut();
             }
             KeyCode::Char('p') => {
                 self.open_dialog(DialogMode::SetCardPoints);
@@ -499,12 +467,10 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => match self.focus.board_focus {
                 BoardFocus::Sprints => {
                     if let Some(board_id) = self.active_board().map(|board| board.id) {
-                        match self
-                            .model
-                            .board_sprints_state(board_id)
-                            .map(<[Sprint]>::len)
-                        {
-                            LoadState::Loaded(sprint_count) => {
+                        match self.model.sprints_state() {
+                            LoadState::Loaded(sprints) => {
+                                let sprint_count =
+                                    sprints.iter().filter(|s| s.board_id == board_id).count();
                                 let current_idx = self.selection.sprint.get().unwrap_or(0);
                                 if sprint_count == 0 || current_idx >= sprint_count - 1 {
                                     if self.model.columns_state().is_loaded() {
@@ -571,32 +537,40 @@ impl App {
                     }
                 }
                 BoardFocus::Columns => {
-                    if let Some(board_id) = self.board_list.get_selected_board_id() {
-                        if self.model.columns_state().is_loaded() {
-                            let column_count = self.column_count_for_board(board_id);
-                            self.dialog_input
-                                .column_list
-                                .update_item_count(column_count);
-                            let was_at_top = self.dialog_input.column_list.navigate_up();
-                            if was_at_top {
-                                match self
-                                    .model
-                                    .board_sprints_state(board_id)
-                                    .map(<[Sprint]>::len)
-                                {
-                                    LoadState::Loaded(sprint_count) => {
-                                        if sprint_count == 0 {
-                                            self.focus.board_focus = BoardFocus::Settings;
-                                        } else {
-                                            self.focus.board_focus = BoardFocus::Sprints;
-                                            self.selection.sprint.set(Some(sprint_count - 1));
-                                        }
-                                    }
-                                    _ => self.set_error("Sprints are not loaded yet"),
+                    let board_id = self.board_list.get_selected_board_id();
+                    let columns_ready =
+                        board_id.is_none() || self.model.columns_state().is_loaded();
+                    if !columns_ready {
+                        self.set_error("Columns are not loaded yet");
+                    } else {
+                        let column_count = board_id
+                            .map(|id| self.column_count_for_board(id))
+                            .unwrap_or(0);
+                        self.dialog_input
+                            .column_list
+                            .update_item_count(column_count);
+                        let was_at_top = self.dialog_input.column_list.navigate_up();
+                        if was_at_top {
+                            let sprints_ready =
+                                board_id.is_none() || self.model.sprints_state().is_loaded();
+                            if !sprints_ready {
+                                self.set_error("Sprints are not loaded yet");
+                            } else {
+                                let sprint_count = board_id
+                                    .and_then(|id| match self.model.sprints_state() {
+                                        LoadState::Loaded(sprints) => Some(
+                                            sprints.iter().filter(|s| s.board_id == id).count(),
+                                        ),
+                                        _ => None,
+                                    })
+                                    .unwrap_or(0);
+                                if sprint_count == 0 {
+                                    self.focus.board_focus = BoardFocus::Settings;
+                                } else {
+                                    self.focus.board_focus = BoardFocus::Sprints;
+                                    self.selection.sprint.set(Some(sprint_count - 1));
                                 }
                             }
-                        } else {
-                            self.set_error("Columns are not loaded yet");
                         }
                     }
                 }
@@ -620,9 +594,14 @@ impl App {
                     if let Some(sprint_idx) = self.selection.sprint.get() {
                         let board_ctx = self.board_in_context().map(|b| b.id);
                         if let Some(board_id) = board_ctx {
-                            match self.model.board_sprints_state(board_id) {
+                            match self.model.sprints_state() {
                                 LoadState::Loaded(sprints) => {
-                                    if let Some(sprint_id) = sprints.get(sprint_idx).map(|s| s.id) {
+                                    let sprint_id = sprints
+                                        .iter()
+                                        .filter(|s| s.board_id == board_id)
+                                        .nth(sprint_idx)
+                                        .map(|s| s.id);
+                                    if let Some(sprint_id) = sprint_id {
                                         self.selection.active_sprint_id = Some(sprint_id);
                                         self.selection.active_board_id = Some(board_id);
                                         self.populate_sprint_task_lists(sprint_id);
@@ -758,40 +737,69 @@ impl App {
         }
     }
 
+    /// Open the assign-to-sprint picker for the active card, primed to its
+    /// current sprint (if any). No-op if the card's board has no sprints to
+    /// assign to.
+    fn handle_assign_sprint_shortcut(&mut self) {
+        if let Some(board) = self.active_board().cloned() {
+            match self.model.sprints_state() {
+                LoadState::Loaded(all_sprints) => {
+                    let sprint_count = all_sprints
+                        .iter()
+                        .filter(|s| s.board_id == board.id)
+                        .count();
+                    if sprint_count > 0 {
+                        let current_sprint_id = self
+                            .selection
+                            .active_card_id
+                            .and_then(|id| self.model.card_by_id_state(id).loaded().copied())
+                            .and_then(|c| c.sprint_id);
+                        self.dialog_input
+                            .assign_sprint_picker
+                            .reset_for_card_assignment(
+                                current_sprint_id,
+                                all_sprints,
+                                &board,
+                                chrono::Utc::now(),
+                            );
+                        self.open_dialog(DialogMode::AssignCardToSprint);
+                    }
+                }
+                _ => self.set_error("Sprints are not loaded yet"),
+            }
+        }
+    }
+
     /// Activate `card_id` and open the assign-to-sprint picker for it, primed
     /// to its current sprint (if any). No-op if the card's board has no
     /// sprints to assign to.
     fn open_assign_sprint_dialog_for(&mut self, card_id: uuid::Uuid) {
         if self.activate_card(card_id) {
             if let Some(board) = self.active_board().cloned() {
-                match self
-                    .model
-                    .board_sprints_state(board.id)
-                    .map(<[Sprint]>::len)
-                {
-                    LoadState::Loaded(sprint_count) if sprint_count > 0 => {
-                        match self.model.sprints_state() {
-                            LoadState::Loaded(all_sprints) => {
-                                let current_sprint_id = self
-                                    .model
-                                    .card_by_id_state(card_id)
-                                    .loaded()
-                                    .copied()
-                                    .and_then(|c| c.sprint_id);
-                                self.dialog_input
-                                    .assign_sprint_picker
-                                    .reset_for_card_assignment(
-                                        current_sprint_id,
-                                        all_sprints,
-                                        &board,
-                                        chrono::Utc::now(),
-                                    );
-                                self.open_dialog(DialogMode::AssignCardToSprint);
-                            }
-                            _ => self.set_error("Sprints are not loaded yet"),
+                match self.model.sprints_state() {
+                    LoadState::Loaded(all_sprints) => {
+                        let sprint_count = all_sprints
+                            .iter()
+                            .filter(|s| s.board_id == board.id)
+                            .count();
+                        if sprint_count > 0 {
+                            let current_sprint_id = self
+                                .model
+                                .card_by_id_state(card_id)
+                                .loaded()
+                                .copied()
+                                .and_then(|c| c.sprint_id);
+                            self.dialog_input
+                                .assign_sprint_picker
+                                .reset_for_card_assignment(
+                                    current_sprint_id,
+                                    all_sprints,
+                                    &board,
+                                    chrono::Utc::now(),
+                                );
+                            self.open_dialog(DialogMode::AssignCardToSprint);
                         }
                     }
-                    LoadState::Loaded(_) => {}
                     _ => self.set_error("Sprints are not loaded yet"),
                 }
             }
@@ -1157,18 +1165,17 @@ impl App {
             }
         };
 
-        let column_ids: std::collections::HashSet<_> =
-            match self.model.board_columns_state(board_id) {
-                LoadState::Loaded(columns) => columns
-                    .iter()
-                    .filter(|c| c.board_id == board_id)
-                    .map(|c| c.id)
-                    .collect(),
-                _ => {
-                    self.set_error("Columns are not loaded yet");
-                    return;
-                }
-            };
+        let column_ids: std::collections::HashSet<_> = match self.model.columns_state() {
+            LoadState::Loaded(columns) => columns
+                .iter()
+                .filter(|c| c.board_id == board_id)
+                .map(|c| c.id)
+                .collect(),
+            _ => {
+                self.set_error("Columns are not loaded yet");
+                return;
+            }
+        };
 
         let descendants = self
             .model
@@ -1227,18 +1234,17 @@ impl App {
             }
         };
 
-        let column_ids: std::collections::HashSet<_> =
-            match self.model.board_columns_state(board_id) {
-                LoadState::Loaded(columns) => columns
-                    .iter()
-                    .filter(|c| c.board_id == board_id)
-                    .map(|c| c.id)
-                    .collect(),
-                _ => {
-                    self.set_error("Columns are not loaded yet");
-                    return;
-                }
-            };
+        let column_ids: std::collections::HashSet<_> = match self.model.columns_state() {
+            LoadState::Loaded(columns) => columns
+                .iter()
+                .filter(|c| c.board_id == board_id)
+                .map(|c| c.id)
+                .collect(),
+            _ => {
+                self.set_error("Columns are not loaded yet");
+                return;
+            }
+        };
 
         let ancestors = self
             .model
@@ -1420,7 +1426,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use crate::app::sprint_view::SprintTaskPanel;
-    use crate::app::{AppMode, BoardFocus, CardFocus};
+    use crate::app::{AppMode, BoardFocus, CardFocus, DialogMode};
     use crate::App;
     use crossterm::event::KeyCode;
     use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, Snapshot};
@@ -1476,45 +1482,6 @@ mod tests {
             prefixes: Vec::new(),
         };
         app.load_snapshot(snap);
-    }
-
-    /// Populates the per-board scoped tiers (`board_columns_state`,
-    /// `board_sprints_state`) for `board_id` from whatever is already in the
-    /// flat tier. `reload_model`/`reload_snapshot`/`load_snapshot` never
-    /// touch these tiers themselves, so a test exercising a genuinely
-    /// board-scoped accessor must populate them explicitly.
-    fn sync_board_scoped_tiers(app: &mut App, board_id: uuid::Uuid) {
-        use kanban_domain::resolved::Collection;
-        use kanban_domain::{LoadState, Resolved};
-        use std::collections::HashMap;
-
-        let columns: Vec<_> = app
-            .model
-            .columns_state()
-            .loaded_or_empty()
-            .iter()
-            .filter(|c| c.board_id == board_id)
-            .cloned()
-            .collect();
-        let sprints: Vec<_> = app
-            .model
-            .sprints_state()
-            .loaded_or_empty()
-            .iter()
-            .filter(|s| s.board_id == board_id)
-            .cloned()
-            .collect();
-        let _ = app.model.apply_resolved(Resolved {
-            columns: Collection {
-                by_parent: HashMap::from([(board_id, LoadState::Loaded(columns))]),
-                ..Default::default()
-            },
-            sprints: Collection {
-                by_parent: HashMap::from([(board_id, LoadState::Loaded(sprints))]),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
     }
 
     fn seed_chain(app: &mut App, titles: &[&str]) -> Vec<uuid::Uuid> {
@@ -1702,7 +1669,6 @@ mod tests {
         // assign to (the dialog only opens when sprint_count > 0).
         app.ctx.create_sprint(board_id, None, None).unwrap();
         reload_snapshot(&mut app);
-        sync_board_scoped_tiers(&mut app, board_id);
         app.sprint_view
             .uncompleted_component
             .update_cards(vec![card_id]);
@@ -1747,7 +1713,6 @@ mod tests {
             )
             .unwrap();
         reload_snapshot(&mut app);
-        sync_board_scoped_tiers(&mut app, board_id);
         app.sprint_view.panel = SprintTaskPanel::Completed;
         app.sprint_view
             .completed_component
@@ -2001,7 +1966,6 @@ mod tests {
     fn test_handle_manage_parents_after_reload_resort_uses_originally_selected_card() {
         let mut app = App::test_default();
         let fx = setup_reload_resort_fixture(&mut app);
-        sync_board_scoped_tiers(&mut app, fx.board_id);
 
         app.handle_manage_parents();
 
@@ -2019,7 +1983,6 @@ mod tests {
     fn test_handle_manage_children_after_reload_resort_uses_originally_selected_card() {
         let mut app = App::test_default();
         let fx = setup_reload_resort_fixture(&mut app);
-        sync_board_scoped_tiers(&mut app, fx.board_id);
 
         app.handle_manage_children();
 
@@ -2090,7 +2053,6 @@ mod tests {
         app.ctx.create_sprint(board_id, None, None).unwrap();
         app.reload_model();
         app.prepare_frame();
-        sync_board_scoped_tiers(&mut app, board_id);
 
         app.dialog_input.column_list.update_item_count(3);
         app.dialog_input.column_list.set_selected_index(Some(0));
@@ -2406,7 +2368,6 @@ mod tests {
         app.selection.active_board_id = Some(alpha.id);
         app.reload_model();
         app.prepare_frame();
-        sync_board_scoped_tiers(&mut app, alpha.id);
         app.push_mode(AppMode::BoardDetail);
         app.focus.board_focus = BoardFocus::Sprints;
         app.selection.sprint.set(Some(1));
@@ -2416,5 +2377,125 @@ mod tests {
         assert_eq!(app.selection.active_sprint_id, Some(a2.id));
         assert_eq!(app.selection.active_board_id, Some(alpha.id));
         assert_eq!(app.mode, AppMode::SprintDetail);
+    }
+
+    fn assert_error_banner(app: &App) {
+        let banner = app
+            .ui_state
+            .banner
+            .as_ref()
+            .expect("expected an error banner to be set");
+        assert_eq!(banner.variant, crate::components::BannerVariant::Error);
+    }
+
+    fn assert_no_banner(app: &App) {
+        assert!(
+            app.ui_state.banner.is_none(),
+            "expected no banner, got {:?}",
+            app.ui_state.banner
+        );
+    }
+
+    #[test]
+    fn test_handle_board_detail_navigation_key_declines_column_navigation_when_columns_not_loaded()
+    {
+        use kanban_domain::{Board, LoadState, Model, ModelLoadStates};
+        let mut app = App::test_default();
+        let board = Board::new("Board", None::<String>);
+        let board_id = board.id;
+        app.model = Model::with_load_states(ModelLoadStates {
+            boards: LoadState::Loaded(vec![board]),
+            sprints: LoadState::Loaded(Vec::new()),
+            ..Default::default()
+        });
+        app.selection.active_board_id = Some(board_id);
+        app.focus.board_focus = BoardFocus::Sprints;
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('j'));
+
+        assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
+        assert_error_banner(&app);
+    }
+
+    #[test]
+    fn test_handle_board_detail_navigation_key_still_navigates_columns_when_loaded() {
+        let mut app = App::test_default();
+        seed_board_with_columns(&mut app, 1);
+        app.focus.board_focus = BoardFocus::Sprints;
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('j'));
+
+        assert_eq!(app.focus.board_focus, BoardFocus::Columns);
+        assert_no_banner(&app);
+        assert_eq!(app.dialog_input.column_list.get_selected_index(), Some(0));
+    }
+
+    #[test]
+    fn test_handle_board_detail_navigation_key_up_falls_back_to_settings_when_no_board_selected() {
+        let mut app = App::test_default();
+        app.focus.board_focus = BoardFocus::Columns;
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('k'));
+
+        assert_eq!(app.focus.board_focus, BoardFocus::Settings);
+        assert_no_banner(&app);
+    }
+
+    #[test]
+    fn test_handle_assign_sprint_shortcut_declines_when_sprints_not_loaded() {
+        use kanban_domain::{Board, Card, Column, LoadState, Model, ModelLoadStates};
+        let mut app = App::test_default();
+        let board = Board::new("Board", None::<String>);
+        let board_id = board.id;
+        let column = Column::new(board_id, "Todo", 0);
+        let card = Card::new(board_id, column.id, "Card", 0);
+        let card_id = card.id;
+        app.model = Model::with_load_states(ModelLoadStates {
+            boards: LoadState::Loaded(vec![board]),
+            cards: LoadState::Loaded(vec![card]),
+            ..Default::default()
+        });
+        app.selection.active_board_id = Some(board_id);
+        app.selection.active_card_id = Some(card_id);
+
+        app.handle_assign_sprint_shortcut();
+
+        assert!(!matches!(
+            app.mode,
+            AppMode::Dialog(DialogMode::AssignCardToSprint)
+        ));
+        assert_error_banner(&app);
+    }
+
+    #[test]
+    fn test_handle_assign_sprint_shortcut_still_opens_when_sprints_loaded() {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "Todo".into(), None)
+            .unwrap();
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Card".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        app.ctx.create_sprint(board.id, None, None).unwrap();
+        app.selection.active_board_id = Some(board.id);
+        app.selection.active_card_id = Some(card.id);
+        app.reload_model();
+        app.prepare_frame();
+
+        app.handle_assign_sprint_shortcut();
+
+        assert!(matches!(
+            app.mode,
+            AppMode::Dialog(DialogMode::AssignCardToSprint)
+        ));
+        assert_no_banner(&app);
     }
 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -7,7 +7,9 @@ use crossterm::event::KeyCode;
 use kanban_core::Editable;
 use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::Model;
-use kanban_domain::{BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, Searcher};
+use kanban_domain::{
+    BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, LoadState, Searcher, Sprint,
+};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -29,7 +31,11 @@ impl App {
     /// resolution in the column handlers, so a filtered list and an
     /// unfiltered handler can never disagree on what index N means.
     pub(crate) fn visible_board_columns(&self, board_id: uuid::Uuid) -> Vec<Column> {
-        let ordered = sorted_board_columns(board_id, self.model.columns());
+        let columns: &[Column] = match self.model.columns_state() {
+            LoadState::Loaded(columns) => columns,
+            _ => &[],
+        };
+        let ordered = sorted_board_columns(board_id, columns);
         let query = self.filter.column_search.active_query().unwrap_or("");
         let searcher = FieldSearcher::new(query, |c: &&Column| c.name.as_str());
         kanban_view::list_query::search_and_sort(
@@ -47,6 +53,10 @@ impl App {
     }
 
     fn enter_column_focus_at_top(&mut self, board_id: uuid::Uuid) {
+        if !self.model.columns_state().is_loaded() {
+            self.set_error("Columns are not loaded yet");
+            return;
+        }
         let column_count = self.column_count_for_board(board_id);
         self.dialog_input
             .column_list
@@ -262,27 +272,36 @@ impl App {
             }
             KeyCode::Char('a') => {
                 if let Some(board) = self.active_board().cloned() {
-                    let sprint_count = self
+                    match self
                         .model
-                        .sprints()
-                        .iter()
-                        .filter(|s| s.board_id == board.id)
-                        .count();
-                    if sprint_count > 0 {
-                        let current_sprint_id = self
-                            .selection
-                            .active_card_id
-                            .and_then(|id| self.model.card_by_id_state(id).loaded().copied())
-                            .and_then(|c| c.sprint_id);
-                        self.dialog_input
-                            .assign_sprint_picker
-                            .reset_for_card_assignment(
-                                current_sprint_id,
-                                self.model.sprints(),
-                                &board,
-                                chrono::Utc::now(),
-                            );
-                        self.open_dialog(DialogMode::AssignCardToSprint);
+                        .board_sprints_state(board.id)
+                        .map(<[Sprint]>::len)
+                    {
+                        LoadState::Loaded(sprint_count) if sprint_count > 0 => {
+                            match self.model.sprints_state() {
+                                LoadState::Loaded(all_sprints) => {
+                                    let current_sprint_id = self
+                                        .selection
+                                        .active_card_id
+                                        .and_then(|id| {
+                                            self.model.card_by_id_state(id).loaded().copied()
+                                        })
+                                        .and_then(|c| c.sprint_id);
+                                    self.dialog_input
+                                        .assign_sprint_picker
+                                        .reset_for_card_assignment(
+                                            current_sprint_id,
+                                            all_sprints,
+                                            &board,
+                                            chrono::Utc::now(),
+                                        );
+                                    self.open_dialog(DialogMode::AssignCardToSprint);
+                                }
+                                _ => self.set_error("Sprints are not loaded yet"),
+                            }
+                        }
+                        LoadState::Loaded(_) => {}
+                        _ => self.set_error("Sprints are not loaded yet"),
                     }
                 }
             }
@@ -480,27 +499,32 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => match self.focus.board_focus {
                 BoardFocus::Sprints => {
                     if let Some(board_id) = self.active_board().map(|board| board.id) {
+                        match self
+                            .model
+                            .board_sprints_state(board_id)
+                            .map(<[Sprint]>::len)
                         {
-                            let sprint_count = self
-                                .model
-                                .sprints()
-                                .iter()
-                                .filter(|s| s.board_id == board_id)
-                                .count();
-                            let current_idx = self.selection.sprint.get().unwrap_or(0);
-                            if sprint_count == 0 || current_idx >= sprint_count - 1 {
-                                self.focus.board_focus = BoardFocus::Columns;
-                                self.enter_column_focus_at_top(board_id);
-                            } else {
-                                self.selection.sprint.next(sprint_count);
+                            LoadState::Loaded(sprint_count) => {
+                                let current_idx = self.selection.sprint.get().unwrap_or(0);
+                                if sprint_count == 0 || current_idx >= sprint_count - 1 {
+                                    if self.model.columns_state().is_loaded() {
+                                        self.focus.board_focus = BoardFocus::Columns;
+                                        self.enter_column_focus_at_top(board_id);
+                                    } else {
+                                        self.set_error("Columns are not loaded yet");
+                                    }
+                                } else {
+                                    self.selection.sprint.next(sprint_count);
+                                }
                             }
+                            _ => self.set_error("Sprints are not loaded yet"),
                         }
                     }
                 }
                 BoardFocus::Columns => {
-                    if let Some(board) = self.active_board() {
-                        {
-                            let column_count = self.column_count_for_board(board.id);
+                    if let Some(board_id) = self.active_board().map(|board| board.id) {
+                        if self.model.columns_state().is_loaded() {
+                            let column_count = self.column_count_for_board(board_id);
                             self.dialog_input
                                 .column_list
                                 .update_item_count(column_count);
@@ -515,6 +539,8 @@ impl App {
                             } else {
                                 self.dialog_input.column_list.navigate_down();
                             }
+                        } else {
+                            self.set_error("Columns are not loaded yet");
                         }
                     }
                 }
@@ -545,32 +571,32 @@ impl App {
                     }
                 }
                 BoardFocus::Columns => {
-                    let column_count = self
-                        .board_list
-                        .get_selected_board_id()
-                        .map(|board_id| self.column_count_for_board(board_id))
-                        .unwrap_or(0);
-                    self.dialog_input
-                        .column_list
-                        .update_item_count(column_count);
-                    let was_at_top = self.dialog_input.column_list.navigate_up();
-                    if was_at_top {
-                        let sprint_count = self
-                            .board_list
-                            .get_selected_board_id()
-                            .map(|board_id| {
-                                self.model
-                                    .sprints()
-                                    .iter()
-                                    .filter(|s| s.board_id == board_id)
-                                    .count()
-                            })
-                            .unwrap_or(0);
-                        if sprint_count == 0 {
-                            self.focus.board_focus = BoardFocus::Settings;
+                    if let Some(board_id) = self.board_list.get_selected_board_id() {
+                        if self.model.columns_state().is_loaded() {
+                            let column_count = self.column_count_for_board(board_id);
+                            self.dialog_input
+                                .column_list
+                                .update_item_count(column_count);
+                            let was_at_top = self.dialog_input.column_list.navigate_up();
+                            if was_at_top {
+                                match self
+                                    .model
+                                    .board_sprints_state(board_id)
+                                    .map(<[Sprint]>::len)
+                                {
+                                    LoadState::Loaded(sprint_count) => {
+                                        if sprint_count == 0 {
+                                            self.focus.board_focus = BoardFocus::Settings;
+                                        } else {
+                                            self.focus.board_focus = BoardFocus::Sprints;
+                                            self.selection.sprint.set(Some(sprint_count - 1));
+                                        }
+                                    }
+                                    _ => self.set_error("Sprints are not loaded yet"),
+                                }
+                            }
                         } else {
-                            self.focus.board_focus = BoardFocus::Sprints;
-                            self.selection.sprint.set(Some(sprint_count - 1));
+                            self.set_error("Columns are not loaded yet");
                         }
                     }
                 }
@@ -594,18 +620,16 @@ impl App {
                     if let Some(sprint_idx) = self.selection.sprint.get() {
                         let board_ctx = self.board_in_context().map(|b| b.id);
                         if let Some(board_id) = board_ctx {
-                            let sprint_id = self
-                                .model
-                                .sprints()
-                                .iter()
-                                .filter(|s| s.board_id == board_id)
-                                .nth(sprint_idx)
-                                .map(|s| s.id);
-                            if let Some(sprint_id) = sprint_id {
-                                self.selection.active_sprint_id = Some(sprint_id);
-                                self.selection.active_board_id = Some(board_id);
-                                self.populate_sprint_task_lists(sprint_id);
-                                self.push_mode(AppMode::SprintDetail);
+                            match self.model.board_sprints_state(board_id) {
+                                LoadState::Loaded(sprints) => {
+                                    if let Some(sprint_id) = sprints.get(sprint_idx).map(|s| s.id) {
+                                        self.selection.active_sprint_id = Some(sprint_id);
+                                        self.selection.active_board_id = Some(board_id);
+                                        self.populate_sprint_task_lists(sprint_id);
+                                        self.push_mode(AppMode::SprintDetail);
+                                    }
+                                }
+                                _ => self.set_error("Sprints are not loaded yet"),
                             }
                         }
                     }
@@ -630,14 +654,17 @@ impl App {
     /// keypress's existing guard exactly.
     pub(crate) fn carry_over_active_sprint_if_eligible(&mut self) {
         if let Some(sprint_id) = self.selection.active_sprint_id {
-            if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
-                use kanban_domain::SprintStatus;
-                if sprint.status == SprintStatus::Completed
-                    || sprint.status == SprintStatus::Cancelled
-                {
-                    let sprint_id = sprint.id;
-                    self.handle_carry_over_for_sprint(sprint_id);
+            match self.model.sprint_by_id_state(sprint_id) {
+                LoadState::Loaded(sprint) => {
+                    use kanban_domain::SprintStatus;
+                    if sprint.status == SprintStatus::Completed
+                        || sprint.status == SprintStatus::Cancelled
+                    {
+                        self.handle_carry_over_for_sprint(sprint_id);
+                    }
                 }
+                LoadState::Missing => {}
+                _ => self.set_error("Sprint is not loaded yet"),
             }
         }
     }
@@ -737,28 +764,35 @@ impl App {
     fn open_assign_sprint_dialog_for(&mut self, card_id: uuid::Uuid) {
         if self.activate_card(card_id) {
             if let Some(board) = self.active_board().cloned() {
-                let sprint_count = self
+                match self
                     .model
-                    .sprints()
-                    .iter()
-                    .filter(|s| s.board_id == board.id)
-                    .count();
-                if sprint_count > 0 {
-                    let current_sprint_id = self
-                        .model
-                        .card_by_id_state(card_id)
-                        .loaded()
-                        .copied()
-                        .and_then(|c| c.sprint_id);
-                    self.dialog_input
-                        .assign_sprint_picker
-                        .reset_for_card_assignment(
-                            current_sprint_id,
-                            self.model.sprints(),
-                            &board,
-                            chrono::Utc::now(),
-                        );
-                    self.open_dialog(DialogMode::AssignCardToSprint);
+                    .board_sprints_state(board.id)
+                    .map(<[Sprint]>::len)
+                {
+                    LoadState::Loaded(sprint_count) if sprint_count > 0 => {
+                        match self.model.sprints_state() {
+                            LoadState::Loaded(all_sprints) => {
+                                let current_sprint_id = self
+                                    .model
+                                    .card_by_id_state(card_id)
+                                    .loaded()
+                                    .copied()
+                                    .and_then(|c| c.sprint_id);
+                                self.dialog_input
+                                    .assign_sprint_picker
+                                    .reset_for_card_assignment(
+                                        current_sprint_id,
+                                        all_sprints,
+                                        &board,
+                                        chrono::Utc::now(),
+                                    );
+                                self.open_dialog(DialogMode::AssignCardToSprint);
+                            }
+                            _ => self.set_error("Sprints are not loaded yet"),
+                        }
+                    }
+                    LoadState::Loaded(_) => {}
+                    _ => self.set_error("Sprints are not loaded yet"),
                 }
             }
         }
@@ -819,19 +853,28 @@ impl App {
             }
             KeyCode::Char('p') => {
                 if let Some(sprint_id) = self.selection.active_sprint_id {
-                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
-                        let current_prefix = sprint.prefix.clone().unwrap_or_else(String::new);
-                        self.input.set(current_prefix);
-                        self.open_dialog(DialogMode::SetSprintPrefix);
+                    match self.model.sprint_by_id_state(sprint_id) {
+                        LoadState::Loaded(sprint) => {
+                            let current_prefix = sprint.prefix.clone().unwrap_or_else(String::new);
+                            self.input.set(current_prefix);
+                            self.open_dialog(DialogMode::SetSprintPrefix);
+                        }
+                        LoadState::Missing => {}
+                        _ => self.set_error("Sprint is not loaded yet"),
                     }
                 }
             }
             KeyCode::Char('C') => {
                 if let Some(sprint_id) = self.selection.active_sprint_id {
-                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
-                        let current_prefix = sprint.card_prefix.clone().unwrap_or_else(String::new);
-                        self.input.set(current_prefix);
-                        self.open_dialog(DialogMode::SetSprintCardPrefix);
+                    match self.model.sprint_by_id_state(sprint_id) {
+                        LoadState::Loaded(sprint) => {
+                            let current_prefix =
+                                sprint.card_prefix.clone().unwrap_or_else(String::new);
+                            self.input.set(current_prefix);
+                            self.open_dialog(DialogMode::SetSprintCardPrefix);
+                        }
+                        LoadState::Missing => {}
+                        _ => self.set_error("Sprint is not loaded yet"),
                     }
                 }
             }
@@ -856,19 +899,27 @@ impl App {
             }
             KeyCode::Char('h') | KeyCode::Left => {
                 if let Some(sprint_id) = self.selection.active_sprint_id {
-                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
-                        if sprint.status == kanban_domain::SprintStatus::Completed {
-                            self.sprint_view.panel = SprintTaskPanel::Uncompleted;
+                    match self.model.sprint_by_id_state(sprint_id) {
+                        LoadState::Loaded(sprint) => {
+                            if sprint.status == kanban_domain::SprintStatus::Completed {
+                                self.sprint_view.panel = SprintTaskPanel::Uncompleted;
+                            }
                         }
+                        LoadState::Missing => {}
+                        _ => self.set_error("Sprint is not loaded yet"),
                     }
                 }
             }
             KeyCode::Char('l') | KeyCode::Right => {
                 if let Some(sprint_id) = self.selection.active_sprint_id {
-                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == sprint_id) {
-                        if sprint.status == kanban_domain::SprintStatus::Completed {
-                            self.sprint_view.panel = SprintTaskPanel::Completed;
+                    match self.model.sprint_by_id_state(sprint_id) {
+                        LoadState::Loaded(sprint) => {
+                            if sprint.status == kanban_domain::SprintStatus::Completed {
+                                self.sprint_view.panel = SprintTaskPanel::Completed;
+                            }
                         }
+                        LoadState::Missing => {}
+                        _ => self.set_error("Sprint is not loaded yet"),
                     }
                 }
             }
@@ -997,13 +1048,22 @@ impl App {
                                     kanban_domain::card_lifecycle::MoveDirection::Left
                                 };
 
-                                let columns = self.model.columns();
-                                let cards = self.model.cards_state().loaded_or_empty();
-                                let move_result = self.active_board().and_then(|board| {
-                                    kanban_domain::card_lifecycle::compute_card_column_move(
-                                        &card, board, columns, cards, direction,
-                                    )
-                                });
+                                let board = self.active_board().cloned();
+                                let move_result = match board {
+                                    Some(board) => match self.model.columns_state() {
+                                        LoadState::Loaded(columns) => {
+                                            let cards = self.model.cards_state().loaded_or_empty();
+                                            kanban_domain::card_lifecycle::compute_card_column_move(
+                                                &card, &board, columns, cards, direction,
+                                            )
+                                        }
+                                        _ => {
+                                            self.set_error("Columns are not loaded yet");
+                                            None
+                                        }
+                                    },
+                                    None => None,
+                                };
 
                                 if let Some(result) = move_result {
                                     use kanban_domain::KanbanOperations;
@@ -1079,143 +1139,143 @@ impl App {
     }
 
     pub fn handle_manage_parents(&mut self) {
-        if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
-                let card_id = card.id;
-                let card_column_id = card.column_id;
+        let Some(active_id) = self.selection.active_card_id else {
+            return;
+        };
+        let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() else {
+            return;
+        };
+        let card_id = card.id;
+        let card_column_id = card.column_id;
 
-                // Get the board for this card's column
-                let board_id = self
-                    .model
-                    .columns()
-                    .iter()
-                    .find(|c| c.id == card_column_id)
-                    .map(|c| c.board_id);
-
-                if let Some(board_id) = board_id {
-                    // Get all descendants to exclude (to prevent cycles)
-                    let descendants = self
-                        .model
-                        .graph_state()
-                        .loaded()
-                        .unwrap_or_else(|| Model::empty_graph())
-                        .descendants(card_id);
-
-                    // Get cards from current board, excluding self and descendants
-                    let column_ids: std::collections::HashSet<_> = self
-                        .model
-                        .columns()
-                        .iter()
-                        .filter(|c| c.board_id == board_id)
-                        .map(|c| c.id)
-                        .collect();
-
-                    let target_is_archived = self.model.archived_card_ids().contains(&card_id);
-
-                    let eligible_cards: Vec<_> = self
-                        .model
-                        .cards_state()
-                        .loaded_or_empty()
-                        .iter()
-                        .filter(|c| column_ids.contains(&c.column_id))
-                        .filter(|c| c.id != card_id)
-                        .filter(|c| !descendants.contains(&c.id))
-                        .filter(|c| {
-                            target_is_archived || !self.model.archived_card_ids().contains(&c.id)
-                        })
-                        .map(|c| c.id)
-                        .collect();
-
-                    // Get current parents (for checkbox display)
-                    let current_parents: std::collections::HashSet<_> = self
-                        .model
-                        .graph_state()
-                        .loaded()
-                        .unwrap_or_else(|| Model::empty_graph())
-                        .parents(card_id)
-                        .into_iter()
-                        .collect();
-
-                    // Set up dialog state
-                    self.relationship.card_ids = eligible_cards;
-                    self.relationship.selected = current_parents;
-                    self.relationship.selection.set(Some(0));
-                    self.relationship.search.clear();
-
-                    self.open_dialog(DialogMode::ManageParents);
-                }
+        let board_id = match self.model.column_by_id_state(card_column_id) {
+            LoadState::Loaded(column) => column.board_id,
+            LoadState::Missing => return,
+            _ => {
+                self.set_error("Column is not loaded yet");
+                return;
             }
-        }
+        };
+
+        let column_ids: std::collections::HashSet<_> =
+            match self.model.board_columns_state(board_id) {
+                LoadState::Loaded(columns) => columns
+                    .iter()
+                    .filter(|c| c.board_id == board_id)
+                    .map(|c| c.id)
+                    .collect(),
+                _ => {
+                    self.set_error("Columns are not loaded yet");
+                    return;
+                }
+            };
+
+        let descendants = self
+            .model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .descendants(card_id);
+
+        let target_is_archived = self.model.archived_card_ids().contains(&card_id);
+
+        let eligible_cards: Vec<_> = self
+            .model
+            .cards_state()
+            .loaded_or_empty()
+            .iter()
+            .filter(|c| column_ids.contains(&c.column_id))
+            .filter(|c| c.id != card_id)
+            .filter(|c| !descendants.contains(&c.id))
+            .filter(|c| target_is_archived || !self.model.archived_card_ids().contains(&c.id))
+            .map(|c| c.id)
+            .collect();
+
+        let current_parents: std::collections::HashSet<_> = self
+            .model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .parents(card_id)
+            .into_iter()
+            .collect();
+
+        self.relationship.card_ids = eligible_cards;
+        self.relationship.selected = current_parents;
+        self.relationship.selection.set(Some(0));
+        self.relationship.search.clear();
+
+        self.open_dialog(DialogMode::ManageParents);
     }
 
     pub fn handle_manage_children(&mut self) {
-        if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
-                let card_id = card.id;
-                let card_column_id = card.column_id;
+        let Some(active_id) = self.selection.active_card_id else {
+            return;
+        };
+        let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() else {
+            return;
+        };
+        let card_id = card.id;
+        let card_column_id = card.column_id;
 
-                // Get the board for this card's column
-                let board_id = self
-                    .model
-                    .columns()
-                    .iter()
-                    .find(|c| c.id == card_column_id)
-                    .map(|c| c.board_id);
-
-                if let Some(board_id) = board_id {
-                    // Get all ancestors to exclude (to prevent cycles)
-                    let ancestors = self
-                        .model
-                        .graph_state()
-                        .loaded()
-                        .unwrap_or_else(|| Model::empty_graph())
-                        .ancestors(card_id);
-
-                    // Get cards from current board, excluding self and ancestors
-                    let column_ids: std::collections::HashSet<_> = self
-                        .model
-                        .columns()
-                        .iter()
-                        .filter(|c| c.board_id == board_id)
-                        .map(|c| c.id)
-                        .collect();
-
-                    let target_is_archived = self.model.archived_card_ids().contains(&card_id);
-
-                    let eligible_cards: Vec<_> = self
-                        .model
-                        .cards_state()
-                        .loaded_or_empty()
-                        .iter()
-                        .filter(|c| column_ids.contains(&c.column_id))
-                        .filter(|c| c.id != card_id)
-                        .filter(|c| !ancestors.contains(&c.id))
-                        .filter(|c| {
-                            target_is_archived || !self.model.archived_card_ids().contains(&c.id)
-                        })
-                        .map(|c| c.id)
-                        .collect();
-
-                    // Get current children (for checkbox display)
-                    let current_children: std::collections::HashSet<_> = self
-                        .model
-                        .graph_state()
-                        .loaded()
-                        .unwrap_or_else(|| Model::empty_graph())
-                        .children(card_id)
-                        .into_iter()
-                        .collect();
-
-                    // Set up dialog state
-                    self.relationship.card_ids = eligible_cards;
-                    self.relationship.selected = current_children;
-                    self.relationship.selection.set(Some(0));
-                    self.relationship.search.clear();
-
-                    self.open_dialog(DialogMode::ManageChildren);
-                }
+        let board_id = match self.model.column_by_id_state(card_column_id) {
+            LoadState::Loaded(column) => column.board_id,
+            LoadState::Missing => return,
+            _ => {
+                self.set_error("Column is not loaded yet");
+                return;
             }
-        }
+        };
+
+        let column_ids: std::collections::HashSet<_> =
+            match self.model.board_columns_state(board_id) {
+                LoadState::Loaded(columns) => columns
+                    .iter()
+                    .filter(|c| c.board_id == board_id)
+                    .map(|c| c.id)
+                    .collect(),
+                _ => {
+                    self.set_error("Columns are not loaded yet");
+                    return;
+                }
+            };
+
+        let ancestors = self
+            .model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .ancestors(card_id);
+
+        let target_is_archived = self.model.archived_card_ids().contains(&card_id);
+
+        let eligible_cards: Vec<_> = self
+            .model
+            .cards_state()
+            .loaded_or_empty()
+            .iter()
+            .filter(|c| column_ids.contains(&c.column_id))
+            .filter(|c| c.id != card_id)
+            .filter(|c| !ancestors.contains(&c.id))
+            .filter(|c| target_is_archived || !self.model.archived_card_ids().contains(&c.id))
+            .map(|c| c.id)
+            .collect();
+
+        let current_children: std::collections::HashSet<_> = self
+            .model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .children(card_id)
+            .into_iter()
+            .collect();
+
+        self.relationship.card_ids = eligible_cards;
+        self.relationship.selected = current_children;
+        self.relationship.selection.set(Some(0));
+        self.relationship.search.clear();
+
+        self.open_dialog(DialogMode::ManageChildren);
     }
 
     pub fn get_current_card_parents(&self) -> Vec<uuid::Uuid> {
@@ -1418,6 +1478,45 @@ mod tests {
         app.load_snapshot(snap);
     }
 
+    /// Populates the per-board scoped tiers (`board_columns_state`,
+    /// `board_sprints_state`) for `board_id` from whatever is already in the
+    /// flat tier. `reload_model`/`reload_snapshot`/`load_snapshot` never
+    /// touch these tiers themselves, so a test exercising a genuinely
+    /// board-scoped accessor must populate them explicitly.
+    fn sync_board_scoped_tiers(app: &mut App, board_id: uuid::Uuid) {
+        use kanban_domain::resolved::Collection;
+        use kanban_domain::{LoadState, Resolved};
+        use std::collections::HashMap;
+
+        let columns: Vec<_> = app
+            .model
+            .columns_state()
+            .loaded_or_empty()
+            .iter()
+            .filter(|c| c.board_id == board_id)
+            .cloned()
+            .collect();
+        let sprints: Vec<_> = app
+            .model
+            .sprints_state()
+            .loaded_or_empty()
+            .iter()
+            .filter(|s| s.board_id == board_id)
+            .cloned()
+            .collect();
+        let _ = app.model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: HashMap::from([(board_id, LoadState::Loaded(columns))]),
+                ..Default::default()
+            },
+            sprints: Collection {
+                by_parent: HashMap::from([(board_id, LoadState::Loaded(sprints))]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+    }
+
     fn seed_chain(app: &mut App, titles: &[&str]) -> Vec<uuid::Uuid> {
         let board = app.ctx.create_board("Board".into(), None).unwrap();
         let column = app
@@ -1603,6 +1702,7 @@ mod tests {
         // assign to (the dialog only opens when sprint_count > 0).
         app.ctx.create_sprint(board_id, None, None).unwrap();
         reload_snapshot(&mut app);
+        sync_board_scoped_tiers(&mut app, board_id);
         app.sprint_view
             .uncompleted_component
             .update_cards(vec![card_id]);
@@ -1647,6 +1747,7 @@ mod tests {
             )
             .unwrap();
         reload_snapshot(&mut app);
+        sync_board_scoped_tiers(&mut app, board_id);
         app.sprint_view.panel = SprintTaskPanel::Completed;
         app.sprint_view
             .completed_component
@@ -1900,6 +2001,7 @@ mod tests {
     fn test_handle_manage_parents_after_reload_resort_uses_originally_selected_card() {
         let mut app = App::test_default();
         let fx = setup_reload_resort_fixture(&mut app);
+        sync_board_scoped_tiers(&mut app, fx.board_id);
 
         app.handle_manage_parents();
 
@@ -1917,6 +2019,7 @@ mod tests {
     fn test_handle_manage_children_after_reload_resort_uses_originally_selected_card() {
         let mut app = App::test_default();
         let fx = setup_reload_resort_fixture(&mut app);
+        sync_board_scoped_tiers(&mut app, fx.board_id);
 
         app.handle_manage_children();
 
@@ -1987,6 +2090,7 @@ mod tests {
         app.ctx.create_sprint(board_id, None, None).unwrap();
         app.reload_model();
         app.prepare_frame();
+        sync_board_scoped_tiers(&mut app, board_id);
 
         app.dialog_input.column_list.update_item_count(3);
         app.dialog_input.column_list.set_selected_index(Some(0));
@@ -2302,6 +2406,7 @@ mod tests {
         app.selection.active_board_id = Some(alpha.id);
         app.reload_model();
         app.prepare_frame();
+        sync_board_scoped_tiers(&mut app, alpha.id);
         app.push_mode(AppMode::BoardDetail);
         app.focus.board_focus = BoardFocus::Sprints;
         app.selection.sprint.set(Some(1));

--- a/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
@@ -1,0 +1,573 @@
+use crossterm::event::KeyCode;
+use kanban_domain::resolved::Collection;
+use kanban_domain::{
+    Board, Card, Column, KanbanOperations, LoadState, Model, ModelLoadStates, Resolved, Sprint,
+};
+use kanban_tui::app::{AppMode, BoardFocus, DialogMode};
+use kanban_tui::events::EventHandler;
+use kanban_tui::App;
+use ratatui::Terminal;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+fn new_terminal() -> Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>> {
+    Terminal::new(ratatui::backend::CrosstermBackend::new(std::io::stdout())).unwrap()
+}
+
+fn set_model(app: &mut App, states: ModelLoadStates) {
+    app.model = Model::with_load_states(states);
+}
+
+fn set_board_columns_loaded(app: &mut App, board_id: Uuid, columns: Vec<Column>) {
+    let _ = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_parent: HashMap::from([(board_id, LoadState::Loaded(columns))]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
+fn set_board_sprints_loaded(app: &mut App, board_id: Uuid, sprints: Vec<Sprint>) {
+    let _ = app.model.apply_resolved(Resolved {
+        sprints: Collection {
+            by_parent: HashMap::from([(board_id, LoadState::Loaded(sprints))]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
+fn set_sprint_by_id(app: &mut App, sprint_id: Uuid, state: LoadState<Sprint>) {
+    let _ = app.model.apply_resolved(Resolved {
+        sprints: Collection {
+            by_id: HashMap::from([(sprint_id, state)]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
+fn set_column_by_id(app: &mut App, column_id: Uuid, state: LoadState<Column>) {
+    let _ = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_id: HashMap::from([(column_id, state)]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
+fn assert_error_banner(app: &App) {
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("expected an error banner to be set");
+    assert_eq!(banner.variant, kanban_tui::components::BannerVariant::Error);
+}
+
+fn assert_no_banner(app: &App) {
+    assert!(
+        app.ui_state.banner.is_none(),
+        "expected no banner, got {:?}",
+        app.ui_state.banner
+    );
+}
+
+#[tokio::test]
+async fn test_handle_board_detail_navigation_key_declines_column_navigation_when_columns_not_loaded(
+) {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            boards: LoadState::Loaded(vec![board]),
+            ..Default::default()
+        },
+    );
+    set_board_sprints_loaded(&mut app, board_id, Vec::new());
+    app.selection.active_board_id = Some(board_id);
+    app.focus.board_focus = BoardFocus::Sprints;
+
+    let mut terminal = new_terminal();
+    let event_handler = EventHandler::new();
+    app.handle_board_detail_key(KeyCode::Char('j'), &mut terminal, &event_handler);
+
+    assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
+    assert_error_banner(&app);
+}
+
+#[tokio::test]
+async fn test_handle_board_detail_navigation_key_still_navigates_columns_when_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "Todo", 0);
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            boards: LoadState::Loaded(vec![board]),
+            columns: LoadState::Loaded(vec![column]),
+            ..Default::default()
+        },
+    );
+    set_board_sprints_loaded(&mut app, board_id, Vec::new());
+    app.selection.active_board_id = Some(board_id);
+    app.focus.board_focus = BoardFocus::Sprints;
+
+    let mut terminal = new_terminal();
+    let event_handler = EventHandler::new();
+    app.handle_board_detail_key(KeyCode::Char('j'), &mut terminal, &event_handler);
+
+    assert_eq!(app.focus.board_focus, BoardFocus::Columns);
+    assert_no_banner(&app);
+    assert_eq!(app.dialog_input.column_list.get_selected_index(), Some(0));
+}
+
+#[tokio::test]
+async fn test_handle_card_detail_key_declines_sprint_assign_shortcut_when_sprints_not_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "Todo", 0);
+    let card = Card::new(board_id, column.id, "Card", 0);
+    let card_id = card.id;
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            boards: LoadState::Loaded(vec![board]),
+            cards: LoadState::Loaded(vec![card]),
+            ..Default::default()
+        },
+    );
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_card_id = Some(card_id);
+
+    let mut terminal = new_terminal();
+    let event_handler = EventHandler::new();
+    app.handle_card_detail_key(KeyCode::Char('a'), &mut terminal, &event_handler);
+
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::AssignCardToSprint)
+    ));
+    assert_error_banner(&app);
+}
+
+#[tokio::test]
+async fn test_handle_card_detail_key_still_opens_sprint_picker_when_sprints_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "Todo", 0);
+    let card = Card::new(board_id, column.id, "Card", 0);
+    let card_id = card.id;
+    let sprint = Sprint::new(board_id, 1, None, None::<String>);
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            boards: LoadState::Loaded(vec![board]),
+            cards: LoadState::Loaded(vec![card]),
+            sprints: LoadState::Loaded(vec![sprint.clone()]),
+            ..Default::default()
+        },
+    );
+    set_board_sprints_loaded(&mut app, board_id, vec![sprint]);
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_card_id = Some(card_id);
+
+    let mut terminal = new_terminal();
+    let event_handler = EventHandler::new();
+    app.handle_card_detail_key(KeyCode::Char('a'), &mut terminal, &event_handler);
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::AssignCardToSprint)
+    ));
+    assert_no_banner(&app);
+}
+
+#[test]
+fn test_carry_over_active_sprint_if_eligible_declines_when_sprint_tier_not_loaded() {
+    let mut app = App::test_default();
+    let sprint_id = Uuid::new_v4();
+    app.selection.active_sprint_id = Some(sprint_id);
+
+    app.handle_sprint_detail_key(KeyCode::Char('M'));
+
+    assert_error_banner(&app);
+}
+
+#[test]
+fn test_carry_over_active_sprint_if_eligible_distinguishes_missing_from_not_loaded() {
+    let mut app = App::test_default();
+    let missing_sprint_id = Uuid::new_v4();
+    app.selection.active_sprint_id = Some(missing_sprint_id);
+    set_sprint_by_id(&mut app, missing_sprint_id, LoadState::Missing);
+
+    app.handle_sprint_detail_key(KeyCode::Char('M'));
+    assert_no_banner(&app);
+
+    let not_loaded_sprint_id = Uuid::new_v4();
+    app.selection.active_sprint_id = Some(not_loaded_sprint_id);
+
+    app.handle_sprint_detail_key(KeyCode::Char('M'));
+    assert_error_banner(&app);
+}
+
+#[test]
+fn test_open_assign_sprint_dialog_for_declines_when_sprints_not_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "Todo", 0);
+    let card = Card::new(board_id, column.id, "Card", 0);
+    let card_id = card.id;
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            boards: LoadState::Loaded(vec![board]),
+            cards: LoadState::Loaded(vec![card]),
+            ..Default::default()
+        },
+    );
+    app.selection.active_board_id = Some(board_id);
+    app.sprint_view.panel = kanban_tui::app::SprintTaskPanel::Uncompleted;
+    app.sprint_view
+        .uncompleted_component
+        .update_cards(vec![card_id]);
+    app.sprint_view
+        .uncompleted_component
+        .set_selected_index(Some(0));
+
+    app.handle_sprint_detail_key(KeyCode::Char('s'));
+
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::AssignCardToSprint)
+    ));
+    assert_error_banner(&app);
+}
+
+#[test]
+fn test_open_assign_sprint_dialog_for_still_opens_when_sprints_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "Todo", 0);
+    let card = Card::new(board_id, column.id, "Card", 0);
+    let card_id = card.id;
+    let sprint = Sprint::new(board_id, 1, None, None::<String>);
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            boards: LoadState::Loaded(vec![board]),
+            cards: LoadState::Loaded(vec![card]),
+            sprints: LoadState::Loaded(vec![sprint.clone()]),
+            ..Default::default()
+        },
+    );
+    set_board_sprints_loaded(&mut app, board_id, vec![sprint]);
+    app.selection.active_board_id = Some(board_id);
+    app.sprint_view.panel = kanban_tui::app::SprintTaskPanel::Uncompleted;
+    app.sprint_view
+        .uncompleted_component
+        .update_cards(vec![card_id]);
+    app.sprint_view
+        .uncompleted_component
+        .set_selected_index(Some(0));
+
+    app.handle_sprint_detail_key(KeyCode::Char('s'));
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::AssignCardToSprint)
+    ));
+    assert_no_banner(&app);
+}
+
+#[test]
+fn test_handle_sprint_detail_key_declines_prefix_edit_when_sprint_tier_not_loaded() {
+    let mut app = App::test_default();
+    let sprint_id = Uuid::new_v4();
+    app.selection.active_sprint_id = Some(sprint_id);
+
+    app.handle_sprint_detail_key(KeyCode::Char('p'));
+
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::SetSprintPrefix)
+    ));
+    assert_error_banner(&app);
+}
+
+#[test]
+fn test_handle_sprint_detail_key_still_opens_prefix_edit_when_sprint_tier_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let sprint = Sprint::new(board.id, 1, None, Some("PRE".to_string()));
+    let sprint_id = sprint.id;
+    set_sprint_by_id(&mut app, sprint_id, LoadState::Loaded(sprint));
+    app.selection.active_sprint_id = Some(sprint_id);
+
+    app.handle_sprint_detail_key(KeyCode::Char('p'));
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::SetSprintPrefix)
+    ));
+    assert_no_banner(&app);
+    assert_eq!(app.input.as_str(), "PRE");
+}
+
+#[test]
+fn test_handle_manage_parents_declines_when_the_cards_column_is_not_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(board.id, column.id, "Card", 0);
+    let card_id = card.id;
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            cards: LoadState::Loaded(vec![card]),
+            ..Default::default()
+        },
+    );
+    app.selection.active_card_id = Some(card_id);
+
+    app.handle_manage_parents();
+
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageParents)
+    ));
+    assert_error_banner(&app);
+}
+
+#[test]
+fn test_handle_manage_parents_declines_when_the_boards_column_list_is_not_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let column_id = column.id;
+    let card = Card::new(board.id, column.id, "Card", 0);
+    let card_id = card.id;
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            cards: LoadState::Loaded(vec![card]),
+            ..Default::default()
+        },
+    );
+    set_column_by_id(&mut app, column_id, LoadState::Loaded(column));
+    app.selection.active_card_id = Some(card_id);
+
+    app.handle_manage_parents();
+
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageParents)
+    ));
+    assert_error_banner(&app);
+}
+
+#[test]
+fn test_handle_manage_parents_still_opens_the_dialog_when_everything_is_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "Todo", 0);
+    let column_id = column.id;
+    let card = Card::new(board_id, column_id, "Card", 0);
+    let card_id = card.id;
+    let other_card = Card::new(board_id, column_id, "Other", 1);
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            cards: LoadState::Loaded(vec![card, other_card]),
+            ..Default::default()
+        },
+    );
+    set_column_by_id(&mut app, column_id, LoadState::Loaded(column.clone()));
+    set_board_columns_loaded(&mut app, board_id, vec![column]);
+    app.selection.active_card_id = Some(card_id);
+
+    app.handle_manage_parents();
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageParents)
+    ));
+    assert_no_banner(&app);
+    assert_eq!(app.relationship.card_ids.len(), 1);
+}
+
+#[test]
+fn test_handle_manage_children_declines_when_the_cards_column_is_not_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(board.id, column.id, "Card", 0);
+    let card_id = card.id;
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            cards: LoadState::Loaded(vec![card]),
+            ..Default::default()
+        },
+    );
+    app.selection.active_card_id = Some(card_id);
+
+    app.handle_manage_children();
+
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageChildren)
+    ));
+    assert_error_banner(&app);
+}
+
+#[test]
+fn test_handle_manage_children_declines_when_the_boards_column_list_is_not_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let column_id = column.id;
+    let card = Card::new(board.id, column.id, "Card", 0);
+    let card_id = card.id;
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            cards: LoadState::Loaded(vec![card]),
+            ..Default::default()
+        },
+    );
+    set_column_by_id(&mut app, column_id, LoadState::Loaded(column));
+    app.selection.active_card_id = Some(card_id);
+
+    app.handle_manage_children();
+
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageChildren)
+    ));
+    assert_error_banner(&app);
+}
+
+#[test]
+fn test_handle_manage_children_still_opens_the_dialog_when_everything_is_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "Todo", 0);
+    let column_id = column.id;
+    let card = Card::new(board_id, column_id, "Card", 0);
+    let card_id = card.id;
+    let other_card = Card::new(board_id, column_id, "Other", 1);
+    set_model(
+        &mut app,
+        ModelLoadStates {
+            cards: LoadState::Loaded(vec![card, other_card]),
+            ..Default::default()
+        },
+    );
+    set_column_by_id(&mut app, column_id, LoadState::Loaded(column.clone()));
+    set_board_columns_loaded(&mut app, board_id, vec![column]);
+    app.selection.active_card_id = Some(card_id);
+
+    app.handle_manage_children();
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageChildren)
+    ));
+    assert_no_banner(&app);
+    assert_eq!(app.relationship.card_ids.len(), 1);
+}
+
+fn seed_move_fixture(app: &mut App, columns_loaded: bool) -> (Uuid, Uuid, Uuid, Uuid) {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let left = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let right = app
+        .ctx
+        .create_column(board.id, "Doing".to_string(), Some(1))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            left.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let columns = if columns_loaded {
+        LoadState::Loaded(vec![left.clone(), right.clone()])
+    } else {
+        LoadState::NotLoaded
+    };
+    set_model(
+        app,
+        ModelLoadStates {
+            boards: LoadState::Loaded(vec![board.clone()]),
+            cards: LoadState::Loaded(vec![card.clone()]),
+            columns,
+            ..Default::default()
+        },
+    );
+    app.selection.active_board_id = Some(board.id);
+    app.sprint_view.panel = kanban_tui::app::SprintTaskPanel::Uncompleted;
+    app.sprint_view
+        .uncompleted_component
+        .update_cards(vec![card.id]);
+    app.sprint_view
+        .uncompleted_component
+        .set_selected_index(Some(0));
+    (board.id, left.id, right.id, card.id)
+}
+
+#[test]
+fn test_move_selected_card_column_declines_when_the_column_tier_is_not_loaded() {
+    let mut app = App::test_default();
+    let (_board_id, left_id, _right_id, card_id) = seed_move_fixture(&mut app, false);
+
+    app.handle_sprint_detail_key(KeyCode::Char('L'));
+
+    assert_error_banner(&app);
+    let stored_column = app
+        .model
+        .cards_state()
+        .loaded_or_empty()
+        .iter()
+        .find(|c| c.id == card_id)
+        .map(|c| c.column_id)
+        .expect("card still present");
+    assert_eq!(stored_column, left_id);
+}
+
+#[test]
+fn test_move_selected_card_column_still_moves_when_the_column_tier_is_loaded() {
+    let mut app = App::test_default();
+    let (_board_id, _left_id, right_id, card_id) = seed_move_fixture(&mut app, true);
+
+    app.handle_sprint_detail_key(KeyCode::Char('L'));
+
+    assert_no_banner(&app);
+    app.reload_model();
+    let moved_column = app
+        .model
+        .cards_state()
+        .loaded_or_empty()
+        .iter()
+        .find(|c| c.id == card_id)
+        .map(|c| c.column_id)
+        .expect("card still present");
+    assert_eq!(moved_column, right_id);
+}

--- a/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
@@ -3,39 +3,13 @@ use kanban_domain::resolved::Collection;
 use kanban_domain::{
     Board, Card, Column, KanbanOperations, LoadState, Model, ModelLoadStates, Resolved, Sprint,
 };
-use kanban_tui::app::{AppMode, BoardFocus, DialogMode};
-use kanban_tui::events::EventHandler;
+use kanban_tui::app::{AppMode, DialogMode};
 use kanban_tui::App;
-use ratatui::Terminal;
 use std::collections::HashMap;
 use uuid::Uuid;
 
-fn new_terminal() -> Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>> {
-    Terminal::new(ratatui::backend::CrosstermBackend::new(std::io::stdout())).unwrap()
-}
-
 fn set_model(app: &mut App, states: ModelLoadStates) {
     app.model = Model::with_load_states(states);
-}
-
-fn set_board_columns_loaded(app: &mut App, board_id: Uuid, columns: Vec<Column>) {
-    let _ = app.model.apply_resolved(Resolved {
-        columns: Collection {
-            by_parent: HashMap::from([(board_id, LoadState::Loaded(columns))]),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-}
-
-fn set_board_sprints_loaded(app: &mut App, board_id: Uuid, sprints: Vec<Sprint>) {
-    let _ = app.model.apply_resolved(Resolved {
-        sprints: Collection {
-            by_parent: HashMap::from([(board_id, LoadState::Loaded(sprints))]),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
 }
 
 fn set_sprint_by_id(app: &mut App, sprint_id: Uuid, state: LoadState<Sprint>) {
@@ -73,121 +47,6 @@ fn assert_no_banner(app: &App) {
         "expected no banner, got {:?}",
         app.ui_state.banner
     );
-}
-
-#[tokio::test]
-async fn test_handle_board_detail_navigation_key_declines_column_navigation_when_columns_not_loaded(
-) {
-    let mut app = App::test_default();
-    let board = Board::new("Board", None::<String>);
-    let board_id = board.id;
-    set_model(
-        &mut app,
-        ModelLoadStates {
-            boards: LoadState::Loaded(vec![board]),
-            ..Default::default()
-        },
-    );
-    set_board_sprints_loaded(&mut app, board_id, Vec::new());
-    app.selection.active_board_id = Some(board_id);
-    app.focus.board_focus = BoardFocus::Sprints;
-
-    let mut terminal = new_terminal();
-    let event_handler = EventHandler::new();
-    app.handle_board_detail_key(KeyCode::Char('j'), &mut terminal, &event_handler);
-
-    assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
-    assert_error_banner(&app);
-}
-
-#[tokio::test]
-async fn test_handle_board_detail_navigation_key_still_navigates_columns_when_loaded() {
-    let mut app = App::test_default();
-    let board = Board::new("Board", None::<String>);
-    let board_id = board.id;
-    let column = Column::new(board_id, "Todo", 0);
-    set_model(
-        &mut app,
-        ModelLoadStates {
-            boards: LoadState::Loaded(vec![board]),
-            columns: LoadState::Loaded(vec![column]),
-            ..Default::default()
-        },
-    );
-    set_board_sprints_loaded(&mut app, board_id, Vec::new());
-    app.selection.active_board_id = Some(board_id);
-    app.focus.board_focus = BoardFocus::Sprints;
-
-    let mut terminal = new_terminal();
-    let event_handler = EventHandler::new();
-    app.handle_board_detail_key(KeyCode::Char('j'), &mut terminal, &event_handler);
-
-    assert_eq!(app.focus.board_focus, BoardFocus::Columns);
-    assert_no_banner(&app);
-    assert_eq!(app.dialog_input.column_list.get_selected_index(), Some(0));
-}
-
-#[tokio::test]
-async fn test_handle_card_detail_key_declines_sprint_assign_shortcut_when_sprints_not_loaded() {
-    let mut app = App::test_default();
-    let board = Board::new("Board", None::<String>);
-    let board_id = board.id;
-    let column = Column::new(board_id, "Todo", 0);
-    let card = Card::new(board_id, column.id, "Card", 0);
-    let card_id = card.id;
-    set_model(
-        &mut app,
-        ModelLoadStates {
-            boards: LoadState::Loaded(vec![board]),
-            cards: LoadState::Loaded(vec![card]),
-            ..Default::default()
-        },
-    );
-    app.selection.active_board_id = Some(board_id);
-    app.selection.active_card_id = Some(card_id);
-
-    let mut terminal = new_terminal();
-    let event_handler = EventHandler::new();
-    app.handle_card_detail_key(KeyCode::Char('a'), &mut terminal, &event_handler);
-
-    assert!(!matches!(
-        app.mode,
-        AppMode::Dialog(DialogMode::AssignCardToSprint)
-    ));
-    assert_error_banner(&app);
-}
-
-#[tokio::test]
-async fn test_handle_card_detail_key_still_opens_sprint_picker_when_sprints_loaded() {
-    let mut app = App::test_default();
-    let board = Board::new("Board", None::<String>);
-    let board_id = board.id;
-    let column = Column::new(board_id, "Todo", 0);
-    let card = Card::new(board_id, column.id, "Card", 0);
-    let card_id = card.id;
-    let sprint = Sprint::new(board_id, 1, None, None::<String>);
-    set_model(
-        &mut app,
-        ModelLoadStates {
-            boards: LoadState::Loaded(vec![board]),
-            cards: LoadState::Loaded(vec![card]),
-            sprints: LoadState::Loaded(vec![sprint.clone()]),
-            ..Default::default()
-        },
-    );
-    set_board_sprints_loaded(&mut app, board_id, vec![sprint]);
-    app.selection.active_board_id = Some(board_id);
-    app.selection.active_card_id = Some(card_id);
-
-    let mut terminal = new_terminal();
-    let event_handler = EventHandler::new();
-    app.handle_card_detail_key(KeyCode::Char('a'), &mut terminal, &event_handler);
-
-    assert!(matches!(
-        app.mode,
-        AppMode::Dialog(DialogMode::AssignCardToSprint)
-    ));
-    assert_no_banner(&app);
 }
 
 #[test]
@@ -270,7 +129,6 @@ fn test_open_assign_sprint_dialog_for_still_opens_when_sprints_loaded() {
             ..Default::default()
         },
     );
-    set_board_sprints_loaded(&mut app, board_id, vec![sprint]);
     app.selection.active_board_id = Some(board_id);
     app.sprint_view.panel = kanban_tui::app::SprintTaskPanel::Uncompleted;
     app.sprint_view
@@ -389,11 +247,11 @@ fn test_handle_manage_parents_still_opens_the_dialog_when_everything_is_loaded()
         &mut app,
         ModelLoadStates {
             cards: LoadState::Loaded(vec![card, other_card]),
+            columns: LoadState::Loaded(vec![column.clone()]),
             ..Default::default()
         },
     );
-    set_column_by_id(&mut app, column_id, LoadState::Loaded(column.clone()));
-    set_board_columns_loaded(&mut app, board_id, vec![column]);
+    set_column_by_id(&mut app, column_id, LoadState::Loaded(column));
     app.selection.active_card_id = Some(card_id);
 
     app.handle_manage_parents();
@@ -472,11 +330,11 @@ fn test_handle_manage_children_still_opens_the_dialog_when_everything_is_loaded(
         &mut app,
         ModelLoadStates {
             cards: LoadState::Loaded(vec![card, other_card]),
+            columns: LoadState::Loaded(vec![column.clone()]),
             ..Default::default()
         },
     );
-    set_column_by_id(&mut app, column_id, LoadState::Loaded(column.clone()));
-    set_board_columns_loaded(&mut app, board_id, vec![column]);
+    set_column_by_id(&mut app, column_id, LoadState::Loaded(column));
     app.selection.active_card_id = Some(card_id);
 
     app.handle_manage_children();

--- a/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
+++ b/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
@@ -24,6 +24,33 @@ fn sync_model_from_store(app: &mut App) {
     app.load_snapshot(snapshot);
 }
 
+/// Populates `board_columns_state(board_id)` from whatever `sync_model_from_store`
+/// already loaded into the flat tier. `load_snapshot` never touches the
+/// per-board scoped tier itself, so a test exercising `handle_manage_parents`/
+/// `handle_manage_children` (which read that tier for their eligible-column
+/// filter) must populate it explicitly.
+fn sync_board_scoped_columns(app: &mut App, board_id: uuid::Uuid) {
+    use kanban_domain::resolved::Collection;
+    use kanban_domain::{LoadState, Resolved};
+    use std::collections::HashMap;
+
+    let columns: Vec<_> = app
+        .model
+        .columns_state()
+        .loaded_or_empty()
+        .iter()
+        .filter(|c| c.board_id == board_id)
+        .cloned()
+        .collect();
+    let _ = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_parent: HashMap::from([(board_id, LoadState::Loaded(columns))]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
 /// Seed a board/column with a target card plus a live and an archived
 /// candidate, all otherwise eligible (same board, no ancestor/descendant
 /// relation to the target).
@@ -188,8 +215,9 @@ fn test_manage_children_from_live_card_still_offers_live_candidates() {
 #[test]
 fn test_card_detail_manage_children_excludes_archived_candidates() {
     let mut app = App::test_default();
-    let (_board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    let (board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
     sync_model_from_store(&mut app);
+    sync_board_scoped_columns(&mut app, board_id);
     app.selection.active_card_id = Some(target_id);
 
     app.handle_manage_children();
@@ -207,8 +235,9 @@ fn test_card_detail_manage_children_excludes_archived_candidates() {
 #[test]
 fn test_card_detail_manage_parents_excludes_archived_candidates() {
     let mut app = App::test_default();
-    let (_board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    let (board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
     sync_model_from_store(&mut app);
+    sync_board_scoped_columns(&mut app, board_id);
     app.selection.active_card_id = Some(target_id);
 
     app.handle_manage_parents();

--- a/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
+++ b/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
@@ -24,33 +24,6 @@ fn sync_model_from_store(app: &mut App) {
     app.load_snapshot(snapshot);
 }
 
-/// Populates `board_columns_state(board_id)` from whatever `sync_model_from_store`
-/// already loaded into the flat tier. `load_snapshot` never touches the
-/// per-board scoped tier itself, so a test exercising `handle_manage_parents`/
-/// `handle_manage_children` (which read that tier for their eligible-column
-/// filter) must populate it explicitly.
-fn sync_board_scoped_columns(app: &mut App, board_id: uuid::Uuid) {
-    use kanban_domain::resolved::Collection;
-    use kanban_domain::{LoadState, Resolved};
-    use std::collections::HashMap;
-
-    let columns: Vec<_> = app
-        .model
-        .columns_state()
-        .loaded_or_empty()
-        .iter()
-        .filter(|c| c.board_id == board_id)
-        .cloned()
-        .collect();
-    let _ = app.model.apply_resolved(Resolved {
-        columns: Collection {
-            by_parent: HashMap::from([(board_id, LoadState::Loaded(columns))]),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-}
-
 /// Seed a board/column with a target card plus a live and an archived
 /// candidate, all otherwise eligible (same board, no ancestor/descendant
 /// relation to the target).
@@ -215,9 +188,8 @@ fn test_manage_children_from_live_card_still_offers_live_candidates() {
 #[test]
 fn test_card_detail_manage_children_excludes_archived_candidates() {
     let mut app = App::test_default();
-    let (board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    let (_board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
     sync_model_from_store(&mut app);
-    sync_board_scoped_columns(&mut app, board_id);
     app.selection.active_card_id = Some(target_id);
 
     app.handle_manage_children();
@@ -235,9 +207,8 @@ fn test_card_detail_manage_children_excludes_archived_candidates() {
 #[test]
 fn test_card_detail_manage_parents_excludes_archived_candidates() {
     let mut app = App::test_default();
-    let (board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    let (_board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
     sync_model_from_store(&mut app);
-    sync_board_scoped_columns(&mut app, board_id);
     app.selection.active_card_id = Some(target_id);
 
     app.handle_manage_parents();


### PR DESCRIPTION
## Summary

Migrates all 18 production `model.columns()`/`model.sprints()` reads in `crates/kanban-tui/src/handlers/detail_view_handlers.rs` onto state-preserving accessors, so a `NotLoaded` column/sprint tier is declined (error banner, action skipped) instead of silently treated as an empty collection.

## Review fixes in this update

This addresses three findings from the first review round:

1. **Headless CI terminal panic.** The new test file constructed a real `Terminal<CrosstermBackend<Stdout>>`, which panicked under CI's non-tty stdout. `handle_card_detail_key`/`handle_board_detail_key` are hard-typed to that concrete backend (used only for the `e`-key external editor path), so a `TestBackend` swap does not type-check against them. Instead:
   - Extracted the card-detail `a` key body into a private `handle_assign_sprint_shortcut` that takes no terminal.
   - Moved that coverage plus the board-detail-navigation coverage into `detail_view_handlers.rs`'s existing inline test module, calling the private handlers directly (the established pattern already used for `handle_board_detail_navigation_key`), which needs no terminal at all.

2. **Board-scoped accessors have no production writer.** `Model::board_columns_state`/`Model::board_sprints_state` are only populated via `Model::apply_resolved`, which `kanban-tui` never calls in production (`reload_model` only fills the flat `columns_state`/`sprints_state` tier). The seven shape-(a) sites that read the by-parent tier would have declined permanently in the real app. Switched those sites to read the flat tier and filter by `board_id` inline, matching the pre-migration `Loaded` behavior exactly. The eleven shape-(b) `column_by_id_state`/`sprint_by_id_state` sites are unaffected (those fall back to the flat tier already).

3. **Lost the `None`-board fallback in the Columns-focus `k` handler.** With no board selected, navigation must still fall through to `BoardFocus::Settings`. Restored that fallback and added a dedicated test pinning it.

## Per-site classification

| site | shape | accessor used |
|---|---|---|
| `visible_board_columns` | (c) flat | `columns_state()` |
| card detail `a` key (`handle_assign_sprint_shortcut`) | (c) flat, filtered by board_id | `sprints_state()` |
| board detail `j`/`k`/Enter sprint resolution | (c) flat, filtered by board_id | `sprints_state()` |
| `carry_over_active_sprint_if_eligible` | (b) by-id | `sprint_by_id_state` |
| `open_assign_sprint_dialog_for` | (c) flat, filtered by board_id | `sprints_state()` |
| sprint detail `p`/`C`/`h`/`l` | (b) by-id | `sprint_by_id_state` |
| card move (`CardListAction::MoveColumn`) | (c) flat | `columns_state()` |
| `handle_manage_parents`/`handle_manage_children`, column lookup | (b) by-id | `column_by_id_state` |
| `handle_manage_parents`/`handle_manage_children`, board column_ids | (c) flat, filtered by board_id | `columns_state()` |

Census re-derived with the parent's exact command (whitespace-flattened, truncated at the first column-zero `#[cfg(test)]`) scoped to this file: **0** hits after the change (was 18 at pickup).

## Test plan

- [x] Census over `crates/kanban-tui/src/handlers/detail_view_handlers.rs` returns 0
- [x] `git grep -nE 'loaded_or_empty|loaded\(\)\.unwrap_or'` over the file has no hits on the migrated columns/sprints sites (remaining hits are all on out-of-scope `cards_state()`/`boards_state()`)
- [x] `git diff --stat origin/develop -- crates/kanban-tui/src crates/kanban-view/src crates/kanban-domain/src` lists only `detail_view_handlers.rs`
- [x] `Model::columns`/`Model::sprints` untouched in `kanban-domain`
- [x] All Red tests present, shown failing before the fix, passing after (moved terminal-dependent cases into the inline test module and mutation-checked the flat-tier and `None`-board fixes by reverting them and confirming the tests fail)
- [x] `cargo test -p kanban-tui --all-features` green
- [x] `cargo clippy -p kanban-tui --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
