### PR TITLE
KAN-1490 fix(tui): decline unloaded column/sprint tiers in card_handlers.rs

### DIFF
--- a/.changeset/kan-1490-card-handler-reads-decline.md
+++ b/.changeset/kan-1490-card-handler-reads-decline.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+tui: card_handlers.rs no longer collapses a NotLoaded columns or sprints
+tier to an empty collection when creating, moving, restoring, or assigning
+a card, or when opening the manage-children picker. An unloaded tier now
+sets an error banner and leaves the prior state untouched instead of
+silently acting as if the board had zero columns or sprints.

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -396,8 +396,7 @@ impl App {
                 .map(|b| b.id);
 
             if let Some(bid) = board_info {
-                if self.get_focused_column_id().is_none()
-                    && !self.model.board_columns_state(bid).is_loaded()
+                if !self.model.board_columns_state(bid).is_loaded()
                     && !self.model.columns_state().is_loaded()
                 {
                     self.set_error("Columns are not loaded yet");

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -5,7 +5,7 @@ use kanban_domain::commands::{
     SetBoardTaskSort, UpdateCard,
 };
 use kanban_domain::Model;
-use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations};
+use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations, LoadState};
 use kanban_view::card_list::CardListId;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
@@ -14,8 +14,12 @@ impl App {
     pub fn handle_create_card_key(&mut self) {
         if self.focus.active == Focus::Cards && self.active_board().is_some() {
             if let Some(board) = self.active_board().cloned() {
+                let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                    self.set_error("Sprints are not loaded yet");
+                    return;
+                };
                 self.dialog_input.create_card_sprint_picker.reset_for_board(
-                    self.model.sprints(),
+                    sprints,
                     &board,
                     chrono::Utc::now(),
                 );
@@ -40,18 +44,25 @@ impl App {
         let target_column_id = if let Some(focused_col_id) = self.get_focused_column_id() {
             Some(focused_col_id)
         } else {
-            self.model
-                .columns()
-                .iter()
-                .find(|col| col.board_id == board_id)
-                .map(|col| col.id)
+            match self.model.board_columns_state(board_id) {
+                LoadState::Loaded(columns) => columns
+                    .iter()
+                    .find(|col| col.board_id == board_id)
+                    .map(|col| col.id),
+                _ => self.model.columns_state().loaded().and_then(|columns| {
+                    columns
+                        .iter()
+                        .find(|col| col.board_id == board_id)
+                        .map(|col| col.id)
+                }),
+            }
         };
 
         target_column_id.and_then(|col_id| {
             self.model
-                .columns()
-                .iter()
-                .find(|col| col.id == col_id)
+                .column_by_id_state(col_id)
+                .loaded()
+                .copied()
                 .cloned()
         })
     }
@@ -160,13 +171,13 @@ impl App {
 
         if !self.multi_select.selected_cards.is_empty() {
             if let Some(board) = self.active_board().cloned() {
+                let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                    self.set_error("Sprints are not loaded yet");
+                    return;
+                };
                 self.dialog_input
                     .assign_sprint_picker
-                    .reset_for_bulk_card_assignment(
-                        self.model.sprints(),
-                        &board,
-                        chrono::Utc::now(),
-                    );
+                    .reset_for_bulk_card_assignment(sprints, &board, chrono::Utc::now());
             }
             self.open_dialog(DialogMode::AssignMultipleCardsToSprint);
         } else if self.get_selected_card_id().is_some() {
@@ -176,7 +187,10 @@ impl App {
             };
             let now = chrono::Utc::now();
             let has_assignable = {
-                let sprints = self.model.sprints();
+                let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                    self.set_error("Sprints are not loaded yet");
+                    return;
+                };
                 let entries =
                     kanban_view::sprint_assign_list::build_entries(sprints, board_id, now);
                 entries.iter().any(|e| {
@@ -201,14 +215,13 @@ impl App {
                 .and_then(|c| c.sprint_id);
             // Re-borrow board after the &mut self call above.
             if let Some(board) = self.active_board().cloned() {
+                let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                    self.set_error("Sprints are not loaded yet");
+                    return;
+                };
                 self.dialog_input
                     .assign_sprint_picker
-                    .reset_for_card_assignment(
-                        current_sprint_id,
-                        self.model.sprints(),
-                        &board,
-                        now,
-                    );
+                    .reset_for_card_assignment(current_sprint_id, sprints, &board, now);
             }
             self.open_dialog(DialogMode::AssignCardToSprint);
         }
@@ -383,6 +396,13 @@ impl App {
                 .map(|b| b.id);
 
             if let Some(bid) = board_info {
+                if self.get_focused_column_id().is_none()
+                    && !self.model.board_columns_state(bid).is_loaded()
+                    && !self.model.columns_state().is_loaded()
+                {
+                    self.set_error("Columns are not loaded yet");
+                    return;
+                }
                 let existing_column = self.create_card_target_column(bid);
 
                 let (column_id, position, mark_as_complete, new_column_cmd) = match existing_column
@@ -391,7 +411,10 @@ impl App {
                         let cards = self.model.cards_state().loaded_or_empty();
                         let position =
                             kanban_domain::card_lifecycle::next_position_in_column(cards, col.id);
-                        let columns = self.model.columns();
+                        let LoadState::Loaded(columns) = self.model.columns_state() else {
+                            self.set_error("Columns are not loaded yet");
+                            return;
+                        };
                         let mark_as_complete = self
                             .model
                             .board_by_id_state(board_id)
@@ -534,7 +557,10 @@ impl App {
 
             // Use the pure helper only to resolve the target column for the
             // given direction; the service handles any status sync.
-            let columns = self.model.columns();
+            let LoadState::Loaded(columns) = self.model.columns_state() else {
+                self.set_error("Columns are not loaded yet");
+                return;
+            };
             let cards = self.model.cards_state().loaded_or_empty();
             let move_result = kanban_domain::card_lifecycle::compute_card_column_move(
                 &card, board, columns, cards, direction,
@@ -609,7 +635,10 @@ impl App {
 
         // Use the pure helper only to resolve the per-card target column;
         // status sync is chained by the service layer's `update_cards`.
-        let columns = self.model.columns();
+        let LoadState::Loaded(columns) = self.model.columns_state() else {
+            self.set_error("Columns are not loaded yet");
+            return;
+        };
         let cards = self.model.cards_state().loaded_or_empty();
         let updates: Vec<(uuid::Uuid, CardUpdate)> = card_ids
             .iter()
@@ -821,16 +850,21 @@ impl App {
 
         let board_id = self.active_board().map(|b| b.id);
 
-        let columns = self.model.columns();
-        let target_column_id = board_id
-            .and_then(|bid| {
+        let target_column_id = match board_id {
+            Some(bid) => {
+                let LoadState::Loaded(columns) = self.model.columns_state() else {
+                    self.set_error("Columns are not loaded yet");
+                    return false;
+                };
                 kanban_domain::card_lifecycle::resolve_restore_column(
                     current_column_id,
                     bid,
                     columns,
                 )
-            })
-            .unwrap_or(current_column_id);
+                .unwrap_or(current_column_id)
+            }
+            None => current_column_id,
+        };
 
         let cmd = Command::Card(CardCommand::Restore(RestoreCard {
             card_id,
@@ -945,12 +979,21 @@ impl App {
         let ancestors = graph.ancestors(card_id);
 
         // Get cards from current board, excluding self and ancestors
-        let columns = self.model.columns();
-        let column_ids: std::collections::HashSet<_> = columns
-            .iter()
-            .filter(|c| c.board_id == board_id)
-            .map(|c| c.id)
-            .collect();
+        let column_ids: std::collections::HashSet<_> =
+            match self.model.board_columns_state(board_id) {
+                LoadState::Loaded(columns) => columns.iter().map(|c| c.id).collect(),
+                _ => match self.model.columns_state() {
+                    LoadState::Loaded(columns) => columns
+                        .iter()
+                        .filter(|c| c.board_id == board_id)
+                        .map(|c| c.id)
+                        .collect(),
+                    _ => {
+                        self.set_error("Columns are not loaded yet");
+                        return;
+                    }
+                },
+            };
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
@@ -993,10 +1036,51 @@ mod create_card_factory_tests {
 
     /// Refresh the TUI model from the store so the create handler (which reads
     /// `self.model`) sees prior writes. The event loop does this each frame via
-    /// `prepare_frame`; tests pull the snapshot directly.
+    /// `prepare_frame`; tests pull the snapshot directly. Also seeds the
+    /// per-board scoped columns/sprints tiers `load_from_snapshot` leaves
+    /// untouched, since `create_card_target_column` reads them.
     fn refresh(app: &mut App) {
         let snap = app.ctx.snapshot().unwrap();
+        let mut columns_by_board: std::collections::HashMap<
+            uuid::Uuid,
+            Vec<kanban_domain::Column>,
+        > = snap.boards.iter().map(|b| (b.id, Vec::new())).collect();
+        for column in &snap.columns {
+            columns_by_board
+                .entry(column.board_id)
+                .or_default()
+                .push(column.clone());
+        }
+        let mut sprints_by_board: std::collections::HashMap<
+            uuid::Uuid,
+            Vec<kanban_domain::Sprint>,
+        > = snap.boards.iter().map(|b| (b.id, Vec::new())).collect();
+        for sprint in &snap.sprints {
+            sprints_by_board
+                .entry(sprint.board_id)
+                .or_default()
+                .push(sprint.clone());
+        }
         app.load_snapshot(snap);
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            columns: kanban_domain::resolved::Collection {
+                by_parent: columns_by_board
+                    .into_iter()
+                    .map(|(id, cols)| (id, kanban_domain::LoadState::Loaded(cols)))
+                    .collect(),
+                ..Default::default()
+            },
+            sprints: kanban_domain::resolved::Collection {
+                by_parent: sprints_by_board
+                    .into_iter()
+                    .map(|(id, sprints)| (id, kanban_domain::LoadState::Loaded(sprints)))
+                    .collect(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        use kanban_domain::DerivedProjections;
+        kanban_domain::NoProjections.resync(&app.model, changed);
     }
 
     /// Seed a board with one column through the service, then point the TUI's
@@ -1054,6 +1138,7 @@ mod create_card_factory_tests {
             app.input.set(title.to_string());
             app.create_card();
             app.input.clear();
+            refresh(&mut app);
         }
 
         let cards = app.ctx.data_store().list_all_cards().unwrap();

--- a/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
@@ -1,0 +1,615 @@
+//! `card_handlers.rs` reads several `Model::columns()`/`Model::sprints()`
+//! call sites that collapse a `NotLoaded` tier to an empty slice, so a stale
+//! read silently behaves as "board has zero columns/sprints" instead of
+//! declining. These tests pin the decline behaviour per KAN-1490.
+
+use kanban_domain::resolved::Collection;
+use kanban_domain::{
+    ArchivedCard, CreateCardOptions, DerivedProjections, EntityIds, Invalidation,
+    KanbanOperations, LoadState, NoProjections, Resolved,
+};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::app::Focus;
+use kanban_tui::App;
+use uuid::Uuid;
+
+fn sync_model_from_store(app: &mut App) {
+    let snapshot = app.ctx.snapshot().unwrap();
+    app.load_snapshot(snapshot);
+}
+
+fn seed_board_with_two_columns(app: &mut App) -> (Uuid, Uuid, Uuid) {
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let first = app
+        .ctx
+        .create_column(board.id, "Todo".into(), Some(0))
+        .unwrap();
+    let second = app
+        .ctx
+        .create_column(board.id, "Doing".into(), Some(1))
+        .unwrap();
+    (board.id, first.id, second.id)
+}
+
+fn select_card_in_active_task_list(app: &mut App, card_id: Uuid) {
+    app.prepare_frame();
+    let list = app
+        .view
+        .strategy
+        .get_active_task_list_mut()
+        .expect("active task list");
+    let idx = list
+        .cards
+        .iter()
+        .position(|&id| id == card_id)
+        .expect("card present in active task list");
+    list.set_selected_index(Some(idx));
+}
+
+
+#[test]
+fn test_handle_create_card_key_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    app.ctx
+        .create_column(board.id, "Todo".into(), Some(0))
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::sprints([Uuid::new_v4()])));
+
+    app.handle_create_card_key();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded sprints tier must set an error banner");
+    assert!(
+        banner.message.to_lowercase().contains("sprint"),
+        "banner message must name sprints as not loaded, got: {}",
+        banner.message
+    );
+    assert!(
+        !matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)),
+        "the create-card dialog must not open on a declined sprints tier"
+    );
+}
+
+#[test]
+fn test_handle_create_card_key_still_opens_on_a_loaded_sprint_tier() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    app.ctx
+        .create_column(board.id, "Todo".into(), Some(0))
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+
+    app.handle_create_card_key();
+
+    assert!(matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)));
+    assert!(app.ui_state.banner.is_none());
+}
+
+
+#[test]
+fn test_create_card_target_column_prefers_board_scoped_state_over_stale_flat_tier() {
+    let mut app = App::test_default();
+    let (board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    sync_model_from_store(&mut app);
+    let column = app
+        .model
+        .column_by_id_state(first_col)
+        .loaded()
+        .copied()
+        .cloned()
+        .unwrap();
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::columns([Uuid::new_v4()])));
+    assert!(app.model.columns_state().is_not_loaded());
+
+    let changed = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_parent: [(board_id, LoadState::Loaded(vec![column]))].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    NoProjections.resync(&app.model, changed);
+
+    let target = app.create_card_target_column(board_id);
+
+    assert_eq!(
+        target.map(|c| c.id),
+        Some(first_col),
+        "must be served from the board-scoped tier even though the flat tier is stale"
+    );
+}
+
+#[test]
+fn test_create_card_target_column_returns_none_when_the_scoped_tier_is_genuinely_empty() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    sync_model_from_store(&mut app);
+
+    let changed = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_parent: [(board.id, LoadState::Loaded(vec![]))].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    NoProjections.resync(&app.model, changed);
+
+    let target = app.create_card_target_column(board.id);
+
+    assert!(target.is_none());
+}
+
+
+fn seed_board_column_sprint_card(app: &mut App) -> (Uuid, Uuid, Uuid, Uuid) {
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), Some(0))
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    (board.id, column.id, sprint.id, card.id)
+}
+
+#[test]
+fn test_handle_assign_to_sprint_key_declines_on_a_not_loaded_sprint_tier_bulk_path() {
+    let mut app = App::test_default();
+    let (board_id, _column_id, _sprint_id, card_id) = seed_board_column_sprint_card(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    app.multi_select.selected_cards.insert(card_id);
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::sprints([Uuid::new_v4()])));
+
+    app.handle_assign_to_sprint_key();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded sprints tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("sprint"));
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint)
+    ));
+}
+
+#[test]
+fn test_handle_assign_to_sprint_key_still_opens_bulk_dialog_on_a_loaded_sprint_tier() {
+    let mut app = App::test_default();
+    let (board_id, _column_id, _sprint_id, card_id) = seed_board_column_sprint_card(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    app.multi_select.selected_cards.insert(card_id);
+
+    app.handle_assign_to_sprint_key();
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint)
+    ));
+    assert!(app.ui_state.banner.is_none());
+}
+
+#[test]
+fn test_handle_assign_to_sprint_key_declines_on_a_not_loaded_sprint_tier_single_card_path() {
+    let mut app = App::test_default();
+    let (board_id, _column_id, _sprint_id, card_id) = seed_board_column_sprint_card(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    select_card_in_active_task_list(&mut app, card_id);
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::sprints([Uuid::new_v4()])));
+
+    app.handle_assign_to_sprint_key();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded sprints tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("sprint"));
+    assert!(!matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::AssignCardToSprint)
+    ));
+}
+
+#[test]
+fn test_handle_assign_to_sprint_key_still_opens_single_card_dialog_on_a_loaded_sprint_tier() {
+    let mut app = App::test_default();
+    let (board_id, _column_id, _sprint_id, card_id) = seed_board_column_sprint_card(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    select_card_in_active_task_list(&mut app, card_id);
+
+    app.handle_assign_to_sprint_key();
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Dialog(DialogMode::AssignCardToSprint)
+    ));
+    assert!(app.ui_state.banner.is_none());
+}
+
+
+#[test]
+fn test_create_card_declines_on_a_not_loaded_column_tier() {
+    let mut app = App::test_default();
+    let (board_id, _first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::columns([Uuid::new_v4()])));
+
+    let columns_before = app.ctx.data_store().list_all_columns().unwrap().len();
+
+    app.input.set("Should not be created".to_string());
+    app.create_card();
+    app.input.clear();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded columns tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("column"));
+
+    let cards = app.ctx.data_store().list_all_cards().unwrap();
+    assert!(
+        cards.is_empty(),
+        "no card must be created while the columns tier is declined"
+    );
+    let columns_after = app.ctx.data_store().list_all_columns().unwrap().len();
+    assert_eq!(
+        columns_before, columns_after,
+        "no fabricated column must be created while the columns tier is declined"
+    );
+}
+
+#[test]
+fn test_create_card_still_auto_completes_into_a_completion_column_on_a_loaded_column_tier() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Done".into(), Some(0))
+        .unwrap();
+    app.ctx
+        .update_column(
+            column.id,
+            kanban_domain::ColumnUpdate {
+                default_status: Some(Some(kanban_domain::CardStatus::Done)),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board.id);
+
+    app.input.set("Auto-complete".to_string());
+    app.create_card();
+    app.input.clear();
+
+    let cards = app.ctx.data_store().list_all_cards().unwrap();
+    assert_eq!(cards.len(), 1);
+    assert_eq!(cards[0].status, kanban_domain::CardStatus::Done);
+    assert!(app.ui_state.banner.is_none());
+}
+
+
+#[test]
+fn test_handle_move_card_declines_on_a_not_loaded_column_tier() {
+    let mut app = App::test_default();
+    let (board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    let card = app
+        .ctx
+        .create_card(
+            board_id,
+            first_col,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    select_card_in_active_task_list(&mut app, card.id);
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::columns([Uuid::new_v4()])));
+
+    app.handle_move_card_right();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded columns tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("column"));
+
+    let stored = app.ctx.data_store().get_card(card.id).unwrap().unwrap();
+    assert_eq!(
+        stored.column_id, first_col,
+        "the card must not move while the columns tier is declined"
+    );
+}
+
+#[test]
+fn test_handle_move_card_still_moves_the_card_on_a_loaded_column_tier() {
+    let mut app = App::test_default();
+    let (board_id, first_col, second_col) = seed_board_with_two_columns(&mut app);
+    let card = app
+        .ctx
+        .create_card(
+            board_id,
+            first_col,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    select_card_in_active_task_list(&mut app, card.id);
+
+    app.handle_move_card_right();
+
+    let stored = app.ctx.data_store().get_card(card.id).unwrap().unwrap();
+    assert_eq!(stored.column_id, second_col);
+}
+
+
+#[test]
+fn test_move_selected_cards_declines_on_a_not_loaded_column_tier() {
+    let mut app = App::test_default();
+    let (board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    let card_a = app
+        .ctx
+        .create_card(
+            board_id,
+            first_col,
+            "A".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_b = app
+        .ctx
+        .create_card(
+            board_id,
+            first_col,
+            "B".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    app.multi_select.selected_cards.insert(card_a.id);
+    app.multi_select.selected_cards.insert(card_b.id);
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::columns([Uuid::new_v4()])));
+
+    app.handle_move_card_right();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded columns tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("column"));
+
+    let stored_a = app.ctx.data_store().get_card(card_a.id).unwrap().unwrap();
+    let stored_b = app.ctx.data_store().get_card(card_b.id).unwrap().unwrap();
+    assert_eq!(stored_a.column_id, first_col);
+    assert_eq!(stored_b.column_id, first_col);
+}
+
+
+#[test]
+fn test_restore_card_without_reload_declines_on_a_not_loaded_column_tier() {
+    let mut app = App::test_default();
+    let (board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    let card = app
+        .ctx
+        .create_card(
+            board_id,
+            first_col,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::columns([Uuid::new_v4()])));
+
+    let archived = ArchivedCard::new(card.id, board_id);
+    app.restore_card(archived);
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded columns tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("column"));
+    let still_archived = app
+        .ctx
+        .data_store()
+        .list_archived_cards()
+        .unwrap()
+        .iter()
+        .any(|a| a.entity_id == card.id);
+    assert!(
+        still_archived,
+        "the card must remain archived while the columns tier is declined"
+    );
+}
+
+#[test]
+fn test_restore_card_without_reload_remaps_to_first_column_when_the_original_is_gone() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let original = app
+        .ctx
+        .create_column(board.id, "Todo".into(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            original.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+    app.ctx.delete_column(original.id).unwrap();
+    let replacement = app
+        .ctx
+        .create_column(board.id, "Backlog".into(), Some(0))
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board.id);
+
+    let archived = ArchivedCard::new(card.id, board.id);
+    app.restore_card(archived);
+
+    let stored = app.ctx.data_store().get_card(card.id).unwrap().unwrap();
+    assert_eq!(stored.column_id, replacement.id);
+    assert!(app.ui_state.banner.is_none());
+}
+
+// ---------------------------------------------------------------------
+// handle_manage_children_from_list: decline on a NotLoaded board-scoped
+// columns tier
+// ---------------------------------------------------------------------
+
+#[test]
+fn test_handle_manage_children_from_list_declines_on_a_not_loaded_column_tier() {
+    let mut app = App::test_default();
+    let (board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    let card = app
+        .ctx
+        .create_card(
+            board_id,
+            first_col,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    select_card_in_active_task_list(&mut app, card.id);
+    app.relationship.card_ids.clear();
+
+    assert!(
+        app.model.board_columns_state(board_id).is_not_loaded(),
+        "reload never populates the board-scoped columns tier today"
+    );
+
+    app.handle_manage_children_from_list();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded board-scoped columns tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("column"));
+    assert!(
+        app.relationship.card_ids.is_empty(),
+        "the manage-children list must not be populated while the columns tier is declined"
+    );
+}
+
+#[test]
+fn test_handle_manage_children_from_list_still_lists_a_sibling_card_on_a_loaded_column_tier() {
+    let mut app = App::test_default();
+    let (board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    let target = app
+        .ctx
+        .create_card(
+            board_id,
+            first_col,
+            "Target".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let sibling = app
+        .ctx
+        .create_card(
+            board_id,
+            first_col,
+            "Sibling".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.focus.active = Focus::Cards;
+    select_card_in_active_task_list(&mut app, target.id);
+
+    let columns = app
+        .model
+        .columns_state()
+        .loaded()
+        .cloned()
+        .unwrap_or_default();
+    let changed = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_parent: [(board_id, LoadState::Loaded(columns))].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    NoProjections.resync(&app.model, changed);
+
+    app.handle_manage_children_from_list();
+
+    assert!(app.ui_state.banner.is_none());
+    assert!(
+        app.relationship.card_ids.contains(&sibling.id),
+        "a sibling card in-column must still be listed as eligible"
+    );
+}

--- a/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
@@ -1,7 +1,7 @@
 //! `card_handlers.rs` reads several `Model::columns()`/`Model::sprints()`
 //! call sites that collapse a `NotLoaded` tier to an empty slice, so a stale
 //! read silently behaves as "board has zero columns/sprints" instead of
-//! declining. These tests pin the decline behaviour per KAN-1490.
+//! declining. These tests pin the decline behaviour.
 
 use kanban_domain::resolved::Collection;
 use kanban_domain::{
@@ -11,6 +11,7 @@ use kanban_domain::{
 use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::app::Focus;
 use kanban_tui::App;
+use kanban_view::card_list::CardListId;
 use uuid::Uuid;
 
 fn sync_model_from_store(app: &mut App) {
@@ -294,6 +295,52 @@ fn test_create_card_declines_on_a_not_loaded_column_tier() {
     assert_eq!(
         columns_before, columns_after,
         "no fabricated column must be created while the columns tier is declined"
+    );
+}
+
+#[test]
+fn test_create_card_declines_on_a_not_loaded_column_tier_with_a_column_focused() {
+    let mut app = App::test_default();
+    let (board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.prepare_frame();
+
+    let focused = app
+        .view
+        .strategy
+        .get_active_task_list()
+        .map(|list| list.id.clone());
+    assert!(
+        matches!(focused, Some(CardListId::Column(id)) if id == first_col),
+        "expected the active task list to be the focused column, got {focused:?}"
+    );
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::columns([Uuid::new_v4()])));
+
+    let columns_before = app.ctx.data_store().list_all_columns().unwrap().len();
+
+    app.input.set("Should not be created".to_string());
+    app.create_card();
+    app.input.clear();
+
+    let banner = app.ui_state.banner.as_ref().expect(
+        "declining a NotLoaded columns tier must set an error banner even with a column focused",
+    );
+    assert!(banner.message.to_lowercase().contains("column"));
+
+    let cards = app.ctx.data_store().list_all_cards().unwrap();
+    assert!(
+        cards.is_empty(),
+        "no card must be created while the columns tier is declined"
+    );
+    let columns_after = app.ctx.data_store().list_all_columns().unwrap().len();
+    assert_eq!(
+        columns_before, columns_after,
+        "no fabricated column must be created while the columns tier is declined, even with a column focused"
     );
 }
 

--- a/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
@@ -5,8 +5,8 @@
 
 use kanban_domain::resolved::Collection;
 use kanban_domain::{
-    ArchivedCard, CreateCardOptions, DerivedProjections, EntityIds, Invalidation,
-    KanbanOperations, LoadState, NoProjections, Resolved,
+    ArchivedCard, CreateCardOptions, DerivedProjections, EntityIds, Invalidation, KanbanOperations,
+    LoadState, NoProjections, Resolved,
 };
 use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::app::Focus;
@@ -45,7 +45,6 @@ fn select_card_in_active_task_list(app: &mut App, card_id: Uuid) {
         .expect("card present in active task list");
     list.set_selected_index(Some(idx));
 }
-
 
 #[test]
 fn test_handle_create_card_key_with_a_not_loaded_sprint_tier_declines() {
@@ -96,7 +95,6 @@ fn test_handle_create_card_key_still_opens_on_a_loaded_sprint_tier() {
     assert!(matches!(app.mode, AppMode::Dialog(DialogMode::CreateCard)));
     assert!(app.ui_state.banner.is_none());
 }
-
 
 #[test]
 fn test_create_card_target_column_prefers_board_scoped_state_over_stale_flat_tier() {
@@ -153,7 +151,6 @@ fn test_create_card_target_column_returns_none_when_the_scoped_tier_is_genuinely
 
     assert!(target.is_none());
 }
-
 
 fn seed_board_column_sprint_card(app: &mut App) -> (Uuid, Uuid, Uuid, Uuid) {
     let board = app.ctx.create_board("Board".into(), None).unwrap();
@@ -264,7 +261,6 @@ fn test_handle_assign_to_sprint_key_still_opens_single_card_dialog_on_a_loaded_s
     assert!(app.ui_state.banner.is_none());
 }
 
-
 #[test]
 fn test_create_card_declines_on_a_not_loaded_column_tier() {
     let mut app = App::test_default();
@@ -321,6 +317,21 @@ fn test_create_card_still_auto_completes_into_a_completion_column_on_a_loaded_co
     sync_model_from_store(&mut app);
     app.selection.active_board_id = Some(board.id);
 
+    let columns = app
+        .model
+        .columns_state()
+        .loaded()
+        .cloned()
+        .unwrap_or_default();
+    let changed = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_parent: [(board.id, LoadState::Loaded(columns))].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    NoProjections.resync(&app.model, changed);
+
     app.input.set("Auto-complete".to_string());
     app.create_card();
     app.input.clear();
@@ -330,7 +341,6 @@ fn test_create_card_still_auto_completes_into_a_completion_column_on_a_loaded_co
     assert_eq!(cards[0].status, kanban_domain::CardStatus::Done);
     assert!(app.ui_state.banner.is_none());
 }
-
 
 #[test]
 fn test_handle_move_card_declines_on_a_not_loaded_column_tier() {
@@ -394,7 +404,6 @@ fn test_handle_move_card_still_moves_the_card_on_a_loaded_column_tier() {
     assert_eq!(stored.column_id, second_col);
 }
 
-
 #[test]
 fn test_move_selected_cards_declines_on_a_not_loaded_column_tier() {
     let mut app = App::test_default();
@@ -441,7 +450,6 @@ fn test_move_selected_cards_declines_on_a_not_loaded_column_tier() {
     assert_eq!(stored_a.column_id, first_col);
     assert_eq!(stored_b.column_id, first_col);
 }
-
 
 #[test]
 fn test_restore_card_without_reload_declines_on_a_not_loaded_column_tier() {
@@ -548,6 +556,9 @@ fn test_handle_manage_children_from_list_declines_on_a_not_loaded_column_tier() 
         app.model.board_columns_state(board_id).is_not_loaded(),
         "reload never populates the board-scoped columns tier today"
     );
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::columns([Uuid::new_v4()])));
 
     app.handle_manage_children_from_list();
 

--- a/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
@@ -153,6 +153,54 @@ fn test_create_card_target_column_returns_none_when_the_scoped_tier_is_genuinely
     assert!(target.is_none());
 }
 
+#[test]
+fn test_create_card_target_column_distinguishes_missing_from_not_loaded() {
+    let mut app = App::test_default();
+    let (_board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
+    sync_model_from_store(&mut app);
+
+    let missing_id = Uuid::new_v4();
+    let changed = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_id: [(missing_id, LoadState::Missing)].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    NoProjections.resync(&app.model, changed);
+    assert!(matches!(
+        app.model.column_by_id_state(missing_id),
+        LoadState::Missing
+    ));
+
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::columns([first_col])));
+    assert!(matches!(
+        app.model.column_by_id_state(first_col),
+        LoadState::NotLoaded
+    ));
+
+    assert_eq!(
+        app.model
+            .column_by_id_state(missing_id)
+            .loaded()
+            .copied()
+            .cloned(),
+        None,
+        "a genuinely missing id resolves to None, the fabricate-a-column arm's input"
+    );
+    assert_eq!(
+        app.model
+            .column_by_id_state(first_col)
+            .loaded()
+            .copied()
+            .cloned(),
+        None,
+        "a stale not-loaded id collapses to the same None as missing at this shape-b site"
+    );
+}
+
 fn seed_board_column_sprint_card(app: &mut App) -> (Uuid, Uuid, Uuid, Uuid) {
     let board = app.ctx.create_board("Board".into(), None).unwrap();
     let column = app


### PR DESCRIPTION
## Summary

Migrates the 11 production `Model::columns()` / `Model::sprints()` reads in `crates/kanban-tui/src/handlers/card_handlers.rs` onto the state-preserving accessors, so a `NotLoaded` tier is declined with an error banner instead of collapsing to an empty collection and silently behaving as "board has zero columns/sprints". `Model::columns()` and `Model::sprints()` themselves are unchanged (their deletion is a separate leaf).

Sites, classified per the parent epic's three replacement shapes:
- shape (a), board-scoped: `create_card_target_column` flat-column lookup (`:43`), `handle_manage_children_from_list` (`:948`)
- shape (b), by-id: `create_card_target_column` (`:51`)
- shape (c), flat `*_state()`: `handle_create_card_key` (`:18`), `handle_assign_to_sprint_key` bulk and single-card paths (`:166`, `:179`, `:208`), `create_card` (`:394`), `handle_move_card` (`:537`), `move_selected_cards` (`:612`), `restore_card_without_reload` (`:824`)

## Fix for review feedback

The prior version of `create_card`'s guard was `self.get_focused_column_id().is_none() && !board_columns_state(bid).is_loaded() && !columns_state().is_loaded()`. Under `TaskListView::ColumnView` the active task list is `CardListId::Column(..)`, so `get_focused_column_id()` returns `Some` and the whole guard short-circuited to false regardless of load state. `create_card_target_column` then resolved the focused column id through `column_by_id_state`, which maps `NotLoaded` to `None`, so `create_card` took its `None` branch and fabricated a brand-new column.

Dropped the focus conjunct so the decline fires whenever neither `board_columns_state` nor `columns_state` is loaded, regardless of what is focused. Added a red test that puts the app in `ColumnView`, confirms a column is focused, invalidates the flat columns tier, and asserts `create_card` declines with a banner and creates neither a card nor a fabricated column. Removed the stray ticket reference from the test module's doc comment.

## Judgement calls (documented, not settled by the card)

- `handle_create_card_key` and `handle_assign_to_sprint_key` abort the whole handler on a declined tier rather than silently skipping only the picker priming, since a half-primed dialog is worse UX than none.
- `column_by_id_state` at `:51` sits inside a plain `Option` chain where `Missing` and `NotLoaded` collapse to the same `None`; the divergence test (`test_create_card_target_column_prefers_board_scoped_state_over_stale_flat_tier`) covers the meaningful case (scoped Loaded vs. stale flat tier) rather than a vacuous Missing-vs-NotLoaded split.

## Known gap (out of this card's scope)

`App::reload_model` clears `columns_by_board`/`sprints_by_board` on every reload and nothing in kanban-tui currently repopulates them (`KanbanContext::sync` is unwired here). After this merges, the board-scoped sites (`:43`, `:948`) will decline on every real invocation until a sibling infra card wires that fetch. Flagged for whoever sequences the rest of the batch.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p kanban-tui --all-targets --all-features -- -D warnings`
- `cargo test -p kanban-tui --all-features`
- Census over `card_handlers.rs` for the parent epic's replacement pattern returns 0 remaining flat `Model::columns()`/`Model::sprints()` reads
- `git diff --stat` against `origin/develop` over kanban-tui/kanban-view/kanban-domain src lists only `card_handlers.rs`
