### PR TITLE
KAN-1428 feat(tui): ViewScope drives the production fetch plan for App

### DIFF
--- a/.changeset/kan-1428-view-scope.md
+++ b/.changeset/kan-1428-view-scope.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+tui: adds `ViewScope`, kanban-tui's first production `kanban_service::FetchPlan` driver, and `App::view_scope`, which maps the current `AppMode`/`DialogMode`/`SelectionHub` state onto a `FetchRound` covering both the flat tiers the renderer reads and the by-parent tiers the handlers read.

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -58,6 +58,8 @@ mod reload_watch;
 mod sprint_management;
 mod ui_feedback;
 mod view_management;
+mod view_scope;
+pub use view_scope::ViewScope;
 
 #[cfg(test)]
 mod dialog_tests;

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -1,0 +1,413 @@
+//! `ViewScope` is the TUI's `FetchPlan`: it names the tiers the current
+//! screen needs. The renderer reads the flat `*_list` tiers and the
+//! handlers read the by-parent tiers, so `next_round` requests both
+//! populations together whenever a board subtree is in scope.
+
+use uuid::Uuid;
+
+use kanban_service::{FetchPlan, FetchRound, LoadedEntities};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ViewScope {
+    pub board_list: bool,
+    pub board: Option<Uuid>,
+    pub board_columns: bool,
+    pub board_cards: bool,
+    pub board_sprints: bool,
+    pub card: Option<Uuid>,
+    pub sprint: Option<Uuid>,
+    pub graph: bool,
+}
+
+impl FetchPlan for ViewScope {
+    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    use kanban_domain::Column;
+    use kanban_service::FetchStatus;
+
+    use super::*;
+
+    struct StubLoaded {
+        board_list: FetchStatus,
+        column_list: RefCell<FetchStatus>,
+        card_list: RefCell<FetchStatus>,
+        sprint_list: RefCell<FetchStatus>,
+        graph: FetchStatus,
+        card: FetchStatus,
+        sprint: FetchStatus,
+        columns_of_board: RefCell<HashMap<Uuid, FetchStatus>>,
+        cards_of_column: RefCell<HashMap<Uuid, FetchStatus>>,
+        sprints_of_board: FetchStatus,
+        loaded_columns: RefCell<HashMap<Uuid, Vec<Column>>>,
+        archived_card_list: FetchStatus,
+        archived_cards_of_board: FetchStatus,
+    }
+
+    impl Default for StubLoaded {
+        fn default() -> Self {
+            StubLoaded {
+                board_list: FetchStatus::NotLoaded,
+                column_list: RefCell::new(FetchStatus::NotLoaded),
+                card_list: RefCell::new(FetchStatus::NotLoaded),
+                sprint_list: RefCell::new(FetchStatus::NotLoaded),
+                graph: FetchStatus::NotLoaded,
+                card: FetchStatus::NotLoaded,
+                sprint: FetchStatus::NotLoaded,
+                columns_of_board: RefCell::new(HashMap::new()),
+                cards_of_column: RefCell::new(HashMap::new()),
+                sprints_of_board: FetchStatus::NotLoaded,
+                loaded_columns: RefCell::new(HashMap::new()),
+                archived_card_list: FetchStatus::NotLoaded,
+                archived_cards_of_board: FetchStatus::NotLoaded,
+            }
+        }
+    }
+
+    impl kanban_service::LoadedState for StubLoaded {
+        fn board_list(&self) -> FetchStatus {
+            self.board_list
+        }
+        fn column_list(&self) -> FetchStatus {
+            *self.column_list.borrow()
+        }
+        fn card_list(&self) -> FetchStatus {
+            *self.card_list.borrow()
+        }
+        fn sprint_list(&self) -> FetchStatus {
+            *self.sprint_list.borrow()
+        }
+        fn graph(&self) -> FetchStatus {
+            self.graph
+        }
+        fn column(&self, _id: Uuid) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
+        fn card(&self, _id: Uuid) -> FetchStatus {
+            self.card
+        }
+        fn sprint(&self, _id: Uuid) -> FetchStatus {
+            self.sprint
+        }
+        fn columns_of_board(&self, board_id: Uuid) -> FetchStatus {
+            self.columns_of_board
+                .borrow()
+                .get(&board_id)
+                .copied()
+                .unwrap_or(FetchStatus::NotLoaded)
+        }
+        fn cards_of_column(&self, column_id: Uuid) -> FetchStatus {
+            self.cards_of_column
+                .borrow()
+                .get(&column_id)
+                .copied()
+                .unwrap_or(FetchStatus::NotLoaded)
+        }
+        fn sprints_of_board(&self, _board_id: Uuid) -> FetchStatus {
+            self.sprints_of_board
+        }
+        fn archived_card_list(&self) -> FetchStatus {
+            self.archived_card_list
+        }
+        fn archived_cards_of_board(&self, _board_id: Uuid) -> FetchStatus {
+            self.archived_cards_of_board
+        }
+    }
+
+    impl LoadedEntities for StubLoaded {
+        fn loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[Column]> {
+            let borrow = self.loaded_columns.borrow();
+            let cols = borrow.get(&board_id)?;
+            let ptr = cols.as_slice() as *const [Column];
+            Some(unsafe { &*ptr })
+        }
+    }
+
+    fn column(id: Uuid) -> Column {
+        let mut column = Column::new(Uuid::new_v4(), "Todo", 0);
+        column.id = id;
+        column
+    }
+
+    #[test]
+    fn test_opening_a_board_converges_to_its_columns_and_their_cards_in_one_drive() {
+        let board = Uuid::new_v4();
+        let c1 = Uuid::new_v4();
+        let c2 = Uuid::new_v4();
+        let stub = StubLoaded::default();
+
+        let scope = ViewScope {
+            board_list: true,
+            board: Some(board),
+            board_columns: true,
+            board_cards: true,
+            ..Default::default()
+        };
+
+        let round1 = scope.next_round(&stub);
+        assert!(round1.board_list);
+        assert!(round1.column_list);
+        assert!(round1.card_list);
+        assert!(round1.sprint_list);
+        assert_eq!(round1.columns_by_board, vec![board]);
+        assert!(round1.cards_by_column.is_empty());
+
+        *stub.column_list.borrow_mut() = FetchStatus::Loaded;
+        *stub.card_list.borrow_mut() = FetchStatus::Loaded;
+        *stub.sprint_list.borrow_mut() = FetchStatus::Loaded;
+        stub.columns_of_board
+            .borrow_mut()
+            .insert(board, FetchStatus::Loaded);
+        stub.loaded_columns
+            .borrow_mut()
+            .insert(board, vec![column(c1), column(c2)]);
+
+        let stub2 = StubLoaded {
+            board_list: FetchStatus::Loaded,
+            column_list: RefCell::new(FetchStatus::Loaded),
+            card_list: RefCell::new(FetchStatus::Loaded),
+            sprint_list: RefCell::new(FetchStatus::Loaded),
+            ..StubLoaded::default()
+        };
+        stub2
+            .columns_of_board
+            .borrow_mut()
+            .insert(board, FetchStatus::Loaded);
+        stub2
+            .loaded_columns
+            .borrow_mut()
+            .insert(board, vec![column(c1), column(c2)]);
+
+        let round2 = scope.next_round(&stub2);
+        assert!(!round2.board_list);
+        assert!(!round2.column_list);
+        assert!(!round2.card_list);
+        assert!(!round2.sprint_list);
+        assert!(round2.columns_by_board.is_empty());
+        let mut cards_by_column = round2.cards_by_column.clone();
+        cards_by_column.sort();
+        let mut expected = vec![c1, c2];
+        expected.sort();
+        assert_eq!(cards_by_column, expected);
+
+        let stub3 = StubLoaded {
+            board_list: FetchStatus::Loaded,
+            column_list: RefCell::new(FetchStatus::Loaded),
+            card_list: RefCell::new(FetchStatus::Loaded),
+            sprint_list: RefCell::new(FetchStatus::Loaded),
+            ..StubLoaded::default()
+        };
+        stub3
+            .columns_of_board
+            .borrow_mut()
+            .insert(board, FetchStatus::Loaded);
+        stub3
+            .loaded_columns
+            .borrow_mut()
+            .insert(board, vec![column(c1), column(c2)]);
+        stub3
+            .cards_of_column
+            .borrow_mut()
+            .insert(c1, FetchStatus::Loaded);
+        stub3
+            .cards_of_column
+            .borrow_mut()
+            .insert(c2, FetchStatus::Loaded);
+
+        let round3 = scope.next_round(&stub3);
+        assert_eq!(round3, FetchRound::default());
+        assert!(round3.is_empty());
+    }
+
+    #[test]
+    fn test_a_loaded_tier_is_not_requested_again() {
+        let board = Uuid::new_v4();
+        let stub = StubLoaded {
+            board_list: FetchStatus::Loaded,
+            column_list: RefCell::new(FetchStatus::Loaded),
+            card_list: RefCell::new(FetchStatus::Loaded),
+            sprint_list: RefCell::new(FetchStatus::Loaded),
+            graph: FetchStatus::Loaded,
+            card: FetchStatus::Loaded,
+            sprint: FetchStatus::Loaded,
+            sprints_of_board: FetchStatus::Loaded,
+            ..StubLoaded::default()
+        };
+        stub.columns_of_board
+            .borrow_mut()
+            .insert(board, FetchStatus::Loaded);
+        stub.loaded_columns.borrow_mut().insert(board, vec![]);
+
+        let scope = ViewScope {
+            board_list: true,
+            board: Some(board),
+            board_columns: true,
+            board_cards: true,
+            board_sprints: true,
+            card: Some(Uuid::new_v4()),
+            sprint: Some(Uuid::new_v4()),
+            graph: true,
+        };
+
+        let round = scope.next_round(&stub);
+        assert_eq!(round, FetchRound::default());
+        assert!(round.is_empty());
+    }
+
+    #[test]
+    fn test_a_failed_tier_is_requested_again() {
+        let board = Uuid::new_v4();
+        let stub = StubLoaded {
+            board_list: FetchStatus::Loaded,
+            column_list: RefCell::new(FetchStatus::Loaded),
+            card_list: RefCell::new(FetchStatus::Loaded),
+            sprint_list: RefCell::new(FetchStatus::Loaded),
+            ..StubLoaded::default()
+        };
+        stub.columns_of_board
+            .borrow_mut()
+            .insert(board, FetchStatus::Failed);
+
+        let scope = ViewScope {
+            board: Some(board),
+            board_columns: true,
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&stub);
+        assert_eq!(round.columns_by_board, vec![board]);
+    }
+
+    #[test]
+    fn test_a_missing_card_is_not_requested_again() {
+        let id = Uuid::new_v4();
+        let stub = StubLoaded {
+            card: FetchStatus::Missing,
+            ..StubLoaded::default()
+        };
+
+        let scope = ViewScope {
+            card: Some(id),
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&stub);
+        assert!(round.cards.is_empty());
+    }
+
+    #[test]
+    fn test_a_column_less_board_stops_after_one_round() {
+        let board = Uuid::new_v4();
+        let stub = StubLoaded {
+            board_list: FetchStatus::Loaded,
+            column_list: RefCell::new(FetchStatus::Loaded),
+            card_list: RefCell::new(FetchStatus::Loaded),
+            sprint_list: RefCell::new(FetchStatus::Loaded),
+            ..StubLoaded::default()
+        };
+        stub.columns_of_board
+            .borrow_mut()
+            .insert(board, FetchStatus::Loaded);
+        stub.loaded_columns.borrow_mut().insert(board, vec![]);
+
+        let scope = ViewScope {
+            board_list: true,
+            board: Some(board),
+            board_columns: true,
+            board_cards: true,
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&stub);
+        assert!(round.cards_by_column.is_empty());
+        assert_eq!(round, FetchRound::default());
+    }
+
+    #[test]
+    fn test_no_board_in_scope_requests_only_the_board_list() {
+        let stub = StubLoaded::default();
+        let scope = ViewScope {
+            board_list: true,
+            board: None,
+            board_columns: true,
+            board_cards: true,
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&stub);
+        assert!(round.board_list);
+        assert!(!round.column_list);
+        assert!(!round.card_list);
+        assert!(!round.sprint_list);
+        assert!(round.columns_by_board.is_empty());
+        assert!(round.cards_by_column.is_empty());
+        assert!(round.sprints_by_board.is_empty());
+    }
+
+    #[test]
+    fn test_board_cards_alone_still_requests_the_flat_and_by_parent_column_tiers() {
+        let board = Uuid::new_v4();
+        let stub = StubLoaded::default();
+        let scope = ViewScope {
+            board: Some(board),
+            board_columns: false,
+            board_cards: true,
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&stub);
+        assert_eq!(round.columns_by_board, vec![board]);
+        assert!(round.column_list);
+        assert!(round.card_list);
+        assert!(round.sprint_list);
+    }
+
+    #[test]
+    fn test_settings_scope_requests_only_the_board_list_even_with_a_board_present() {
+        let board = Uuid::new_v4();
+        let stub = StubLoaded::default();
+        let scope = ViewScope {
+            board_list: true,
+            board: Some(board),
+            board_columns: false,
+            board_cards: false,
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&stub);
+        assert!(round.board_list);
+        assert!(!round.column_list);
+        assert!(!round.card_list);
+        assert!(!round.sprint_list);
+        assert!(round.columns_by_board.is_empty());
+        assert!(round.cards_by_column.is_empty());
+        assert!(round.sprints_by_board.is_empty());
+    }
+
+    #[test]
+    fn test_archived_tiers_are_never_requested_regardless_of_status() {
+        let board = Uuid::new_v4();
+        let stub = StubLoaded::default();
+        let scope = ViewScope {
+            board_list: true,
+            board: Some(board),
+            board_columns: true,
+            board_cards: true,
+            board_sprints: true,
+            card: Some(Uuid::new_v4()),
+            sprint: Some(Uuid::new_v4()),
+            graph: true,
+        };
+
+        let round = scope.next_round(&stub);
+        assert!(!round.archived_card_list);
+        assert!(round.archived_cards_by_board.is_empty());
+    }
+}

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -5,7 +5,9 @@
 
 use uuid::Uuid;
 
