### PR TITLE
KAN-1495 feat(domain): populate board-scoped column and sprint tiers on snapshot load

### DIFF
--- a/.changeset/kan-1495-board-scoped-tiers.md
+++ b/.changeset/kan-1495-board-scoped-tiers.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+domain: `Model::load_from_snapshot` now populates the board-scoped columns
+and sprints tiers by grouping the snapshot's flat rows by board id, instead
+of leaving them cleared and empty after every load.

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -169,7 +169,7 @@ pub use test_helpers::ModelLoadStates;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Board, Card, Column, Snapshot};
+    use crate::{Board, Card, Column, Snapshot, Sprint};
 
     fn make_card(board: &Board, column_id: Uuid) -> Card {
         Card::new(board.id, column_id, "task", 0)
@@ -242,6 +242,108 @@ mod tests {
         // Reload with no cards — stale index entry must be gone
         let _ = m.load_from_snapshot(Snapshot::default());
         assert!(m.card_by_id_state(old_id).loaded().copied().is_none());
+    }
+
+    #[test]
+    fn test_load_from_snapshot_populates_board_scoped_column_and_sprint_tiers() {
+        let mut m = Model::default();
+        let board_a = Board::new("A", None::<String>);
+        let board_b = Board::new("B", None::<String>);
+        let col_a = Column::new(board_a.id, "Col A", 0);
+        let col_b = Column::new(board_b.id, "Col B", 0);
+        let sprint_a = Sprint::new(board_a.id, 1, None, None::<String>);
+        let sprint_b = Sprint::new(board_b.id, 1, None, None::<String>);
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board_a.clone(), board_b.clone()],
+            columns: vec![col_a.clone(), col_b.clone()],
+            sprints: vec![sprint_a.clone(), sprint_b.clone()],
+            ..Default::default()
+        });
+
+        let cols_a_state = m.board_columns_state(board_a.id);
+        let cols_a = cols_a_state.loaded().unwrap();
+        assert_eq!(cols_a.len(), 1);
+        assert_eq!(cols_a[0].id, col_a.id);
+
+        let cols_b_state = m.board_columns_state(board_b.id);
+        let cols_b = cols_b_state.loaded().unwrap();
+        assert_eq!(cols_b.len(), 1);
+        assert_eq!(cols_b[0].id, col_b.id);
+
+        let sprints_a_state = m.board_sprints_state(board_a.id);
+        let sprints_a = sprints_a_state.loaded().unwrap();
+        assert_eq!(sprints_a.len(), 1);
+        assert_eq!(sprints_a[0].id, sprint_a.id);
+
+        let sprints_b_state = m.board_sprints_state(board_b.id);
+        let sprints_b = sprints_b_state.loaded().unwrap();
+        assert_eq!(sprints_b.len(), 1);
+        assert_eq!(sprints_b[0].id, sprint_b.id);
+    }
+
+    #[test]
+    fn test_load_from_snapshot_marks_a_board_with_no_columns_loaded_empty() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board.clone()],
+            ..Default::default()
+        });
+
+        let cols_state = m.board_columns_state(board.id);
+        assert!(cols_state.loaded().unwrap().is_empty());
+        let sprints_state = m.board_sprints_state(board.id);
+        assert!(sprints_state.loaded().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_board_scoped_tiers_stay_not_loaded_for_a_board_absent_from_the_snapshot() {
+        let mut m = Model::default();
+        let board_a = Board::new("A", None::<String>);
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board_a],
+            ..Default::default()
+        });
+
+        let other = Uuid::new_v4();
+        assert!(m.board_columns_state(other).is_not_loaded());
+        assert!(m.board_sprints_state(other).is_not_loaded());
+    }
+
+    #[test]
+    fn test_load_from_snapshot_replaces_stale_board_scoped_tiers() {
+        let mut m = Model::default();
+        let board_a = Board::new("A", None::<String>);
+        let col_a1 = Column::new(board_a.id, "Col A1", 0);
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board_a.clone()],
+            columns: vec![col_a1.clone()],
+            ..Default::default()
+        });
+        let loaded_state = m.board_columns_state(board_a.id);
+        let loaded = loaded_state.loaded().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, col_a1.id);
+
+        let board_b = Board::new("B", None::<String>);
+        let col_a2 = Column::new(board_a.id, "Col A2", 0);
+        let col_b1 = Column::new(board_b.id, "Col B1", 0);
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board_a.clone(), board_b.clone()],
+            columns: vec![col_a2.clone(), col_b1.clone()],
+            ..Default::default()
+        });
+
+        let loaded_a_state = m.board_columns_state(board_a.id);
+        let loaded_a = loaded_a_state.loaded().unwrap();
+        assert_eq!(loaded_a.len(), 1);
+        assert_eq!(loaded_a[0].id, col_a2.id);
+        assert!(!loaded_a.iter().any(|c| c.id == col_a1.id));
+
+        let loaded_b_state = m.board_columns_state(board_b.id);
+        let loaded_b = loaded_b_state.loaded().unwrap();
+        assert_eq!(loaded_b.len(), 1);
+        assert_eq!(loaded_b[0].id, col_b1.id);
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -102,10 +102,8 @@ impl Model {
         self.columns_by_id.clear();
         self.cards_by_id.clear();
         self.sprints_by_id.clear();
-        self.columns_by_board.clear();
         self.cards_by_column.clear();
         self.scoped_card_index.clear();
-        self.sprints_by_board.clear();
         self.archived_cards_by_board.clear();
 
         self.absorb_archival_markers(
@@ -115,8 +113,47 @@ impl Model {
 
         self.rebuild_card_index();
         self.rebuild_board_index();
+        self.rebuild_board_scoped_tiers();
 
         ModelChanged::new()
+    }
+
+    fn rebuild_board_scoped_tiers(&mut self) {
+        self.columns_by_board.clear();
+        self.sprints_by_board.clear();
+
+        if let LoadState::Loaded(boards) = &self.boards {
+            for b in boards {
+                self.columns_by_board
+                    .insert(b.id, LoadState::Loaded(Vec::new()));
+                self.sprints_by_board
+                    .insert(b.id, LoadState::Loaded(Vec::new()));
+            }
+        }
+        if let LoadState::Loaded(columns) = &self.columns {
+            for c in columns {
+                let LoadState::Loaded(bucket) = self
+                    .columns_by_board
+                    .entry(c.board_id)
+                    .or_insert_with(|| LoadState::Loaded(Vec::new()))
+                else {
+                    unreachable!("entry is always seeded as Loaded above")
+                };
+                bucket.push(c.clone());
+            }
+        }
+        if let LoadState::Loaded(sprints) = &self.sprints {
+            for s in sprints {
+                let LoadState::Loaded(bucket) = self
+                    .sprints_by_board
+                    .entry(s.board_id)
+                    .or_insert_with(|| LoadState::Loaded(Vec::new()))
+                else {
+                    unreachable!("entry is always seeded as Loaded above")
+                };
+                bucket.push(s.clone());
+            }
+        }
     }
 
     fn absorb_archival_markers(

--- a/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
@@ -648,8 +648,8 @@ fn test_handle_manage_children_from_list_declines_on_a_not_loaded_column_tier() 
     app.relationship.card_ids.clear();
 
     assert!(
-        app.model.board_columns_state(board_id).is_not_loaded(),
-        "reload never populates the board-scoped columns tier today"
+        app.model.board_columns_state(board_id).is_loaded(),
+        "a synced board must report its board-scoped columns tier loaded"
     );
     let _ = app
         .model


### PR DESCRIPTION
## Changes

- `Model::load_from_snapshot` now populates `columns_by_board` and `sprints_by_board` by grouping the snapshot's flat `columns`/`sprints` by `board_id`, seeding every board present in the snapshot with `Loaded(vec![])` first so a board with zero columns or sprints reads as `Loaded([])` rather than `NotLoaded`.
- The two `clear()` calls that used to leave those tiers empty after every load were moved into the new private `rebuild_board_scoped_tiers` helper, which clears then rebuilds both maps so a board removed between two snapshot loads reverts to `NotLoaded` rather than keeping a stale entry.
- A board id absent from the snapshot's `boards` still resolves to `NotLoaded` for both tiers, unchanged.
- Added four tests covering: population across two boards, a board with an empty column/sprint set staying `Loaded([])`, a board absent from the snapshot staying `NotLoaded`, and a reload replacing stale per-board entries.
- Updated `test_handle_manage_children_from_list_declines_on_a_not_loaded_column_tier` in `kanban-tui`, which pinned the pre-fix `NotLoaded` state as its setup precondition. A synced board now correctly reports its board-scoped columns tier as `Loaded`, so the precondition is updated to `is_loaded()`; the test still exercises the real decline path via the `invalidate()` call that follows it.

## Scope

`crates/kanban-domain/src/model/mod.rs` carries the fix. `collections.rs` accessors (`board_columns_state`, `board_sprints_state`, etc.) and `apply.rs`/`invalidate.rs` are untouched. `crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs` carries the one precondition update above; no production `kanban-tui` source changed.
