### PR TITLE
KAN-1427 feat(tui): forward TuiContext sync and sync_invalidated to KanbanContext

### DIFF
--- a/.changeset/kan-1427-tuicontext-forwards-context-sync-path.md
+++ b/.changeset/kan-1427-tuicontext-forwards-context-sync-path.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+kanban-tui: `TuiContext` gains two thin forwarding methods, `sync` and `sync_invalidated`, delegating to the identically named `KanbanContext` methods. This gives the TUI its only production path to the resolve-and-apply-and-resync seam, mirroring the pass-through pattern already used by `kanban-cli` and `kanban-mcp`. Both methods take `&self` and never touch the save coordinator, since a read must never queue a save.

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -154,6 +154,25 @@ impl TuiContext {
         self.inner.data_store()
     }
 
+    pub fn sync(
+        &self,
+        plan: &dyn kanban_service::FetchPlan,
+        model: &mut kanban_domain::Model,
+        proj: &mut impl kanban_domain::DerivedProjections,
+    ) {
+        self.inner.sync(plan, model, proj);
+    }
+
+    pub fn sync_invalidated(
+        &self,
+        inv: kanban_domain::Invalidation,
+        plan: &dyn kanban_service::FetchPlan,
+        model: &mut kanban_domain::Model,
+        proj: &mut impl kanban_domain::DerivedProjections,
+    ) {
+        self.inner.sync_invalidated(inv, plan, model, proj);
+    }
+
     pub fn persistence_metadata(&self) -> Option<kanban_persistence::PersistenceMetadata> {
         self.inner.persistence_metadata()
     }

