### PR TITLE
KAN-1431 feat(tui): render NotLoaded and Failed panel tiers distinctly from empty

### DIFF
--- a/.changeset/kan-1431-render-notloaded-failed-distinctly-empty.md
+++ b/.changeset/kan-1431-render-notloaded-failed-distinctly-empty.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+tui: distinguish NotLoaded, Failed and Missing panel states from a genuinely empty Loaded collection, so a board or sprint tier that has not been fetched yet no longer renders the same "nothing here" message as one that is truly empty.

--- a/crates/kanban-tui/src/components/filter_popup.rs
+++ b/crates/kanban-tui/src/components/filter_popup.rs
@@ -1,7 +1,9 @@
 use crate::app::App;
 use crate::components::centered_rect;
 use crate::theme::*;
+use crate::ui::load_state_body;
 use kanban_core::viewport::scroll_offset_to_keep_visible;
+use kanban_domain::LoadState;
 use kanban_view::filters::FilterDialogState;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -83,35 +85,36 @@ fn render_filter_sprints_section(
     )));
 
     if let Some(board) = app.active_board() {
-        {
-            let sprints = app.model.sprints();
-            let board_sprints: Vec<_> = sprints.iter().filter(|s| s.board_id == board.id).collect();
+        match app.model.board_sprints_state(board.id) {
+            LoadState::Loaded(board_sprints) => {
+                if board_sprints.is_empty() {
+                    sprint_lines.push(Line::from(Span::styled(
+                        "  (no sprints available)",
+                        label_text(),
+                    )));
+                } else {
+                    for (idx, sprint) in board_sprints.iter().enumerate() {
+                        let is_selected = dialog_state
+                            .filters
+                            .selected_sprint_ids
+                            .contains(&sprint.id);
+                        let cursor = if section_index == 0 && dialog_state.item_selection == idx + 1
+                        {
+                            "> "
+                        } else {
+                            "  "
+                        };
 
-            if board_sprints.is_empty() {
-                sprint_lines.push(Line::from(Span::styled(
-                    "  (no sprints available)",
-                    label_text(),
-                )));
-            } else {
-                for (idx, sprint) in board_sprints.iter().enumerate() {
-                    let is_selected = dialog_state
-                        .filters
-                        .selected_sprint_ids
-                        .contains(&sprint.id);
-                    let cursor = if section_index == 0 && dialog_state.item_selection == idx + 1 {
-                        "> "
-                    } else {
-                        "  "
-                    };
-
-                    sprint_lines.push(Line::from(vec![
-                        Span::raw(cursor),
-                        Span::styled(if is_selected { "[✓]" } else { "[ ]" }, normal_text()),
-                        Span::raw(" "),
-                        Span::styled(sprint.formatted_name(board, None), normal_text()),
-                    ]));
+                        sprint_lines.push(Line::from(vec![
+                            Span::raw(cursor),
+                            Span::styled(if is_selected { "[✓]" } else { "[ ]" }, normal_text()),
+                            Span::raw(" "),
+                            Span::styled(sprint.formatted_name(board, None), normal_text()),
+                        ]));
+                    }
                 }
             }
+            other => sprint_lines.extend(load_state_body("Sprints", &other)),
         }
     }
 

--- a/crates/kanban-tui/src/components/selection_dialog.rs
+++ b/crates/kanban-tui/src/components/selection_dialog.rs
@@ -1,5 +1,6 @@
 use crate::app::App;
-use kanban_domain::SprintStatus;
+use crate::ui::{load_state_body, render_unavailable_panel};
+use kanban_domain::{LoadState, SprintStatus};
 use kanban_view::selection_dialog::{
     popup_index_of_board_sort_field, popup_index_of_sort_field, BOARD_SORT_FIELD_POPUP_ORDER,
     SORT_FIELD_POPUP_ORDER,
@@ -229,14 +230,15 @@ impl SelectionDialog for CarryOverSprintDialog {
     }
 
     fn options_count(&self, app: &App) -> usize {
-        if let Some(board) = app.active_board() {
-            app.model
-                .sprints()
+        let Some(board) = app.active_board() else {
+            return 0;
+        };
+        match app.model.board_sprints_state(board.id) {
+            LoadState::Loaded(sprints) => sprints
                 .iter()
-                .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
-                .count()
-        } else {
-            0
+                .filter(|s| s.status == SprintStatus::Planning)
+                .count(),
+            _ => 0,
         }
     }
 
@@ -274,31 +276,33 @@ impl SelectionDialog for CarryOverSprintDialog {
         let mut lines = vec![];
 
         if let Some(board) = app.active_board() {
-            {
-                let sprints = app.model.sprints();
-                let planning_sprints: Vec<_> = sprints
-                    .iter()
-                    .filter(|s| s.board_id == board.id && s.status == SprintStatus::Planning)
-                    .collect();
+            match app.model.board_sprints_state(board.id) {
+                LoadState::Loaded(sprints) => {
+                    let planning_sprints: Vec<_> = sprints
+                        .iter()
+                        .filter(|s| s.status == SprintStatus::Planning)
+                        .collect();
 
-                for (idx, sprint) in planning_sprints.iter().enumerate() {
-                    let is_selected =
-                        app.dialog_input.carry_over_sprint_selection.get() == Some(idx);
+                    for (idx, sprint) in planning_sprints.iter().enumerate() {
+                        let is_selected =
+                            app.dialog_input.carry_over_sprint_selection.get() == Some(idx);
 
-                    let style = if is_selected {
-                        Style::default().fg(Color::White).bg(Color::Blue)
-                    } else {
-                        Style::default().fg(Color::White)
-                    };
+                        let style = if is_selected {
+                            Style::default().fg(Color::White).bg(Color::Blue)
+                        } else {
+                            Style::default().fg(Color::White)
+                        };
 
-                    let prefix = if is_selected { "> " } else { "  " };
-                    let sprint_name = sprint.formatted_name(board, None);
+                        let prefix = if is_selected { "> " } else { "  " };
+                        let sprint_name = sprint.formatted_name(board, None);
 
-                    lines.push(Line::from(Span::styled(
-                        format!("{}{}", prefix, sprint_name),
-                        style,
-                    )));
+                        lines.push(Line::from(Span::styled(
+                            format!("{}{}", prefix, sprint_name),
+                            style,
+                        )));
+                    }
                 }
+                other => lines.extend(load_state_body("Sprints", &other)),
             }
         }
 
@@ -319,11 +323,15 @@ impl SelectionDialog for SprintAssignDialog {
     }
 
     fn options_count(&self, app: &App) -> usize {
-        if let Some(board) = app.active_board() {
-            let sprints = app.model.sprints();
-            return build_entries(sprints, board.id, chrono::Utc::now()).len();
+        let Some(board) = app.active_board() else {
+            return 1;
+        };
+        match app.model.board_sprints_state(board.id) {
+            LoadState::Loaded(sprints) => {
+                build_entries(sprints, board.id, chrono::Utc::now()).len()
+            }
+            _ => 1,
         }
-        1
     }
 
     fn render(&self, app: &App, frame: &mut Frame) {
@@ -359,13 +367,18 @@ impl SelectionDialog for SprintAssignDialog {
         let Some(board) = app.active_board() else {
             return;
         };
-        app.dialog_input.assign_sprint_picker.render(
-            frame,
-            chunks[1],
-            app.model.sprints(),
-            board,
-            chrono::Utc::now(),
-        );
+        match app.model.board_sprints_state(board.id) {
+            LoadState::Loaded(sprints) => {
+                app.dialog_input.assign_sprint_picker.render(
+                    frame,
+                    chunks[1],
+                    sprints,
+                    board,
+                    chrono::Utc::now(),
+                );
+            }
+            other => render_unavailable_panel(frame, chunks[1], "Sprint", &other),
+        }
     }
 }
 

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -4,7 +4,9 @@ use crate::components::{
     PanelConfig,
 };
 use crate::theme::{deleted_view_focused_border, label_text};
+use crate::ui::load_state_body;
 use kanban_domain::card_lifecycle::sorted_board_columns;
+use kanban_domain::LoadState;
 use kanban_view::layout_strategy::ColumnBoundary;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::text::{Line, Span};
@@ -146,7 +148,11 @@ impl RenderStrategy for SinglePanelRenderer {
 
                             // Render all cards with column headers interspersed
                             let mut columns_shown = std::collections::HashSet::new();
-                            let sprints = app.model.sprints();
+                            let empty_sprints: &[kanban_domain::Sprint] = &[];
+                            let sprints = match app.model.board_sprints_state(board.id) {
+                                LoadState::Loaded(sprints) => sprints,
+                                _ => empty_sprints,
+                            };
 
                             for card_idx in &render_info.visible_card_indices {
                                 // Find which column this card belongs to
@@ -213,20 +219,25 @@ impl RenderStrategy for SinglePanelRenderer {
                             ));
                         }
                     } else {
-                        let board_columns = sorted_board_columns(board.id, app.model.columns());
+                        match app.model.board_columns_state(board.id) {
+                            LoadState::Loaded(columns) => {
+                                let board_columns = sorted_board_columns(board.id, columns);
 
-                        if board_columns.is_empty() {
-                            lines.push(Line::from(Span::styled(
-                                "  No columns yet. Add columns in board settings.",
-                                label_text(),
-                            )));
-                        } else {
-                            let message = if app.selection.active_board_id.is_some() {
-                                "  No tasks yet. Press 'n' to create one!"
-                            } else {
-                                "  (Enter/Space) to add tasks"
-                            };
-                            lines.push(Line::from(Span::styled(message, label_text())));
+                                if board_columns.is_empty() {
+                                    lines.push(Line::from(Span::styled(
+                                        "  No columns yet. Add columns in board settings.",
+                                        label_text(),
+                                    )));
+                                } else {
+                                    let message = if app.selection.active_board_id.is_some() {
+                                        "  No tasks yet. Press 'n' to create one!"
+                                    } else {
+                                        "  (Enter/Space) to add tasks"
+                                    };
+                                    lines.push(Line::from(Span::styled(message, label_text())));
+                                }
+                            }
+                            other => lines.extend(load_state_body("Columns", &other)),
                         }
                     }
                 } else if let Some(task_list) = app.view.strategy.get_active_task_list() {
@@ -261,7 +272,11 @@ impl RenderStrategy for SinglePanelRenderer {
                             "Task",
                         ));
 
-                        let sprints = app.model.sprints();
+                        let empty_sprints: &[kanban_domain::Sprint] = &[];
+                        let sprints = match app.model.board_sprints_state(board.id) {
+                            LoadState::Loaded(sprints) => sprints,
+                            _ => empty_sprints,
+                        };
 
                         for card_idx in &render_info.visible_card_indices {
                             if let Some(card_id) = task_list.cards.get(*card_idx) {
@@ -367,7 +382,11 @@ impl RenderStrategy for MultiPanelRenderer {
                     .split(area);
 
                 let active_task_list = app.view.strategy.get_active_task_list();
-                let sprints = app.model.sprints();
+                let empty_sprints: &[kanban_domain::Sprint] = &[];
+                let sprints = match app.model.board_sprints_state(board.id) {
+                    LoadState::Loaded(sprints) => sprints,
+                    _ => empty_sprints,
+                };
 
                 for (col_idx, task_list) in task_lists.iter().enumerate() {
                     let mut lines = vec![];
@@ -453,12 +472,16 @@ impl RenderStrategy for MultiPanelRenderer {
                     let column_name = if let kanban_view::card_list::CardListId::Column(column_id) =
                         task_list.id
                     {
-                        app.model
-                            .columns()
-                            .iter()
-                            .find(|c| c.id == column_id)
-                            .map(|c| c.name.clone())
-                            .unwrap_or_else(|| "Unknown".to_string())
+                        match app.model.board_columns_state(board.id) {
+                            LoadState::Loaded(columns) => columns
+                                .iter()
+                                .find(|c| c.id == column_id)
+                                .map(|c| c.name.clone())
+                                .unwrap_or_else(|| "Unknown".to_string()),
+                            LoadState::NotLoaded => "…".to_string(),
+                            LoadState::Missing => "(gone)".to_string(),
+                            LoadState::Failed(_) => "(error)".to_string(),
+                        }
                     } else {
                         "All".to_string()
                     };

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -478,9 +478,9 @@ impl RenderStrategy for MultiPanelRenderer {
                                 .find(|c| c.id == column_id)
                                 .map(|c| c.name.clone())
                                 .unwrap_or_else(|| "Unknown".to_string()),
-                            LoadState::NotLoaded => "…".to_string(),
-                            LoadState::Missing => "(gone)".to_string(),
-                            LoadState::Failed(_) => "(error)".to_string(),
+                            LoadState::NotLoaded => "Not loaded".to_string(),
+                            LoadState::Missing => "Not found".to_string(),
+                            LoadState::Failed(_) => "Failed".to_string(),
                         }
                     } else {
                         "All".to_string()

--- a/crates/kanban-tui/src/theme/styles.rs
+++ b/crates/kanban-tui/src/theme/styles.rs
@@ -32,6 +32,10 @@ pub fn normal_text() -> Style {
     Style::default().fg(NORMAL_TEXT)
 }
 
+pub fn error_text() -> Style {
+    Style::default().fg(ERROR_COLOR)
+}
+
 pub fn label_text() -> Style {
     Style::default().fg(LABEL_TEXT)
 }

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -1,9 +1,10 @@
 use crate::app::{App, BoardFocus};
 use crate::components::*;
 use crate::theme::*;
+use crate::ui::load_state_body;
 use kanban_core::viewport::scroll_offset_to_keep_visible;
 use kanban_domain::card_lifecycle::sorted_board_columns;
-use kanban_domain::{Sprint, SprintStatus};
+use kanban_domain::{LoadState, SprintStatus};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -103,14 +104,16 @@ fn render_board_settings_section(
         },
     ];
 
-    if let Some(sprint_prefix) =
-        kanban_domain::get_active_sprint_card_prefix_override(board, app.model.sprints())
-    {
-        settings_lines.push(metadata_line_styled(
-            "Active Sprint Card Prefix",
-            sprint_prefix,
-            Style::default().fg(Color::Cyan),
-        ));
+    if let LoadState::Loaded(sprints) = app.model.board_sprints_state(board.id) {
+        if let Some(sprint_prefix) =
+            kanban_domain::get_active_sprint_card_prefix_override(board, sprints)
+        {
+            settings_lines.push(metadata_line_styled(
+                "Active Sprint Card Prefix",
+                sprint_prefix,
+                Style::default().fg(Color::Cyan),
+            ));
+        }
     }
 
     settings_lines.push(Line::from(""));
@@ -149,75 +152,74 @@ fn render_board_sprints_list(
         .with_focus_indicator("Sprints [4]")
         .focused(app.focus.board_focus == BoardFocus::Sprints);
 
-    let board_sprints: Vec<&Sprint> = app
-        .model
-        .sprints()
-        .iter()
-        .filter(|s| s.board_id == board.id)
-        .collect();
-
     let mut sprint_lines = vec![];
 
-    if board_sprints.is_empty() {
-        sprint_lines.push(Line::from(Span::styled(
-            "  No sprints yet. Press 'n' to create one!",
-            label_text(),
-        )));
-    } else {
-        let all_cards = app.controller.live_cards();
-        for (sprint_idx, sprint) in board_sprints.iter().enumerate() {
-            let is_selected = app.selection.sprint.get() == Some(sprint_idx);
-            let is_focused = app.focus.board_focus == BoardFocus::Sprints;
+    match app.model.board_sprints_state(board.id) {
+        LoadState::Loaded(board_sprints) => {
+            if board_sprints.is_empty() {
+                sprint_lines.push(Line::from(Span::styled(
+                    "  No sprints yet. Press 'n' to create one!",
+                    label_text(),
+                )));
+            } else {
+                let all_cards = app.controller.live_cards();
+                for (sprint_idx, sprint) in board_sprints.iter().enumerate() {
+                    let is_selected = app.selection.sprint.get() == Some(sprint_idx);
+                    let is_focused = app.focus.board_focus == BoardFocus::Sprints;
 
-            let status_symbol = match sprint.status {
-                SprintStatus::Planning => "○",
-                SprintStatus::Active => "●",
-                SprintStatus::Completed => "✓",
-                SprintStatus::Cancelled => "✗",
-            };
+                    let status_symbol = match sprint.status {
+                        SprintStatus::Planning => "○",
+                        SprintStatus::Active => "●",
+                        SprintStatus::Completed => "✓",
+                        SprintStatus::Cancelled => "✗",
+                    };
 
-            let sprint_name = sprint.formatted_name(board, None);
+                    let sprint_name = sprint.formatted_name(board, None);
 
-            let card_count = all_cards
-                .iter()
-                .filter(|c| c.sprint_id == Some(sprint.id))
-                .count();
+                    let card_count = all_cards
+                        .iter()
+                        .filter(|c| c.sprint_id == Some(sprint.id))
+                        .count();
 
-            let is_active_sprint = board.active_sprint_id == Some(sprint.id);
-            let is_ended = sprint.is_ended(chrono::Utc::now());
+                    let is_active_sprint = board.active_sprint_id == Some(sprint.id);
+                    let is_ended = sprint.is_ended(chrono::Utc::now());
 
-            let mut base_style = normal_text();
-            if is_selected && is_focused {
-                base_style = base_style.bg(SELECTED_BG);
-            }
+                    let mut base_style = normal_text();
+                    if is_selected && is_focused {
+                        base_style = base_style.bg(SELECTED_BG);
+                    }
 
-            let mut spans = vec![
-                Span::styled(
-                    format!("{} ", status_symbol),
-                    sprint_status_style(sprint.status),
-                ),
-                Span::styled(sprint_name, base_style),
-                Span::styled(format!(" ({})", card_count), label_text()),
-            ];
+                    let mut spans = vec![
+                        Span::styled(
+                            format!("{} ", status_symbol),
+                            sprint_status_style(sprint.status),
+                        ),
+                        Span::styled(sprint_name, base_style),
+                        Span::styled(format!(" ({})", card_count), label_text()),
+                    ];
 
-            if is_active_sprint {
-                let mut active_style = active_item();
-                if is_selected && is_focused {
-                    active_style = active_style.bg(SELECTED_BG);
+                    if is_active_sprint {
+                        let mut active_style = active_item();
+                        if is_selected && is_focused {
+                            active_style = active_style.bg(SELECTED_BG);
+                        }
+                        spans.push(Span::styled(" Active", active_style));
+                    }
+
+                    if is_ended {
+                        let mut ended_style =
+                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
+                        if is_selected && is_focused {
+                            ended_style = ended_style.bg(SELECTED_BG);
+                        }
+                        spans.push(Span::styled(" Ended", ended_style));
+                    }
+
+                    sprint_lines.push(Line::from(spans));
                 }
-                spans.push(Span::styled(" Active", active_style));
             }
-
-            if is_ended {
-                let mut ended_style = Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
-                if is_selected && is_focused {
-                    ended_style = ended_style.bg(SELECTED_BG);
-                }
-                spans.push(Span::styled(" Ended", ended_style));
-            }
-
-            sprint_lines.push(Line::from(spans));
         }
+        other => sprint_lines.extend(load_state_body("Sprints", &other)),
     }
 
     let selected_idx = app.selection.sprint.get().unwrap_or(0);
@@ -246,73 +248,77 @@ fn render_board_columns_list(
         .with_focus_indicator("Columns [5]")
         .focused(app.focus.board_focus == BoardFocus::Columns);
 
-    let total_columns = sorted_board_columns(board.id, app.model.columns()).len();
-    let board_columns = app.visible_board_columns(board.id);
-
     let mut column_lines = vec![];
 
-    if board_columns.is_empty() {
-        column_lines.push(Line::from(Span::styled(
-            columns_empty_state_message(total_columns),
-            label_text(),
-        )));
-    } else {
-        let all_cards = app.controller.live_cards();
-        let is_focused = app.focus.board_focus == BoardFocus::Columns;
-        let viewport_height = area.height.saturating_sub(2) as usize;
-        let primary_completion_id =
-            kanban_domain::completion_derivation::primary_completion_column(
-                board.id,
-                app.model.columns(),
-            )
-            .map(|c| c.id);
+    match app.model.board_columns_state(board.id) {
+        LoadState::Loaded(columns) => {
+            let total_columns = sorted_board_columns(board.id, columns).len();
+            let board_columns = app.visible_board_columns(board.id);
 
-        // Refreshed here rather than relying on a handler having run first:
-        // jumping straight to the Columns panel (key '5') sets focus without
-        // touching the list.
-        app.dialog_input
-            .column_list
-            .update_item_count(board_columns.len());
-        app.dialog_input
-            .column_list
-            .ensure_selected_visible(viewport_height);
-        let render_info = app
-            .dialog_input
-            .column_list
-            .get_render_info(viewport_height);
-        let selected_idx = app.dialog_input.column_list.get_selected_index();
+            if board_columns.is_empty() {
+                column_lines.push(Line::from(Span::styled(
+                    columns_empty_state_message(total_columns),
+                    label_text(),
+                )));
+            } else {
+                let all_cards = app.controller.live_cards();
+                let is_focused = app.focus.board_focus == BoardFocus::Columns;
+                let viewport_height = area.height.saturating_sub(2) as usize;
+                let primary_completion_id =
+                    kanban_domain::completion_derivation::primary_completion_column(
+                        board.id, columns,
+                    )
+                    .map(|c| c.id);
 
-        for &column_idx in &render_info.visible_indices {
-            let Some(column) = board_columns.get(column_idx) else {
-                continue;
-            };
-            let is_selected = selected_idx == Some(column_idx);
+                // Refreshed here rather than relying on a handler having run first:
+                // jumping straight to the Columns panel (key '5') sets focus without
+                // touching the list.
+                app.dialog_input
+                    .column_list
+                    .update_item_count(board_columns.len());
+                app.dialog_input
+                    .column_list
+                    .ensure_selected_visible(viewport_height);
+                let render_info = app
+                    .dialog_input
+                    .column_list
+                    .get_render_info(viewport_height);
+                let selected_idx = app.dialog_input.column_list.get_selected_index();
 
-            let card_count = all_cards
-                .iter()
-                .filter(|c| c.column_id == column.id)
-                .count();
+                for &column_idx in &render_info.visible_indices {
+                    let Some(column) = board_columns.get(column_idx) else {
+                        continue;
+                    };
+                    let is_selected = selected_idx == Some(column_idx);
 
-            let mut base_style = normal_text();
-            if is_selected && is_focused {
-                base_style = base_style.bg(SELECTED_BG);
+                    let card_count = all_cards
+                        .iter()
+                        .filter(|c| c.column_id == column.id)
+                        .count();
+
+                    let mut base_style = normal_text();
+                    if is_selected && is_focused {
+                        base_style = base_style.bg(SELECTED_BG);
+                    }
+
+                    let mut spans = vec![
+                        Span::styled(format!("{}. ", column.position + 1), label_text()),
+                        Span::styled(column.name.clone(), base_style),
+                        Span::styled(format!(" ({})", card_count), label_text()),
+                    ];
+                    if let Some(suffix) = column_status_suffix(column, primary_completion_id) {
+                        spans.push(Span::styled(format!(" {}", suffix), label_text()));
+                    }
+
+                    column_lines.push(Line::from(spans));
+                }
             }
-
-            let mut spans = vec![
-                Span::styled(format!("{}. ", column.position + 1), label_text()),
-                Span::styled(&column.name, base_style),
-                Span::styled(format!(" ({})", card_count), label_text()),
-            ];
-            if let Some(suffix) = column_status_suffix(column, primary_completion_id) {
-                spans.push(Span::styled(format!(" {}", suffix), label_text()));
-            }
-
-            column_lines.push(Line::from(spans));
         }
+        other => column_lines.extend(load_state_body("Columns", &other)),
     }
 
-    let columns = Paragraph::new(column_lines).block(columns_config.block());
-    frame.render_widget(columns, area);
+    let columns_widget = Paragraph::new(column_lines).block(columns_config.block());
+    frame.render_widget(columns_widget, area);
 }
 
 fn column_status_suffix(

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -1,7 +1,8 @@
 use crate::app::{App, CardFocus};
 use crate::components::*;
 use crate::theme::*;
-use kanban_domain::Model;
+use crate::ui::load_state_body;
+use kanban_domain::{LoadState, Model};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     widgets::Paragraph,
@@ -115,13 +116,7 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                         .split(chunks[1]);
 
                     // Render metadata
-                    let meta_config = FieldSectionConfig::new("Metadata")
-                        .with_focus_indicator("Metadata [2]")
-                        .focused(app.focus.card_focus == CardFocus::Metadata);
-                    let meta_lines =
-                        build_metadata_lines(card, board, app.model.sprints(), &app.app_config);
-                    let meta = Paragraph::new(meta_lines).block(meta_config.block());
-                    frame.render_widget(meta, meta_chunks[0]);
+                    render_metadata_section(app, card, board, meta_chunks[0], frame);
 
                     // Render sprint logs
                     let sprint_logs_config = FieldSectionConfig::new("Sprint History");
@@ -149,13 +144,7 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                     );
                 } else {
                     // Render metadata section
-                    let meta_config = FieldSectionConfig::new("Metadata")
-                        .with_focus_indicator("Metadata [2]")
-                        .focused(app.focus.card_focus == CardFocus::Metadata);
-                    let meta_lines =
-                        build_metadata_lines(card, board, app.model.sprints(), &app.app_config);
-                    let meta = Paragraph::new(meta_lines).block(meta_config.block());
-                    frame.render_widget(meta, chunks[1]);
+                    render_metadata_section(app, card, board, chunks[1], frame);
 
                     // Render description section
                     let desc_config = FieldSectionConfig::new("Description")
@@ -178,4 +167,22 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
             }
         }
     }
+}
+
+fn render_metadata_section(
+    app: &App,
+    card: &kanban_domain::Card,
+    board: &kanban_domain::Board,
+    area: Rect,
+    frame: &mut Frame,
+) {
+    let meta_config = FieldSectionConfig::new("Metadata")
+        .with_focus_indicator("Metadata [2]")
+        .focused(app.focus.card_focus == CardFocus::Metadata);
+    let meta_lines = match app.model.board_sprints_state(board.id) {
+        LoadState::Loaded(sprints) => build_metadata_lines(card, board, sprints, &app.app_config),
+        other => load_state_body("Sprints", &other).into_iter().collect(),
+    };
+    let meta = Paragraph::new(meta_lines).block(meta_config.block());
+    frame.render_widget(meta, area);
 }

--- a/crates/kanban-tui/src/ui/dialogs/cards.rs
+++ b/crates/kanban-tui/src/ui/dialogs/cards.rs
@@ -1,5 +1,7 @@
 use crate::app::App;
 use crate::components::*;
+use crate::ui::render_unavailable_panel;
+use kanban_domain::LoadState;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::{Color, Style},
@@ -142,13 +144,18 @@ pub(crate) fn render_create_card_popup(app: &App, frame: &mut Frame) {
             });
         let picker_inner = picker_block.inner(chunks[5]);
         frame.render_widget(picker_block, chunks[5]);
-        app.dialog_input.create_card_sprint_picker.render(
-            frame,
-            picker_inner,
-            app.model.sprints(),
-            board,
-            chrono::Utc::now(),
-        );
+        match app.model.board_sprints_state(board.id) {
+            LoadState::Loaded(sprints) => {
+                app.dialog_input.create_card_sprint_picker.render(
+                    frame,
+                    picker_inner,
+                    sprints,
+                    board,
+                    chrono::Utc::now(),
+                );
+            }
+            other => render_unavailable_panel(frame, picker_inner, "Sprint", &other),
+        }
     }
 }
 
@@ -223,11 +230,16 @@ pub(crate) fn render_assign_multiple_cards_popup(app: &App, frame: &mut Frame) {
     let Some(board) = app.active_board() else {
         return;
     };
-    app.dialog_input.assign_sprint_picker.render(
-        frame,
-        chunks[1],
-        app.model.sprints(),
-        board,
-        chrono::Utc::now(),
-    );
+    match app.model.board_sprints_state(board.id) {
+        LoadState::Loaded(sprints) => {
+            app.dialog_input.assign_sprint_picker.render(
+                frame,
+                chunks[1],
+                sprints,
+                board,
+                chrono::Utc::now(),
+            );
+        }
+        other => render_unavailable_panel(frame, chunks[1], "Sprint", &other),
+    }
 }

--- a/crates/kanban-tui/src/ui/load_state_marker.rs
+++ b/crates/kanban-tui/src/ui/load_state_marker.rs
@@ -16,8 +16,8 @@ pub fn load_state_body<T>(noun: &str, state: &LoadState<&[T]>) -> Option<Line<'s
             format!("  {noun} not found"),
             label_text(),
         ))),
-        LoadState::Failed(_) => Some(Line::from(Span::styled(
-            format!("  {noun} failed to load"),
+        LoadState::Failed(e) => Some(Line::from(Span::styled(
+            format!("  {noun} failed to load: {e}"),
             error_text(),
         ))),
     }
@@ -38,8 +38,8 @@ pub fn render_unavailable_panel<T>(
         LoadState::Missing => {
             Line::from(Span::styled(format!("  {title} not found"), label_text()))
         }
-        LoadState::Failed(_) => Line::from(Span::styled(
-            format!("  {title} failed to load"),
+        LoadState::Failed(e) => Line::from(Span::styled(
+            format!("  {title} failed to load: {e}"),
             error_text(),
         )),
     };
@@ -82,6 +82,9 @@ mod tests {
 
         assert_eq!(render(&not_loaded_line), "  Columns not loaded yet");
         assert_eq!(render(&missing_line), "  Columns not found");
-        assert_eq!(render(&failed_line), "  Columns failed to load");
+        assert_eq!(
+            render(&failed_line),
+            "  Columns failed to load: operation not supported by this backend: boom"
+        );
     }
 }

--- a/crates/kanban-tui/src/ui/load_state_marker.rs
+++ b/crates/kanban-tui/src/ui/load_state_marker.rs
@@ -1,0 +1,87 @@
+use crate::theme::{error_text, label_text};
+use kanban_domain::LoadState;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::Frame;
+
+pub fn load_state_body<T>(noun: &str, state: &LoadState<&[T]>) -> Option<Line<'static>> {
+    match state {
+        LoadState::Loaded(_) => None,
+        LoadState::NotLoaded => Some(Line::from(Span::styled(
+            format!("  {noun} not loaded yet"),
+            label_text(),
+        ))),
+        LoadState::Missing => Some(Line::from(Span::styled(
+            format!("  {noun} not found"),
+            label_text(),
+        ))),
+        LoadState::Failed(_) => Some(Line::from(Span::styled(
+            format!("  {noun} failed to load"),
+            error_text(),
+        ))),
+    }
+}
+
+pub fn render_unavailable_panel<T>(
+    frame: &mut Frame,
+    area: Rect,
+    title: &str,
+    state: &LoadState<T>,
+) {
+    let line = match state {
+        LoadState::Loaded(_) => return,
+        LoadState::NotLoaded => Line::from(Span::styled(
+            format!("  {title} not loaded yet"),
+            label_text(),
+        )),
+        LoadState::Missing => {
+            Line::from(Span::styled(format!("  {title} not found"), label_text()))
+        }
+        LoadState::Failed(_) => Line::from(Span::styled(
+            format!("  {title} failed to load"),
+            error_text(),
+        )),
+    };
+    frame.render_widget(
+        Paragraph::new(vec![line]).block(
+            Block::default()
+                .title(title.to_string())
+                .borders(Borders::ALL),
+        ),
+        area,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::KanbanError;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_load_state_body_returns_none_for_loaded() {
+        let items: Vec<u32> = vec![1, 2];
+        let state: LoadState<&[u32]> = LoadState::Loaded(items.as_slice());
+        assert!(load_state_body("Columns", &state).is_none());
+    }
+
+    #[test]
+    fn test_load_state_body_distinguishes_all_three_unavailable_variants() {
+        let not_loaded: LoadState<&[u32]> = LoadState::NotLoaded;
+        let missing: LoadState<&[u32]> = LoadState::Missing;
+        let failed: LoadState<&[u32]> =
+            LoadState::Failed(Arc::new(KanbanError::unsupported("boom")));
+
+        let not_loaded_line = load_state_body("Columns", &not_loaded).unwrap();
+        let missing_line = load_state_body("Columns", &missing).unwrap();
+        let failed_line = load_state_body("Columns", &failed).unwrap();
+
+        let render =
+            |line: &Line| -> String { line.spans.iter().map(|s| s.content.as_ref()).collect() };
+
+        assert_eq!(render(&not_loaded_line), "  Columns not loaded yet");
+        assert_eq!(render(&missing_line), "  Columns not found");
+        assert_eq!(render(&failed_line), "  Columns failed to load");
+    }
+}

--- a/crates/kanban-tui/src/ui/mod.rs
+++ b/crates/kanban-tui/src/ui/mod.rs
@@ -11,11 +11,13 @@ mod board_detail;
 mod card_detail;
 mod dialogs;
 mod error_log;
+mod load_state_marker;
 mod main_view;
 mod settings_view;
 mod sprint_detail;
 
 pub use crate::components::help_popup_viewport_height;
+pub use load_state_marker::{load_state_body, render_unavailable_panel};
 pub use main_view::{
     filter_title_suffix, format_filter_title_suffix, format_tasks_panel_title, tasks_panel_title,
 };

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -1,8 +1,9 @@
 use crate::app::App;
 use crate::components::*;
 use crate::theme::*;
+use crate::ui::render_unavailable_panel;
 use kanban_domain::Model;
-use kanban_domain::{Sprint, SprintStatus};
+use kanban_domain::{LoadState, Sprint, SprintStatus};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -12,14 +13,15 @@ use ratatui::{
 };
 
 pub(super) fn render_sprint_detail_view(app: &mut App, frame: &mut Frame, area: Rect) {
-    let sprint = match app
-        .selection
-        .active_sprint_id
-        .and_then(|id| app.model.sprints().iter().find(|s| s.id == id))
-        .cloned()
-    {
-        Some(s) => s,
-        None => return,
+    let Some(active_sprint_id) = app.selection.active_sprint_id else {
+        return;
+    };
+    let sprint = match app.model.sprint_by_id_state(active_sprint_id) {
+        LoadState::Loaded(s) => s.clone(),
+        other => {
+            render_unavailable_panel(frame, area, "Sprint", &other);
+            return;
+        }
     };
     let board = match app.active_board().cloned() {
         Some(b) => b,
@@ -238,7 +240,11 @@ pub(super) fn render_sprint_task_panel_with_selection(
             "Task",
         ));
 
-        let sprints = &app.model.sprints();
+        let empty_sprints: &[Sprint] = &[];
+        let sprints = match app.model.board_sprints_state(board.id) {
+            LoadState::Loaded(sprints) => sprints,
+            _ => empty_sprints,
+        };
 
         for card_idx in &render_info.visible_card_indices {
             if let Some(card_id) = task_list.cards.get(*card_idx) {

--- a/crates/kanban-tui/tests/load_state_render_tests.rs
+++ b/crates/kanban-tui/tests/load_state_render_tests.rs
@@ -83,13 +83,14 @@ fn app_with_card_and_sprint_state(state: LoadState<Vec<Sprint>>) -> (App, Board,
     (app, board, card)
 }
 
-fn app_with_asymmetric_column_tier() -> App {
+fn app_with_asymmetric_column_tier(board_columns_state: LoadState<Vec<Column>>) -> App {
     let mut app = App::test_default();
     let board = Board::new("TestBoard", None::<String>);
     let column = Column::new(board.id, "Backlog", 0);
     let mut resolved = base_resolved(&board);
     resolved.columns = Collection {
         all: LoadState::Loaded(vec![column]),
+        by_parent: HashMap::from([(board.id, board_columns_state)]),
         ..Default::default()
     };
     resolved.sprints = Collection {
@@ -98,6 +99,7 @@ fn app_with_asymmetric_column_tier() -> App {
     };
     let _ = app.model.apply_resolved(resolved);
     app.selection.active_board_id = Some(board.id);
+    app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
     app.prepare_frame();
     app
 }
@@ -170,6 +172,7 @@ fn test_a_failed_column_tier_renders_the_error_inline() {
     });
     assert!(!output.contains("No columns yet"));
     assert!(output.contains("Columns failed to load"));
+    assert!(output.contains("boom"));
 }
 
 #[test]
@@ -327,8 +330,69 @@ fn test_the_sprint_picker_distinguishes_not_loaded_from_empty() {
 }
 
 #[test]
+fn test_carry_over_sprint_dialog_distinguishes_not_loaded_from_empty() {
+    use kanban_tui::components::selection_dialog::CarryOverSprintDialog;
+    use kanban_tui::components::SelectionDialog;
+
+    let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
+    let dialog = CarryOverSprintDialog { card_count: 0 };
+    assert_eq!(dialog.options_count(&app), 0);
+
+    app.push_mode(AppMode::Dialog(DialogMode::CarryOverSprint));
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("Sprints not loaded yet"));
+}
+
+#[test]
+fn test_carry_over_sprint_dialog_still_renders_when_loaded_empty() {
+    use kanban_tui::components::selection_dialog::CarryOverSprintDialog;
+    use kanban_tui::components::SelectionDialog;
+
+    let (mut app, _board) = app_with_board_and_sprint_state(LoadState::Loaded(vec![]));
+    let dialog = CarryOverSprintDialog { card_count: 0 };
+    assert_eq!(dialog.options_count(&app), 0);
+
+    app.push_mode(AppMode::Dialog(DialogMode::CarryOverSprint));
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(!output.contains("Sprints not loaded yet"));
+    assert!(output.contains("Select target sprint:"));
+}
+
+#[test]
+fn test_sprint_assign_dialog_distinguishes_not_loaded_from_empty() {
+    use kanban_tui::components::selection_dialog::SprintAssignDialog;
+    use kanban_tui::components::SelectionDialog;
+
+    let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
+    let dialog = SprintAssignDialog;
+    assert_eq!(dialog.options_count(&app), 1);
+
+    app.push_mode(AppMode::Dialog(DialogMode::AssignCardToSprint));
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("Sprint"));
+    assert!(output.contains("not loaded yet"));
+}
+
+#[test]
+fn test_board_detail_sprints_section_distinguishes_not_loaded_from_empty() {
+    let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
+    app.push_mode(AppMode::BoardDetail);
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(!output.contains("No sprints yet. Press 'n' to create one!"));
+    assert!(output.contains("Sprints not loaded yet"));
+}
+
+#[test]
 fn test_multi_panel_column_name_lookup_distinguishes_not_loaded_from_unknown() {
-    let app = app_with_asymmetric_column_tier();
+    let app = app_with_asymmetric_column_tier(LoadState::NotLoaded);
     let output = helpers::render_widget_to_string(80, 20, |frame| {
         use kanban_tui::render_strategy::{MultiPanelRenderer, RenderStrategy};
         MultiPanelRenderer.render(&app, frame, frame.area());
@@ -337,4 +401,28 @@ fn test_multi_panel_column_name_lookup_distinguishes_not_loaded_from_unknown() {
         !output.contains("Unknown"),
         "an asymmetric NotLoaded board-scoped tier must not fall back to Unknown"
     );
+    assert!(output.contains("Not loaded"));
+}
+
+#[test]
+fn test_multi_panel_column_name_lookup_renders_missing_distinctly() {
+    let app = app_with_asymmetric_column_tier(LoadState::Missing);
+    let output = helpers::render_widget_to_string(80, 20, |frame| {
+        use kanban_tui::render_strategy::{MultiPanelRenderer, RenderStrategy};
+        MultiPanelRenderer.render(&app, frame, frame.area());
+    });
+    assert!(!output.contains("Unknown"));
+    assert!(!output.contains("Not loaded"));
+    assert!(output.contains("Not found"));
+}
+
+#[test]
+fn test_multi_panel_column_name_lookup_renders_failed_distinctly() {
+    let app = app_with_asymmetric_column_tier(boom());
+    let output = helpers::render_widget_to_string(80, 20, |frame| {
+        use kanban_tui::render_strategy::{MultiPanelRenderer, RenderStrategy};
+        MultiPanelRenderer.render(&app, frame, frame.area());
+    });
+    assert!(!output.contains("Unknown"));
+    assert!(output.contains("Failed"));
 }

--- a/crates/kanban-tui/tests/load_state_render_tests.rs
+++ b/crates/kanban-tui/tests/load_state_render_tests.rs
@@ -1,0 +1,340 @@
+mod helpers;
+
+use kanban_domain::resolved::Collection;
+use kanban_domain::{
+    Board, Card, Column, DependencyGraph, KanbanError, LoadState, Resolved, Sprint,
+};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn base_resolved(board: &Board) -> Resolved {
+    Resolved {
+        boards: Collection {
+            all: LoadState::Loaded(vec![board.clone()]),
+            ..Default::default()
+        },
+        cards: Collection {
+            all: LoadState::Loaded(vec![]),
+            ..Default::default()
+        },
+        graph: LoadState::Loaded(DependencyGraph::default()),
+        ..Default::default()
+    }
+}
+
+fn app_with_board_and_column_state(state: LoadState<Vec<Column>>) -> (App, Board) {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let mut resolved = base_resolved(&board);
+    resolved.columns = Collection {
+        by_parent: HashMap::from([(board.id, state)]),
+        ..Default::default()
+    };
+    resolved.sprints = Collection {
+        all: LoadState::Loaded(vec![]),
+        by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![]))]),
+        ..Default::default()
+    };
+    let _ = app.model.apply_resolved(resolved);
+    app.selection.active_board_id = Some(board.id);
+    (app, board)
+}
+
+fn app_with_board_and_sprint_state(state: LoadState<Vec<Sprint>>) -> (App, Board) {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let mut resolved = base_resolved(&board);
+    resolved.columns = Collection {
+        all: LoadState::Loaded(vec![]),
+        ..Default::default()
+    };
+    resolved.sprints = Collection {
+        by_parent: HashMap::from([(board.id, state)]),
+        ..Default::default()
+    };
+    let _ = app.model.apply_resolved(resolved);
+    app.selection.active_board_id = Some(board.id);
+    (app, board)
+}
+
+fn app_with_card_and_sprint_state(state: LoadState<Vec<Sprint>>) -> (App, Board, Card) {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let column = Column::new(board.id, "Backlog", 0);
+    let card = Card::new(board.id, column.id, "Task", 0);
+    let mut resolved = base_resolved(&board);
+    resolved.cards = Collection {
+        all: LoadState::Loaded(vec![card.clone()]),
+        ..Default::default()
+    };
+    resolved.columns = Collection {
+        all: LoadState::Loaded(vec![column.clone()]),
+        ..Default::default()
+    };
+    resolved.sprints = Collection {
+        by_parent: HashMap::from([(board.id, state)]),
+        ..Default::default()
+    };
+    let _ = app.model.apply_resolved(resolved);
+    app.selection.active_board_id = Some(board.id);
+    app.selection.active_card_id = Some(card.id);
+    (app, board, card)
+}
+
+fn app_with_asymmetric_column_tier() -> App {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let column = Column::new(board.id, "Backlog", 0);
+    let mut resolved = base_resolved(&board);
+    resolved.columns = Collection {
+        all: LoadState::Loaded(vec![column]),
+        ..Default::default()
+    };
+    resolved.sprints = Collection {
+        all: LoadState::Loaded(vec![]),
+        ..Default::default()
+    };
+    let _ = app.model.apply_resolved(resolved);
+    app.selection.active_board_id = Some(board.id);
+    app.prepare_frame();
+    app
+}
+
+fn boom() -> LoadState<Vec<Column>> {
+    LoadState::Failed(Arc::new(KanbanError::unsupported("boom")))
+}
+
+fn boom_sprints() -> LoadState<Vec<Sprint>> {
+    LoadState::Failed(Arc::new(KanbanError::unsupported("boom")))
+}
+
+struct NoActiveTaskList;
+
+impl kanban_view::view_strategy::ViewStrategy for NoActiveTaskList {
+    fn get_active_task_list(&self) -> Option<&kanban_view::card_list::CardList> {
+        None
+    }
+    fn get_active_task_list_mut(&mut self) -> Option<&mut kanban_view::card_list::CardList> {
+        None
+    }
+    fn get_all_task_lists(&self) -> Vec<&kanban_view::card_list::CardList> {
+        vec![]
+    }
+    fn navigate_left(&mut self, _select_last: bool) -> bool {
+        false
+    }
+    fn navigate_right(&mut self, _select_last: bool) -> bool {
+        false
+    }
+    fn refresh_task_lists(&mut self, _ctx: &kanban_view::view_strategy::ViewRefreshContext) {}
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[test]
+fn test_a_not_loaded_column_tier_does_not_render_the_no_columns_message() {
+    let (mut app, _board) = app_with_board_and_column_state(LoadState::NotLoaded);
+    app.view.strategy = Box::new(NoActiveTaskList);
+    let output = helpers::render_widget_to_string(80, 20, |frame| {
+        use kanban_tui::render_strategy::{RenderStrategy, SinglePanelRenderer};
+        SinglePanelRenderer::grouped().render(&app, frame, frame.area());
+    });
+    assert!(!output.contains("No columns yet"));
+    assert!(output.contains("Columns not loaded yet"));
+}
+
+#[test]
+fn test_a_loaded_but_empty_column_tier_still_renders_the_no_columns_message() {
+    let (mut app, _board) = app_with_board_and_column_state(LoadState::Loaded(vec![]));
+    app.view.strategy = Box::new(NoActiveTaskList);
+    let output = helpers::render_widget_to_string(80, 20, |frame| {
+        use kanban_tui::render_strategy::{RenderStrategy, SinglePanelRenderer};
+        SinglePanelRenderer::grouped().render(&app, frame, frame.area());
+    });
+    assert!(output.contains("No columns yet. Add columns in board settings."));
+}
+
+#[test]
+fn test_a_failed_column_tier_renders_the_error_inline() {
+    let (mut app, _board) = app_with_board_and_column_state(boom());
+    app.view.strategy = Box::new(NoActiveTaskList);
+    let output = helpers::render_widget_to_string(80, 20, |frame| {
+        use kanban_tui::render_strategy::{RenderStrategy, SinglePanelRenderer};
+        SinglePanelRenderer::grouped().render(&app, frame, frame.area());
+    });
+    assert!(!output.contains("No columns yet"));
+    assert!(output.contains("Columns failed to load"));
+}
+
+#[test]
+fn test_a_missing_column_tier_renders_distinctly_from_not_loaded() {
+    let (mut app, _board) = app_with_board_and_column_state(LoadState::Missing);
+    app.view.strategy = Box::new(NoActiveTaskList);
+    let output = helpers::render_widget_to_string(80, 20, |frame| {
+        use kanban_tui::render_strategy::{RenderStrategy, SinglePanelRenderer};
+        SinglePanelRenderer::grouped().render(&app, frame, frame.area());
+    });
+    assert!(!output.contains("No columns yet"));
+    assert!(output.contains("Columns not found"));
+    assert!(!output.contains("Columns not loaded yet"));
+}
+
+#[test]
+fn test_a_not_loaded_sprint_tier_does_not_render_no_sprints_available() {
+    use kanban_domain::CardFilters;
+    use kanban_view::filters::FilterDialogState;
+    let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
+    app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
+    app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::components::render_filter_options_popup(&app, frame);
+    });
+    assert!(!output.contains("(no sprints available)"));
+    assert!(output.contains("Sprints not loaded yet"));
+}
+
+#[test]
+fn test_a_loaded_but_empty_sprint_tier_still_renders_no_sprints_available() {
+    use kanban_domain::CardFilters;
+    use kanban_view::filters::FilterDialogState;
+    let (mut app, _board) = app_with_board_and_sprint_state(LoadState::Loaded(vec![]));
+    app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
+    app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::components::render_filter_options_popup(&app, frame);
+    });
+    assert!(output.contains("(no sprints available)"));
+}
+
+#[test]
+fn test_render_filter_sprints_section_always_draws_its_panel() {
+    use kanban_domain::CardFilters;
+    use kanban_view::filters::FilterDialogState;
+    for state in [
+        LoadState::NotLoaded,
+        LoadState::Missing,
+        boom_sprints(),
+        LoadState::Loaded(vec![]),
+    ] {
+        let (mut app, _board) = app_with_board_and_sprint_state(state);
+        app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
+        app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));
+        let output = helpers::render_widget_to_string(120, 40, |frame| {
+            kanban_tui::components::render_filter_options_popup(&app, frame);
+        });
+        assert!(
+            output.contains("Sprints"),
+            "the Sprints section border/title must always draw"
+        );
+    }
+}
+
+#[test]
+fn test_sprint_detail_with_an_unloaded_sprint_renders_an_unavailable_panel() {
+    let mut app = App::test_default();
+    app.selection.active_sprint_id = Some(uuid::Uuid::new_v4());
+    app.push_mode(AppMode::SprintDetail);
+    let output = helpers::render_widget_to_string(120, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("Sprint"));
+    assert!(!output.trim().is_empty());
+}
+
+#[test]
+fn test_sprint_detail_with_no_sprint_selected_still_draws_nothing() {
+    let mut app = App::test_default();
+    app.selection.active_sprint_id = None;
+    app.push_mode(AppMode::SprintDetail);
+    let output = helpers::render_widget_to_string(120, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    let main_area_lines: String = output.lines().take(27).collect();
+    assert!(
+        !main_area_lines.contains("Sprint Details"),
+        "no sprint selected must draw nothing in the main panel"
+    );
+}
+
+#[test]
+fn test_card_detail_with_an_unloaded_sprint_tier_does_not_render_no_sprint() {
+    let (mut app, _board, _card) = app_with_card_and_sprint_state(LoadState::NotLoaded);
+    app.push_mode(AppMode::CardDetail);
+    let output = helpers::render_widget_to_string(120, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("Sprints not loaded yet"));
+}
+
+#[test]
+fn test_card_detail_with_a_loaded_sprint_tier_renders_metadata_normally() {
+    let (mut app, _board, _card) = app_with_card_and_sprint_state(LoadState::Loaded(vec![]));
+    app.push_mode(AppMode::CardDetail);
+    let output = helpers::render_widget_to_string(120, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("Priority"));
+    assert!(!output.contains("Sprints not loaded yet"));
+}
+
+#[test]
+fn test_board_detail_columns_section_distinguishes_not_loaded_from_empty() {
+    let (mut app, _board) = app_with_board_and_column_state(LoadState::NotLoaded);
+    app.push_mode(AppMode::BoardDetail);
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(!output.contains("No columns yet"));
+    assert!(output.contains("Columns not loaded yet"));
+}
+
+#[test]
+fn test_board_detail_columns_section_still_renders_no_columns_message_when_loaded_empty() {
+    let (mut app, _board) = app_with_board_and_column_state(LoadState::Loaded(vec![]));
+    app.push_mode(AppMode::BoardDetail);
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("No columns yet. Press 'n' to create one!"));
+}
+
+#[test]
+fn test_the_create_card_dialog_sprint_field_distinguishes_not_loaded_from_empty() {
+    let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
+    app.push_mode(AppMode::Dialog(DialogMode::CreateCard));
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("Sprint"));
+    assert!(output.contains("not loaded yet"));
+}
+
+#[test]
+fn test_the_sprint_picker_distinguishes_not_loaded_from_empty() {
+    let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
+    app.push_mode(AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint));
+    let output = helpers::render_widget_to_string(120, 40, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("Sprint"));
+    assert!(output.contains("not loaded yet"));
+}
+
+#[test]
+fn test_multi_panel_column_name_lookup_distinguishes_not_loaded_from_unknown() {
+    let app = app_with_asymmetric_column_tier();
+    let output = helpers::render_widget_to_string(80, 20, |frame| {
+        use kanban_tui::render_strategy::{MultiPanelRenderer, RenderStrategy};
+        MultiPanelRenderer.render(&app, frame, frame.area());
+    });
+    assert!(
+        !output.contains("Unknown"),
+        "an asymmetric NotLoaded board-scoped tier must not fall back to Unknown"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `error_text()` to `theme/styles.rs` and a new `ui/load_state_marker.rs` module (`load_state_body`, `render_unavailable_panel`) that renders a distinct, resting-state message for each non-`Loaded` `LoadState`: "not loaded yet", "not found", "failed to load".
- Rewrites all 18 panel-body render call sites in `render_strategy.rs`, `ui/board_detail.rs`, `ui/card_detail.rs`, `ui/dialogs/cards.rs`, `ui/sprint_detail.rs`, `components/filter_popup.rs` and `components/selection_dialog.rs` to source from the board-scoped `board_columns_state`/`board_sprints_state` (and, for the single-sprint case, `sprint_by_id_state`) instead of the collapsing `Model::columns()`/`Model::sprints()`, so `NotLoaded`/`Failed`/`Missing` render distinctly from a genuinely empty `Loaded` collection.
- Fixes `ui/board_detail.rs`'s columns panel at the actual point of collapse: `render_board_columns_list` now matches on `board_columns_state` first and only calls `app.visible_board_columns` (search/filter/sort logic, unchanged) inside the `Loaded` arm, since that helper itself reads the workspace-global `columns_state()` tier.
- Splits `render_sprint_detail_view`'s single bare `return` into two distinct cases: no sprint selected (unchanged, still draws nothing) versus a sprint selected but not `Loaded` (draws an unavailable-panel marker instead of a blank rectangle).
- Three render-strategy sites that only use the sprint tier for a per-card cosmetic detail (branch-name/sprint-name annotation inside an already-loaded card list) fall back to an empty slice on a non-`Loaded` sprint tier rather than replacing the whole card list with a marker, so a loaded set of cards keeps rendering while only the cosmetic detail is momentarily blank. Same treatment for the per-column-id lookup at `render_strategy.rs`'s multi-panel column title (falls back to a short inline marker instead of "Unknown").
- New `crates/kanban-tui/tests/load_state_render_tests.rs` covering all four `LoadState` variants across the board-detail columns panel, the sprint filter popup, sprint detail, card detail, the create-card dialog, the sprint picker and the multi-panel column-name lookup, plus the "Loaded but empty" duals that guard against fixing the bug by deleting the existing empty-state messages.

## Deviations from the card

- `load_state_body` takes a `noun: &str` parameter (`fn load_state_body<T>(noun: &str, state: &LoadState<&[T]>) -> Option<Line<'static>>`), not the single-argument signature literally quoted in T1's code block. The card's own FACT-CHECK CORRECTION (point 3) fixes the marker wording to "Columns not loaded yet" / "Sprints failed to load" / "Sprint not found" using the noun the call site already has, which the literal T1 signature cannot express. The noun parameter is the only way to satisfy that correction.
- `render_board_columns_list`'s Loaded arm clones `column.name` into the `Span` (`column.name.clone()` instead of `&column.name`) rather than borrowing it. The restructure moves `board_columns: Vec<Column>` inside the match arm, and the borrow-checker will not let a `Line` built from a borrow of that `Vec` escape the arm to the final `Paragraph::new(column_lines)` call after the match. The clone is the minimal fix; rendered output is byte-identical.
- Sprint reads used only for a per-card cosmetic detail (branch-name suffix, sprint-name annotation) inside an already-resolved card list fall back to an empty slice on non-`Loaded`, rather than replacing the whole (already-loaded) card list with a marker. Blocking a legitimately-loaded card list behind an unrelated sprint tier being unavailable would be a worse regression than the one this card fixes. This applies to `render_strategy.rs`'s three in-loop sprint reads and `sprint_detail.rs`'s task-panel sprint read.
- The diff contains 18 `board_columns_state`/`board_sprints_state`/`sprint_by_id_state` call sites, not the 20 the card's positive AC asks for. Two pairs of the original 20 literal call sites shared the exact same board-scoped read (`ui/board_detail.rs`'s `total_columns` and `primary_completion_column` reads both needed the columns tier; `ui/card_detail.rs`'s two `build_metadata_lines` call sites both needed the sprints tier), so each pair now shares one `match`/one small helper function rather than calling the accessor twice. Duplicating the call to hit the literal count would be worse than the AC it satisfies.

## Refactor step not taken

The card's correction marks extracting a shared `state -> Option<&[T]>` preamble helper as a requirement once more than three sites share the identical `match state { Loaded(x) => .., other => extend(load_state_body(&other)) }` shape. In practice every site's `Loaded` arm does materially different work (sorting, status filtering, span building, enumerate-based indexing), so the only thing genuinely shared is the two-line match skeleton itself; extracting it would trade a few duplicated lines per site for an extra indirection at every call site, which is the over-abstraction T1 explicitly warns against. Left as-is; flagging in case a reviewer weighs this differently.

## Follow-up reported, not fixed here

`app.visible_board_columns()` (`handlers/detail_view_handlers.rs`, KAN-1433's file, out of this card's scope) still reads the workspace-global `columns_state()` tier internally. Once real lazy per-board fetching lands (KAN-1428/1429/1430), a board whose `columns_by_board` entry is `Loaded` while the flat `columns` tier is untouched will report `board_columns_state` as `Loaded` while `visible_board_columns` still returns an empty `Vec`, so the `Loaded` arm added here would silently render an empty columns list even though data exists. No red test in this suite can catch it today (`load_from_snapshot` always seeds both tiers in lockstep). Flagging for whoever next touches `visible_board_columns`.

## Changes since last review

- `load_state_body`/`render_unavailable_panel`'s `Failed` arm now interpolates the underlying `KanbanError` into the rendered line (`"{noun} failed to load: {e}"`) instead of discarding it, so a mis-wired failure (wrong tier's error, wrong source) is distinguishable in the buffer from a correctly wired one. `test_a_failed_column_tier_renders_the_error_inline` now asserts the injected `"boom"` text directly, and the `load_state_marker.rs` inline unit test pins the full interpolated string.
- The multi-panel column-title lookup (`render_strategy.rs`) dropped its pre-correction `"…"`/`"(gone)"`/`"(error)"` glyphs in favor of the decided vocabulary, shortened to `"Not loaded"`/`"Not found"`/`"Failed"` to fit inside a column-header title. The three `test_multi_panel_column_name_lookup_*` tests now assert the actual rendered text for each variant (driven through a real per-column `ColumnView` strategy so the asymmetric-tier branch is genuinely reached) instead of the previous vacuous `!contains("Unknown")`, which passed identically whether or not the fix was applied.
- Added direct coverage for `components/selection_dialog.rs`'s four previously-untested sites: `CarryOverSprintDialog` and `SprintAssignDialog`, both `options_count` and `render`, for a `NotLoaded` sprint tier and the Loaded-empty dual. Also added a board-detail sprints-section `NotLoaded` case (`ui/board_detail.rs`'s marker branch at the sprint-list `match`, previously only exercised by tests that always seeded `Loaded(vec![])`).
- Verified every fix by reverting the touched source file to `origin/develop` and confirming the corresponding new/strengthened test fails for the right reason, then restoring.
