### PR TITLE
KAN-1488 refactor(tui): decline prepare_frame's task-list rebuild on unloaded tiers

### DIFF
--- a/.changeset/kan-1488-tui-prepare-frame-declines-once.md
+++ b/.changeset/kan-1488-tui-prepare-frame-declines-once.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: `App::prepare_frame` now declines to rebuild the task lists when the columns or sprints tier is not loaded, instead of silently collapsing to an empty collection.

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -2,7 +2,7 @@ use super::{App, AppMode};
 use crate::view_strategy::UnifiedViewStrategy;
 use kanban_domain::{
     filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, KanbanResult,
-    Snapshot,
+    LoadState, Snapshot,
 };
 use kanban_view::view_strategy::{ViewRefreshContext, ViewStrategy};
 use std::collections::HashMap;
@@ -123,21 +123,26 @@ impl App {
             board_id.and_then(|id| self.model.board_by_id_state(id).loaded().copied());
 
         if let Some(board) = board {
-            let search_query = if self.filter.search.is_active {
-                Some(self.filter.search.query())
-            } else {
-                None
-            };
-            let ctx = ViewRefreshContext {
-                board,
-                all_cards: cards_for_display,
-                all_columns: self.model.columns(),
-                all_sprints: self.model.sprints(),
-                active_sprint_filters: self.filter.active_sprint_filters.clone(),
-                hide_assigned_cards: self.filter.hide_assigned_cards,
-                search_query,
-            };
-            self.view.strategy.refresh_task_lists(&ctx);
+            if let (LoadState::Loaded(all_columns), LoadState::Loaded(all_sprints)) = (
+                self.model.columns_state().as_ref(),
+                self.model.sprints_state().as_ref(),
+            ) {
+                let search_query = if self.filter.search.is_active {
+                    Some(self.filter.search.query())
+                } else {
+                    None
+                };
+                let ctx = ViewRefreshContext {
+                    board,
+                    all_cards: cards_for_display,
+                    all_columns,
+                    all_sprints,
+                    active_sprint_filters: self.filter.active_sprint_filters.clone(),
+                    hide_assigned_cards: self.filter.hide_assigned_cards,
+                    search_query,
+                };
+                self.view.strategy.refresh_task_lists(&ctx);
+            }
         }
         self.sync_card_list_component();
     }