-use kanban_service::{FetchPlan, FetchRound, LoadedEntities};
+use kanban_service::{requestable, FetchPlan, FetchRound, LoadedEntities};
+
+use super::{App, AppMode, DialogMode};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ViewScope {
@@ -20,8 +22,118 @@ pub struct ViewScope {
 }
 
 impl FetchPlan for ViewScope {
-    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
-        unimplemented!()
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        let mut round = FetchRound {
+            board_list: self.board_list && requestable(loaded.board_list()),
+            graph: self.graph && requestable(loaded.graph()),
+            ..Default::default()
+        };
+
+        if let Some(card_id) = self.card {
+            if requestable(loaded.card(card_id)) {
+                round.cards.push(card_id);
+            }
+        }
+
+        if let Some(sprint_id) = self.sprint {
+            if requestable(loaded.sprint(sprint_id)) {
+                round.sprints.push(sprint_id);
+            }
+        }
+
+        if let Some(board_id) = self.board {
+            let board_subtree = self.board_columns || self.board_cards;
+
+            if board_subtree {
+                if requestable(loaded.column_list()) {
+                    round.column_list = true;
+                }
+                if requestable(loaded.card_list()) {
+                    round.card_list = true;
+                }
+                if requestable(loaded.sprint_list()) {
+                    round.sprint_list = true;
+                }
+                if requestable(loaded.columns_of_board(board_id)) {
+                    round.columns_by_board.push(board_id);
+                }
+            }
+
+            if self.board_sprints && requestable(loaded.sprints_of_board(board_id)) {
+                round.sprints_by_board.push(board_id);
+            }
+
+            if self.board_cards {
+                if let Some(columns) = loaded.loaded_columns_of_board(board_id) {
+                    for column in columns {
+                        if requestable(loaded.cards_of_column(column.id)) {
+                            round.cards_by_column.push(column.id);
+                        }
+                    }
+                }
+            }
+        }
+
+        round
+    }
+}
+
+impl App {
+    pub fn view_scope(&self) -> ViewScope {
+        let board = self
+            .selection
+            .active_board_id
+            .or_else(|| self.board_list.get_selected_board_id());
+
+        let mut scope = ViewScope {
+            board_list: true,
+            board,
+            board_columns: true,
+            board_cards: true,
+            ..Default::default()
+        };
+
+        let mut base = self.get_base_mode();
+        while let AppMode::Help(inner) = base {
+            base = inner.as_ref();
+        }
+
+        match base {
+            AppMode::CardDetail => {
+                scope.card = self.selection.active_card_id;
+                scope.board_sprints = true;
+                scope.graph = true;
+            }
+            AppMode::BoardDetail => {
+                scope.board_sprints = true;
+            }
+            AppMode::SprintDetail => {
+                scope.sprint = self.selection.active_sprint_id;
+                scope.board_sprints = true;
+            }
+            AppMode::Settings => {
+                scope.board_columns = false;
+                scope.board_cards = false;
+            }
+            AppMode::ArchivedCardsView => {}
+            _ => {}
+        }
+
+        match &self.mode {
+            AppMode::Dialog(DialogMode::ManageParents | DialogMode::ManageChildren) => {
+                scope.graph = true;
+            }
+            AppMode::Dialog(DialogMode::CarryOverSprint) => {
+                scope.board_sprints = true;
+            }
+            _ => {}
+        }
+
+        if !self.filter.active_sprint_filters.is_empty() {
+            scope.board_sprints = true;
+        }
+
+        scope
     }
 }
 

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -115,7 +115,15 @@ impl App {
                 scope.board_columns = false;
                 scope.board_cards = false;
             }
