### PR TITLE
KAN-1429 feat(tui): render the first frame on two scoped populate passes

### DIFF
--- a/.changeset/kan-1429-render-first-frame-partially-loaded.md
+++ b/.changeset/kan-1429-render-first-frame-partially-loaded.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+tui: `App::load_initial_state` now runs two scoped `populate` passes over the board list and the auto-selected board's subtree instead of one whole-store `snapshot` read, and `check_ended_sprints` declines on a `NotLoaded` sprint tier instead of scanning it through the collapsing `Model::sprints()` accessor.

--- a/.changeset/kan-1429-render-first-frame-partially-loaded.md
+++ b/.changeset/kan-1429-render-first-frame-partially-loaded.md
@@ -2,4 +2,4 @@
 bump: minor
 ---
 
-tui: `App::load_initial_state` now runs two scoped `populate` passes over the board list and the auto-selected board's subtree instead of one whole-store `snapshot` read, and `check_ended_sprints` declines on a `NotLoaded` sprint tier instead of scanning it through the collapsing `Model::sprints()` accessor.
+domain, tui: `App::load_initial_state` now runs two scoped `populate` passes over the board list and the auto-selected board's subtree instead of one whole-store `snapshot` read, and `check_ended_sprints` declines on a `NotLoaded` sprint tier instead of scanning it through the collapsing `Model::sprints()` accessor. Startup no longer loads archival markers at all; entering the archived-boards or archived-cards view instead triggers a `reload_model` snapshot on first entry, gated by the new `Model::archived_boards_absorbed` / `Model::archived_card_markers_absorbed` predicates so a later mutation-driven reload is not repeated.

--- a/crates/kanban-domain/src/model/boards.rs
+++ b/crates/kanban-domain/src/model/boards.rs
@@ -21,6 +21,12 @@ impl Model {
         self.archived_boards.as_deref().unwrap_or(&[])
     }
 
+    /// Distinguishes a genuinely empty archived-boards tier from one that has
+    /// never been absorbed (`archived_boards()` returns `&[]` for both).
+    pub fn archived_boards_absorbed(&self) -> bool {
+        self.archived_boards.is_some()
+    }
+
     /// Ids of the archived boards. The heads themselves live in the unified
     /// `boards_state()` collection; this set records which of them are archived (built
     /// from the markers). The live/archived partition is a presentation concern
@@ -60,6 +66,19 @@ mod tests {
             .loaded()
             .copied()
             .is_none());
