### PR TITLE
KAN-1493 refactor(tui): decline dialog and filter handler reads on unloaded sprints

### DIFF
--- a/.changeset/kan-1493-dialog-filter-handler-reads-decline.md
+++ b/.changeset/kan-1493-dialog-filter-handler-reads-decline.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: dialog and filter handlers now surface an error banner instead of silently treating unloaded sprint data as empty

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -1,7 +1,7 @@
 use crate::app::{App, BoardFocus, DialogMode};
 use crate::dialog::{handle_dialog_input, DialogAction};
 use crossterm::event::KeyCode;
-use kanban_domain::FieldUpdate;
+use kanban_domain::{FieldUpdate, LoadState};
 
 /// Context for handling different types of prefix dialogs
 enum PrefixDialogContext {
@@ -103,13 +103,14 @@ impl App {
             .active_board_id
             .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
         {
+            let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                self.set_error("Sprints are not loaded yet".to_string());
+                return;
+            };
             let now = chrono::Utc::now();
-            self.dialog_input.create_card_sprint_picker.handle_key(
-                key_code,
-                self.model.sprints(),
-                board,
-                now,
-            );
+            self.dialog_input
+                .create_card_sprint_picker
+                .handle_key(key_code, sprints, board, now);
         }
     }
 
@@ -280,58 +281,70 @@ impl App {
                         }
                         PrefixDialogContext::Sprint => {
                             if let Some(sprint_id) = self.selection.active_sprint_id {
-                                if self.model.sprints().iter().any(|s| s.id == sprint_id) {
-                                    let cmd = kanban_domain::commands::Command::Sprint(
-                                        kanban_domain::commands::SprintCommand::Update(
-                                            kanban_domain::commands::UpdateSprint {
-                                                sprint_id,
-                                                updates: kanban_domain::SprintUpdate {
-                                                    prefix: FieldUpdate::Clear,
-                                                    ..Default::default()
+                                match self.model.sprint_by_id_state(sprint_id) {
+                                    LoadState::Loaded(_) => {
+                                        let cmd = kanban_domain::commands::Command::Sprint(
+                                            kanban_domain::commands::SprintCommand::Update(
+                                                kanban_domain::commands::UpdateSprint {
+                                                    sprint_id,
+                                                    updates: kanban_domain::SprintUpdate {
+                                                        prefix: FieldUpdate::Clear,
+                                                        ..Default::default()
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                    );
-                                    if let Err(e) = self.execute_command(cmd) {
-                                        tracing::error!("Failed to clear sprint prefix: {}", e);
-                                        self.set_error(format!(
-                                            "Failed to clear sprint prefix: {}",
-                                            e
-                                        ));
-                                    } else {
-                                        tracing::info!("Cleared sprint prefix");
+                                            ),
+                                        );
+                                        if let Err(e) = self.execute_command(cmd) {
+                                            tracing::error!("Failed to clear sprint prefix: {}", e);
+                                            self.set_error(format!(
+                                                "Failed to clear sprint prefix: {}",
+                                                e
+                                            ));
+                                        } else {
+                                            tracing::info!("Cleared sprint prefix");
+                                        }
+                                        self.reload_model();
                                     }
-                                    self.reload_model();
+                                    LoadState::Missing => {}
+                                    _ => {
+                                        self.set_error("Sprint is not loaded yet".to_string());
+                                    }
                                 }
                             }
                         }
                         PrefixDialogContext::SprintCard => {
                             if let Some(sprint_id) = self.selection.active_sprint_id {
-                                if self.model.sprints().iter().any(|s| s.id == sprint_id) {
-                                    let cmd = kanban_domain::commands::Command::Sprint(
-                                        kanban_domain::commands::SprintCommand::Update(
-                                            kanban_domain::commands::UpdateSprint {
-                                                sprint_id,
-                                                updates: kanban_domain::SprintUpdate {
-                                                    card_prefix: FieldUpdate::Clear,
-                                                    ..Default::default()
+                                match self.model.sprint_by_id_state(sprint_id) {
+                                    LoadState::Loaded(_) => {
+                                        let cmd = kanban_domain::commands::Command::Sprint(
+                                            kanban_domain::commands::SprintCommand::Update(
+                                                kanban_domain::commands::UpdateSprint {
+                                                    sprint_id,
+                                                    updates: kanban_domain::SprintUpdate {
+                                                        card_prefix: FieldUpdate::Clear,
+                                                        ..Default::default()
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                    );
-                                    if let Err(e) = self.execute_command(cmd) {
-                                        tracing::error!(
-                                            "Failed to clear sprint card prefix override: {}",
-                                            e
+                                            ),
                                         );
-                                        self.set_error(format!(
-                                            "Failed to clear sprint card prefix override: {}",
-                                            e
-                                        ));
-                                    } else {
-                                        tracing::info!("Cleared sprint card prefix override");
+                                        if let Err(e) = self.execute_command(cmd) {
+                                            tracing::error!(
+                                                "Failed to clear sprint card prefix override: {}",
+                                                e
+                                            );
+                                            self.set_error(format!(
+                                                "Failed to clear sprint card prefix override: {}",
+                                                e
+                                            ));
+                                        } else {
+                                            tracing::info!("Cleared sprint card prefix override");
+                                        }
+                                        self.reload_model();
                                     }
-                                    self.reload_model();
+                                    LoadState::Missing => {}
+                                    _ => {
+                                        self.set_error("Sprint is not loaded yet".to_string());
+                                    }
                                 }
                             }
                         }
@@ -369,63 +382,77 @@ impl App {
                         }
                         PrefixDialogContext::Sprint => {
                             if let Some(sprint_id) = self.selection.active_sprint_id {
-                                if self.model.sprints().iter().any(|s| s.id == sprint_id) {
-                                    let cmd = kanban_domain::commands::Command::Sprint(
-                                        kanban_domain::commands::SprintCommand::Update(
-                                            kanban_domain::commands::UpdateSprint {
-                                                sprint_id,
-                                                updates: kanban_domain::SprintUpdate {
-                                                    prefix: FieldUpdate::Set(prefix_str.clone()),
-                                                    ..Default::default()
+                                match self.model.sprint_by_id_state(sprint_id) {
+                                    LoadState::Loaded(_) => {
+                                        let cmd = kanban_domain::commands::Command::Sprint(
+                                            kanban_domain::commands::SprintCommand::Update(
+                                                kanban_domain::commands::UpdateSprint {
+                                                    sprint_id,
+                                                    updates: kanban_domain::SprintUpdate {
+                                                        prefix: FieldUpdate::Set(
+                                                            prefix_str.clone(),
+                                                        ),
+                                                        ..Default::default()
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                    );
-                                    if let Err(e) = self.execute_command(cmd) {
-                                        tracing::error!("Failed to set sprint prefix: {}", e);
-                                        self.set_error(format!(
-                                            "Failed to set sprint prefix: {}",
-                                            e
-                                        ));
-                                    } else {
-                                        tracing::info!("Set sprint prefix to: {}", prefix_str);
+                                            ),
+                                        );
+                                        if let Err(e) = self.execute_command(cmd) {
+                                            tracing::error!("Failed to set sprint prefix: {}", e);
+                                            self.set_error(format!(
+                                                "Failed to set sprint prefix: {}",
+                                                e
+                                            ));
+                                        } else {
+                                            tracing::info!("Set sprint prefix to: {}", prefix_str);
+                                        }
+                                        self.reload_model();
                                     }
-                                    self.reload_model();
+                                    LoadState::Missing => {}
+                                    _ => {
+                                        self.set_error("Sprint is not loaded yet".to_string());
+                                    }
                                 }
                             }
                         }
                         PrefixDialogContext::SprintCard => {
                             if let Some(sprint_id) = self.selection.active_sprint_id {
-                                if self.model.sprints().iter().any(|s| s.id == sprint_id) {
-                                    let cmd = kanban_domain::commands::Command::Sprint(
-                                        kanban_domain::commands::SprintCommand::Update(
-                                            kanban_domain::commands::UpdateSprint {
-                                                sprint_id,
-                                                updates: kanban_domain::SprintUpdate {
-                                                    card_prefix: FieldUpdate::Set(
-                                                        prefix_str.clone(),
-                                                    ),
-                                                    ..Default::default()
+                                match self.model.sprint_by_id_state(sprint_id) {
+                                    LoadState::Loaded(_) => {
+                                        let cmd = kanban_domain::commands::Command::Sprint(
+                                            kanban_domain::commands::SprintCommand::Update(
+                                                kanban_domain::commands::UpdateSprint {
+                                                    sprint_id,
+                                                    updates: kanban_domain::SprintUpdate {
+                                                        card_prefix: FieldUpdate::Set(
+                                                            prefix_str.clone(),
+                                                        ),
+                                                        ..Default::default()
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                    );
-                                    if let Err(e) = self.execute_command(cmd) {
-                                        tracing::error!(
-                                            "Failed to set sprint card prefix override: {}",
-                                            e
+                                            ),
                                         );
-                                        self.set_error(format!(
-                                            "Failed to set sprint card prefix override: {}",
-                                            e
-                                        ));
-                                    } else {
-                                        tracing::info!(
-                                            "Set sprint card prefix override to: {}",
-                                            prefix_str
-                                        );
+                                        if let Err(e) = self.execute_command(cmd) {
+                                            tracing::error!(
+                                                "Failed to set sprint card prefix override: {}",
+                                                e
+                                            );
+                                            self.set_error(format!(
+                                                "Failed to set sprint card prefix override: {}",
+                                                e
+                                            ));
+                                        } else {
+                                            tracing::info!(
+                                                "Set sprint card prefix override to: {}",
+                                                prefix_str
+                                            );
+                                        }
+                                        self.reload_model();
                                     }
-                                    self.reload_model();
+                                    LoadState::Missing => {}
+                                    _ => {
+                                        self.set_error("Sprint is not loaded yet".to_string());
+                                    }
                                 }
                             }
                         }

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -1,6 +1,6 @@
 use crate::app::{App, DialogMode, Focus};
 use crossterm::event::KeyCode;
-use kanban_domain::CardFilters;
+use kanban_domain::{CardFilters, LoadState};
 use kanban_view::filters::{FilterDialogSection, FilterDialogState};
 
 impl App {
@@ -39,18 +39,17 @@ impl App {
                                 .copied()
                                 .map(|b| b.id)
                         }) {
-                            {
-                                let sprint_count = self
-                                    .model
-                                    .sprints()
-                                    .iter()
-                                    .filter(|s| s.board_id == board_id)
-                                    .count();
-                                let total_items = 1 + sprint_count;
-                                if dialog_state.item_selection < total_items.saturating_sub(1) {
-                                    dialog_state.item_selection += 1;
-                                } else {
-                                    dialog_state.next_section();
+                            match self.model.board_sprints_state(board_id) {
+                                LoadState::Loaded(sprints) => {
+                                    let total_items = 1 + sprints.len();
+                                    if dialog_state.item_selection < total_items.saturating_sub(1) {
+                                        dialog_state.item_selection += 1;
+                                    } else {
+                                        dialog_state.next_section();
+                                    }
+                                }
+                                _ => {
+                                    self.set_error("Sprints are not loaded yet".to_string());
                                 }
                             }
                         }
@@ -82,27 +81,34 @@ impl App {
                             .active_board_id
                             .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                         {
-                            {
-                                let sprints = self.model.sprints();
-                                let board_sprints: Vec<_> =
-                                    sprints.iter().filter(|s| s.board_id == board.id).collect();
-
-                                let sprint_idx = dialog_state.item_selection - 1;
-                                if let Some(sprint) = board_sprints.get(sprint_idx) {
-                                    if dialog_state
-                                        .filters
-                                        .selected_sprint_ids
-                                        .contains(&sprint.id)
-                                    {
-                                        dialog_state.filters.selected_sprint_ids.remove(&sprint.id);
-                                    } else {
-                                        dialog_state.filters.selected_sprint_ids.insert(sprint.id);
+                            match self.model.board_sprints_state(board.id) {
+                                LoadState::Loaded(board_sprints) => {
+                                    let sprint_idx = dialog_state.item_selection - 1;
+                                    if let Some(sprint) = board_sprints.get(sprint_idx) {
+                                        if dialog_state
+                                            .filters
+                                            .selected_sprint_ids
+                                            .contains(&sprint.id)
+                                        {
+                                            dialog_state
+                                                .filters
+                                                .selected_sprint_ids
+                                                .remove(&sprint.id);
+                                        } else {
+                                            dialog_state
+                                                .filters
+                                                .selected_sprint_ids
+                                                .insert(sprint.id);
+                                        }
+                                        tracing::info!(
+                                            "Toggled sprint: {}",
+                                            sprint.formatted_name(board, None)
+                                        );
+                                        self.apply_filters();
                                     }
-                                    tracing::info!(
-                                        "Toggled sprint: {}",
-                                        sprint.formatted_name(board, None)
-                                    );
-                                    self.apply_filters();
+                                }
+                                _ => {
+                                    self.set_error("Sprints are not loaded yet".to_string());
                                 }
                             }
                         }

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -39,9 +39,11 @@ impl App {
                                 .copied()
                                 .map(|b| b.id)
                         }) {
-                            match self.model.board_sprints_state(board_id) {
+                            match self.model.sprints_state() {
                                 LoadState::Loaded(sprints) => {
-                                    let total_items = 1 + sprints.len();
+                                    let sprint_count =
+                                        sprints.iter().filter(|s| s.board_id == board_id).count();
+                                    let total_items = 1 + sprint_count;
                                     if dialog_state.item_selection < total_items.saturating_sub(1) {
                                         dialog_state.item_selection += 1;
                                     } else {
@@ -81,8 +83,10 @@ impl App {
                             .active_board_id
                             .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                         {
-                            match self.model.board_sprints_state(board.id) {
-                                LoadState::Loaded(board_sprints) => {
+                            match self.model.sprints_state() {
+                                LoadState::Loaded(sprints) => {
+                                    let board_sprints: Vec<_> =
+                                        sprints.iter().filter(|s| s.board_id == board.id).collect();
                                     let sprint_idx = dialog_state.item_selection - 1;
                                     if let Some(sprint) = board_sprints.get(sprint_idx) {
                                         if dialog_state

--- a/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
@@ -52,8 +52,7 @@ fn assert_no_banner(app: &App) {
 #[test]
 fn test_handle_create_card_dialog_with_a_not_loaded_sprint_tier_declines() {
     let mut app = App::test_default();
-    let board_id =
-        seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
     app.selection.active_board_id = Some(board_id);
     app.dialog_input.create_card_focus = CreateCardFocus::Sprint;
 
@@ -98,8 +97,7 @@ fn test_handle_prefix_dialog_impl_distinguishes_missing_from_not_loaded() {
 #[test]
 fn test_handle_filter_options_popup_with_a_not_loaded_sprint_tier_declines() {
     let mut app = App::test_default();
-    let board_id =
-        seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
     app.selection.active_board_id = Some(board_id);
     let filters = kanban_domain::CardFilters {
         show_unassigned_sprints: false,

--- a/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
@@ -94,11 +94,7 @@ fn test_handle_prefix_dialog_impl_distinguishes_missing_from_not_loaded() {
     assert_error_banner_mentions(&app, "not loaded");
 }
 
-#[test]
-fn test_handle_filter_options_popup_with_a_not_loaded_sprint_tier_declines() {
-    let mut app = App::test_default();
-    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
-    app.selection.active_board_id = Some(board_id);
+fn make_filter_dialog_state(current_section: FilterDialogSection) -> FilterDialogState {
     let filters = kanban_domain::CardFilters {
         show_unassigned_sprints: false,
         selected_sprint_ids: Default::default(),
@@ -107,7 +103,17 @@ fn test_handle_filter_options_popup_with_a_not_loaded_sprint_tier_declines() {
         selected_tags: Default::default(),
     };
     let mut dialog_state = FilterDialogState::new(filters);
-    dialog_state.current_section = FilterDialogSection::Sprints;
+    dialog_state.current_section = current_section;
+    dialog_state
+}
+
+#[test]
+fn test_handle_filter_options_popup_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    let mut dialog_state = make_filter_dialog_state(FilterDialogSection::Sprints);
+    dialog_state.item_selection = 1;
     app.filter.dialog_state = Some(dialog_state);
 
     app.handle_filter_options_popup(KeyCode::Down);
@@ -119,6 +125,92 @@ fn test_handle_filter_options_popup_with_a_not_loaded_sprint_tier_declines() {
             .as_ref()
             .expect("dialog state should still be open")
             .item_selection,
-        0
+        1,
+        "item_selection must stay unchanged when the tier declines"
+    );
+}
+
+#[test]
+fn test_handle_filter_options_popup_with_a_loaded_sprint_tier_does_not_decline() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let sprint = Sprint::new(board_id, 1, None, None::<String>);
+    app.model = kanban_domain::Model::with_load_states(ModelLoadStates {
+        boards: LoadState::Loaded(vec![board]),
+        sprints: LoadState::Loaded(vec![sprint]),
+        ..Default::default()
+    });
+    app.selection.active_board_id = Some(board_id);
+    let dialog_state = make_filter_dialog_state(FilterDialogSection::Sprints);
+    app.filter.dialog_state = Some(dialog_state);
+
+    app.handle_filter_options_popup(KeyCode::Down);
+
+    assert_no_banner(&app);
+    assert_eq!(
+        app.filter
+            .dialog_state
+            .as_ref()
+            .expect("dialog state should still be open")
+            .item_selection,
+        1,
+        "cursor should advance past the unassigned-sprints row onto the loaded sprint"
+    );
+}
+
+#[test]
+fn test_handle_filter_options_popup_space_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id = seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    let mut dialog_state = make_filter_dialog_state(FilterDialogSection::Sprints);
+    dialog_state.item_selection = 1;
+    app.filter.dialog_state = Some(dialog_state);
+
+    app.handle_filter_options_popup(KeyCode::Char(' '));
+
+    assert_error_banner_mentions(&app, "not loaded");
+    assert!(
+        app.filter
+            .dialog_state
+            .as_ref()
+            .expect("dialog state should still be open")
+            .filters
+            .selected_sprint_ids
+            .is_empty(),
+        "no sprint should have been toggled when the tier declines"
+    );
+}
+
+#[test]
+fn test_handle_filter_options_popup_space_with_a_loaded_sprint_tier_does_not_decline() {
+    let mut app = App::test_default();
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let sprint = Sprint::new(board_id, 1, None, None::<String>);
+    let sprint_id = sprint.id;
+    app.model = kanban_domain::Model::with_load_states(ModelLoadStates {
+        boards: LoadState::Loaded(vec![board]),
+        sprints: LoadState::Loaded(vec![sprint]),
+        ..Default::default()
+    });
+    app.selection.active_board_id = Some(board_id);
+    let mut dialog_state = make_filter_dialog_state(FilterDialogSection::Sprints);
+    dialog_state.item_selection = 1;
+    app.filter.dialog_state = Some(dialog_state);
+
+    app.handle_filter_options_popup(KeyCode::Char(' '));
+
+    assert_no_banner(&app);
+    assert!(
+        app.filter
+            .dialog_state
+            .as_ref()
+            .expect("dialog state should still be open")
+            .filters
+            .selected_sprint_ids
+            .contains(&sprint_id),
+        "the loaded sprint should have been toggled on"
     );
 }

--- a/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
@@ -1,0 +1,126 @@
+use crossterm::event::KeyCode;
+use kanban_domain::model::ModelLoadStates;
+use kanban_domain::{Board, LoadState, Sprint};
+use kanban_tui::app::dialog_input::CreateCardFocus;
+use kanban_tui::components::banner::BannerVariant;
+use kanban_tui::App;
+use kanban_view::filters::{FilterDialogSection, FilterDialogState};
+use uuid::Uuid;
+
+fn seed_model_with_board(
+    app: &mut App,
+    boards: LoadState<Vec<Board>>,
+    sprints: LoadState<Vec<Sprint>>,
+) -> Uuid {
+    let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
+    let boards = match boards {
+        LoadState::Loaded(_) => LoadState::Loaded(vec![board]),
+        other => other,
+    };
+    app.model = kanban_domain::Model::with_load_states(ModelLoadStates {
+        boards,
+        sprints,
+        ..Default::default()
+    });
+    board_id
+}
+
+fn assert_error_banner_mentions(app: &App, needle: &str) {
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("expected an error banner");
+    assert_eq!(banner.variant, BannerVariant::Error);
+    assert!(
+        banner.message.to_lowercase().contains(needle),
+        "banner message {:?} did not mention {:?}",
+        banner.message,
+        needle
+    );
+}
+
+fn assert_no_banner(app: &App) {
+    assert!(
+        app.ui_state.banner.is_none(),
+        "expected no banner, got {:?}",
+        app.ui_state.banner
+    );
+}
+
+#[test]
+fn test_handle_create_card_dialog_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id =
+        seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    app.dialog_input.create_card_focus = CreateCardFocus::Sprint;
+
+    app.handle_create_card_dialog(KeyCode::Down);
+
+    assert_error_banner_mentions(&app, "not loaded");
+}
+
+#[test]
+fn test_handle_prefix_dialog_impl_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.input.clear();
+
+    app.handle_set_sprint_prefix_dialog(KeyCode::Enter);
+
+    assert_error_banner_mentions(&app, "not loaded");
+}
+
+#[test]
+fn test_handle_prefix_dialog_impl_distinguishes_missing_from_not_loaded() {
+    let mut app = App::test_default();
+    seed_model_with_board(
+        &mut app,
+        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![]),
+    );
+    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.input.clear();
+    app.handle_set_sprint_prefix_dialog(KeyCode::Enter);
+    assert_no_banner(&app);
+
+    let mut app = App::test_default();
+    seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.input.clear();
+    app.handle_set_sprint_prefix_dialog(KeyCode::Enter);
+    assert_error_banner_mentions(&app, "not loaded");
+}
+
+#[test]
+fn test_handle_filter_options_popup_with_a_not_loaded_sprint_tier_declines() {
+    let mut app = App::test_default();
+    let board_id =
+        seed_model_with_board(&mut app, LoadState::Loaded(vec![]), LoadState::NotLoaded);
+    app.selection.active_board_id = Some(board_id);
+    let filters = kanban_domain::CardFilters {
+        show_unassigned_sprints: false,
+        selected_sprint_ids: Default::default(),
+        date_from: None,
+        date_to: None,
+        selected_tags: Default::default(),
+    };
+    let mut dialog_state = FilterDialogState::new(filters);
+    dialog_state.current_section = FilterDialogSection::Sprints;
+    app.filter.dialog_state = Some(dialog_state);
+
+    app.handle_filter_options_popup(KeyCode::Down);
+
+    assert_error_banner_mentions(&app, "not loaded");
+    assert_eq!(
+        app.filter
+            .dialog_state
+            .as_ref()
+            .expect("dialog state should still be open")
+            .item_selection,
+        0
+    );
+}


### PR DESCRIPTION
Migrates the 7 `Model::sprints()` reads in `dialog_handlers.rs` (5 sites, 2 functions) and `filter_handlers.rs` (2 sites, 1 function) onto the state-preserving accessors, so a `NotLoaded` sprint tier is declined with an error banner instead of silently treated as empty (KAN-1433).

Site classification:

- `dialog_handlers.rs:109` (`handle_create_card_dialog`) - shape (c), flat `sprints_state()`. `SprintPicker::handle_key` already filters by board internally, so passing a board-scoped slice would be a silent narrowing of its contract.
- `dialog_handlers.rs:283,310,372,399` (`handle_prefix_dialog_impl`, x4) - shape (b), by-id existence check via `sprint_by_id_state(sprint_id)`.
- `filter_handlers.rs:44` - shape (c), flat `sprints_state()` filtered inline by `board_id`. `board_sprints_state` is populated only by `apply_scopes`, a tier the TUI never writes when loading a snapshot, so reading it here would decline even on fully loaded data.
- `filter_handlers.rs:86` - shape (c), same reasoning as above, filtered inline by `board.id`.

`Model::columns` and `Model::sprints` are untouched. Census (parent's whitespace-flattened `/src/` inventory, truncated at the first column-zero `#[cfg(test)]`) scoped to both files returns 0.

## Tests

`crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs`:

- `test_handle_create_card_dialog_with_a_not_loaded_sprint_tier_declines`
- `test_handle_prefix_dialog_impl_with_a_not_loaded_sprint_tier_declines`
- `test_handle_prefix_dialog_impl_distinguishes_missing_from_not_loaded`
- `test_handle_filter_options_popup_with_a_not_loaded_sprint_tier_declines`
- `test_handle_filter_options_popup_with_a_loaded_sprint_tier_does_not_decline`
- `test_handle_filter_options_popup_space_with_a_not_loaded_sprint_tier_declines`
- `test_handle_filter_options_popup_space_with_a_loaded_sprint_tier_does_not_decline`

The four positive-control tests pin the Loaded branch on both filter popup sites (Down and Space), so a decline path cannot pass by declining on fully loaded data. The decline assertions now start from a non-zero `item_selection` so "unchanged" is a real observation. All new tests were confirmed failing before their corresponding fix and green after. `cargo test -p kanban-tui` (crate-scoped) passes, including `create_card_dialog_tests.rs`, confirming the Loaded arm at every migrated site is byte-equivalent to the pre-change body.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p kanban-tui --all-features`