+            // Archived cards are snapshot-fed from the marker set populated on
+            // load, not fetched through a round, so this view requests nothing
+            // beyond the default board scope. The archived tier itself has no
+            // producer here.
             AppMode::ArchivedCardsView => {}
+            // Card search filters the board already in scope (`board_cards`
+            // covers it) and board search filters the board list
+            // (`board_list` covers it); `CardQueryBuilder::execute` cannot
+            // express an unscoped search, so there is no wider set to fetch.
             _ => {}
         }
 
@@ -139,7 +147,6 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
     use std::collections::HashMap;
 
     use kanban_domain::Column;
@@ -149,16 +156,16 @@ mod tests {
 
     struct StubLoaded {
         board_list: FetchStatus,
-        column_list: RefCell<FetchStatus>,
-        card_list: RefCell<FetchStatus>,
-        sprint_list: RefCell<FetchStatus>,
+        column_list: FetchStatus,
+        card_list: FetchStatus,
+        sprint_list: FetchStatus,
         graph: FetchStatus,
         card: FetchStatus,
         sprint: FetchStatus,
-        columns_of_board: RefCell<HashMap<Uuid, FetchStatus>>,
-        cards_of_column: RefCell<HashMap<Uuid, FetchStatus>>,
+        columns_of_board: HashMap<Uuid, FetchStatus>,
+        cards_of_column: HashMap<Uuid, FetchStatus>,
         sprints_of_board: FetchStatus,
-        loaded_columns: RefCell<HashMap<Uuid, Vec<Column>>>,
+        loaded_columns: HashMap<Uuid, Vec<Column>>,
         archived_card_list: FetchStatus,
         archived_cards_of_board: FetchStatus,
     }
@@ -167,16 +174,16 @@ mod tests {
         fn default() -> Self {
             StubLoaded {
                 board_list: FetchStatus::NotLoaded,
-                column_list: RefCell::new(FetchStatus::NotLoaded),
-                card_list: RefCell::new(FetchStatus::NotLoaded),
-                sprint_list: RefCell::new(FetchStatus::NotLoaded),
+                column_list: FetchStatus::NotLoaded,
+                card_list: FetchStatus::NotLoaded,
+                sprint_list: FetchStatus::NotLoaded,
                 graph: FetchStatus::NotLoaded,
                 card: FetchStatus::NotLoaded,
                 sprint: FetchStatus::NotLoaded,
-                columns_of_board: RefCell::new(HashMap::new()),
-                cards_of_column: RefCell::new(HashMap::new()),
+                columns_of_board: HashMap::new(),
+                cards_of_column: HashMap::new(),
                 sprints_of_board: FetchStatus::NotLoaded,
-                loaded_columns: RefCell::new(HashMap::new()),
+                loaded_columns: HashMap::new(),
                 archived_card_list: FetchStatus::NotLoaded,
                 archived_cards_of_board: FetchStatus::NotLoaded,
             }
@@ -188,13 +195,13 @@ mod tests {
             self.board_list
         }
         fn column_list(&self) -> FetchStatus {
-            *self.column_list.borrow()
+            self.column_list
         }
         fn card_list(&self) -> FetchStatus {
-            *self.card_list.borrow()
+            self.card_list
         }
         fn sprint_list(&self) -> FetchStatus {
-            *self.sprint_list.borrow()
+            self.sprint_list
         }
         fn graph(&self) -> FetchStatus {
             self.graph
@@ -210,14 +217,12 @@ mod tests {
         }
         fn columns_of_board(&self, board_id: Uuid) -> FetchStatus {
             self.columns_of_board
-                .borrow()
                 .get(&board_id)
                 .copied()
                 .unwrap_or(FetchStatus::NotLoaded)
         }
         fn cards_of_column(&self, column_id: Uuid) -> FetchStatus {
             self.cards_of_column
-                .borrow()
                 .get(&column_id)
                 .copied()
                 .unwrap_or(FetchStatus::NotLoaded)
@@ -235,10 +240,7 @@ mod tests {
 
     impl LoadedEntities for StubLoaded {
         fn loaded_columns_of_board(&self, board_id: Uuid) -> Option<&[Column]> {
-            let borrow = self.loaded_columns.borrow();
-            let cols = borrow.get(&board_id)?;
-            let ptr = cols.as_slice() as *const [Column];
-            Some(unsafe { &*ptr })
+            self.loaded_columns.get(&board_id).map(Vec::as_slice)
         }
     }
 
@@ -271,31 +273,15 @@ mod tests {
         assert_eq!(round1.columns_by_board, vec![board]);
         assert!(round1.cards_by_column.is_empty());
 
-        *stub.column_list.borrow_mut() = FetchStatus::Loaded;
-        *stub.card_list.borrow_mut() = FetchStatus::Loaded;
-        *stub.sprint_list.borrow_mut() = FetchStatus::Loaded;
-        stub.columns_of_board
-            .borrow_mut()
-            .insert(board, FetchStatus::Loaded);
-        stub.loaded_columns
-            .borrow_mut()
-            .insert(board, vec![column(c1), column(c2)]);
-
         let stub2 = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: RefCell::new(FetchStatus::Loaded),
-            card_list: RefCell::new(FetchStatus::Loaded),
-            sprint_list: RefCell::new(FetchStatus::Loaded),
+            column_list: FetchStatus::Loaded,
+            card_list: FetchStatus::Loaded,
+            sprint_list: FetchStatus::Loaded,
+            columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            loaded_columns: HashMap::from([(board, vec![column(c1), column(c2)])]),
             ..StubLoaded::default()
         };
-        stub2
-            .columns_of_board
-            .borrow_mut()
-            .insert(board, FetchStatus::Loaded);
-        stub2
-            .loaded_columns
-            .borrow_mut()
-            .insert(board, vec![column(c1), column(c2)]);
 
         let round2 = scope.next_round(&stub2);
         assert!(!round2.board_list);
@@ -311,27 +297,14 @@ mod tests {
 
         let stub3 = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: RefCell::new(FetchStatus::Loaded),
-            card_list: RefCell::new(FetchStatus::Loaded),
-            sprint_list: RefCell::new(FetchStatus::Loaded),
+            column_list: FetchStatus::Loaded,
+            card_list: FetchStatus::Loaded,
+            sprint_list: FetchStatus::Loaded,
+            columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            loaded_columns: HashMap::from([(board, vec![column(c1), column(c2)])]),
+            cards_of_column: HashMap::from([(c1, FetchStatus::Loaded), (c2, FetchStatus::Loaded)]),
             ..StubLoaded::default()
         };
-        stub3
-            .columns_of_board
-            .borrow_mut()
-            .insert(board, FetchStatus::Loaded);
-        stub3
-            .loaded_columns
-            .borrow_mut()
-            .insert(board, vec![column(c1), column(c2)]);
-        stub3
-            .cards_of_column
-            .borrow_mut()
-            .insert(c1, FetchStatus::Loaded);
-        stub3
-            .cards_of_column
-            .borrow_mut()
-            .insert(c2, FetchStatus::Loaded);
 
         let round3 = scope.next_round(&stub3);
         assert_eq!(round3, FetchRound::default());
@@ -343,19 +316,17 @@ mod tests {
         let board = Uuid::new_v4();
         let stub = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: RefCell::new(FetchStatus::Loaded),
-            card_list: RefCell::new(FetchStatus::Loaded),
-            sprint_list: RefCell::new(FetchStatus::Loaded),
+            column_list: FetchStatus::Loaded,
+            card_list: FetchStatus::Loaded,
+            sprint_list: FetchStatus::Loaded,
             graph: FetchStatus::Loaded,
             card: FetchStatus::Loaded,
             sprint: FetchStatus::Loaded,
             sprints_of_board: FetchStatus::Loaded,
+            columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            loaded_columns: HashMap::from([(board, vec![])]),
             ..StubLoaded::default()
         };
-        stub.columns_of_board
-            .borrow_mut()
-            .insert(board, FetchStatus::Loaded);
-        stub.loaded_columns.borrow_mut().insert(board, vec![]);
 
         let scope = ViewScope {
             board_list: true,
@@ -378,14 +349,12 @@ mod tests {
         let board = Uuid::new_v4();
         let stub = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: RefCell::new(FetchStatus::Loaded),
-            card_list: RefCell::new(FetchStatus::Loaded),
-            sprint_list: RefCell::new(FetchStatus::Loaded),
+            column_list: FetchStatus::Loaded,
+            card_list: FetchStatus::Loaded,
+            sprint_list: FetchStatus::Loaded,
+            columns_of_board: HashMap::from([(board, FetchStatus::Failed)]),
             ..StubLoaded::default()
         };
-        stub.columns_of_board
-            .borrow_mut()
-            .insert(board, FetchStatus::Failed);
 
         let scope = ViewScope {
             board: Some(board),
@@ -419,15 +388,13 @@ mod tests {
         let board = Uuid::new_v4();
         let stub = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: RefCell::new(FetchStatus::Loaded),
-            card_list: RefCell::new(FetchStatus::Loaded),
-            sprint_list: RefCell::new(FetchStatus::Loaded),
+            column_list: FetchStatus::Loaded,
+            card_list: FetchStatus::Loaded,
+            sprint_list: FetchStatus::Loaded,
+            columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            loaded_columns: HashMap::from([(board, vec![])]),
             ..StubLoaded::default()
         };
-        stub.columns_of_board
-            .borrow_mut()
-            .insert(board, FetchStatus::Loaded);
-        stub.loaded_columns.borrow_mut().insert(board, vec![]);
 
         let scope = ViewScope {
             board_list: true,

--- a/crates/kanban-tui/tests/view_scope_tests.rs
+++ b/crates/kanban-tui/tests/view_scope_tests.rs
@@ -1,0 +1,180 @@
+use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+use uuid::Uuid;
+
+fn seed_board_column_sprint_card(app: &mut App) -> (Uuid, Uuid, Uuid, Uuid) {
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.assign_card_to_sprint(card.id, sprint.id).unwrap();
+    (board.id, column.id, sprint.id, card.id)
+}
+
+#[test]
+fn test_normal_mode_scopes_the_highlighted_board_when_none_is_opened() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.board_list.update_boards(vec![board_id]);
+
+    let scope = app.view_scope();
+
+    assert_eq!(scope.board, Some(board_id));
+}
+
+#[test]
+fn test_card_detail_scopes_the_active_card_the_sprints_and_the_graph() {
+    let mut app = App::test_default();
+    let (board_id, _column_id, _sprint_id, card_id) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_card_id = Some(card_id);
+    app.mode = AppMode::CardDetail;
+
+    let scope = app.view_scope();
+
+    assert_eq!(scope.card, Some(card_id));
+    assert!(scope.board_sprints);
+    assert!(scope.graph);
+}
+
+#[test]
+fn test_sprint_detail_scopes_the_active_sprint() {
+    let mut app = App::test_default();
+    let (board_id, _column_id, sprint_id, _card_id) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_sprint_id = Some(sprint_id);
+    app.mode = AppMode::SprintDetail;
+
+    let scope = app.view_scope();
+
+    assert_eq!(scope.sprint, Some(sprint_id));
+    assert!(scope.board_sprints);
+}
+
+#[test]
+fn test_archived_cards_view_keeps_the_default_board_scope_and_requests_no_archived_tier() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::ArchivedCardsView;
+
+    let scope = app.view_scope();
+
+    assert!(scope.board_columns);
+    assert!(scope.board_cards);
+}
+
+#[test]
+fn test_help_over_card_detail_keeps_the_card_scope() {
+    let mut app = App::test_default();
+    let (board_id, _column_id, _sprint_id, card_id) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_card_id = Some(card_id);
+    app.mode = AppMode::Help(Box::new(AppMode::CardDetail));
+
+    let scope = app.view_scope();
+
+    assert_eq!(scope.card, Some(card_id));
+    assert!(scope.graph);
+    assert!(scope.board_sprints);
+}
+
+#[test]
+fn test_manage_children_dialog_scopes_the_graph() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::Normal;
+    app.push_mode(AppMode::Dialog(DialogMode::ManageChildren));
+
+    let scope = app.view_scope();
+
+    assert!(scope.graph);
+}
+
+#[test]
+fn test_an_active_sprint_filter_scopes_the_sprints_in_normal_mode() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::Normal;
+    app.filter.active_sprint_filters.insert(Uuid::new_v4());
+
+    let scope = app.view_scope();
+
+    assert!(scope.board_sprints);
+}
+
+#[test]
+fn test_settings_mode_keeps_the_board_list_and_drops_the_board_subtree() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::Settings;
+
+    let scope = app.view_scope();
+
+    assert!(scope.board_list);
+    assert!(!scope.board_columns);
+    assert!(!scope.board_cards);
+}
+
+#[test]
+fn test_error_log_mode_keeps_the_board_columns_and_cards_it_renders_over() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::ErrorLog;
+
+    let scope = app.view_scope();
+
+    assert!(scope.board_columns);
+    assert!(scope.board_cards);
+    assert!(scope.board_list);
+}
+
+#[test]
+fn test_search_mode_needs_no_scope_beyond_the_board_it_filters() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::Search;
+
+    let scope = app.view_scope();
+
+    assert!(scope.board_list);
+    assert!(scope.board_columns);
+    assert!(scope.board_cards);
+    assert_eq!(
+        scope,
+        kanban_tui::app::ViewScope {
+            board_list: true,
+            board: Some(board_id),
+            board_columns: true,
+            board_cards: true,
+            ..Default::default()
+        }
+    );
+}


### PR DESCRIPTION
Adds `crates/kanban-tui/src/app/view_scope.rs`, holding `ViewScope` (implements `kanban_service::FetchPlan`) and `App::view_scope()`, the TUI's first production fetch-plan driver mapping `AppMode`/`DialogMode`/`SelectionHub` onto a `FetchRound`.

- `ViewScope::next_round` requests both the transitional flat tiers (`column_list`, `card_list`, `sprint_list`) the renderer still reads and the by-parent tiers (`columns_by_board`, `cards_by_column`, `sprints_by_board`) the handlers read, whenever a board subtree is in scope, and never requests the archived tiers (that gap is owned by a later card).
- `App::view_scope` resolves the highlighted or opened board, peels `AppMode::Help(inner)` before matching on the base mode, and sets card/sprint/graph/sprint scope per mode and per open dialog.
- 9 inline unit tests on `ViewScope::next_round` and 10 integration tests on `App::view_scope` in `crates/kanban-tui/tests/view_scope_tests.rs`.
- Registers the module in `crates/kanban-tui/src/app/mod.rs`.

`view_scope()` is not yet wired into `reload_model`/`prepare_frame`/startup; that is a later card's job.

Verified: `cargo fmt --all -- --check`, `cargo clippy -p kanban-tui --all-targets --all-features -- -D warnings`, and `cargo test -p kanban-tui --all-features` all pass clean.