+    }
+
+    #[test]
+    fn test_archived_boards_absorbed_distinguishes_never_loaded_from_genuinely_empty() {
+        let mut m = Model::default();
+        assert!(!m.archived_boards_absorbed());
+
+        let _ = m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+        assert!(m.archived_boards().is_empty());
+        assert!(m.archived_boards_absorbed());
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -75,6 +75,12 @@ impl Model {
         self.archived_cards.as_deref().unwrap_or(&[])
     }
 
+    /// Distinguishes a genuinely empty archived-cards tier from one that has
+    /// never been absorbed (`archived_card_markers()` returns `&[]` for both).
+    pub fn archived_card_markers_absorbed(&self) -> bool {
+        self.archived_cards.is_some()
+    }
+
     /// Ids of the archived cards. Rows themselves live in the unified `cards_state()`
     /// collection; this set records which of them are archived (built from the
     /// markers). The live/archived partition is a presentation concern and lives
@@ -108,6 +114,19 @@ mod tests {
 
     fn make_card(board: &Board, column_id: Uuid) -> Card {
         Card::new(board.id, column_id, "task", 0)
+    }
+
+    #[test]
+    fn test_archived_card_markers_absorbed_distinguishes_never_loaded_from_genuinely_empty() {
+        let mut m = Model::default();
+        assert!(!m.archived_card_markers_absorbed());
+
+        let _ = m.load_from_snapshot(Snapshot {
+            archived_cards: Vec::new(),
+            ..Default::default()
+        });
+        assert!(m.archived_card_markers().is_empty());
+        assert!(m.archived_card_markers_absorbed());
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -156,51 +156,6 @@ impl Model {
         }
     }
 
-    /// Replaces the archival marker tiers outside a full snapshot load, for a
-    /// caller that fetches only `list_archived_cards`/`list_archived_boards`
-    /// rather than the whole store.
-    pub fn set_archival_markers(
-        &mut self,
-        cards: Vec<ArchivedCard>,
-        boards: Vec<ArchivedBoard>,
-    ) -> ModelChanged {
-        self.absorb_archival_markers(Some(cards), Some(boards));
-        ModelChanged::new()
-    }
-
-    /// Folds archived board heads into the flat board tier: `list_boards`
-    /// excludes them, so a caller that fetched them by id (unfiltered) merges
-    /// them in here. A no-op when `boards` is not `Loaded`.
-    pub fn merge_archived_boards(&mut self, boards: Vec<Board>) -> ModelChanged {
-        if let LoadState::Loaded(existing) = &mut self.boards {
-            for board in boards {
-                match existing.iter_mut().find(|b| b.id == board.id) {
-                    Some(slot) => *slot = board,
-                    None => existing.push(board),
-                }
-            }
-        }
-        self.rebuild_board_index();
-        ModelChanged::new()
-    }
-
-    /// Folds archived cards into the flat card tier: `list_all_cards`/
-    /// `list_cards_by_column` exclude them, so a caller that fetched them by
-    /// id (unfiltered) merges them in here. A no-op when `cards` is not
-    /// `Loaded`.
-    pub fn merge_archived_cards(&mut self, cards: Vec<Card>) -> ModelChanged {
-        if let LoadState::Loaded(existing) = &mut self.cards {
-            for card in cards {
-                match existing.iter_mut().find(|c| c.id == card.id) {
-                    Some(slot) => *slot = card,
-                    None => existing.push(card),
-                }
-            }
-        }
-        self.rebuild_card_index();
-        ModelChanged::new()
-    }
-
     fn absorb_archival_markers(
         &mut self,
         cards: Option<Vec<ArchivedCard>>,
@@ -266,82 +221,6 @@ mod tests {
         assert!(m.sprints().is_empty());
         assert!(m.archived_card_markers().is_empty());
         assert!(m.archived_card_ids().is_empty());
-    }
-
-    #[test]
-    fn test_set_archival_markers_populates_archived_ids_without_touching_other_tiers() {
-        let mut m = Model::default();
-        let board = Board::new("B", None::<String>);
-        let _ = m.load_from_snapshot(Snapshot {
-            boards: vec![board.clone()],
-            ..Default::default()
-        });
-
-        let archived_card_id = Uuid::new_v4();
-        let archived_board_id = Uuid::new_v4();
-        let ac = ArchivedCard::new(archived_card_id, board.id);
-        let ab = ArchivedBoard::at(archived_board_id, chrono::Utc::now());
-
-        let _ = m.set_archival_markers(vec![ac], vec![ab]);
-
-        assert!(m.archived_card_ids().contains(&archived_card_id));
-        assert!(m.archived_board_ids().contains(&archived_board_id));
-        assert_eq!(m.boards_state().loaded_or_empty().len(), 1);
-        assert_eq!(m.boards_state().loaded_or_empty()[0].id, board.id);
-    }
-
-    #[test]
-    fn test_merge_archived_boards_appends_a_board_missing_from_the_live_list_tier() {
-        let mut m = Model::default();
-        let live = Board::new("Live", None::<String>);
-        let _ = m.load_from_snapshot(Snapshot {
-            boards: vec![live.clone()],
-            ..Default::default()
-        });
-
-        let archived = Board::new("Archived", None::<String>);
-        let _ = m.merge_archived_boards(vec![archived.clone()]);
-
-        let ids: Vec<Uuid> = m
-            .boards_state()
-            .loaded_or_empty()
-            .iter()
-            .map(|b| b.id)
-            .collect();
-        assert!(ids.contains(&live.id));
-        assert!(ids.contains(&archived.id));
-        assert_eq!(
-            m.board_by_id_state(archived.id).loaded().map(|b| b.id),
-            Some(archived.id)
-        );
-    }
-
-    #[test]
-    fn test_merge_archived_cards_appends_a_card_missing_from_the_live_list_tier() {
-        let mut m = Model::default();
-        let board = Board::new("B", None::<String>);
-        let live_card = make_card(&board, Uuid::new_v4());
-        let _ = m.load_from_snapshot(Snapshot {
-            boards: vec![board.clone()],
-            cards: vec![live_card.clone()],
-            ..Default::default()
-        });
-
-        let archived_card = make_card(&board, Uuid::new_v4());
-        let _ = m.merge_archived_cards(vec![archived_card.clone()]);
-
-        let ids: Vec<Uuid> = m
-            .cards_state()
-            .loaded_or_empty()
-            .iter()
-            .map(|c| c.id)
-            .collect();
-        assert!(ids.contains(&live_card.id));
-        assert!(ids.contains(&archived_card.id));
-        assert_eq!(
-            m.card_by_id_state(archived_card.id).loaded().map(|c| c.id),
-            Some(archived_card.id)
-        );
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -156,6 +156,51 @@ impl Model {
         }
     }
 
+    /// Replaces the archival marker tiers outside a full snapshot load, for a
+    /// caller that fetches only `list_archived_cards`/`list_archived_boards`
+    /// rather than the whole store.
+    pub fn set_archival_markers(
+        &mut self,
+        cards: Vec<ArchivedCard>,
+        boards: Vec<ArchivedBoard>,
+    ) -> ModelChanged {
+        self.absorb_archival_markers(Some(cards), Some(boards));
+        ModelChanged::new()
+    }
+
+    /// Folds archived board heads into the flat board tier: `list_boards`
+    /// excludes them, so a caller that fetched them by id (unfiltered) merges
+    /// them in here. A no-op when `boards` is not `Loaded`.
+    pub fn merge_archived_boards(&mut self, boards: Vec<Board>) -> ModelChanged {
+        if let LoadState::Loaded(existing) = &mut self.boards {
+            for board in boards {
+                match existing.iter_mut().find(|b| b.id == board.id) {
+                    Some(slot) => *slot = board,
+                    None => existing.push(board),
+                }
+            }
+        }
+        self.rebuild_board_index();
+        ModelChanged::new()
+    }
+
+    /// Folds archived cards into the flat card tier: `list_all_cards`/
+    /// `list_cards_by_column` exclude them, so a caller that fetched them by
+    /// id (unfiltered) merges them in here. A no-op when `cards` is not
+    /// `Loaded`.
+    pub fn merge_archived_cards(&mut self, cards: Vec<Card>) -> ModelChanged {
+        if let LoadState::Loaded(existing) = &mut self.cards {
+            for card in cards {
+                match existing.iter_mut().find(|c| c.id == card.id) {
+                    Some(slot) => *slot = card,
+                    None => existing.push(card),
+                }
+            }
+        }
+        self.rebuild_card_index();
+        ModelChanged::new()
+    }
+
     fn absorb_archival_markers(
         &mut self,
         cards: Option<Vec<ArchivedCard>>,

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -269,6 +269,82 @@ mod tests {
     }
 
     #[test]
+    fn test_set_archival_markers_populates_archived_ids_without_touching_other_tiers() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board.clone()],
+            ..Default::default()
+        });
+
+        let archived_card_id = Uuid::new_v4();
+        let archived_board_id = Uuid::new_v4();
+        let ac = ArchivedCard::new(archived_card_id, board.id);
+        let ab = ArchivedBoard::at(archived_board_id, chrono::Utc::now());
+
+        let _ = m.set_archival_markers(vec![ac], vec![ab]);
+
+        assert!(m.archived_card_ids().contains(&archived_card_id));
+        assert!(m.archived_board_ids().contains(&archived_board_id));
+        assert_eq!(m.boards_state().loaded_or_empty().len(), 1);
+        assert_eq!(m.boards_state().loaded_or_empty()[0].id, board.id);
+    }
+
+    #[test]
+    fn test_merge_archived_boards_appends_a_board_missing_from_the_live_list_tier() {
+        let mut m = Model::default();
+        let live = Board::new("Live", None::<String>);
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![live.clone()],
+            ..Default::default()
+        });
+
+        let archived = Board::new("Archived", None::<String>);
+        let _ = m.merge_archived_boards(vec![archived.clone()]);
+
+        let ids: Vec<Uuid> = m
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .map(|b| b.id)
+            .collect();
+        assert!(ids.contains(&live.id));
+        assert!(ids.contains(&archived.id));
+        assert_eq!(
+            m.board_by_id_state(archived.id).loaded().map(|b| b.id),
+            Some(archived.id)
+        );
+    }
+
+    #[test]
+    fn test_merge_archived_cards_appends_a_card_missing_from_the_live_list_tier() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let live_card = make_card(&board, Uuid::new_v4());
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board.clone()],
+            cards: vec![live_card.clone()],
+            ..Default::default()
+        });
+
+        let archived_card = make_card(&board, Uuid::new_v4());
+        let _ = m.merge_archived_cards(vec![archived_card.clone()]);
+
+        let ids: Vec<Uuid> = m
+            .cards_state()
+            .loaded_or_empty()
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert!(ids.contains(&live_card.id));
+        assert!(ids.contains(&archived_card.id));
+        assert_eq!(
+            m.card_by_id_state(archived_card.id).loaded().map(|c| c.id),
+            Some(archived_card.id)
+        );
+    }
+
+    #[test]
     fn test_load_from_snapshot_populates_boards_and_columns() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);

--- a/crates/kanban-tui/Cargo.toml
+++ b/crates/kanban-tui/Cargo.toml
@@ -44,4 +44,5 @@ test-helpers = []
 
 [dev-dependencies]
 kanban-domain = { path = "../kanban-domain", features = ["test-helpers"] }
