### PR TITLE
KAN-1432 feat(view,tui): panel title count declines an unloaded card tier

### DIFF
--- a/.changeset/kan-1432-panel-titles-never-print-count.md
+++ b/.changeset/kan-1432-panel-titles-never-print-count.md
@@ -1,0 +1,10 @@
+---
+bump: minor
+---
+
+view,tui: `TasksPanelTitle.count` is now a `PanelCount` (`Known`/`NotLoaded`/
+`Failed`) instead of a bare `usize`, so the tasks panel title never prints a
+confident `(0)` for a card, column, or sprint tier that has not loaded or has
+failed to load. `build_filter_title_parts` resolves active sprint filter
+names through the board-scoped sprint tier so an active filter always shows a
+label even when that tier is unloaded.

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -2,7 +2,8 @@ use crate::app::{App, AppMode, Focus};
 use crate::components::*;
 use crate::theme::*;
 use crate::view_strategy::UnifiedViewStrategy;
-use kanban_view::panel_titles::{TasksPanelKind, TasksPanelTitle};
+use kanban_domain::LoadState;
+use kanban_view::panel_titles::{PanelCount, TasksPanelKind, TasksPanelTitle};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     text::{Line, Span},
@@ -121,10 +122,15 @@ pub fn format_filter_title_suffix(parts: &[String]) -> Option<String> {
 /// Renders a `TasksPanelTitle` as the terminal panel title. The `[2]` hint is
 /// re-inserted here because it names a TUI-only key that focuses this panel.
 pub fn format_tasks_panel_title(title: &TasksPanelTitle) -> String {
+    let count = match title.count {
+        PanelCount::Known(n) => n.to_string(),
+        PanelCount::NotLoaded => "…".to_string(),
+        PanelCount::Failed => "!".to_string(),
+    };
     let mut rendered = match title.kind {
-        TasksPanelKind::Archive => format!("Archive [{}]", title.count),
-        TasksPanelKind::ArchivedBoardTasks => format!("[ARCHIVED] Tasks [2] ({})", title.count),
-        TasksPanelKind::FocusedTasks => format!("Tasks [2] ({})", title.count),
+        TasksPanelKind::Archive => format!("Archive [{count}]"),
+        TasksPanelKind::ArchivedBoardTasks => format!("[ARCHIVED] Tasks [2] ({count})"),
+        TasksPanelKind::FocusedTasks => format!("Tasks [2] ({count})"),
         TasksPanelKind::UnfocusedTasks => "Tasks".to_string(),
     };
 
@@ -149,12 +155,20 @@ pub fn filter_title_suffix(app: &App) -> Option<String> {
 /// Resolves the App-native primitives, asks `kanban_view::panel_titles` for
 /// the structured title, and renders it for the terminal.
 pub fn tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
-    let active_task_list_len = app
-        .view
-        .strategy
-        .get_active_task_list()
-        .map(|l| l.len())
-        .unwrap_or(0);
+    let all_tiers_loaded = matches!(app.model.columns_state(), LoadState::Loaded(_))
+        && matches!(app.model.sprints_state(), LoadState::Loaded(_));
+    let active_task_list = match (app.model.cards_state(), all_tiers_loaded) {
+        (LoadState::Failed(_), _) => PanelCount::Failed,
+        (_, false) => PanelCount::NotLoaded,
+        (LoadState::Loaded(_), true) => PanelCount::Known(
+            app.view
+                .strategy
+                .get_active_task_list()
+                .map(|l| l.len())
+                .unwrap_or(0),
+        ),
+        (_, true) => PanelCount::NotLoaded,
+    };
     // Display indicator: the active board's head is archived (a pure display
     // concern — the tasks behave identically to a live board).
     let viewing_archived_board = app
@@ -169,7 +183,7 @@ pub fn tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
     let focus_is_cards = app.focus.active == Focus::Cards;
 
     format_tasks_panel_title(&kanban_view::panel_titles::build_tasks_panel_title(
-        active_task_list_len,
+        active_task_list,
         viewing_archived_board,
         viewing_archived_cards,
         focus_is_cards,

--- a/crates/kanban-tui/tests/panel_title_tests.rs
+++ b/crates/kanban-tui/tests/panel_title_tests.rs
@@ -1,11 +1,16 @@
-use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_domain::resolved::Collection;
+use kanban_domain::{
+    Board, Card, Column, CreateCardOptions, DependencyGraph, KanbanError, KanbanOperations,
+    LoadState, Resolved, Sprint,
+};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::ui::{
     filter_title_suffix, format_filter_title_suffix, format_tasks_panel_title, tasks_panel_title,
 };
 use kanban_tui::App;
-use kanban_view::panel_titles::{TasksPanelKind, TasksPanelTitle};
+use kanban_view::panel_titles::{PanelCount, TasksPanelKind, TasksPanelTitle};
+use std::sync::Arc;
 
 #[test]
 fn test_build_tasks_panel_title_cards_focus_with_cards() {
@@ -118,7 +123,7 @@ fn test_filter_title_suffix_with_no_active_board_omits_sprint_filter_suffix() {
     );
 }
 
-fn title(kind: TasksPanelKind, count: usize, filters: Vec<String>) -> TasksPanelTitle {
+fn title(kind: TasksPanelKind, count: PanelCount, filters: Vec<String>) -> TasksPanelTitle {
     TasksPanelTitle {
         kind,
         count,
@@ -129,7 +134,11 @@ fn title(kind: TasksPanelKind, count: usize, filters: Vec<String>) -> TasksPanel
 #[test]
 fn test_format_tasks_panel_title_focused_shows_panel_hotkey_and_count() {
     assert_eq!(
-        format_tasks_panel_title(&title(TasksPanelKind::FocusedTasks, 3, vec![])),
+        format_tasks_panel_title(&title(
+            TasksPanelKind::FocusedTasks,
+            PanelCount::Known(3),
+            vec![]
+        )),
         "Tasks [2] (3)"
     );
 }
@@ -137,7 +146,11 @@ fn test_format_tasks_panel_title_focused_shows_panel_hotkey_and_count() {
 #[test]
 fn test_format_tasks_panel_title_unfocused_omits_hotkey_and_count() {
     assert_eq!(
-        format_tasks_panel_title(&title(TasksPanelKind::UnfocusedTasks, 3, vec![])),
+        format_tasks_panel_title(&title(
+            TasksPanelKind::UnfocusedTasks,
+            PanelCount::Known(3),
+            vec![]
+        )),
         "Tasks"
     );
 }
@@ -145,7 +158,11 @@ fn test_format_tasks_panel_title_unfocused_omits_hotkey_and_count() {
 #[test]
 fn test_format_tasks_panel_title_archived_board_prefixes_marker() {
     assert_eq!(
-        format_tasks_panel_title(&title(TasksPanelKind::ArchivedBoardTasks, 5, vec![])),
+        format_tasks_panel_title(&title(
+            TasksPanelKind::ArchivedBoardTasks,
+            PanelCount::Known(5),
+            vec![]
+        )),
         "[ARCHIVED] Tasks [2] (5)"
     );
 }
@@ -153,7 +170,7 @@ fn test_format_tasks_panel_title_archived_board_prefixes_marker() {
 #[test]
 fn test_format_tasks_panel_title_archive_uses_bracketed_count() {
     assert_eq!(
-        format_tasks_panel_title(&title(TasksPanelKind::Archive, 2, vec![])),
+        format_tasks_panel_title(&title(TasksPanelKind::Archive, PanelCount::Known(2), vec![])),
         "Archive [2]"
     );
 }
@@ -163,10 +180,160 @@ fn test_format_tasks_panel_title_appends_filter_suffix() {
     assert_eq!(
         format_tasks_panel_title(&title(
             TasksPanelKind::FocusedTasks,
-            0,
+            PanelCount::Known(0),
             vec!["Unassigned Cards".to_string()]
         )),
         "Tasks [2] (0) - Unassigned Cards"
+    );
+}
+
+fn seed_model_states(
+    app: &mut App,
+    board: &Board,
+    cards: LoadState<Vec<Card>>,
+    columns: LoadState<Vec<Column>>,
+    sprints: LoadState<Vec<Sprint>>,
+) {
+    let resolved = Resolved {
+        boards: Collection {
+            all: LoadState::Loaded(vec![board.clone()]),
+            ..Default::default()
+        },
+        cards: Collection {
+            all: cards,
+            ..Default::default()
+        },
+        columns: Collection {
+            all: columns,
+            ..Default::default()
+        },
+        sprints: Collection {
+            all: sprints,
+            ..Default::default()
+        },
+        graph: LoadState::Loaded(DependencyGraph::default()),
+        ..Default::default()
+    };
+    let _ = app.model.apply_resolved(resolved);
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.prepare_frame();
+}
+
+fn boom_cards() -> LoadState<Vec<Card>> {
+    LoadState::Failed(Arc::new(KanbanError::unsupported("boom")))
+}
+
+#[test]
+fn test_a_not_loaded_card_tier_titles_the_panel_without_a_count() {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    seed_model_states(
+        &mut app,
+        &board,
+        LoadState::NotLoaded,
+        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![]),
+    );
+
+    let rendered = tasks_panel_title(&app, false);
+    assert!(
+        !rendered
+            .split('(')
+            .nth(1)
+            .is_some_and(|tail| tail.chars().next().is_some_and(|c| c.is_ascii_digit())),
+        "a NotLoaded card tier must not print a confident count: {rendered}"
+    );
+}
+
+#[test]
+fn test_a_loaded_empty_card_tier_still_titles_the_panel_with_zero() {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    seed_model_states(
+        &mut app,
+        &board,
+        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![Column::new(board.id, "Todo", 0)]),
+        LoadState::Loaded(vec![]),
+    );
+
+    assert_eq!(tasks_panel_title(&app, false), "Tasks [2] (0)");
+}
+
+#[test]
+fn test_a_failed_card_tier_titles_the_panel_distinctly_from_not_loaded() {
+    let mut app_not_loaded = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    seed_model_states(
+        &mut app_not_loaded,
+        &board,
+        LoadState::NotLoaded,
+        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![]),
+    );
+    let not_loaded_rendered = tasks_panel_title(&app_not_loaded, false);
+
+    let mut app_failed = App::test_default();
+    seed_model_states(
+        &mut app_failed,
+        &board,
+        boom_cards(),
+        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![]),
+    );
+    let failed_rendered = tasks_panel_title(&app_failed, false);
+
+    assert_ne!(
+        not_loaded_rendered, failed_rendered,
+        "a Failed card tier must render distinctly from a NotLoaded one"
+    );
+}
+
+#[test]
+fn test_the_archived_panel_title_count_is_state_aware_too() {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    seed_model_states(
+        &mut app,
+        &board,
+        LoadState::NotLoaded,
+        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![]),
+    );
+    app.mode = AppMode::ArchivedCardsView;
+
+    let rendered = tasks_panel_title(&app, false);
+    assert!(
+        !rendered
+            .split('[')
+            .nth(1)
+            .is_some_and(|tail| tail.chars().next().is_some_and(|c| c.is_ascii_digit())),
+        "the Archive panel's bracketed count must not show a digit when the card tier is not loaded: {rendered}"
+    );
+}
+
+#[test]
+fn test_tasks_panel_title_with_loaded_cards_but_not_loaded_columns_reports_not_loaded() {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
+    let card = Card::new(board.id, column.id, "Card", 0);
+    seed_model_states(
+        &mut app,
+        &board,
+        LoadState::Loaded(vec![card]),
+        LoadState::NotLoaded,
+        LoadState::Loaded(vec![]),
+    );
+
+    let rendered = tasks_panel_title(&app, false);
+    assert!(
+        !rendered
+            .split('(')
+            .nth(1)
+            .is_some_and(|tail| tail.chars().next().is_some_and(|c| c.is_ascii_digit())),
+        "cards Loaded but columns NotLoaded must still report NotLoaded, not a stale digit: {rendered}"
     );
 }
 

--- a/crates/kanban-tui/tests/panel_title_tests.rs
+++ b/crates/kanban-tui/tests/panel_title_tests.rs
@@ -170,7 +170,11 @@ fn test_format_tasks_panel_title_archived_board_prefixes_marker() {
 #[test]
 fn test_format_tasks_panel_title_archive_uses_bracketed_count() {
     assert_eq!(
-        format_tasks_panel_title(&title(TasksPanelKind::Archive, PanelCount::Known(2), vec![])),
+        format_tasks_panel_title(&title(
+            TasksPanelKind::Archive,
+            PanelCount::Known(2),
+            vec![]
+        )),
         "Archive [2]"
     );
 }

--- a/crates/kanban-view/src/panel_titles.rs
+++ b/crates/kanban-view/src/panel_titles.rs
@@ -130,7 +130,7 @@ mod tests {
     /// exactly that board and those sprints — pure kanban-domain
     /// construction, no kanban-service dependency (kanban-view must not
     /// depend on it).
-    fn board_with_sprints(names: &[&str]) -> (Board, Model) {
+    fn board_with_sprints(names: &[&str]) -> (Board, Vec<Sprint>, Model) {
         let mut board = Board::new("Test Board", None::<String>);
         let sprints: Vec<Sprint> = names
             .iter()
@@ -148,10 +148,10 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            sprints,
+            sprints.clone(),
             DependencyGraph::default(),
         ));
-        (board, model)
+        (board, sprints, model)
     }
 
     #[test]
@@ -192,9 +192,9 @@ mod tests {
 
     #[test]
     fn test_build_filter_title_parts_sprint_filter_formats_sprint_name() {
-        let (board, model) = board_with_sprints(&["Sprint"]);
+        let (board, sprints, model) = board_with_sprints(&["Sprint"]);
         let mut filter = FilterState::default();
-        filter.active_sprint_filters.insert(model.sprints()[0].id);
+        filter.active_sprint_filters.insert(sprints[0].id);
 
         let parts = build_filter_title_parts(&filter, &model, Some(&board));
         assert_eq!(parts.len(), 1, "one active sprint filter yields one label");
@@ -206,10 +206,10 @@ mod tests {
 
     #[test]
     fn test_build_filter_title_parts_multiple_sprint_filters_sorted() {
-        let (board, model) = board_with_sprints(&["Sprint A", "Sprint B"]);
+        let (board, sprints, model) = board_with_sprints(&["Sprint A", "Sprint B"]);
         let mut filter = FilterState::default();
-        filter.active_sprint_filters.insert(model.sprints()[0].id);
-        filter.active_sprint_filters.insert(model.sprints()[1].id);
+        filter.active_sprint_filters.insert(sprints[0].id);
+        filter.active_sprint_filters.insert(sprints[1].id);
 
         assert_eq!(
             build_filter_title_parts(&filter, &model, Some(&board)),

--- a/crates/kanban-view/src/panel_titles.rs
+++ b/crates/kanban-view/src/panel_titles.rs
@@ -100,7 +100,10 @@ pub fn build_tasks_panel_title(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kanban_domain::{Board, DependencyGraph, Snapshot, Sprint};
+    use kanban_domain::resolved::Collection;
+    use kanban_domain::{Board, DependencyGraph, KanbanError, LoadState, Resolved, Snapshot, Sprint};
+    use std::collections::HashMap;
+    use std::sync::Arc;
 
     /// Builds a board plus `names.len()` sprints on it (each named from
     /// `names`, in order), and a `Model` loaded from a snapshot containing
@@ -275,10 +278,108 @@ mod tests {
     fn test_build_tasks_panel_title_carries_no_terminal_hotkey_hint() {
         let filter = FilterState::default();
         let model = Model::default();
-        let title = build_tasks_panel_title(0, false, false, true, false, &filter, &model, None);
+        let title = build_tasks_panel_title(
+            PanelCount::Known(0),
+            false,
+            false,
+            true,
+            false,
+            &filter,
+            &model,
+            None,
+        );
         assert!(
             !format!("{:?}", title).contains("[2]"),
             "the [2] panel hotkey is a terminal concern, not view data"
         );
+    }
+
+    #[test]
+    fn test_build_tasks_panel_title_passes_the_count_through_unchanged() {
+        let filter = FilterState::default();
+        let model = Model::default();
+
+        for count in [
+            PanelCount::Known(3),
+            PanelCount::NotLoaded,
+            PanelCount::Failed,
+        ] {
+            let title =
+                build_tasks_panel_title(count, false, false, true, false, &filter, &model, None);
+            assert_eq!(title.count, count);
+        }
+    }
+
+    fn board_with_sprint_state(state: LoadState<Vec<Sprint>>) -> (Board, Model) {
+        let board = Board::new("Test Board", None::<String>);
+        let mut model = Model::default();
+        let resolved = Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board.clone()]),
+                ..Default::default()
+            },
+            sprints: Collection {
+                by_parent: HashMap::from([(board.id, state)]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = model.apply_resolved(resolved);
+        (board, model)
+    }
+
+    #[test]
+    fn test_an_active_sprint_filter_over_an_unloaded_sprint_tier_still_shows_a_filter_label() {
+        let (board, model) = board_with_sprint_state(LoadState::NotLoaded);
+        let mut filter = FilterState::default();
+        filter.active_sprint_filters.insert(uuid::Uuid::new_v4());
+
+        let parts = build_filter_title_parts(&filter, &model, Some(&board));
+        assert!(
+            !parts.is_empty(),
+            "an active sprint filter must show a label even when the sprint tier is not loaded"
+        );
+    }
+
+    #[test]
+    fn test_a_loaded_sprint_tier_still_shows_the_sprint_names() {
+        let sprint_a = Sprint::new(uuid::Uuid::new_v4(), 1, None, None::<String>);
+        let sprint_a_id = sprint_a.id;
+        let sprint_b = Sprint::new(uuid::Uuid::new_v4(), 2, None, None::<String>);
+        let (board, model) =
+            board_with_sprint_state(LoadState::Loaded(vec![sprint_a.clone(), sprint_b]));
+        let mut filter = FilterState::default();
+        filter.active_sprint_filters.insert(sprint_a_id);
+
+        let parts = build_filter_title_parts(&filter, &model, Some(&board));
+        assert_eq!(parts, vec![sprint_a.formatted_name(&board, None)]);
+    }
+
+    #[test]
+    fn test_a_failed_sprint_tier_shows_a_filter_label_rather_than_silence() {
+        let (board, model) = board_with_sprint_state(LoadState::Failed(Arc::new(
+            KanbanError::unsupported("boom"),
+        )));
+        let mut filter = FilterState::default();
+        filter.active_sprint_filters.insert(uuid::Uuid::new_v4());
+
+        let parts = build_filter_title_parts(&filter, &model, Some(&board));
+        assert!(
+            !parts.is_empty(),
+            "a failed sprint tier must still show a filter label, not silently drop it"
+        );
+    }
+
+    #[test]
+    fn test_no_active_sprint_filter_adds_no_label_regardless_of_load_state() {
+        for state in [
+            LoadState::NotLoaded,
+            LoadState::Loaded(vec![]),
+            LoadState::Failed(Arc::new(KanbanError::unsupported("boom"))),
+        ] {
+            let (board, model) = board_with_sprint_state(state);
+            let filter = FilterState::default();
+            assert!(build_filter_title_parts(&filter, &model, Some(&board)).is_empty());
+        }
     }
 }

--- a/crates/kanban-view/src/panel_titles.rs
+++ b/crates/kanban-view/src/panel_titles.rs
@@ -17,13 +17,22 @@ pub enum TasksPanelKind {
     UnfocusedTasks,
 }
 
+/// A tasks-panel entry count, distinguishing a genuinely empty collection
+/// from one whose load state means the count cannot be trusted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PanelCount {
+    Known(usize),
+    NotLoaded,
+    Failed,
+}
+
 /// Everything a renderer needs to title the tasks panel: which panel it is,
 /// how many entries it holds, and the active filter labels. Carries no
 /// separators, no counts baked into prose, and no keyboard hints.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TasksPanelTitle {
     pub kind: TasksPanelKind,
-    pub count: usize,
+    pub count: PanelCount,
     pub filters: Vec<String>,
 }
 
@@ -45,14 +54,23 @@ pub fn build_filter_title_parts(
 
     if !filter.active_sprint_filters.is_empty() {
         if let Some(board) = board {
-            let mut sprint_names: Vec<String> = model
-                .sprints()
-                .iter()
-                .filter(|s| filter.active_sprint_filters.contains(&s.id))
-                .map(|s| s.formatted_name(board, None))
-                .collect();
-            sprint_names.sort();
-            filters.extend(sprint_names);
+            match model.board_sprints_state(board.id) {
+                kanban_domain::LoadState::Loaded(sprints) => {
+                    let mut sprint_names: Vec<String> = sprints
+                        .iter()
+                        .filter(|s| filter.active_sprint_filters.contains(&s.id))
+                        .map(|s| s.formatted_name(board, None))
+                        .collect();
+                    sprint_names.sort();
+                    filters.extend(sprint_names);
+                }
+                _ => {
+                    filters.push(format!(
+                        "{} sprint filter(s)",
+                        filter.active_sprint_filters.len()
+                    ));
+                }
+            }
         }
     }
 
@@ -65,7 +83,7 @@ pub fn build_filter_title_parts(
 /// App-coupled state resolution and not the rendering.
 #[allow(clippy::too_many_arguments)]
 pub fn build_tasks_panel_title(
-    active_task_list_len: usize,
+    active_task_list: PanelCount,
     viewing_archived_board: bool,
     viewing_archived_cards: bool,
     focus_is_cards: bool,
@@ -92,7 +110,7 @@ pub fn build_tasks_panel_title(
 
     TasksPanelTitle {
         kind,
-        count: active_task_list_len,
+        count: active_task_list,
         filters,
     }
 }
@@ -101,7 +119,9 @@ pub fn build_tasks_panel_title(
 mod tests {
     use super::*;
     use kanban_domain::resolved::Collection;
-    use kanban_domain::{Board, DependencyGraph, KanbanError, LoadState, Resolved, Snapshot, Sprint};
+    use kanban_domain::{
+        Board, DependencyGraph, KanbanError, LoadState, Resolved, Snapshot, Sprint,
+    };
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -216,7 +236,16 @@ mod tests {
     fn test_build_tasks_panel_title_default_focus_not_cards() {
         let filter = FilterState::default();
         let model = Model::default();
-        let title = build_tasks_panel_title(0, false, false, false, false, &filter, &model, None);
+        let title = build_tasks_panel_title(
+            PanelCount::Known(0),
+            false,
+            false,
+            false,
+            false,
+            &filter,
+            &model,
+            None,
+        );
         assert_eq!(title.kind, TasksPanelKind::UnfocusedTasks);
         assert!(title.filters.is_empty());
     }
@@ -225,27 +254,54 @@ mod tests {
     fn test_build_tasks_panel_title_archived_cards_view() {
         let filter = FilterState::default();
         let model = Model::default();
-        let title = build_tasks_panel_title(3, false, true, false, false, &filter, &model, None);
+        let title = build_tasks_panel_title(
+            PanelCount::Known(3),
+            false,
+            true,
+            false,
+            false,
+            &filter,
+            &model,
+            None,
+        );
         assert_eq!(title.kind, TasksPanelKind::Archive);
-        assert_eq!(title.count, 3);
+        assert_eq!(title.count, PanelCount::Known(3));
     }
 
     #[test]
     fn test_build_tasks_panel_title_archived_board_takes_precedence_over_focus() {
         let filter = FilterState::default();
         let model = Model::default();
-        let title = build_tasks_panel_title(5, true, false, false, false, &filter, &model, None);
+        let title = build_tasks_panel_title(
+            PanelCount::Known(5),
+            true,
+            false,
+            false,
+            false,
+            &filter,
+            &model,
+            None,
+        );
         assert_eq!(title.kind, TasksPanelKind::ArchivedBoardTasks);
-        assert_eq!(title.count, 5);
+        assert_eq!(title.count, PanelCount::Known(5));
     }
 
     #[test]
     fn test_build_tasks_panel_title_cards_focus() {
         let filter = FilterState::default();
         let model = Model::default();
-        let title = build_tasks_panel_title(0, false, false, true, false, &filter, &model, None);
+        let title = build_tasks_panel_title(
+            PanelCount::Known(0),
+            false,
+            false,
+            true,
+            false,
+            &filter,
+            &model,
+            None,
+        );
         assert_eq!(title.kind, TasksPanelKind::FocusedTasks);
-        assert_eq!(title.count, 0);
+        assert_eq!(title.count, PanelCount::Known(0));
     }
 
     #[test]
@@ -255,7 +311,16 @@ mod tests {
             ..Default::default()
         };
         let model = Model::default();
-        let title = build_tasks_panel_title(0, false, false, false, true, &filter, &model, None);
+        let title = build_tasks_panel_title(
+            PanelCount::Known(0),
+            false,
+            false,
+            false,
+            true,
+            &filter,
+            &model,
+            None,
+        );
         assert_eq!(title.filters, vec!["Unassigned Cards".to_string()]);
     }
 
@@ -266,7 +331,16 @@ mod tests {
             ..Default::default()
         };
         let model = Model::default();
-        let title = build_tasks_panel_title(0, false, true, false, true, &filter, &model, None);
+        let title = build_tasks_panel_title(
+            PanelCount::Known(0),
+            false,
+            true,
+            false,
+            true,
+            &filter,
+            &model,
+            None,
+        );
         assert_eq!(title.kind, TasksPanelKind::Archive);
         assert!(
             title.filters.is_empty(),


### PR DESCRIPTION
## Summary

- `TasksPanelTitle.count` (`kanban-view`) is now a `PanelCount` enum (`Known(usize)` / `NotLoaded` / `Failed`) instead of a bare `usize`, so the tasks panel title never prints a confident `(0)` for a card, column, or sprint tier that has not loaded or has failed to load.
- `build_filter_title_parts` resolves active sprint filter names through the board-scoped `Model::board_sprints_state`, instead of the collapsing `Model::sprints()`, so an active sprint filter always shows a label regardless of that tier's load state.
- `tasks_panel_title` in `kanban-tui` builds `PanelCount` from `Model::cards_state()`, gated on `Model::columns_state()` and `Model::sprints_state()` both being `Loaded`, mirroring the same condition `prepare_frame` already uses to decide whether to refresh the active task list.
- `format_tasks_panel_title` renders `NotLoaded` as `…` and `Failed` as `!` in the count position, for both the parenthesized and bracketed forms.
- Repaired every pre-existing `build_tasks_panel_title` call site and `title.count` assertion broken by the type change, in both `kanban-view`'s inline tests and `kanban-tui`'s `panel_title_tests.rs`.

## Test plan

- [x] `cargo test -p kanban-view --lib` green
- [x] `cargo test -p kanban-tui --all-features` green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] New tests confirmed red before the fix (compile failures against the old `usize` type and the collapsing `Model::sprints()` accessor)
- [x] Mutation-checked the columns/sprints gating condition and the sprint-label fallback path; both catch a reverted fix