--- a/crates/kanban-tui/tests/tui_context_sync.rs
+++ b/crates/kanban-tui/tests/tui_context_sync.rs
@@ -88,10 +88,10 @@ fn test_tui_context_sync_invalidated_refetches_before_planning() {
     let ctx = KanbanContext::open_deferred(Arc::new(store), AppConfig::default());
     let (mut tui_ctx, _save_rx, _completion_rx) = TuiContext::new(ctx).unwrap();
 
-    let board = tui_ctx.create_board("Board".into(), Some("BRD".into())).unwrap();
-    let column = tui_ctx
-        .create_column(board.id, "Col".into(), None)
+    let board = tui_ctx
+        .create_board("Board".into(), Some("BRD".into()))
         .unwrap();
+    let column = tui_ctx.create_column(board.id, "Col".into(), None).unwrap();
     let card = tui_ctx
         .create_card(
             board.id,

--- a/crates/kanban-tui/tests/tui_context_sync.rs
+++ b/crates/kanban-tui/tests/tui_context_sync.rs
@@ -1,0 +1,132 @@
+use kanban_domain::{CreateCardOptions, KanbanOperations, Model, NoProjections};
+use kanban_service::{
+    fetch_plan::{requestable, FetchPlan, FetchRound, LoadedEntities},
+    AppConfig, KanbanContext, StoreManager,
+};
+use kanban_tui::tui_context::TuiContext;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+struct BoardListPlan;
+impl FetchPlan for BoardListPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            board_list: requestable(loaded.board_list()),
+            ..Default::default()
+        }
+    }
+}
+
+struct CardListPlan;
+impl FetchPlan for CardListPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            card_list: requestable(loaded.card_list()),
+            ..Default::default()
+        }
+    }
+}
+
+fn test_store_manager() -> StoreManager {
+    let mut registry = kanban_persistence::StoreRegistry::new();
+    let mut backends = kanban_backend::KanbanBackendRegistry::new();
+    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
+    backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+    registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+    backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+    StoreManager::new(registry, backends)
+}
+
+#[test]
+fn test_tui_context_sync_applies_a_resolved_pass_into_the_model() {
+    let store = kanban_backend_memory::InMemoryStore::new();
+    let board = kanban_domain::Board::new("Seeded", None::<String>);
+    kanban_domain::DataStore::upsert_board(&store, board.clone()).unwrap();
+    let ctx = KanbanContext::open_deferred(Arc::new(store), AppConfig::default());
+    let (tui_ctx, _save_rx, _completion_rx) = TuiContext::new(ctx).unwrap();
+
+    let mut model = Model::default();
+    assert!(model.boards_state().is_not_loaded());
+
+    tui_ctx.sync(&BoardListPlan, &mut model, &mut NoProjections);
+
+    assert!(model.boards_state().is_loaded());
+    assert!(model
+        .boards_state()
+        .loaded_or_empty()
+        .iter()
+        .any(|b| b.id == board.id));
+}
+
+#[tokio::test]
+async fn test_tui_context_sync_does_not_queue_a_save() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("sync.json");
+    let sm = test_store_manager();
+    let backend = sm
+        .make_backend(path.to_str().unwrap(), &AppConfig::default())
+        .await
+        .unwrap();
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let (tui_ctx, save_rx, _completion_rx) = TuiContext::new(ctx).unwrap();
+    let mut save_rx = save_rx.expect("json backend must provide a save channel");
+
+    let mut model = Model::default();
+    tui_ctx.sync(&BoardListPlan, &mut model, &mut NoProjections);
+
+    assert!(
+        save_rx.try_recv().is_err(),
+        "sync must not queue a save flush"
+    );
+}
+
+#[test]
+fn test_tui_context_sync_invalidated_refetches_before_planning() {
+    let store = kanban_backend_memory::InMemoryStore::new();
+    let ctx = KanbanContext::open_deferred(Arc::new(store), AppConfig::default());
+    let (mut tui_ctx, _save_rx, _completion_rx) = TuiContext::new(ctx).unwrap();
+
+    let board = tui_ctx.create_board("Board".into(), Some("BRD".into())).unwrap();
+    let column = tui_ctx
+        .create_column(board.id, "Col".into(), None)
+        .unwrap();
+    let card = tui_ctx
+        .create_card(
+            board.id,
+            column.id,
+            "before".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let mut model = Model::default();
+    tui_ctx.sync(&CardListPlan, &mut model, &mut NoProjections);
+    assert_eq!(
+        model.card_by_id_state(card.id).loaded().unwrap().title,
+        "before"
+    );
+
+    tui_ctx
+        .update_card(
+            card.id,
+            kanban_domain::CardUpdate {
+                title: Some("after".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    tui_ctx.sync_invalidated(
+        kanban_domain::Invalidation::All,
+        &CardListPlan,
+        &mut model,
+        &mut NoProjections,
+    );
+
+    assert_eq!(
+        model.card_by_id_state(card.id).loaded().unwrap().title,
+        "after"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds two thin, `&self` forwarding methods to `TuiContext`: `sync` and `sync_invalidated`, each delegating one line to the identically named `KanbanContext` methods.
- This gives the TUI its only production path to the resolve-and-apply-and-resync seam, mirroring the pass-through pattern `kanban-cli` and `kanban-mcp` already use.
- Neither method touches `save_coordinator` or `with_flush`: a read must never queue a save. Pinned by a JSON-backend test that asserts no flush signal is sent.
- `sync_invalidated` forwards a real `proj: &mut impl DerivedProjections` (unlike the MCP wrappers, which always inject `NoProjections` internally), since the TUI owns a real controller that needs to resync.

## Tests

- `test_tui_context_sync_applies_a_resolved_pass_into_the_model`: an in-memory backend sync resolves a seeded board into the model.
- `test_tui_context_sync_does_not_queue_a_save`: JSON-backend regression proving `sync` never queues a save flush (mutation-tested by temporarily routing through the flush path and confirming the assertion fails).
- `test_tui_context_sync_invalidated_refetches_before_planning`: mutating a card's title through `TuiContext` and calling `sync_invalidated` reflects the new title in the model.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -p kanban-tui -- -D warnings`
- [x] `cargo test -p kanban-tui --all-features`