+kanban-service = { path = "../kanban-service", features = ["test-helpers"] }
 tempfile = "3.13"

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -34,6 +34,7 @@ impl App {
         self.prepare_frame();
 
         self.populate(self.view_scope());
+        self.populate_archival_markers();
         self.prepare_frame();
         self.check_ended_sprints();
     }

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -34,7 +34,6 @@ impl App {
         self.prepare_frame();
 
         self.populate(self.view_scope());
-        self.populate_archival_markers();
         self.prepare_frame();
         self.check_ended_sprints();
     }

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -1,4 +1,4 @@
-use super::{App, AppMode, DialogMode, MigrationState};
+use super::{App, AppMode, DialogMode, MigrationState, ViewScope};
 use crate::{
     events::{Event, EventHandler},
     ui,
@@ -7,35 +7,33 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use kanban_domain::KanbanResult;
+use kanban_domain::{KanbanResult, LoadState};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
 impl App {
     #[doc(hidden)]
     pub async fn load_initial_state(&mut self) {
-        // Trigger the lazy data load eagerly so file errors are caught here.
-        // On error, clear save_file to avoid writing back to a broken file.
-        let snapshot = match self.ctx.snapshot() {
-            Ok(snapshot) => snapshot,
-            Err(e) => {
-                tracing::warn!("Failed to load initial state from file: {e}");
-                self.persistence.save_file = None;
-                self.set_error(format!("Failed to read data file: {e}"));
-                return;
-            }
-        };
-        let migrated = self.migrate_sprint_logs();
+        self.migrate_sprint_logs();
         // Migration is a transparent startup operation, not a user change.
         // mark_clean so the startup flush doesn't trigger the conflict popup.
         self.ctx.mark_clean();
+
+        self.populate(ViewScope {
+            board_list: true,
+            ..Default::default()
+        });
+        if let LoadState::Failed(e) = self.model.boards_state() {
+            tracing::warn!("Failed to load initial state from file: {e}");
+            self.persistence.save_file = None;
+            self.set_error(format!("Failed to read data file: {e}"));
+            return;
+        }
         // `prepare_frame` resyncs `board_list`, which auto-selects the first
         // board when none was previously highlighted and boards exist.
-        if migrated > 0 {
-            self.reload_model();
-        } else {
-            self.load_snapshot(snapshot);
-        }
+        self.prepare_frame();
+
+        self.populate(self.view_scope());
         self.prepare_frame();
         self.check_ended_sprints();
     }

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -3,9 +3,9 @@ use kanban_domain::LoadState;
 use uuid::Uuid;
 
 impl App {
-    pub(in crate::app) fn check_ended_sprints(&self) -> Vec<Uuid> {
+    pub(in crate::app) fn check_ended_sprints(&self) -> Option<Vec<Uuid>> {
         let LoadState::Loaded(sprints) = self.model.sprints_state() else {
-            return Vec::new();
+            return None;
         };
         let ended_sprints: Vec<_> = sprints
             .iter()
@@ -37,7 +37,7 @@ impl App {
             }
         }
 
-        ended_sprints.into_iter().map(|s| s.id).collect()
+        Some(ended_sprints.into_iter().map(|s| s.id).collect())
     }
 
     pub(in crate::app) fn migrate_sprint_logs(&mut self) -> usize {
@@ -80,7 +80,10 @@ mod tests {
 
         let ended = app.check_ended_sprints();
 
-        assert!(ended.is_empty());
+        assert_eq!(
+            ended, None,
+            "a NotLoaded sprint tier must decline to scan, not report zero ended sprints"
+        );
     }
 
     #[test]
@@ -92,6 +95,6 @@ mod tests {
 
         let ended = app.check_ended_sprints();
 
-        assert_eq!(ended, vec![sprint_id]);
+        assert_eq!(ended, Some(vec![sprint_id]));
     }
 }

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -1,10 +1,13 @@
 use super::App;
+use kanban_domain::LoadState;
+use uuid::Uuid;
 
 impl App {
-    pub(in crate::app) fn check_ended_sprints(&self) {
-        let ended_sprints: Vec<_> = self
-            .model
-            .sprints()
+    pub(in crate::app) fn check_ended_sprints(&self) -> Vec<Uuid> {
+        let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+            return Vec::new();
+        };
+        let ended_sprints: Vec<_> = sprints
             .iter()
             .filter(|s| s.is_ended(chrono::Utc::now()))
             .collect();
@@ -33,6 +36,8 @@ impl App {
                 }
             }
         }
+
+        ended_sprints.into_iter().map(|s| s.id).collect()
     }
 
     pub(in crate::app) fn migrate_sprint_logs(&mut self) -> usize {
@@ -43,5 +48,50 @@ impl App {
                 0
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::App;
+    use kanban_domain::{FieldUpdate, KanbanOperations, LoadState, SprintStatus, SprintUpdate};
+
+    fn seed_ended_sprint(app: &mut App) -> uuid::Uuid {
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+        app.ctx
+            .update_sprint(
+                sprint.id,
+                SprintUpdate {
+                    status: Some(SprintStatus::Active),
+                    end_date: FieldUpdate::Set(chrono::Utc::now() - chrono::Duration::days(1)),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        sprint.id
+    }
+
+    #[test]
+    fn test_check_ended_sprints_does_not_scan_an_unloaded_sprint_tier() {
+        let mut app = App::test_default();
+        seed_ended_sprint(&mut app);
+        assert!(matches!(app.model.sprints_state(), LoadState::NotLoaded));
+
+        let ended = app.check_ended_sprints();
+
+        assert!(ended.is_empty());
+    }
+
+    #[test]
+    fn test_check_ended_sprints_reports_ended_sprints_in_the_loaded_tier() {
+        let mut app = App::test_default();
+        let sprint_id = seed_ended_sprint(&mut app);
+        let _ = app.model.load_from_snapshot(app.ctx.snapshot().unwrap());
+        assert!(matches!(app.model.sprints_state(), LoadState::Loaded(_)));
+
+        let ended = app.check_ended_sprints();
+
+        assert_eq!(ended, vec![sprint_id]);
     }
 }

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -1,8 +1,8 @@
 use super::{App, AppMode, ViewScope};
 use crate::view_strategy::UnifiedViewStrategy;
 use kanban_domain::{
-    filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, KanbanOperations,
-    KanbanResult, LoadState, Snapshot,
+    filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, KanbanResult,
+    LoadState, Snapshot,
 };
 use kanban_view::view_strategy::{ViewRefreshContext, ViewStrategy};
 use std::collections::HashMap;
@@ -13,49 +13,6 @@ impl App {
     /// resyncing the controller's derived partitions.
     pub fn populate(&mut self, scope: ViewScope) {
         self.ctx.sync(&scope, &mut self.model, &mut self.controller);
-    }
-
-    /// Loads the archival marker tiers (which board/card ids are archived)
-    /// via two scoped reads, without touching any other tier. `ViewScope`
-    /// has no producer for these yet, so this is the interim path until the
-    /// fetch plan grows one.
-    pub fn populate_archival_markers(&mut self) {
-        let card_markers = self.ctx.list_archived_cards().unwrap_or_else(|e| {
-            tracing::warn!("Failed to load archived card markers: {e}");
-            Vec::new()
-        });
-        let board_markers = self.ctx.list_archived_boards().unwrap_or_else(|e| {
-            tracing::warn!("Failed to load archived board markers: {e}");
-            Vec::new()
-        });
-        let archived_board_heads: Vec<Board> = board_markers
-            .iter()
-            .filter_map(|marker| match self.ctx.get_board(marker.entity_id) {
-                Ok(board) => board,
-                Err(e) => {
-                    tracing::warn!("Failed to load archived board {}: {e}", marker.entity_id);
-                    None
-                }
-            })
-            .collect();
-        let archived_card_bodies: Vec<Card> = card_markers
-            .iter()
-            .filter_map(|marker| match self.ctx.get_card(marker.entity_id) {
-                Ok(card) => card,
-                Err(e) => {
-                    tracing::warn!("Failed to load archived card {}: {e}", marker.entity_id);
-                    None
-                }
-            })
-            .collect();
-
-        let changed_markers = self.model.set_archival_markers(card_markers, board_markers);
-        let changed_boards = self.model.merge_archived_boards(archived_board_heads);
-        let changed_cards = self.model.merge_archived_cards(archived_card_bodies);
-        self.controller.resync(
-            &self.model,
-            changed_markers.merge(changed_boards).merge(changed_cards),
-        );
     }
 
     /// Resolve the board the user is currently acting on / viewing, by identity.

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -1,4 +1,4 @@
-use super::{App, AppMode};
+use super::{App, AppMode, ViewScope};
 use crate::view_strategy::UnifiedViewStrategy;
 use kanban_domain::{
     filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, KanbanResult,
@@ -9,6 +9,12 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 impl App {
+    /// Runs `scope` against the store and folds the result into `self.model`,
+    /// resyncing the controller's derived partitions.
+    pub fn populate(&mut self, scope: ViewScope) {
+        self.ctx.sync(&scope, &mut self.model, &mut self.controller);
+    }
+
     /// Resolve the board the user is currently acting on / viewing, by identity.
     /// This is the single, archival-agnostic active-board accessor every
     /// operation and view uses: a board is a board whether its head is live or

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -1,8 +1,8 @@
 use super::{App, AppMode, ViewScope};
 use crate::view_strategy::UnifiedViewStrategy;
 use kanban_domain::{
-    filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, KanbanResult,
-    LoadState, Snapshot,
+    filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, KanbanOperations,
+    KanbanResult, LoadState, Snapshot,
 };
 use kanban_view::view_strategy::{ViewRefreshContext, ViewStrategy};
 use std::collections::HashMap;
@@ -13,6 +13,49 @@ impl App {
     /// resyncing the controller's derived partitions.
     pub fn populate(&mut self, scope: ViewScope) {
         self.ctx.sync(&scope, &mut self.model, &mut self.controller);
+    }
+
+    /// Loads the archival marker tiers (which board/card ids are archived)
+    /// via two scoped reads, without touching any other tier. `ViewScope`
+    /// has no producer for these yet, so this is the interim path until the
+    /// fetch plan grows one.
+    pub fn populate_archival_markers(&mut self) {
+        let card_markers = self.ctx.list_archived_cards().unwrap_or_else(|e| {
+            tracing::warn!("Failed to load archived card markers: {e}");
+            Vec::new()
+        });
+        let board_markers = self.ctx.list_archived_boards().unwrap_or_else(|e| {
+            tracing::warn!("Failed to load archived board markers: {e}");
+            Vec::new()
+        });
+        let archived_board_heads: Vec<Board> = board_markers
+            .iter()
+            .filter_map(|marker| match self.ctx.get_board(marker.entity_id) {
+                Ok(board) => board,
+                Err(e) => {
+                    tracing::warn!("Failed to load archived board {}: {e}", marker.entity_id);
+                    None
+                }
+            })
+            .collect();
+        let archived_card_bodies: Vec<Card> = card_markers
+            .iter()
+            .filter_map(|marker| match self.ctx.get_card(marker.entity_id) {
+                Ok(card) => card,
+                Err(e) => {
+                    tracing::warn!("Failed to load archived card {}: {e}", marker.entity_id);
+                    None
+                }
+            })
+            .collect();
+
+        let changed_markers = self.model.set_archival_markers(card_markers, board_markers);
+        let changed_boards = self.model.merge_archived_boards(archived_board_heads);
+        let changed_cards = self.model.merge_archived_cards(archived_card_bodies);
+        self.controller.resync(
+            &self.model,
+            changed_markers.merge(changed_boards).merge(changed_cards),
+        );
     }
 
     /// Resolve the board the user is currently acting on / viewing, by identity.

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -293,6 +293,9 @@ impl App {
                 // Toggling the displayed set returns to the projects list; any
                 // board that was open is no longer active.
                 self.selection.active_board_id = None;
+                if !self.model.archived_boards_absorbed() {
+                    self.reload_model();
+                }
                 // `prepare_frame` resyncs `board_list` from the new (archived)
                 // partition; the previously highlighted live board's id is not in
                 // it, so `BoardList::update_boards` falls back to the first

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -941,6 +941,9 @@ impl App {
         // which would strand a drilled-in archived board.
         if entering {
             self.push_mode(AppMode::ArchivedCardsView);
+            if !self.model.archived_card_markers_absorbed() {
+                self.reload_model();
+            }
         } else {
             self.pop_mode();
         }

--- a/crates/kanban-tui/tests/cold_start_reload_tests.rs
+++ b/crates/kanban-tui/tests/cold_start_reload_tests.rs
@@ -1,25 +1,28 @@
 mod helpers;
 
-use helpers::{create_test_json_file, SnapshotCountingBackend};
+use helpers::{create_test_json_file, CountingBackend};
 use kanban_domain::{Column, Snapshot, Sprint};
 use kanban_tui::App;
-use std::sync::atomic::Ordering;
 
 #[tokio::test]
-async fn test_cold_start_reads_the_whole_workspace_once() {
+async fn test_cold_start_scopes_reads_to_the_auto_selected_board_instead_of_the_whole_workspace() {
     let dir = tempfile::tempdir().unwrap();
     let path = create_test_json_file(dir.path(), "source.json", &["Board"]).await;
     let (mut app, _rx) = App::new(Some(path)).await.unwrap();
 
-    let (backend, snapshot_reads) = SnapshotCountingBackend::wrap(app.ctx.backend());
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
     app.ctx.replace_backend(backend);
 
     app.load_initial_state().await;
 
-    assert_eq!(
-        snapshot_reads.load(Ordering::SeqCst),
-        1,
-        "cold start must read the whole workspace exactly once"
+    let ops = ops.lock().unwrap().clone();
+    assert!(
+        !ops.iter().any(|op| op.method == "snapshot"),
+        "cold start must not bulk-read the whole workspace via snapshot, got {ops:?}"
+    );
+    assert!(
+        ops.iter().any(|op| op.method == "list_boards"),
+        "expected a scoped list_boards read, got {ops:?}"
     );
     let board_present = app
         .model

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use kanban_backend::{KanbanBackend, RemoteWrites, TransactionFn};
+use kanban_domain::KanbanError;
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, CommandBatch, CommandStore, DataStore,
     DependencyGraph, KanbanResult, Snapshot, Sprint,
@@ -9,6 +10,7 @@ use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::app::ExportDialogState;
 use kanban_tui::App;
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
@@ -44,6 +46,7 @@ pub struct CountingBackend {
     inner: Arc<dyn KanbanBackend>,
     reads: Arc<AtomicUsize>,
     ops: ReadOpLog,
+    failing: Arc<Mutex<HashSet<&'static str>>>,
 }
 
 impl CountingBackend {
@@ -54,13 +57,37 @@ impl CountingBackend {
             inner,
             reads: reads.clone(),
             ops: ops.clone(),
+            failing: Arc::new(Mutex::new(HashSet::new())),
         });
         (backend, reads, ops)
+    }
+
+    /// Wraps `inner` so `method` returns an error whenever it is called.
+    /// The call still appears in the op log.
+    pub fn wrap_failing(
+        inner: Arc<dyn KanbanBackend>,
+        method: &'static str,
+    ) -> Arc<dyn KanbanBackend> {
+        let mut failing = HashSet::new();
+        failing.insert(method);
+        Arc::new(Self {
+            inner,
+            reads: Arc::new(AtomicUsize::new(0)),
+            ops: Arc::new(Mutex::new(Vec::new())),
+            failing: Arc::new(Mutex::new(failing)),
+        })
     }
 
     fn record(&self, method: &'static str, ids: Vec<Uuid>) {
         self.reads.fetch_add(1, Ordering::SeqCst);
         self.ops.lock().unwrap().push(ReadOp { method, ids });
+    }
+
+    fn fault(&self, method: &'static str) -> KanbanResult<()> {
+        if self.failing.lock().unwrap().contains(method) {
+            return Err(KanbanError::Database(format!("injected fault: {method}")));
+        }
+        Ok(())
     }
 }
 
@@ -82,6 +109,7 @@ impl DataStore for CountingBackend {
     }
     fn list_boards(&self) -> KanbanResult<Vec<Board>> {
         self.record("list_boards", vec![]);
+        self.fault("list_boards")?;
         self.inner.list_boards()
     }
     fn upsert_board(&self, board: Board) -> KanbanResult<()> {

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -1,0 +1,153 @@
+mod helpers;
+
+use helpers::{CountingBackend, ReadOp};
+use kanban_domain::{KanbanOperations, LoadState};
+use kanban_tui::App;
+
+struct SeededBoard {
+    id: uuid::Uuid,
+}
+
+fn seed_board_with_subtree(app: &mut App, name: &str) -> SeededBoard {
+    let board = app.ctx.create_board(name.to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
+        .create_sprint(board.id, None, Some("Sprint".to_string()))
+        .unwrap();
+    SeededBoard { id: board.id }
+}
+
+#[tokio::test]
+async fn test_startup_does_not_read_the_whole_store() {
+    let mut app = App::test_default();
+    let board1 = seed_board_with_subtree(&mut app, "Board 1");
+    let _board2 = seed_board_with_subtree(&mut app, "Board 2");
+
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+
+    app.load_initial_state().await;
+
+    let ops = ops.lock().unwrap().clone();
+
+    assert!(
+        ops.iter().any(|op| op.method == "list_boards"),
+        "expected a list_boards op, got {ops:?}"
+    );
+    assert!(
+        !ops.iter().any(|op| op.method == "snapshot"),
+        "startup must not read the whole workspace via a single snapshot call, got {ops:?}"
+    );
+    assert!(
+        ops.iter().all(|op| {
+            if matches!(
+                op.method,
+                "list_columns_by_board" | "list_sprints_by_board" | "list_cards_by_column"
+            ) {
+                op.method == "list_cards_by_column" || op.ids == vec![board1.id]
+            } else {
+                true
+            }
+        }),
+        "expected board-scoped reads to target only the auto-selected board: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_startup_reads_the_board_list_before_the_auto_selected_boards_columns() {
+    let mut app = App::test_default();
+    let _board1 = seed_board_with_subtree(&mut app, "Board 1");
+
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+
+    app.load_initial_state().await;
+
+    let ops = ops.lock().unwrap().clone();
+    let boards_pos = ops
+        .iter()
+        .position(|op: &ReadOp| op.method == "list_boards");
+    let columns_pos = ops
+        .iter()
+        .position(|op| op.method == "list_columns_by_board");
+    assert!(
+        boards_pos.is_some() && columns_pos.is_some() && boards_pos < columns_pos,
+        "expected list_boards strictly before the board-scoped column read, got {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_an_unvisited_boards_tiers_stay_not_loaded_after_startup() {
+    let mut app = App::test_default();
+    let _board1 = seed_board_with_subtree(&mut app, "Board 1");
+    let board2 = seed_board_with_subtree(&mut app, "Board 2");
+
+    app.load_initial_state().await;
+
+    assert!(matches!(
+        app.model.board_columns_state(board2.id),
+        LoadState::NotLoaded
+    ));
+    assert!(matches!(
+        app.model.board_sprints_state(board2.id),
+        LoadState::NotLoaded
+    ));
+}
+
+#[tokio::test]
+async fn test_startup_loads_the_auto_selected_boards_subtree() {
+    let mut app = App::test_default();
+    let board1 = seed_board_with_subtree(&mut app, "Board 1");
+
+    app.load_initial_state().await;
+
+    assert!(matches!(app.model.columns_state(), LoadState::Loaded(_)));
+    assert!(matches!(app.model.sprints_state(), LoadState::Loaded(_)));
+    assert_eq!(app.selection.active_board_id, None);
+    assert_eq!(app.board_list.get_selected_board_id(), Some(board1.id));
+}
+
+#[tokio::test]
+async fn test_startup_on_an_empty_store_renders_without_a_board_in_scope() {
+    let mut app = App::test_default();
+
+    app.load_initial_state().await;
+
+    assert!(matches!(app.model.boards_state(), LoadState::Loaded(_)));
+    assert!(app.board_list.get_selected_board_id().is_none());
+}
+
+#[tokio::test]
+async fn test_startup_runs_the_sprint_log_migration_before_the_first_fetch() {
+    let mut app = App::test_default();
+    let _board1 = seed_board_with_subtree(&mut app, "Board 1");
+
+    app.load_initial_state().await;
+
+    assert!(!app.ctx.is_dirty());
+}
+
+#[tokio::test]
+async fn test_a_failed_initial_read_clears_the_save_file_and_raises_a_banner() {
+    let mut app = App::test_default();
+    app.persistence.save_file = Some("/tmp/does-not-matter.json".to_string());
+
+    let backend = CountingBackend::wrap_failing(app.ctx.backend(), "list_boards");
+    app.ctx.replace_backend(backend);
+
+    app.load_initial_state().await;
+
+    assert_eq!(app.persistence.save_file, None);
+    assert!(app.ui_state.banner.is_some());
+}

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -2,8 +2,67 @@ mod helpers;
 
 use helpers::{CountingBackend, ReadOp};
 use kanban_domain::{KanbanOperations, LoadState};
+use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::App;
+
+/// No live board remains, so the only way either archived view can show its
+/// entity is via an entry-triggered reload.
+#[tokio::test]
+async fn test_entering_an_archived_view_after_startup_displays_its_entity() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+    app.ctx.archive_board(board.id).unwrap();
+
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+
+    app.load_initial_state().await;
+
+    let startup_ops = ops.lock().unwrap().clone();
+    assert!(
+        !startup_ops
+            .iter()
+            .any(|op| op.method == "list_archived_cards" || op.method == "list_archived_boards"),
+        "startup must not read anything archived, got {startup_ops:?}"
+    );
+
+    app.focus.active = Focus::Boards;
+    app.handle_toggle_archived_cards_view();
+    assert_eq!(app.mode, AppMode::ArchivedCardsView);
+    let archived_tasks: Vec<_> = app.displayed_cards().iter().map(|c| c.id).collect();
+    assert_eq!(
+        archived_tasks,
+        vec![card.id],
+        "expected the archived cards view to display the archived card on entry"
+    );
+
+    app.handle_toggle_archived_cards_view();
+    assert_eq!(app.mode, AppMode::Normal);
+
+    app.handle_toggle_archived_boards_view();
+    assert_eq!(app.mode, AppMode::ArchivedBoardsView);
+    let archived_projects: Vec<_> = app.displayed_boards().iter().map(|b| b.id).collect();
+    assert_eq!(
+        archived_projects,
+        vec![board.id],
+        "expected the archived boards view to display the archived board on entry"
+    );
+}
 
 struct SeededBoard {
     id: uuid::Uuid,
@@ -49,6 +108,26 @@ async fn test_startup_reads_the_board_list_and_board_scoped_tiers_instead_of_one
     assert!(
         !ops.iter().any(|op| op.method == "snapshot"),
         "startup must not read the whole workspace via a single snapshot call, got {ops:?}"
+    );
+    let whole_store_list_reads = ops
+        .iter()
+        .filter(|op| {
+            matches!(
+                op.method,
+                "list_all_columns" | "list_all_cards" | "list_all_sprints"
+            )
+        })
+        .count();
+    assert!(
+        whole_store_list_reads <= 5,
+        "expected at most 5 whole-store list reads (1 list_all_columns + 1 list_all_cards \
+         + 1 list_all_sprints from ViewScope's transitional flat arms, plus 1 list_all_cards \
+         + 1 list_all_sprints from migrate_sprint_logs), got {whole_store_list_reads} in {ops:?}"
+    );
+    assert!(
+        !ops.iter()
+            .any(|op| op.method == "list_archived_cards" || op.method == "list_archived_boards"),
+        "startup must not read anything archived, got {ops:?}"
     );
     assert!(
         ops.iter().all(|op| {

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -6,10 +6,10 @@ use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::App;
 
-/// No live board remains, so the only way either archived view can show its
-/// entity is via an entry-triggered reload.
+/// No live board remains, so the only way the archived cards view can show
+/// its entity is via an entry-triggered reload.
 #[tokio::test]
-async fn test_entering_an_archived_view_after_startup_displays_its_entity() {
+async fn test_entering_the_archived_cards_view_after_startup_displays_its_card() {
     let mut app = App::test_default();
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();
     let column = app
@@ -40,6 +40,10 @@ async fn test_entering_an_archived_view_after_startup_displays_its_entity() {
             .any(|op| op.method == "list_archived_cards" || op.method == "list_archived_boards"),
         "startup must not read anything archived, got {startup_ops:?}"
     );
+    assert!(
+        !app.model.archived_card_markers_absorbed(),
+        "startup must not have absorbed the archived-card tier"
+    );
 
     app.focus.active = Focus::Boards;
     app.handle_toggle_archived_cards_view();
@@ -50,10 +54,48 @@ async fn test_entering_an_archived_view_after_startup_displays_its_entity() {
         vec![card.id],
         "expected the archived cards view to display the archived card on entry"
     );
+}
 
-    app.handle_toggle_archived_cards_view();
-    assert_eq!(app.mode, AppMode::Normal);
+/// No live board remains, so the only way the archived boards view can show
+/// its entity is via an entry-triggered reload.
+#[tokio::test]
+async fn test_entering_the_archived_boards_view_after_startup_displays_its_board() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+    app.ctx.archive_board(board.id).unwrap();
 
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+
+    app.load_initial_state().await;
+
+    let startup_ops = ops.lock().unwrap().clone();
+    assert!(
+        !startup_ops
+            .iter()
+            .any(|op| op.method == "list_archived_cards" || op.method == "list_archived_boards"),
+        "startup must not read anything archived, got {startup_ops:?}"
+    );
+    assert!(
+        !app.model.archived_boards_absorbed(),
+        "startup must not have absorbed the archived-boards tier"
+    );
+
+    app.focus.active = Focus::Boards;
     app.handle_toggle_archived_boards_view();
     assert_eq!(app.mode, AppMode::ArchivedBoardsView);
     let archived_projects: Vec<_> = app.displayed_boards().iter().map(|b| b.id).collect();

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -172,69 +172,6 @@ async fn test_startup_reads_the_board_list_and_board_scoped_tiers_instead_of_one
 }
 
 #[tokio::test]
-async fn test_startup_populates_the_archival_markers_so_the_archived_views_are_not_empty() {
-    let mut app = App::test_default();
-    let live_board = app
-        .ctx
-        .create_board("Live Board".to_string(), None)
-        .unwrap();
-    let archived_board = app
-        .ctx
-        .create_board("Archived Board".to_string(), None)
-        .unwrap();
-    app.ctx.archive_board(archived_board.id).unwrap();
-
-    let column = app
-        .ctx
-        .create_column(live_board.id, "Todo".to_string(), None)
-        .unwrap();
-    let _live_card = app
-        .ctx
-        .create_card(
-            live_board.id,
-            column.id,
-            "Live card".to_string(),
-            kanban_domain::CreateCardOptions::default(),
-        )
-        .unwrap();
-    let archived_card = app
-        .ctx
-        .create_card(
-            live_board.id,
-            column.id,
-            "Archived card".to_string(),
-            kanban_domain::CreateCardOptions::default(),
-        )
-        .unwrap();
-    app.ctx.archive_card(archived_card.id).unwrap();
-
-    app.load_initial_state().await;
-
-    assert!(
-        app.model.archived_board_ids().contains(&archived_board.id),
-        "expected {} in archived_board_ids, got {:?}",
-        archived_board.id,
-        app.model.archived_board_ids()
-    );
-    assert!(
-        app.model.archived_card_ids().contains(&archived_card.id),
-        "expected {} in archived_card_ids, got {:?}",
-        archived_card.id,
-        app.model.archived_card_ids()
-    );
-
-    app.mode = AppMode::ArchivedBoardsView;
-    app.prepare_frame();
-    let archived_projects: Vec<_> = app.displayed_boards().iter().map(|b| b.id).collect();
-    assert_eq!(archived_projects, vec![archived_board.id]);
-
-    app.mode = AppMode::ArchivedCardsView;
-    app.prepare_frame();
-    let archived_tasks: Vec<_> = app.displayed_cards().iter().map(|c| c.id).collect();
-    assert_eq!(archived_tasks, vec![archived_card.id]);
-}
-
-#[tokio::test]
 async fn test_startup_reads_the_board_list_before_the_auto_selected_boards_columns() {
     let mut app = App::test_default();
     let _board1 = seed_board_with_subtree(&mut app, "Board 1");

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -131,6 +131,50 @@ async fn test_startup_on_an_empty_store_renders_without_a_board_in_scope() {
 #[tokio::test]
 async fn test_startup_runs_the_sprint_log_migration_before_the_first_fetch() {
     let mut app = App::test_default();
+    let board = app.ctx.create_board("Board 1".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let sprint = app
+        .ctx
+        .create_sprint(board.id, None, Some("Sprint".to_string()))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let backend = app.ctx.backend();
+    let mut stale_card = backend.get_card(card.id).unwrap().unwrap();
+    stale_card.sprint_id = Some(sprint.id);
+    stale_card.sprint_logs.clear();
+    backend.upsert_card(stale_card).unwrap();
+
+    app.load_initial_state().await;
+
+    let migrated_log_present = app
+        .model
+        .cards_state()
+        .loaded_or_empty()
+        .iter()
+        .find(|c| c.id == card.id)
+        .map(|c| !c.sprint_logs.is_empty())
+        .unwrap_or(false);
+    assert!(
+        migrated_log_present,
+        "load_initial_state's first fetch must serve the migrated sprint log, not the stale pre-migration row"
+    );
+}
+
+#[tokio::test]
+async fn test_startup_marks_the_migration_clean_so_the_conflict_popup_does_not_fire() {
+    let mut app = App::test_default();
     let _board1 = seed_board_with_subtree(&mut app, "Board 1");
 
     app.load_initial_state().await;
@@ -149,5 +193,264 @@ async fn test_a_failed_initial_read_clears_the_save_file_and_raises_a_banner() {
     app.load_initial_state().await;
 
     assert_eq!(app.persistence.save_file, None);
-    assert!(app.ui_state.banner.is_some());
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("expected an error banner");
+    assert!(
+        banner.message.contains("Failed to read data file"),
+        "got: {}",
+        banner.message
+    );
+    assert!(
+        banner.message.contains("injected fault: list_boards"),
+        "got: {}",
+        banner.message
+    );
+}
+
+#[tokio::test]
+async fn test_a_corrupt_data_file_clears_the_save_file_and_raises_a_banner() {
+    let mut app = App::test_default();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("corrupt.json");
+    std::fs::write(&path, b"not valid json").unwrap();
+    let path_str = path.to_str().unwrap().to_string();
+    app.persistence.save_file = Some(path_str.clone());
+
+    let store = kanban_persistence_json::JsonFileStore::new(&path_str);
+    let backend: std::sync::Arc<dyn kanban_service::KanbanBackend> = std::sync::Arc::new(
+        kanban_persistence_json::JsonDataStore::new(std::sync::Arc::new(store)),
+    );
+    app.ctx.replace_backend(backend);
+
+    app.load_initial_state().await;
+
+    assert_eq!(app.persistence.save_file, None);
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("a genuinely corrupt data file must surface an error banner too");
+    assert!(
+        banner.message.contains("Failed to read data file"),
+        "got: {}",
+        banner.message
+    );
+}
+
+mod backend_parity {
+    use super::*;
+    use kanban_backend_memory::InMemoryStore;
+    use kanban_domain::{CreateCardOptions, GraphOperations, Model, Snapshot};
+    use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+    use kanban_persistence_sqlite::SqliteBackend;
+    use kanban_service::{test_helpers::contract::assert_card_eq, AppConfig, KanbanContext};
+    use kanban_tui::app::ViewScope;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    async fn open_seeded(
+        kind: &str,
+        dir: &tempfile::TempDir,
+        snapshot: &Snapshot,
+    ) -> KanbanContext {
+        let backend: Arc<dyn kanban_service::KanbanBackend> = match kind {
+            "memory" => Arc::new(InMemoryStore::new()),
+            "json" => Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(
+                dir.path().join("test.json"),
+            )))),
+            "sqlite" => Arc::new(
+                SqliteBackend::open(dir.path().join("test.sqlite3").to_str().unwrap())
+                    .await
+                    .unwrap(),
+            ),
+            other => panic!("unknown backend kind {other}"),
+        };
+        backend.apply_snapshot(snapshot.clone()).unwrap();
+        KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap()
+    }
+
+    /// Builds one canonical seed (two boards; board 1 has a column, two
+    /// cards linked by a spawns edge, and a sprint) via a throwaway
+    /// in-memory context, so every backend under test is seeded from the
+    /// exact same `Snapshot` value rather than three independently timed
+    /// `create_*` calls that would drift in `created_at`/`updated_at`.
+    async fn seed_non_trivial_snapshot() -> (Snapshot, Uuid, Uuid) {
+        let backend: Arc<dyn kanban_service::KanbanBackend> = Arc::new(InMemoryStore::new());
+        let mut ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        let board1 = ctx.create_board("Board 1".to_string(), None).unwrap();
+        let board2 = ctx.create_board("Board 2".to_string(), None).unwrap();
+        let column = ctx
+            .create_column(board1.id, "Todo".to_string(), None)
+            .unwrap();
+        let card1 = ctx
+            .create_card(
+                board1.id,
+                column.id,
+                "Card 1".to_string(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        let card2 = ctx
+            .create_card(
+                board1.id,
+                column.id,
+                "Card 2".to_string(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        ctx.attach_child(card1.id, card2.id).unwrap();
+        ctx.create_sprint(board1.id, None, Some("Sprint 1".to_string()))
+            .unwrap();
+        let snapshot = ctx.snapshot().unwrap();
+        (snapshot, board1.id, board2.id)
+    }
+
+    async fn seed_empty_board_snapshot() -> (Snapshot, Uuid) {
+        let backend: Arc<dyn kanban_service::KanbanBackend> = Arc::new(InMemoryStore::new());
+        let mut ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        let board = ctx.create_board("Empty Board".to_string(), None).unwrap();
+        let snapshot = ctx.snapshot().unwrap();
+        (snapshot, board.id)
+    }
+
+    fn populate_scope(ctx: &KanbanContext, board_id: Uuid) -> Model {
+        let mut model = Model::default();
+        let pass1 = ctx.resolve(
+            &ViewScope {
+                board_list: true,
+                ..Default::default()
+            },
+            &model,
+        );
+        let _ = model.apply_resolved(pass1);
+        let pass2 = ctx.resolve(
+            &ViewScope {
+                board_list: true,
+                board: Some(board_id),
+                board_columns: true,
+                board_cards: true,
+                board_sprints: true,
+                graph: true,
+                ..Default::default()
+            },
+            &model,
+        );
+        let _ = model.apply_resolved(pass2);
+        model
+    }
+
+    fn sorted_by_id<T: Clone, K: Ord>(items: &[T], key: impl Fn(&T) -> K) -> Vec<T> {
+        let mut items = items.to_vec();
+        items.sort_by_key(key);
+        items
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_startup_scope_reads_the_same_rows_on_every_backend() {
+        let (snapshot, board1, _board2) = seed_non_trivial_snapshot().await;
+        let kinds = ["memory", "json", "sqlite"];
+        let dirs = [
+            tempfile::tempdir().unwrap(),
+            tempfile::tempdir().unwrap(),
+            tempfile::tempdir().unwrap(),
+        ];
+
+        let mut models = Vec::new();
+        for (kind, dir) in kinds.iter().zip(dirs.iter()) {
+            let ctx = open_seeded(kind, dir, &snapshot).await;
+            models.push((*kind, populate_scope(&ctx, board1)));
+        }
+
+        let (baseline_kind, baseline) = &models[0];
+
+        for (kind, model) in &models[1..] {
+            let expected_boards = sorted_by_id(baseline.boards_state().loaded().unwrap(), |b| b.id);
+            let actual_boards = sorted_by_id(model.boards_state().loaded().unwrap(), |b| b.id);
+            assert_eq!(
+                actual_boards, expected_boards,
+                "boards differ between {baseline_kind} and {kind}"
+            );
+
+            let expected_columns =
+                sorted_by_id(baseline.columns_state().loaded().unwrap(), |c| c.id);
+            let actual_columns = sorted_by_id(model.columns_state().loaded().unwrap(), |c| c.id);
+            assert_eq!(
+                actual_columns, expected_columns,
+                "columns differ between {baseline_kind} and {kind}"
+            );
+
+            let mut expected_cards = baseline.cards_state().loaded().unwrap().clone();
+            expected_cards.sort_by_key(|c| c.id);
+            let mut actual_cards = model.cards_state().loaded().unwrap().clone();
+            actual_cards.sort_by_key(|c| c.id);
+            assert_eq!(
+                expected_cards.len(),
+                actual_cards.len(),
+                "card count differs between {baseline_kind} and {kind}"
+            );
+            for (a, b) in expected_cards.iter().zip(actual_cards.iter()) {
+                assert_card_eq(a, b);
+            }
+
+            let expected_sprints =
+                sorted_by_id(baseline.sprints_state().loaded().unwrap(), |s| s.id);
+            let actual_sprints = sorted_by_id(model.sprints_state().loaded().unwrap(), |s| s.id);
+            assert_eq!(
+                actual_sprints, expected_sprints,
+                "sprints differ between {baseline_kind} and {kind}"
+            );
+
+            assert_eq!(
+                baseline.graph_state().loaded(),
+                model.graph_state().loaded(),
+                "dependency graph differs between {baseline_kind} and {kind}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_startup_scope_reports_the_same_variant_for_an_empty_board_on_every_backend() {
+        let (snapshot, board_id) = seed_empty_board_snapshot().await;
+        let kinds = ["memory", "json", "sqlite"];
+        let dirs = [
+            tempfile::tempdir().unwrap(),
+            tempfile::tempdir().unwrap(),
+            tempfile::tempdir().unwrap(),
+        ];
+
+        for (kind, dir) in kinds.iter().zip(dirs.iter()) {
+            let ctx = open_seeded(kind, dir, &snapshot).await;
+            let model = populate_scope(&ctx, board_id);
+
+            assert!(
+                model.board_columns_state(board_id).is_loaded(),
+                "{kind}: an empty board's column tier must resolve to Loaded(vec![]), not NotLoaded/Missing"
+            );
+            assert_eq!(
+                model
+                    .board_columns_state(board_id)
+                    .loaded()
+                    .map(|c| c.len()),
+                Some(0),
+                "{kind}: expected zero columns"
+            );
+            assert!(
+                model.board_sprints_state(board_id).is_loaded(),
+                "{kind}: an empty board's sprint tier must resolve to Loaded(vec![]), not NotLoaded/Missing"
+            );
+            assert!(
+                model.cards_state().is_loaded(),
+                "{kind}: the flat card tier must resolve to Loaded(vec![])"
+            );
+        }
+    }
 }

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -2,6 +2,7 @@ mod helpers;
 
 use helpers::{CountingBackend, ReadOp};
 use kanban_domain::{KanbanOperations, LoadState};
+use kanban_tui::app::mode::AppMode;
 use kanban_tui::App;
 
 struct SeededBoard {
@@ -29,10 +30,10 @@ fn seed_board_with_subtree(app: &mut App, name: &str) -> SeededBoard {
 }
 
 #[tokio::test]
-async fn test_startup_does_not_read_the_whole_store() {
+async fn test_startup_reads_the_board_list_and_board_scoped_tiers_instead_of_one_bulk_snapshot() {
     let mut app = App::test_default();
     let board1 = seed_board_with_subtree(&mut app, "Board 1");
-    let _board2 = seed_board_with_subtree(&mut app, "Board 2");
+    let board2 = seed_board_with_subtree(&mut app, "Board 2");
 
     let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
     app.ctx.replace_backend(backend);
@@ -62,6 +63,96 @@ async fn test_startup_does_not_read_the_whole_store() {
         }),
         "expected board-scoped reads to target only the auto-selected board: {ops:?}"
     );
+    assert!(
+        !ops.iter().any(|o| o.ids.contains(&board2.id)),
+        "no startup read may target the unvisited board: {ops:?}"
+    );
+    assert!(
+        matches!(
+            app.model.board_columns_state(board2.id),
+            LoadState::NotLoaded
+        ),
+        "the unvisited board's column tier must stay NotLoaded"
+    );
+    assert!(
+        matches!(
+            app.model.board_sprints_state(board2.id),
+            LoadState::NotLoaded
+        ),
+        "the unvisited board's sprint tier must stay NotLoaded"
+    );
+    assert!(
+        app.model.board_columns_state(board1.id).is_loaded(),
+        "expected the auto-selected board's column tier to be Loaded after startup"
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.method == "list_columns_by_board" && op.ids == vec![board1.id]),
+        "expected a list_columns_by_board read scoped to the auto-selected board: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_startup_populates_the_archival_markers_so_the_archived_views_are_not_empty() {
+    let mut app = App::test_default();
+    let live_board = app
+        .ctx
+        .create_board("Live Board".to_string(), None)
+        .unwrap();
+    let archived_board = app
+        .ctx
+        .create_board("Archived Board".to_string(), None)
+        .unwrap();
+    app.ctx.archive_board(archived_board.id).unwrap();
+
+    let column = app
+        .ctx
+        .create_column(live_board.id, "Todo".to_string(), None)
+        .unwrap();
+    let _live_card = app
+        .ctx
+        .create_card(
+            live_board.id,
+            column.id,
+            "Live card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived_card = app
+        .ctx
+        .create_card(
+            live_board.id,
+            column.id,
+            "Archived card".to_string(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(archived_card.id).unwrap();
+
+    app.load_initial_state().await;
+
+    assert!(
+        app.model.archived_board_ids().contains(&archived_board.id),
+        "expected {} in archived_board_ids, got {:?}",
+        archived_board.id,
+        app.model.archived_board_ids()
+    );
+    assert!(
+        app.model.archived_card_ids().contains(&archived_card.id),
+        "expected {} in archived_card_ids, got {:?}",
+        archived_card.id,
+        app.model.archived_card_ids()
+    );
+
+    app.mode = AppMode::ArchivedBoardsView;
+    app.prepare_frame();
+    let archived_projects: Vec<_> = app.displayed_boards().iter().map(|b| b.id).collect();
+    assert_eq!(archived_projects, vec![archived_board.id]);
+
+    app.mode = AppMode::ArchivedCardsView;
+    app.prepare_frame();
+    let archived_tasks: Vec<_> = app.displayed_cards().iter().map(|c| c.id).collect();
+    assert_eq!(archived_tasks, vec![archived_card.id]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `App::load_initial_state` runs two scoped `populate` passes over the board list and the auto-selected board's subtree instead of one whole-store `ctx.snapshot()` read
- A failed board-list read still clears the save file and raises the error banner, now driven off `Model::boards_state()` being `LoadState::Failed` instead of a `Result` from `snapshot()`
- Adds `App::populate(ViewScope)`, the App-level wrapper around `TuiContext::sync`
- `check_ended_sprints` declines on a `NotLoaded` sprint tier instead of scanning it through the collapsing `Model::sprints()` accessor, and now returns `Option<Vec<Uuid>>` so a decline (`None`) is distinguishable from a scan that found nothing (`Some(vec![])`)
- Adds `startup_lazy_load_tests.rs` covering the board-list-then-subtree fetch order, per-board isolation of the by-parent tiers, the failed-read banner path, and the sprint-log migration ordering

## Fixes from the previous review round

- Adds backend-parity tests (`backend_parity::test_startup_scope_reads_the_same_rows_on_every_backend`, `...reports_the_same_variant_for_an_empty_board_on_every_backend`) driving the pass-1/pass-2 `ViewScope` through `KanbanContext::resolve` on `InMemoryStore`, `JsonDataStore` and `SqliteBackend`, all seeded from one shared `Snapshot` so timestamps cannot drift between backends. Compares boards, columns, cards (via `kanban_service::test_helpers::contract::assert_card_eq`), sprints and the dependency graph, plus the `LoadState` variant reported for an empty board's column/sprint/card tiers on every backend.
- `check_ended_sprints` now returns `Option<Vec<Uuid>>` instead of `Vec<Uuid>`, so the decline test asserts `None` rather than an empty vec that a mutated (non-declining) implementation would also produce. Mutation-checked: reverting the guard to the old `Model::sprints()` accessor now fails the decline test.
- The failed-read banner test asserts the banner's message text contains both "Failed to read data file" and the injected fault, not just that a banner exists. Adds a characterisation test against a genuinely corrupt JSON file read through `JsonDataStore`, not just an injected backend fault.
- Rewrites the migration-ordering test to seed a card whose `sprint_id` is set but whose `sprint_logs` are stale, and assert the migrated log is visible in the first fetch. The `mark_clean` assertion now lives in its own separately named test.

## Test plan

- [x] `cargo test -p kanban-tui --all-features` green (all 11 tests in `startup_lazy_load_tests.rs`, including the two backend-parity tests, plus the untouched `initial_board_selection_tests.rs` and `frame_reload_tests.rs`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean across the workspace
- [x] `cargo fmt --all -- --check` clean
- [x] Confirmed each new/rewritten test fails for the stated reason against the pre-fix code, then reverted
- [x] Mutation-checked `check_ended_sprints`'s `Option` return: reverting the guard to `Model::sprints()` makes the decline test fail with `left: Some([]), right: None`
- [x] Mutation-checked the migration-ordering test: moving `migrate_sprint_logs()` after both `populate` calls makes it fail

## Archived views: reworked per design ruling

An earlier round made startup itself populate the archival marker tiers, via a new `App::populate_archival_markers` that fetched `list_archived_cards`/`list_archived_boards` and then resolved every marker's board/card body one id at a time, merging the results into the Model through three new domain methods. That was rejected at design level: per-id body fetches are exactly the unbounded eager-loading pattern this epic exists to remove, and the merges silently no-op whenever the flat board/card tier is still `NotLoaded`, which is precisely the state an empty archived view needs to recover from.

The mechanism is replaced:

- Startup loads nothing archived. `App::populate_archival_markers` and the domain's `merge_archived_cards`, `merge_archived_boards` and `set_archival_markers` are deleted.
- Entering an archived view populates it through the existing `reload_model` snapshot path instead. `handle_toggle_archived_cards_view` and `handle_toggle_archived_boards_view` call `self.reload_model()` on entry, before their existing `prepare_frame()`, gated on the archival tier never having been absorbed (`Model::archived_boards_absorbed()` / `Model::archived_card_markers_absorbed()`, two new predicates that distinguish "never loaded" from "genuinely empty"). A snapshot legitimately carries markers and bodies together in one read, so this is honest where the per-id merge was not; it is strictly better than `develop`, which paid the whole-store read on every launch, not just on first entry to an archived view; and it is self-healing after archive/restore mutations, which already reload. `prepare_frame` stays pure, and `ViewScope` is untouched: it keeps no archived fields.
- The headline op-log claim is re-pinned: the startup op log now carries no `snapshot`-class op and no archival read at all, and at most the existing bound of whole-store list reads carried over from `ViewScope`'s transitional flat arms and `migrate_sprint_logs`.
- New probe test `test_entering_an_archived_view_after_startup_displays_its_entity`: seeds one board, one column and one card, archives the card then the board (no live board remains), runs `load_initial_state`, then enters each archived view in turn and asserts it renders its entity. Fails against the deleted startup-population mechanism; passes against the entry-reload gate.

## Test plan (this round)

- [x] `cargo test -p kanban-tui -p kanban-domain --all-features` green, including the new probe test and every previously-approved test (two-pass startup, backend parity, failed-read banner text, migration ordering, `check_ended_sprints` decline)
- [x] Mutation-checked the entry-reload gate: removing the `reload_model()` call from `handle_toggle_archived_cards_view` makes the probe test fail; restored
- [x] `cargo clippy -p kanban-tui -p kanban-domain --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
