### PR TITLE
KAN-1492 feat(tui): sprint and sprint-popup handlers decline on a not-loaded sprint tier

### DIFF
--- a/.changeset/kan-1492-sprint-popup-handler-reads-decline.md
+++ b/.changeset/kan-1492-sprint-popup-handler-reads-decline.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: sprint and sprint-popup handlers (`handle_activate_sprint_key`, `handle_complete_sprint_key`, `handle_carry_over_for_sprint`, `create_sprint`, `handle_assign_card_to_sprint_popup`, `handle_assign_multiple_cards_to_sprint_popup`, `handle_carry_over_sprint_popup`) now read sprints through the state-preserving `Model` accessors instead of the collapsing `Model::sprints()`, so a `NotLoaded` sprint tier surfaces an error banner instead of silently behaving as an empty collection.

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -516,23 +516,6 @@ mod tests {
         app.ctx.complete_sprint(completed.id).unwrap();
         app.reload_model();
         app.prepare_frame();
-        let board_sprints: Vec<_> = app
-            .model
-            .sprints()
-            .iter()
-            .filter(|s| s.board_id == board.id)
-            .cloned()
-            .collect();
-        let resolved = kanban_domain::Resolved {
-            sprints: kanban_domain::resolved::Collection {
-                by_parent: [(board.id, kanban_domain::LoadState::Loaded(board_sprints))]
-                    .into_iter()
-                    .collect(),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let _ = app.model.apply_resolved(resolved);
         app.selection.active_sprint_id = Some(completed.id);
         app.mode = AppMode::SprintDetail;
 

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -516,6 +516,23 @@ mod tests {
         app.ctx.complete_sprint(completed.id).unwrap();
         app.reload_model();
         app.prepare_frame();
+        let board_sprints: Vec<_> = app
+            .model
+            .sprints()
+            .iter()
+            .filter(|s| s.board_id == board.id)
+            .cloned()
+            .collect();
+        let resolved = kanban_domain::Resolved {
+            sprints: kanban_domain::resolved::Collection {
+                by_parent: [(board.id, kanban_domain::LoadState::Loaded(board_sprints))]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
         app.selection.active_sprint_id = Some(completed.id);
         app.mode = AppMode::SprintDetail;
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,7 +1,7 @@
 use crate::app::{App, AppMode};
 use crossterm::event::KeyCode;
 use kanban_domain::commands::{ColumnCommand, Command, UpdateColumn};
-use kanban_domain::{ColumnUpdate, GraphOperations, KanbanOperations, SortOrder};
+use kanban_domain::{ColumnUpdate, GraphOperations, KanbanOperations, LoadState, SortOrder};
 
 const PRIORITY_COUNT: usize = 4;
 const DEFAULT_STATUS_COUNT: usize = 5;
@@ -413,13 +413,14 @@ impl App {
                     .active_board_id
                     .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                 {
+                    let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                        self.set_error("Sprints are not loaded yet".to_string());
+                        return;
+                    };
                     let now = chrono::Utc::now();
-                    self.dialog_input.assign_sprint_picker.handle_key(
-                        key_code,
-                        self.model.sprints(),
-                        board,
-                        now,
-                    );
+                    self.dialog_input
+                        .assign_sprint_picker
+                        .handle_key(key_code, sprints, board, now);
                 }
             }
         }
@@ -491,13 +492,14 @@ impl App {
                     .active_board_id
                     .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                 {
+                    let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                        self.set_error("Sprints are not loaded yet".to_string());
+                        return;
+                    };
                     let now = chrono::Utc::now();
-                    self.dialog_input.assign_sprint_picker.handle_key(
-                        key_code,
-                        self.model.sprints(),
-                        board,
-                        now,
-                    );
+                    self.dialog_input
+                        .assign_sprint_picker
+                        .handle_key(key_code, sprints, board, now);
                 }
             }
         }
@@ -520,18 +522,24 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(source_id) = self.dialog_input.carry_over_source_sprint_id {
-                    if let Some(sprint) = self.model.sprints().iter().find(|s| s.id == source_id) {
-                        let board_id = sprint.board_id;
-                        let count = self
-                            .model
-                            .sprints()
-                            .iter()
-                            .filter(|s| {
-                                s.board_id == board_id
-                                    && s.status == kanban_domain::SprintStatus::Planning
-                            })
-                            .count();
-                        self.dialog_input.carry_over_sprint_selection.next(count);
+                    match self.model.sprint_by_id_state(source_id) {
+                        LoadState::Loaded(sprint) => {
+                            let board_id = sprint.board_id;
+                            match self.model.board_sprints_state(board_id) {
+                                LoadState::Loaded(board_sprints) => {
+                                    let count = board_sprints
+                                        .iter()
+                                        .filter(|s| {
+                                            s.status == kanban_domain::SprintStatus::Planning
+                                        })
+                                        .count();
+                                    self.dialog_input.carry_over_sprint_selection.next(count);
+                                }
+                                _ => self.set_error("Sprints are not loaded yet".to_string()),
+                            }
+                        }
+                        LoadState::Missing => {}
+                        _ => self.set_error("Sprint is not loaded yet".to_string()),
                     }
                 }
             }
@@ -541,56 +549,63 @@ impl App {
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if let Some(idx) = self.dialog_input.carry_over_sprint_selection.get() {
                     if let Some(source_id) = self.dialog_input.carry_over_source_sprint_id {
-                        if let Some(sprint) =
-                            self.model.sprints().iter().find(|s| s.id == source_id)
-                        {
-                            let board_id = sprint.board_id;
-                            let planning_sprint_ids: Vec<uuid::Uuid> = self
-                                .model
-                                .sprints()
-                                .iter()
-                                .filter(|s| {
-                                    s.board_id == board_id
-                                        && s.status == kanban_domain::SprintStatus::Planning
-                                })
-                                .map(|s| s.id)
-                                .collect();
-
-                            if let Some(&to_sprint_id) = planning_sprint_ids.get(idx) {
-                                let sprint_label = self
-                                    .model
-                                    .sprints()
-                                    .iter()
-                                    .find(|s| s.id == to_sprint_id)
-                                    .map(|s| {
-                                        self.model
-                                            .boards_state()
-                                            .loaded_or_empty()
+                        match self.model.sprint_by_id_state(source_id) {
+                            LoadState::Loaded(sprint) => {
+                                let board_id = sprint.board_id;
+                                match self.model.board_sprints_state(board_id) {
+                                    LoadState::Loaded(board_sprints) => {
+                                        let planning_sprint_ids: Vec<uuid::Uuid> = board_sprints
                                             .iter()
-                                            .find(|b| b.id == board_id)
-                                            .and_then(|b| s.get_name(b))
-                                            .map(|n| n.to_string())
-                                            .unwrap_or_else(|| {
-                                                format!("Sprint {}", s.sprint_number)
+                                            .filter(|s| {
+                                                s.status == kanban_domain::SprintStatus::Planning
                                             })
-                                    })
-                                    .unwrap_or_else(|| "sprint".to_string());
+                                            .map(|s| s.id)
+                                            .collect();
 
-                                match self.ctx.carry_over_sprint_cards(source_id, to_sprint_id) {
-                                    Ok(count) => {
-                                        self.reload_model();
-                                        self.set_success(format!(
-                                            "Carried over {} card(s) to {}",
-                                            count, sprint_label
-                                        ));
-                                        self.populate_sprint_task_lists(source_id);
+                                        if let Some(&to_sprint_id) = planning_sprint_ids.get(idx) {
+                                            let sprint_label =
+                                                match self.model.sprint_by_id_state(to_sprint_id) {
+                                                    LoadState::Loaded(s) => self
+                                                        .model
+                                                        .boards_state()
+                                                        .loaded_or_empty()
+                                                        .iter()
+                                                        .find(|b| b.id == board_id)
+                                                        .and_then(|b| s.get_name(b))
+                                                        .map(|n| n.to_string())
+                                                        .unwrap_or_else(|| {
+                                                            format!("Sprint {}", s.sprint_number)
+                                                        }),
+                                                    _ => "sprint".to_string(),
+                                                };
+
+                                            match self
+                                                .ctx
+                                                .carry_over_sprint_cards(source_id, to_sprint_id)
+                                            {
+                                                Ok(count) => {
+                                                    self.reload_model();
+                                                    self.set_success(format!(
+                                                        "Carried over {} card(s) to {}",
+                                                        count, sprint_label
+                                                    ));
+                                                    self.populate_sprint_task_lists(source_id);
+                                                }
+                                                Err(e) => {
+                                                    tracing::error!("Carry-over failed: {}", e);
+                                                    self.set_error(format!(
+                                                        "Carry-over failed: {}",
+                                                        e
+                                                    ));
+                                                }
+                                            }
+                                        }
                                     }
-                                    Err(e) => {
-                                        tracing::error!("Carry-over failed: {}", e);
-                                        self.set_error(format!("Carry-over failed: {}", e));
-                                    }
+                                    _ => self.set_error("Sprints are not loaded yet".to_string()),
                                 }
                             }
+                            LoadState::Missing => {}
+                            _ => self.set_error("Sprint is not loaded yet".to_string()),
                         }
                     }
                 }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -525,12 +525,13 @@ impl App {
                     match self.model.sprint_by_id_state(source_id) {
                         LoadState::Loaded(sprint) => {
                             let board_id = sprint.board_id;
-                            match self.model.board_sprints_state(board_id) {
-                                LoadState::Loaded(board_sprints) => {
-                                    let count = board_sprints
+                            match self.model.sprints_state() {
+                                LoadState::Loaded(sprints) => {
+                                    let count = sprints
                                         .iter()
                                         .filter(|s| {
-                                            s.status == kanban_domain::SprintStatus::Planning
+                                            s.board_id == board_id
+                                                && s.status == kanban_domain::SprintStatus::Planning
                                         })
                                         .count();
                                     self.dialog_input.carry_over_sprint_selection.next(count);
@@ -552,12 +553,14 @@ impl App {
                         match self.model.sprint_by_id_state(source_id) {
                             LoadState::Loaded(sprint) => {
                                 let board_id = sprint.board_id;
-                                match self.model.board_sprints_state(board_id) {
-                                    LoadState::Loaded(board_sprints) => {
-                                        let planning_sprint_ids: Vec<uuid::Uuid> = board_sprints
+                                match self.model.sprints_state() {
+                                    LoadState::Loaded(sprints) => {
+                                        let planning_sprint_ids: Vec<uuid::Uuid> = sprints
                                             .iter()
                                             .filter(|s| {
-                                                s.status == kanban_domain::SprintStatus::Planning
+                                                s.board_id == board_id
+                                                    && s.status
+                                                        == kanban_domain::SprintStatus::Planning
                                             })
                                             .map(|s| s.id)
                                             .collect();

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -132,14 +132,15 @@ impl App {
 
                 {
                     use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-                    let LoadState::Loaded(board_sprints) = self.model.board_sprints_state(board_id)
-                    else {
+                    let LoadState::Loaded(sprints) = self.model.sprints_state() else {
                         self.set_error("Sprints are not loaded yet".to_string());
                         return;
                     };
-                    let has_planning = board_sprints
-                        .iter()
-                        .any(|s| s.status == SprintStatus::Planning && s.id != sprint_id);
+                    let has_planning = sprints.iter().any(|s| {
+                        s.board_id == board_id
+                            && s.status == SprintStatus::Planning
+                            && s.id != sprint_id
+                    });
 
                     if has_planning
                         && !get_sprint_uncompleted_cards(sprint_id, self.controller.live_cards())
@@ -164,10 +165,10 @@ impl App {
             }
         };
 
-        let has_planning_sprint = match self.model.board_sprints_state(board_id) {
-            LoadState::Loaded(board_sprints) => board_sprints
+        let has_planning_sprint = match self.model.sprints_state() {
+            LoadState::Loaded(sprints) => sprints
                 .iter()
-                .any(|s| s.status == SprintStatus::Planning),
+                .any(|s| s.board_id == board_id && s.status == SprintStatus::Planning),
             _ => {
                 self.set_error("Sprints are not loaded yet".to_string());
                 return;
@@ -205,8 +206,10 @@ impl App {
                 .to_string();
 
             let sprint_id = uuid::Uuid::new_v4();
-            let prior_sprint_count = match self.model.board_sprints_state(board_id) {
-                LoadState::Loaded(board_sprints) => board_sprints.len(),
+            let prior_sprint_count = match self.model.sprints_state() {
+                LoadState::Loaded(sprints) => {
+                    sprints.iter().filter(|s| s.board_id == board_id).count()
+                }
                 _ => {
                     self.set_error("Sprints are not loaded yet".to_string());
                     return;
@@ -252,8 +255,7 @@ mod create_sprint_factory_tests {
     /// Seed a board through the service, then point the TUI's active selection
     /// at it so `create_sprint` has a board to mint against.
     fn seed_active_board(app: &mut App) {
-        let board = app
-            .ctx
+        app.ctx
             .create_board("Board".into(), Some("KAN".into()))
             .unwrap();
         refresh(app);
@@ -263,17 +265,6 @@ mod create_sprint_factory_tests {
             .loaded_or_empty()
             .first()
             .map(|b| b.id);
-
-        let resolved = kanban_domain::Resolved {
-            sprints: kanban_domain::resolved::Collection {
-                by_parent: [(board.id, kanban_domain::LoadState::Loaded(vec![]))]
-                    .into_iter()
-                    .collect(),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let _ = app.model.apply_resolved(resolved);
     }
 
     /// KAN-798: the TUI sprint-create entry point funnels through the Sprint

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -2,7 +2,7 @@ use crate::app::{App, BoardFocus, DialogMode};
 use kanban_domain::commands::{
     ActivateSprint, BoardCommand, Command, CompleteSprint, CreateSprint, SprintCommand, UpdateBoard,
 };
-use kanban_domain::{BoardUpdate, FieldUpdate, SprintStatus};
+use kanban_domain::{BoardUpdate, FieldUpdate, LoadState, SprintStatus};
 use uuid::Uuid;
 
 impl App {
@@ -15,22 +15,29 @@ impl App {
 
     pub fn handle_activate_sprint_key(&mut self) {
         if let Some(sprint_id) = self.selection.active_sprint_id {
-            // Collect sprint info before mutations
+            let mut needs_loaded_error = false;
             let sprint_info = {
                 let context_board = self.board_in_context();
-                if let (Some(sprint), Some(board)) = (
-                    self.model.sprints().iter().find(|s| s.id == sprint_id),
-                    context_board,
-                ) {
-                    if sprint.status == SprintStatus::Planning {
-                        Some((sprint.id, sprint.formatted_name(board, None)))
-                    } else {
+                match (self.model.sprint_by_id_state(sprint_id), context_board) {
+                    (LoadState::Loaded(sprint), Some(board)) => {
+                        if sprint.status == SprintStatus::Planning {
+                            Some((sprint.id, sprint.formatted_name(board, None)))
+                        } else {
+                            None
+                        }
+                    }
+                    (LoadState::Missing, _) | (_, None) => None,
+                    _ => {
+                        needs_loaded_error = true;
                         None
                     }
-                } else {
-                    None
                 }
             };
+
+            if needs_loaded_error {
+                self.set_error("Sprint is not loaded yet".to_string());
+                return;
+            }
 
             if let Some((sprint_id, sprint_name)) = sprint_info {
                 {
@@ -69,24 +76,31 @@ impl App {
 
     pub fn handle_complete_sprint_key(&mut self) {
         if let Some(sprint_id) = self.selection.active_sprint_id {
-            // Collect sprint and board info before mutations
+            let mut needs_loaded_error = false;
             let sprint_info = {
                 let context_board = self.board_in_context();
-                if let (Some(sprint), Some(board)) = (
-                    self.model.sprints().iter().find(|s| s.id == sprint_id),
-                    context_board,
-                ) {
-                    if sprint.status == SprintStatus::Active
-                        || sprint.status == SprintStatus::Planning
-                    {
-                        Some((sprint.id, board.id, sprint.formatted_name(board, None)))
-                    } else {
+                match (self.model.sprint_by_id_state(sprint_id), context_board) {
+                    (LoadState::Loaded(sprint), Some(board)) => {
+                        if sprint.status == SprintStatus::Active
+                            || sprint.status == SprintStatus::Planning
+                        {
+                            Some((sprint.id, board.id, sprint.formatted_name(board, None)))
+                        } else {
+                            None
+                        }
+                    }
+                    (LoadState::Missing, _) | (_, None) => None,
+                    _ => {
+                        needs_loaded_error = true;
                         None
                     }
-                } else {
-                    None
                 }
             };
+
+            if needs_loaded_error {
+                self.set_error("Sprint is not loaded yet".to_string());
+                return;
+            }
 
             if let Some((sprint_id, board_id, sprint_name)) = sprint_info {
                 // Execute CompleteSprint and UpdateBoard as batch
@@ -118,11 +132,14 @@ impl App {
 
                 {
                     use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-                    let has_planning = self.model.sprints().iter().any(|s| {
-                        s.board_id == board_id
-                            && s.status == SprintStatus::Planning
-                            && s.id != sprint_id
-                    });
+                    let LoadState::Loaded(board_sprints) = self.model.board_sprints_state(board_id)
+                    else {
+                        self.set_error("Sprints are not loaded yet".to_string());
+                        return;
+                    };
+                    let has_planning = board_sprints
+                        .iter()
+                        .any(|s| s.status == SprintStatus::Planning && s.id != sprint_id);
 
                     if has_planning
                         && !get_sprint_uncompleted_cards(sprint_id, self.controller.live_cards())
@@ -138,16 +155,24 @@ impl App {
     }
 
     pub fn handle_carry_over_for_sprint(&mut self, from_sprint_id: Uuid) {
-        let board_id = match self.model.sprints().iter().find(|s| s.id == from_sprint_id) {
-            Some(sprint) => sprint.board_id,
-            None => return,
+        let board_id = match self.model.sprint_by_id_state(from_sprint_id) {
+            LoadState::Loaded(sprint) => sprint.board_id,
+            LoadState::Missing => return,
+            _ => {
+                self.set_error("Sprint is not loaded yet".to_string());
+                return;
+            }
         };
 
-        let has_planning_sprint = self
-            .model
-            .sprints()
-            .iter()
-            .any(|s| s.board_id == board_id && s.status == SprintStatus::Planning);
+        let has_planning_sprint = match self.model.board_sprints_state(board_id) {
+            LoadState::Loaded(board_sprints) => board_sprints
+                .iter()
+                .any(|s| s.status == SprintStatus::Planning),
+            _ => {
+                self.set_error("Sprints are not loaded yet".to_string());
+                return;
+            }
+        };
 
         if has_planning_sprint {
             self.dialog_input.carry_over_source_sprint_id = Some(from_sprint_id);
@@ -180,12 +205,13 @@ impl App {
                 .to_string();
 
             let sprint_id = uuid::Uuid::new_v4();
-            let prior_sprint_count = self
-                .model
-                .sprints()
-                .iter()
-                .filter(|s| s.board_id == board_id)
-                .count();
+            let prior_sprint_count = match self.model.board_sprints_state(board_id) {
+                LoadState::Loaded(board_sprints) => board_sprints.len(),
+                _ => {
+                    self.set_error("Sprints are not loaded yet".to_string());
+                    return;
+                }
+            };
 
             let cmd = Command::Sprint(SprintCommand::Create(CreateSprint {
                 id: sprint_id,
@@ -226,7 +252,8 @@ mod create_sprint_factory_tests {
     /// Seed a board through the service, then point the TUI's active selection
     /// at it so `create_sprint` has a board to mint against.
     fn seed_active_board(app: &mut App) {
-        app.ctx
+        let board = app
+            .ctx
             .create_board("Board".into(), Some("KAN".into()))
             .unwrap();
         refresh(app);
@@ -236,6 +263,17 @@ mod create_sprint_factory_tests {
             .loaded_or_empty()
             .first()
             .map(|b| b.id);
+
+        let resolved = kanban_domain::Resolved {
+            sprints: kanban_domain::resolved::Collection {
+                by_parent: [(board.id, kanban_domain::LoadState::Loaded(vec![]))]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
     }
 
     /// KAN-798: the TUI sprint-create entry point funnels through the Sprint

--- a/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
@@ -1,7 +1,6 @@
 use crossterm::event::KeyCode;
 use kanban_domain::model::ModelLoadStates;
-use kanban_domain::resolved::Collection;
-use kanban_domain::{Board, LoadState, Resolved, Sprint};
+use kanban_domain::{Board, LoadState, Sprint};
 use kanban_tui::components::banner::BannerVariant;
 use kanban_tui::App;
 use uuid::Uuid;
@@ -23,19 +22,6 @@ fn seed_model_with_board(
         ..Default::default()
     });
     board_id
-}
-
-pub fn populate_board_scoped_sprints(app: &mut App, board_id: Uuid, sprints: Vec<Sprint>) {
-    let resolved = Resolved {
-        sprints: Collection {
-            by_parent: [(board_id, LoadState::Loaded(sprints))]
-                .into_iter()
-                .collect(),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    let _ = app.model.apply_resolved(resolved);
 }
 
 fn assert_error_banner_mentions(app: &App, needle: &str) {

--- a/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
@@ -1,7 +1,7 @@
 use crossterm::event::KeyCode;
 use kanban_domain::model::ModelLoadStates;
 use kanban_domain::resolved::Collection;
-use kanban_domain::{Board, KanbanOperations, LoadState, Resolved, Sprint};
+use kanban_domain::{Board, LoadState, Resolved, Sprint};
 use kanban_tui::components::banner::BannerVariant;
 use kanban_tui::App;
 use uuid::Uuid;
@@ -35,7 +35,7 @@ pub fn populate_board_scoped_sprints(app: &mut App, board_id: Uuid, sprints: Vec
         },
         ..Default::default()
     };
-    app.model.apply_resolved(resolved);
+    let _ = app.model.apply_resolved(resolved);
 }
 
 fn assert_error_banner_mentions(app: &App, needle: &str) {

--- a/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
@@ -1,0 +1,244 @@
+use crossterm::event::KeyCode;
+use kanban_domain::model::ModelLoadStates;
+use kanban_domain::resolved::Collection;
+use kanban_domain::{Board, KanbanOperations, LoadState, Resolved, Sprint};
+use kanban_tui::components::banner::BannerVariant;
+use kanban_tui::App;
+use uuid::Uuid;
+
+fn seed_model_with_board(
+    app: &mut App,
+    boards: LoadState<Vec<Board>>,
+    sprints: LoadState<Vec<Sprint>>,
+) -> Uuid {
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let boards = match boards {
+        LoadState::Loaded(_) => LoadState::Loaded(vec![board]),
+        other => other,
+    };
+    app.model = kanban_domain::Model::with_load_states(ModelLoadStates {
+        boards,
+        sprints,
+        ..Default::default()
+    });
+    board_id
+}
+
+pub fn populate_board_scoped_sprints(app: &mut App, board_id: Uuid, sprints: Vec<Sprint>) {
+    let resolved = Resolved {
+        sprints: Collection {
+            by_parent: [(board_id, LoadState::Loaded(sprints))]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    app.model.apply_resolved(resolved);
+}
+
+fn assert_error_banner_mentions(app: &App, needle: &str) {
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("expected an error banner");
+    assert_eq!(banner.variant, BannerVariant::Error);
+    assert!(
+        banner.message.to_lowercase().contains(needle),
+        "banner message {:?} did not mention {:?}",
+        banner.message,
+        needle
+    );
+}
+
+fn assert_no_banner(app: &App) {
+    assert!(
+        app.ui_state.banner.is_none(),
+        "expected no banner, got {:?}",
+        app.ui_state.banner
+    );
+}
+
+#[test]
+fn test_handle_activate_sprint_key_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_sprint_id = Some(Uuid::new_v4());
+
+    app.handle_activate_sprint_key();
+
+    assert_error_banner_mentions(&app, "not loaded");
+}
+
+#[test]
+fn test_handle_activate_sprint_key_distinguishes_missing_from_not_loaded() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(
+        &mut app,
+        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![]),
+    );
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.handle_activate_sprint_key();
+    assert_no_banner(&app);
+
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.handle_activate_sprint_key();
+    assert_error_banner_mentions(&app, "not loaded");
+}
+
+#[test]
+fn test_handle_complete_sprint_key_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    let sprint_id = Uuid::new_v4();
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_sprint_id = Some(sprint_id);
+
+    app.handle_complete_sprint_key();
+
+    assert_error_banner_mentions(&app, "not loaded");
+    assert_eq!(app.selection.active_sprint_id, Some(sprint_id));
+    assert!(app.ctx.data_store().list_all_sprints().unwrap().is_empty());
+}
+
+#[test]
+fn test_handle_complete_sprint_key_distinguishes_missing_from_not_loaded() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(
+        &mut app,
+        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![]),
+    );
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.handle_complete_sprint_key();
+    assert_no_banner(&app);
+
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.handle_complete_sprint_key();
+    assert_error_banner_mentions(&app, "not loaded");
+}
+
+#[test]
+fn test_handle_carry_over_for_sprint_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    seed_model_with_board(&mut app, LoadState::NotLoaded, LoadState::NotLoaded);
+
+    app.handle_carry_over_for_sprint(Uuid::new_v4());
+
+    assert_error_banner_mentions(&app, "not loaded");
+    assert_eq!(app.dialog_input.carry_over_source_sprint_id, None);
+}
+
+#[test]
+fn test_handle_carry_over_for_sprint_distinguishes_missing_from_not_loaded() {
+    let mut app = App::test_default();
+    seed_model_with_board(&mut app, LoadState::NotLoaded, LoadState::Loaded(vec![]));
+    app.handle_carry_over_for_sprint(Uuid::new_v4());
+    assert_no_banner(&app);
+
+    let mut app = App::test_default();
+    seed_model_with_board(&mut app, LoadState::NotLoaded, LoadState::NotLoaded);
+    app.handle_carry_over_for_sprint(Uuid::new_v4());
+    assert_error_banner_mentions(&app, "not loaded");
+}
+
+#[test]
+fn test_create_sprint_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    app.input.set("Alpha".to_string());
+
+    app.create_sprint();
+
+    assert_error_banner_mentions(&app, "not loaded");
+    assert!(app.ctx.data_store().list_all_sprints().unwrap().is_empty());
+}
+
+#[test]
+fn test_handle_assign_card_to_sprint_popup_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    let cursor_before = app.dialog_input.assign_sprint_picker.cursor_sprint_id();
+    let selected_before = app.dialog_input.assign_sprint_picker.selected_sprint_id();
+
+    app.handle_assign_card_to_sprint_popup(KeyCode::Down);
+
+    assert_error_banner_mentions(&app, "not loaded");
+    assert_eq!(
+        app.dialog_input.assign_sprint_picker.cursor_sprint_id(),
+        cursor_before
+    );
+    assert_eq!(
+        app.dialog_input.assign_sprint_picker.selected_sprint_id(),
+        selected_before
+    );
+}
+
+#[test]
+fn test_handle_assign_multiple_cards_to_sprint_popup_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    let cursor_before = app.dialog_input.assign_sprint_picker.cursor_sprint_id();
+    let selected_before = app.dialog_input.assign_sprint_picker.selected_sprint_id();
+
+    app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Down);
+
+    assert_error_banner_mentions(&app, "not loaded");
+    assert_eq!(
+        app.dialog_input.assign_sprint_picker.cursor_sprint_id(),
+        cursor_before
+    );
+    assert_eq!(
+        app.dialog_input.assign_sprint_picker.selected_sprint_id(),
+        selected_before
+    );
+}
+
+#[test]
+fn test_handle_carry_over_sprint_popup_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    seed_model_with_board(&mut app, LoadState::NotLoaded, LoadState::NotLoaded);
+    let source_id = Uuid::new_v4();
+    app.dialog_input.carry_over_source_sprint_id = Some(source_id);
+    let selection_before = app.dialog_input.carry_over_sprint_selection.get();
+
+    app.handle_carry_over_sprint_popup(KeyCode::Down);
+
+    assert_error_banner_mentions(&app, "not loaded");
+    assert_eq!(
+        app.dialog_input.carry_over_sprint_selection.get(),
+        selection_before
+    );
+}
+
+#[test]
+fn test_handle_carry_over_sprint_popup_distinguishes_missing_from_not_loaded() {
+    let mut app = App::test_default();
+    seed_model_with_board(&mut app, LoadState::NotLoaded, LoadState::Loaded(vec![]));
+    let source_id = Uuid::new_v4();
+    app.dialog_input.carry_over_source_sprint_id = Some(source_id);
+    app.handle_carry_over_sprint_popup(KeyCode::Down);
+    assert_no_banner(&app);
+
+    let mut app = App::test_default();
+    seed_model_with_board(&mut app, LoadState::NotLoaded, LoadState::NotLoaded);
+    let source_id = Uuid::new_v4();
+    app.dialog_input.carry_over_source_sprint_id = Some(source_id);
+    app.handle_carry_over_sprint_popup(KeyCode::Down);
+    assert_error_banner_mentions(&app, "not loaded");
+}

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -3,27 +3,6 @@ use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::app::BoardFocus;
 use kanban_tui::App;
-use uuid::Uuid;
-
-fn populate_board_scoped_sprints(app: &mut App, board_id: Uuid) {
-    let sprints: Vec<_> = app
-        .model
-        .sprints()
-        .iter()
-        .filter(|s| s.board_id == board_id)
-        .cloned()
-        .collect();
-    let resolved = kanban_domain::Resolved {
-        sprints: kanban_domain::resolved::Collection {
-            by_parent: [(board_id, kanban_domain::LoadState::Loaded(sprints))]
-                .into_iter()
-                .collect(),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    let _ = app.model.apply_resolved(resolved);
-}
 
 fn setup_app_with_board() -> App {
     let mut app = App::test_default();
@@ -212,8 +191,6 @@ fn test_create_sprint_selects_new_sprint() {
     let mut app = setup_app_with_board();
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
-    let active_board_id = app.selection.active_board_id.unwrap();
-    populate_board_scoped_sprints(&mut app, active_board_id);
 
     app.input.set("".to_string());
     app.create_sprint();
@@ -277,7 +254,6 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     // Create a single sprint (Planning status by default)
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
-    populate_board_scoped_sprints(&mut app, board.id);
     app.input.set("".to_string());
     app.create_sprint();
     app.prepare_frame();
@@ -303,7 +279,6 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.prepare_frame();
 
     // Navigate to sprint detail and complete it
-    populate_board_scoped_sprints(&mut app, board.id);
     app.selection.active_sprint_id = Some(sprint_id);
     app.handle_complete_sprint_key();
     app.prepare_frame();
@@ -339,11 +314,9 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     // Create two sprints (both start as Planning)
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
-    populate_board_scoped_sprints(&mut app, board.id);
     app.input.set("".to_string());
     app.create_sprint();
     app.prepare_frame();
-    populate_board_scoped_sprints(&mut app, board.id);
     app.input.set("".to_string());
     app.create_sprint();
     app.prepare_frame();
@@ -374,34 +347,15 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     app.reload_model();
     app.prepare_frame();
 
-    // handle_complete_sprint_key's own reload_model() call clears board_sprints_state
-    // right before the carry-over-eligibility check runs, so populating it here does not
-    // survive to that check.
-    populate_board_scoped_sprints(&mut app, board.id);
+    // Complete sprint 1, sprint 2 is still Planning
     app.selection.active_sprint_id = Some(sprint1_id);
     app.handle_complete_sprint_key();
     app.prepare_frame();
 
     assert_eq!(
-        app.ctx
-            .data_store()
-            .get_sprint(sprint1_id)
-            .unwrap()
-            .unwrap()
-            .status,
-        kanban_domain::SprintStatus::Completed,
-        "sprint 1 is still completed even though carry-over now declines"
-    );
-    assert_eq!(
-        app.dialog_input.carry_over_source_sprint_id, None,
-        "carry-over dialog cannot open: board_sprints_state is NotLoaded by the time \
-         the eligibility check runs, since handle_complete_sprint_key's own reload_model \
-         already cleared it"
-    );
-    let banner = app.ui_state.banner.as_ref().expect("expected a banner");
-    assert_eq!(
-        banner.variant,
-        kanban_tui::components::banner::BannerVariant::Error
+        app.dialog_input.carry_over_source_sprint_id,
+        Some(sprint1_id),
+        "carry-over dialog should open with sprint 1 as source"
     );
 }
 

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -3,6 +3,27 @@ use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::app::BoardFocus;
 use kanban_tui::App;
+use uuid::Uuid;
+
+fn populate_board_scoped_sprints(app: &mut App, board_id: Uuid) {
+    let sprints: Vec<_> = app
+        .model
+        .sprints()
+        .iter()
+        .filter(|s| s.board_id == board_id)
+        .cloned()
+        .collect();
+    let resolved = kanban_domain::Resolved {
+        sprints: kanban_domain::resolved::Collection {
+            by_parent: [(board_id, kanban_domain::LoadState::Loaded(sprints))]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let _ = app.model.apply_resolved(resolved);
+}
 
 fn setup_app_with_board() -> App {
     let mut app = App::test_default();
@@ -191,6 +212,8 @@ fn test_create_sprint_selects_new_sprint() {
     let mut app = setup_app_with_board();
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
+    let active_board_id = app.selection.active_board_id.unwrap();
+    populate_board_scoped_sprints(&mut app, active_board_id);
 
     app.input.set("".to_string());
     app.create_sprint();
@@ -254,6 +277,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     // Create a single sprint (Planning status by default)
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
+    populate_board_scoped_sprints(&mut app, board.id);
     app.input.set("".to_string());
     app.create_sprint();
     app.prepare_frame();
@@ -279,6 +303,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.prepare_frame();
 
     // Navigate to sprint detail and complete it
+    populate_board_scoped_sprints(&mut app, board.id);
     app.selection.active_sprint_id = Some(sprint_id);
     app.handle_complete_sprint_key();
     app.prepare_frame();
@@ -314,9 +339,11 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     // Create two sprints (both start as Planning)
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Sprints;
+    populate_board_scoped_sprints(&mut app, board.id);
     app.input.set("".to_string());
     app.create_sprint();
     app.prepare_frame();
+    populate_board_scoped_sprints(&mut app, board.id);
     app.input.set("".to_string());
     app.create_sprint();
     app.prepare_frame();
@@ -347,16 +374,34 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     app.reload_model();
     app.prepare_frame();
 
-    // Complete sprint 1 — sprint 2 is still Planning
+    // handle_complete_sprint_key's own reload_model() call clears board_sprints_state
+    // right before the carry-over-eligibility check runs, so populating it here does not
+    // survive to that check.
+    populate_board_scoped_sprints(&mut app, board.id);
     app.selection.active_sprint_id = Some(sprint1_id);
     app.handle_complete_sprint_key();
     app.prepare_frame();
 
-    // Carry-over dialog should open because sprint 2 is Planning and sprint 1 has uncompleted cards
     assert_eq!(
-        app.dialog_input.carry_over_source_sprint_id,
-        Some(sprint1_id),
-        "carry-over dialog should open with sprint 1 as source"
+        app.ctx
+            .data_store()
+            .get_sprint(sprint1_id)
+            .unwrap()
+            .unwrap()
+            .status,
+        kanban_domain::SprintStatus::Completed,
+        "sprint 1 is still completed even though carry-over now declines"
+    );
+    assert_eq!(
+        app.dialog_input.carry_over_source_sprint_id, None,
+        "carry-over dialog cannot open: board_sprints_state is NotLoaded by the time \
+         the eligibility check runs, since handle_complete_sprint_key's own reload_model \
+         already cleared it"
+    );
+    let banner = app.ui_state.banner.as_ref().expect("expected a banner");
+    assert_eq!(
+        banner.variant,
+        kanban_tui::components::banner::BannerVariant::Error
     );
 }
 


### PR DESCRIPTION
## What

Migrates every `Model::sprints()` read in `sprint_handlers.rs` (6 sites) and `popup_handlers.rs` (7 sites) onto the state-preserving `Model` accessors added in KAN-1465, so a `NotLoaded` sprint tier surfaces an error banner instead of silently behaving as an empty collection. `Model::sprints()`/`Model::columns()` themselves are unchanged; their removal is KAN-1434, after every leaf lands.

Per-site classification (13 sites, matching the parent census exactly):

**By-id (`sprint_by_id_state`), Missing vs NotLoaded distinguished:**
- `handle_activate_sprint_key`
- `handle_complete_sprint_key`'s own sprint lookup
- `handle_carry_over_for_sprint`'s source-sprint lookup
- `handle_carry_over_sprint_popup`'s Down arm and Enter arm source-sprint lookups

**Flat pass-through (`sprints_state`), board_id filter retained:**
- `handle_complete_sprint_key`'s carry-over-eligibility check
- `handle_carry_over_for_sprint`'s planning-sprint check
- `create_sprint`'s prior-sprint count
- `handle_carry_over_sprint_popup`'s Down-arm count and Enter-arm collect

**Flat pass-through (`sprints_state`), no board filter needed (picker itself is board-bound):**
- `handle_assign_card_to_sprint_popup`
- `handle_assign_multiple_cards_to_sprint_popup`

**Deliberate exception:** `handle_carry_over_sprint_popup`'s `sprint_label` lookup collapses Missing and NotLoaded to the existing `"sprint"` fallback, since the value only feeds a cosmetic success message after the mutation is already decided.

Census over both files with the parent's whitespace-flattened, `#[cfg(test)]`-truncated command: `.model.sprints()` occurrences after the change = 0.

### Why the board-scoped sites use the flat tier, not `board_sprints_state`

`board_sprints_state`/`board_columns_state` can never be `Loaded` via any path `kanban-tui` exercises today: `reload_model` -> `Model::load_from_snapshot` clears the by-board maps and never repopulates them, and `Model::apply_resolved` (the only writer) is never called anywhere in `kanban-tui`. Routing these sites through that accessor would make them decline on every call in the shipped app, unlike the pre-migration code which read the flat collection and filtered by `board_id`. Using `sprints_state()` with the `board_id` filter kept in place preserves byte-equivalent behaviour on the Loaded branch while still declining correctly when the flat tier itself is `NotLoaded`.

## Tests

11 new decline tests in `crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs`, one function-scoped test file (not the parent's originally-planned shared file, to avoid a guaranteed multi-PR conflict with sibling leaves branching off the same base tip).

## Verification

- `cargo fmt --all -- --check` green
- `cargo clippy --all-targets --all-features -p kanban-tui -- -D warnings` green
- `cargo test -p kanban-tui --all-features` green (297+ tests across all suites, 0 failed)
- `git diff --stat origin/develop -- crates/kanban-tui/src crates/kanban-view/src crates/kanban-domain/src` touches only `sprint_handlers.rs` and `popup_handlers.rs`
- `git grep -nE 'loaded_or_empty|loaded\(\)\.unwrap_or' -- crates/kanban-tui/src/handlers/sprint_handlers.rs crates/kanban-tui/src/handlers/popup_handlers.rs` returns nothing tied to sprints (only pre-existing, unrelated `boards_state()`/`cards_state()` calls)
- Mutation check: reverted `create_sprint`'s site to `board_sprints_state`, confirmed `test_create_sprint_selects_new_sprint` fails (0 sprints created instead of 1), restored the fix and reran green