--- a/crates/kanban-tui/tests/view_management_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/view_management_collapsing_accessor_tests.rs
@@ -1,0 +1,88 @@
+//! `App::prepare_frame` reads `Model::columns()`/`Model::sprints()`, which
+//! collapse a `NotLoaded` tier to an empty slice, so a stale read silently
+//! rebuilds the task lists as if the board had zero columns/sprints instead
+//! of declining. These tests pin the decline behaviour.
+
+use kanban_domain::{CreateCardOptions, EntityIds, Invalidation, KanbanOperations};
+use kanban_tui::App;
+use uuid::Uuid;
+
+fn sync_model_from_store(app: &mut App) {
+    let snapshot = app.ctx.snapshot().unwrap();
+    app.load_snapshot(snapshot);
+}
+
+fn seed_board_with_column_and_card(app: &mut App) -> (Uuid, Uuid) {
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    (board.id, card.id)
+}
+
+#[test]
+fn test_prepare_frame_leaves_the_task_lists_intact_when_the_tiers_are_unloaded() {
+    let mut app = App::test_default();
+    let (board_id, card_id) = seed_board_with_column_and_card(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+
+    app.prepare_frame();
+    let baseline = app
+        .view
+        .strategy
+        .get_active_task_list()
+        .expect("active task list")
+        .cards
+        .clone();
+    assert_eq!(
+        baseline,
+        vec![card_id],
+        "fixture sanity: the seeded card must appear in the task list while loaded"
+    );
+
+    let mut ids = EntityIds::columns([Uuid::new_v4()]);
+    ids.merge(EntityIds::sprints([Uuid::new_v4()]));
+    let _ = app.model.invalidate(Invalidation::Entities(ids));
+
+    app.prepare_frame();
+
+    let after = app
+        .view
+        .strategy
+        .get_active_task_list()
+        .expect("active task list")
+        .cards
+        .clone();
+    assert_eq!(
+        after, baseline,
+        "an unloaded columns/sprints tier must decline, leaving the prior task lists untouched"
+    );
+}
+
+#[test]
+fn test_prepare_frame_rebuilds_the_task_lists_when_the_tiers_are_loaded() {
+    let mut app = App::test_default();
+    let (board_id, card_id) = seed_board_with_column_and_card(&mut app);
+    sync_model_from_store(&mut app);
+    app.selection.active_board_id = Some(board_id);
+
+    app.prepare_frame();
+
+    let list = app
+        .view
+        .strategy
+        .get_active_task_list()
+        .expect("active task list");
+    assert_eq!(list.cards, vec![card_id]);
+}


### PR DESCRIPTION
Part of KAN-1433 (decline `NotLoaded` tiers instead of collapsing to empty).

## Changes

- `App::prepare_frame` (`crates/kanban-tui/src/app/view_management.rs`) no longer reads `Model::columns()` / `Model::sprints()`, which collapse a `NotLoaded` tier to an empty slice. It now reads the flat `columns_state()` / `sprints_state()` accessors and only rebuilds the task lists when both are `Loaded`, matching the other declined sites in this tree. `sync_card_list_component()` still runs exactly once, unconditionally, on every path.
- Confirmed the re-derived census (whitespace-flattened, `/src/`-filtered, `#[cfg(test)]`-truncated) for `crates/kanban-tui/src/app/view_management.rs` reports 0 remaining `self.model.columns()` / `self.model.sprints()` calls.
- `git grep -nE 'loaded_or_empty|loaded\(\)\.unwrap_or' -- crates/kanban-tui/src/app/view_management.rs` returns nothing.
- The `LoadState<Vec<T>>::as_ref()` bound value (`&Vec<T>`) coerces to `&[T]` at the `ViewRefreshContext` struct-literal field position with no explicit `.as_slice()` needed; confirmed with `cargo check -p kanban-tui`.

## Correction from the card handoff

This leaf's card body still described the site generically as shape-(a)/(b) and pointed at the parent's withdrawn, board-scoped `board_columns_state`/`board_sprints_state` implementation. That shape is wrong here: `load_from_snapshot` clears `columns_by_board`/`sprints_by_board` and nothing in production repopulates them, so a board-scoped implementation would decline forever, not just on invalidation (this is also called out and tested directly in the existing `card_handlers_collapsing_accessor_tests.rs`, at `assert!(app.model.board_columns_state(board_id).is_not_loaded(), "reload never populates the board-scoped columns tier today")`). This PR implements the flat, state-preserving shape instead.

## Tests

`crates/kanban-tui/tests/view_management_collapsing_accessor_tests.rs` (new):
- `test_prepare_frame_leaves_the_task_lists_intact_when_the_tiers_are_unloaded`: seeds a board/column/card, snapshots the task list contents, invalidates both the columns and sprints tiers in one call, then asserts the task list is unchanged after `prepare_frame()` runs again. Confirmed Red before the fix (empty list vs the seeded card id), confirmed Green after, and mutation-tested by reverting the fix and reconfirming the failure.
- `test_prepare_frame_rebuilds_the_task_lists_when_the_tiers_are_loaded`: same fixture, no invalidation, asserts the task list still contains the seeded card (proves the Loaded branch stays byte-equivalent to the old behavior).

## Verification

- `nix develop --command cargo fmt --all -- --check`
- `nix develop --command cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop --command cargo test -p kanban-tui --all-features` (302 unit tests + all integration test files green, including the two new tests)
- `git diff --stat origin/develop -- crates/kanban-tui/src crates/kanban-view/src crates/kanban-domain/src` touches only `view_management.rs`
