### PR TITLE
KAN-1104 feat(persistence-sqlite): sqlitestore instance_id becomes inherent

### DIFF
--- a/.changeset/kan-1104-make-sqlitestore-instance-id-inherent.md
+++ b/.changeset/kan-1104-make-sqlitestore-instance-id-inherent.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+persistence-sqlite: add an inherent `SqliteStore::instance_id` method so callers no longer need `PersistenceStore` in scope to read it, and switch `SqliteBackend`'s own lookup to use it.

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -295,7 +295,7 @@ impl kanban_backend::KanbanBackend for SqliteBackend {
     }
 
     fn instance_id(&self) -> Uuid {
-        <SqliteStore as PersistenceStore>::instance_id(&self.db)
+        self.db.instance_id()
     }
 
     fn local_persistence(&self) -> Option<&dyn kanban_backend::LocalPersistence> {

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -389,4 +389,15 @@ mod tests {
         assert_eq!(boards.len(), 1);
         assert_eq!(boards[0].name, "A");
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sqlite_backend_instance_id_matches_its_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.sqlite3");
+        let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
+        assert_eq!(
+            KanbanBackend::instance_id(&backend),
+            backend.db.instance_id()
+        );
+    }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs
@@ -172,4 +172,8 @@ impl SqliteStore {
     pub fn pool(&self) -> &Pool<Sqlite> {
         &self.pool
     }
+
+    pub fn instance_id(&self) -> Uuid {
+        self.instance_id
+    }
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/instance_id.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/instance_id.rs
@@ -1,0 +1,19 @@
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use super::super::SqliteStore;
+use super::make_rt;
+
+#[test]
+fn test_sqlite_store_instance_id_is_stable_across_calls() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    let rt = make_rt();
+    rt.block_on(async {
+        let store = SqliteStore::open(&path).await.unwrap();
+        let first = store.instance_id();
+        let second = store.instance_id();
+        assert_eq!(first, second);
+        assert_ne!(first, Uuid::nil());
+    });
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -13,6 +13,7 @@ mod entities;
 mod filtered_reads;
 mod graph;
 mod init;
+mod instance_id;
 mod metadata;
 mod migration_coverage;
 mod migration_v11_to_v12;


### PR DESCRIPTION
## Summary

- Add an inherent `SqliteStore::instance_id(&self) -> Uuid` method (a plain field read) alongside the existing `PersistenceStore` impl.
- Swap the sole trait-qualified call site in `sqlite_backend.rs` (`<SqliteStore as PersistenceStore>::instance_id(&self.db)`) to `self.db.instance_id()`.
- `PersistenceStore` stays imported in `sqlite_backend.rs`: `close()` on the same file still relies on it, so that import cannot be dropped by this change. The `PersistenceStore` impl for `SqliteStore` is untouched.

## Deviations from the handoff

- The handoff's acceptance criterion `grep -rn "PersistenceStore" crates/kanban-persistence-sqlite/src/sqlite_backend.rs` returning empty does not hold: the same file also calls `self.db.close()`, which is a `PersistenceStore` trait method, so the import is still required. Removing it broke the build. Left the import in place; only the `instance_id` call site was swapped to the inherent method.

## Test plan

- [x] Two new Red tests (`test_sqlite_store_instance_id_is_stable_across_calls`, `test_sqlite_backend_instance_id_matches_its_store`) proven to fail to compile before the inherent method existed, and pass after.
- [x] `cargo test -p kanban-persistence-sqlite --all-features` green (all 235 tests).
- [x] `cargo clippy -p kanban-persistence-sqlite --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Mutation check: reverted the inherent method to return `Uuid::nil()`, confirmed the new store-level test failed, restored it.
- [x] `grep -n "as PersistenceStore>::instance_id" crates/kanban-persistence-sqlite/src/` returns nothing.
