### PR TITLE
KAN-1108 feat(persistence-sqlite,service,mcp): delete SqliteStoreFactory and its 34 registrations

### DIFF
--- a/.changeset/kan-1108-delete-sqlitestorefactory-registrations.md
+++ b/.changeset/kan-1108-delete-sqlitestorefactory-registrations.md
@@ -1,0 +1,12 @@
+---
+bump: minor
+---
+
+persistence-sqlite: removes the public `SqliteStoreFactory` struct and its
+`StoreFactory` impl, since `StoreManager::make_backend` and `detect_backend`
+already resolve SQLite locators through the `KanbanBackendRegistry` alone.
+service: `StoreManager::detect_backend` now delegates its fallback sniff to
+the backend registry instead of a hardcoded `#[cfg(feature = "sqlite")]`
+magic-byte check, so it also recognises a not-yet-created `.db` path.
+mcp: adds `McpServer::register_backend_only` for registering a backend
+factory without a paired `StoreFactory`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,10 +177,9 @@ cargo tarpaulin        # Code coverage
 - Debounced saving (500ms minimum interval)
 
 ### kanban-persistence-sqlite
-**Purpose**: SQLite storage backend implementing `StoreFactory`
+**Purpose**: SQLite storage backend implementing `PersistenceStore`
 
 - `SqliteStore` - `PersistenceStore` impl with WAL mode, foreign keys, max 2 connections
-- `SqliteStoreFactory` - `matches_content` sniffs the SQLite magic bytes (`SQLite format 3\0`); no extension matching
 - Also hosts the `KanbanBackend` adapter over that store: `SqliteBackend` (in `sqlite_backend.rs`, `impl KanbanBackend`/`LocalPersistence`) and `SqliteBackendFactory` (in `backend_factory.rs`, `impl KanbanBackendFactory`). This is why the crate depends on `kanban-backend` and `kanban-backend-memory`.
 - Relational schema. The table set and `SUPPORTED_SCHEMA_VERSION` are defined by `crates/kanban-persistence-sqlite/src/sqlite_store/mod.rs`; what each migration step does is documented on its function in `crates/kanban-persistence-sqlite/src/sqlite_store/init.rs` — read those doc comments rather than a copy here (they also cover cross-step ordering constraints, e.g. why the `prefixes`-seeding step must run before the legacy-counter-dropping step). Active migrations upgrade older databases on open, each guarded by a durable `VACUUM INTO` pre-migration `.v{N}.backup`; a database newer than the binary supports is refused with `UnsupportedFutureVersion` rather than opened
 - Auto-creates database file on first use

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -201,7 +201,6 @@ impl CliApp {
         let mut backends = kanban_backend::KanbanBackendRegistry::new();
         #[cfg(feature = "sqlite")]
         {
-            registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
             backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
         }
         #[cfg(feature = "json")]

--- a/crates/kanban-cli/tests/migrate.rs
+++ b/crates/kanban-cli/tests/migrate.rs
@@ -11,7 +11,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -517,7 +517,6 @@ mod tests {
     fn test_store_manager() -> StoreManager {
         let mut registry = kanban_persistence::StoreRegistry::new();
         let mut backends = kanban_backend::KanbanBackendRegistry::new();
-        registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
         backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
         registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
         backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -65,7 +65,6 @@ mod tests {
     fn test_store_manager() -> StoreManager {
         let mut registry = kanban_persistence::StoreRegistry::new();
         let mut backends = kanban_backend::KanbanBackendRegistry::new();
-        registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
         backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
         registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
         backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -43,7 +43,6 @@ impl McpServer {
         let mut backends = kanban_backend::KanbanBackendRegistry::new();
         #[cfg(feature = "sqlite")]
         {
-            registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
             backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
         }
         #[cfg(feature = "json")]
@@ -121,6 +120,18 @@ impl McpServer {
         backend_factory: Box<dyn kanban_backend::KanbanBackendFactory>,
     ) -> Self {
         self.registry.register(store_factory);
+        self.backends.register(backend_factory);
+        self
+    }
+
+    /// Registers `backend_factory` without a paired `StoreFactory`, for
+    /// backends whose locators the `KanbanBackendRegistry` can resolve on
+    /// its own. Only `make_backend` and content-sniffed detection dispatch
+    /// through it, not `make_store`/`make_store_with_config`.
+    pub fn register_backend_only(
+        mut self,
+        backend_factory: Box<dyn kanban_backend::KanbanBackendFactory>,
+    ) -> Self {
         self.backends.register(backend_factory);
         self
     }

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -62,11 +62,10 @@ impl McpServer {
     /// `PersistenceStore` (used by `make_store`/`make_store_with_config` for
     /// direct storage operations); `backend_factory` builds the
     /// `KanbanBackend` that `make_backend` dispatches to. A backend that
-    /// only ever needs `make_backend` cannot skip `store_factory` — both are
-    /// required together, so a factory registered through this method is
-    /// never reachable through only one dispatch path and unreachable
-    /// through the other. Order matters for content sniffing on both
-    /// registries — factories registered earlier win when multiple match.
+    /// needs no `PersistenceStore` registers through
+    /// [`McpServer::register_backend_only`] instead. Order matters for
+    /// content sniffing on both registries — factories registered earlier
+    /// win when multiple match.
     ///
     /// # Example — third-party binary with a custom backend
     ///

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -355,7 +355,7 @@ mod tests {
     use kanban_core::AppConfig;
     use kanban_domain::Model;
     use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
-    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_persistence_sqlite::SqliteBackendFactory;
     use kanban_service::test_helpers::FaultInjectingBackend;
     use kanban_service::FetchPlan;
     use rmcp::model::ErrorCode;
@@ -449,13 +449,10 @@ mod tests {
         let path = dir.path().join(file_name);
 
         let server = McpServer::default()
-            .register_backend(
-                Box::new(SqliteStoreFactory),
-                Box::new(RecordingFactory {
-                    inner: Box::new(SqliteBackendFactory),
-                    handle: Arc::clone(&sqlite_handle),
-                }),
-            )
+            .register_backend_only(Box::new(RecordingFactory {
+                inner: Box::new(SqliteBackendFactory),
+                handle: Arc::clone(&sqlite_handle),
+            }))
             .register_backend(
                 Box::new(JsonStoreFactory),
                 Box::new(RecordingFactory {

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -166,7 +166,7 @@ mod tests {
     use kanban_backend::{KanbanBackend, KanbanBackendFactory};
     use kanban_core::AppConfig;
     use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
-    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_persistence_sqlite::SqliteBackendFactory;
     use kanban_service::test_helpers::FaultInjectingBackend;
     use rmcp::model::ErrorCode;
     use std::sync::{Arc, Mutex};
@@ -223,13 +223,10 @@ mod tests {
         let path = dir.path().join(file_name);
 
         let server = McpServer::default()
-            .register_backend(
-                Box::new(SqliteStoreFactory),
-                Box::new(RecordingFactory {
-                    inner: Box::new(SqliteBackendFactory),
-                    handle: Arc::clone(&sqlite_handle),
-                }),
-            )
+            .register_backend_only(Box::new(RecordingFactory {
+                inner: Box::new(SqliteBackendFactory),
+                handle: Arc::clone(&sqlite_handle),
+            }))
             .register_backend(
                 Box::new(JsonStoreFactory),
                 Box::new(RecordingFactory {

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -425,7 +425,7 @@ mod tests {
     use kanban_backend::{KanbanBackend, KanbanBackendFactory};
     use kanban_core::AppConfig;
     use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
-    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_persistence_sqlite::SqliteBackendFactory;
     use kanban_service::test_helpers::FaultInjectingBackend;
     use rmcp::model::ErrorCode;
     use std::sync::{Arc, Mutex};
@@ -485,13 +485,10 @@ mod tests {
         let path = dir.path().join(file_name);
 
         let server = McpServer::default()
-            .register_backend(
-                Box::new(SqliteStoreFactory),
-                Box::new(RecordingFactory {
-                    inner: Box::new(SqliteBackendFactory),
-                    handle: Arc::clone(&sqlite_handle),
-                }),
-            )
+            .register_backend_only(Box::new(RecordingFactory {
+                inner: Box::new(SqliteBackendFactory),
+                handle: Arc::clone(&sqlite_handle),
+            }))
             .register_backend(
                 Box::new(JsonStoreFactory),
                 Box::new(RecordingFactory {

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -170,7 +170,7 @@ mod tests {
     use kanban_backend::{KanbanBackend, KanbanBackendFactory};
     use kanban_core::AppConfig;
     use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
-    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_persistence_sqlite::SqliteBackendFactory;
     use kanban_service::test_helpers::FaultInjectingBackend;
     use rmcp::model::ErrorCode;
     use std::sync::{Arc, Mutex};
@@ -228,13 +228,10 @@ mod tests {
         let path = dir.path().join(file_name);
 
         let server = McpServer::default()
-            .register_backend(
-                Box::new(SqliteStoreFactory),
-                Box::new(RecordingFactory {
-                    inner: Box::new(SqliteBackendFactory),
-                    handle: Arc::clone(&sqlite_handle),
-                }),
-            )
+            .register_backend_only(Box::new(RecordingFactory {
+                inner: Box::new(SqliteBackendFactory),
+                handle: Arc::clone(&sqlite_handle),
+            }))
             .register_backend(
                 Box::new(JsonStoreFactory),
                 Box::new(RecordingFactory {

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -210,7 +210,7 @@ mod tests {
     use kanban_core::AppConfig;
     use kanban_domain::Model;
     use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
-    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_persistence_sqlite::SqliteBackendFactory;
     use kanban_service::test_helpers::FaultInjectingBackend;
     use kanban_service::FetchPlan;
     use rmcp::model::ErrorCode;
@@ -345,13 +345,10 @@ mod tests {
         let path = dir.path().join(file_name);
 
         let server = McpServer::default()
-            .register_backend(
-                Box::new(SqliteStoreFactory),
-                Box::new(RecordingFactory {
-                    inner: Box::new(SqliteBackendFactory),
-                    handle: Arc::clone(&sqlite_handle),
-                }),
-            )
+            .register_backend_only(Box::new(RecordingFactory {
+                inner: Box::new(SqliteBackendFactory),
+                handle: Arc::clone(&sqlite_handle),
+            }))
             .register_backend(
                 Box::new(JsonStoreFactory),
                 Box::new(RecordingFactory {

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -331,7 +331,7 @@ mod tests {
     use kanban_core::AppConfig;
     use kanban_domain::Model;
     use kanban_persistence_json::{JsonBackendFactory, JsonStoreFactory};
-    use kanban_persistence_sqlite::{SqliteBackendFactory, SqliteStoreFactory};
+    use kanban_persistence_sqlite::SqliteBackendFactory;
     use kanban_service::test_helpers::FaultInjectingBackend;
     use kanban_service::FetchPlan;
     use rmcp::model::ErrorCode;
@@ -453,13 +453,10 @@ mod tests {
         let path = dir.path().join(file_name);
 
         let server = McpServer::default()
-            .register_backend(
-                Box::new(SqliteStoreFactory),
-                Box::new(RecordingFactory {
-                    inner: Box::new(SqliteBackendFactory),
-                    handle: Arc::clone(&sqlite_handle),
-                }),
-            )
+            .register_backend_only(Box::new(RecordingFactory {
+                inner: Box::new(SqliteBackendFactory),
+                handle: Arc::clone(&sqlite_handle),
+            }))
             .register_backend(
                 Box::new(JsonStoreFactory),
                 Box::new(RecordingFactory {

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -7,7 +7,6 @@ use tempfile::TempDir;
 fn default_store_manager() -> StoreManager {
     let mut registry = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-persistence-sqlite/README.md
+++ b/crates/kanban-persistence-sqlite/README.md
@@ -1,6 +1,6 @@
 # kanban-persistence-sqlite
 
-SQLite storage backend for the kanban workspace. Implements `StoreFactory` and `PersistenceStore` from `kanban-persistence`.
+SQLite storage backend for the kanban workspace. Implements `PersistenceStore` from `kanban-persistence` and `KanbanBackendFactory`/`KanbanBackend` from `kanban-backend`.
 
 ## `SqliteStore`
 
@@ -97,7 +97,7 @@ There is no dedicated `schema_version` table. The `metadata` table carries the `
 
 `kanban-persistence-sqlite` mirrors `kanban-persistence-json`'s shape: it
 implements both the storage-format layer (`kanban-persistence`'s
-`StoreFactory`/`PersistenceStore`) and the `KanbanBackend` layer above it.
+`PersistenceStore`) and the `KanbanBackend` layer above it.
 
 ```mermaid
 graph TD
@@ -133,7 +133,7 @@ dev-dependency-only cycle, never reachable from a release build. See the
 
 | Crate | Purpose |
 |-------|---------|
-| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore`, `StoreFactory` traits |
+| [`kanban-persistence`](../kanban-persistence/README.md) | `PersistenceStore` trait |
 | [`kanban-core`](../kanban-core/README.md) | `KanbanError`, `KanbanResult` |
 | [`kanban-domain`](../kanban-domain/README.md) | `Snapshot` type |
 | [`kanban-backend`](../kanban-backend/README.md) | `KanbanBackend` trait this backend's `KanbanBackendFactory` produces |

--- a/crates/kanban-persistence-sqlite/README.md
+++ b/crates/kanban-persistence-sqlite/README.md
@@ -93,27 +93,6 @@ There is no dedicated `schema_version` table. The `metadata` table carries the `
 
 ---
 
-## `SqliteStoreFactory`
-
-```rust
-pub struct SqliteStoreFactory;
-
-impl StoreFactory for SqliteStoreFactory {
-    fn name(&self) -> &str { "sqlite" }
-    fn matches_content(&self, header: &[u8]) -> bool {
-        header.starts_with(b"SQLite format 3\0")
-    }
-    fn create(&self, locator: &str)
-        -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError>;
-}
-```
-
-Backend selection is content-sniffed, not extension-based. `StoreRegistry` reads the first 32 bytes of the file and asks each registered factory whether it recognises the header. `SqliteStoreFactory::matches_content` returns `true` iff the header starts with the SQLite magic string `"SQLite format 3\0"`. Files that do not yet exist are not detected by sniffing; in that case the caller picks a backend by name (`create_store("sqlite", path)`).
-
-`create` requires a multi-thread Tokio runtime — it uses `block_in_place` and returns an error on a `current_thread` runtime. Tests must use `#[tokio::test(flavor = "multi_thread")]`.
-
----
-
 ## Position in the workspace
 
 `kanban-persistence-sqlite` mirrors `kanban-persistence-json`'s shape: it

--- a/crates/kanban-persistence-sqlite/src/lib.rs
+++ b/crates/kanban-persistence-sqlite/src/lib.rs
@@ -8,9 +8,8 @@ pub use sqlite_backend::SqliteBackend;
 pub use sqlite_store::SqliteStore;
 pub use sqlite_store::SUPPORTED_SCHEMA_VERSION;
 
-use kanban_domain::KanbanError;
-use kanban_persistence::{PersistenceError, PersistenceStore, StoreFactory};
-use std::sync::Arc;
+#[cfg(feature = "test-helpers")]
+use kanban_persistence::PersistenceError;
 
 /// Construct a SQLite database file at `path` with a `metadata` row whose
 /// `schema_version` is forced to `version`. Intended for cross-crate
@@ -83,84 +82,4 @@ pub async fn read_test_schema_version(
             .map_err(|e| PersistenceError::Database(e.to_string()))?;
     pool.close().await;
     Ok(version)
-}
-
-pub struct SqliteStoreFactory;
-
-impl StoreFactory for SqliteStoreFactory {
-    fn name(&self) -> &str {
-        "sqlite"
-    }
-
-    fn matches_content(&self, header: &[u8]) -> bool {
-        header.starts_with(b"SQLite format 3\0")
-    }
-
-    fn create(
-        &self,
-        locator: &str,
-    ) -> Result<Arc<dyn PersistenceStore + Send + Sync>, PersistenceError> {
-        let handle = tokio::runtime::Handle::current();
-        if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
-            return Err(PersistenceError::Database(
-                "SqliteStoreFactory::create requires a multi-thread Tokio runtime; \
-                 block_in_place is unavailable on a current_thread runtime. \
-                 Use #[tokio::test(flavor = \"multi_thread\")] in tests."
-                    .to_string(),
-            ));
-        }
-        let store = tokio::task::block_in_place(|| handle.block_on(SqliteStore::open(locator)))
-            // Preserve typed variants across the KanbanError → PersistenceError
-            // boundary so downstream callers can discriminate them (esp.
-            // UnsupportedFutureVersion via `KanbanError::is_unsupported_future_version`).
-            // Stringifying everything into Database would flatten the typed
-            // variant and break the cross-surface refusal contract.
-            .map_err(|e| match e {
-                KanbanError::UnsupportedFutureVersion {
-                    file_version,
-                    binary_max,
-                } => PersistenceError::UnsupportedFutureVersion {
-                    file_version,
-                    binary_max,
-                },
-                other => PersistenceError::Database(other.to_string()),
-            })?;
-        Ok(Arc::new(store))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use kanban_persistence::StoreFactory;
-
-    #[test]
-    fn test_sqlite_factory_matches_content_sqlite_magic_bytes() {
-        let header = b"SQLite format 3\0extra";
-        assert!(SqliteStoreFactory.matches_content(header));
-    }
-
-    #[test]
-    fn test_sqlite_factory_matches_content_rejects_json() {
-        let header = b"{\"boards\": []}";
-        assert!(!SqliteStoreFactory.matches_content(header));
-    }
-
-    #[test]
-    fn test_sqlite_factory_matches_content_rejects_empty() {
-        assert!(!SqliteStoreFactory.matches_content(b""));
-    }
-
-    #[test]
-    fn test_sqlite_factory_name_is_sqlite() {
-        assert_eq!(SqliteStoreFactory.name(), "sqlite");
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_sqlite_factory_create_returns_persistence_store() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.db");
-        let store = SqliteStoreFactory.create(path.to_str().unwrap()).unwrap();
-        assert!(store.exists().await);
-    }
 }

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -49,7 +49,6 @@ async fn run(
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -885,13 +885,24 @@ mod tests {
         }
 
         #[test]
-        fn test_detect_backend_without_the_sqlite_feature_returns_none_for_a_db_path() {
+        fn test_detect_backend_with_no_registered_factories_returns_none() {
             let sm = StoreManager::new(
                 StoreRegistry::new(),
                 kanban_backend::KanbanBackendRegistry::new(),
             );
 
             assert_eq!(sm.detect_backend("whatever.db"), None);
+        }
+
+        #[test]
+        fn test_detect_backend_for_a_db_path_without_a_sqlite_backend_falls_back_to_json() {
+            let mut registry = StoreRegistry::new();
+            registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+            let mut backends = kanban_backend::KanbanBackendRegistry::new();
+            backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+            let sm = StoreManager::new(registry, backends);
+
+            assert_eq!(sm.detect_backend("whatever.db"), Some("json".to_string()));
         }
     }
 }

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -40,9 +40,10 @@ impl StoreManager {
         !self.backends.is_empty()
     }
 
-    /// Returns the names of all registered factories in registration order.
+    /// Returns the names of all registered backend factories in
+    /// registration order.
     pub fn backend_names(&self) -> Vec<&str> {
-        self.registry.backend_names()
+        self.backends.names()
     }
 
     /// Returns `true` if `locator` points to a SQLite database — either
@@ -61,27 +62,15 @@ impl StoreManager {
     }
 
     /// Pattern-matches `locator` against all registered factories and returns
-    /// the name of the first match. For existing SQLite files, detects by
-    /// magic bytes even when no SQLite factory is in the registry.
+    /// the name of the first match. Falls back to the backend registry when
+    /// no store factory matches.
     pub fn detect_backend(&self, locator: &str) -> Option<String> {
         if let Some(name) = self.registry.detect_backend(locator) {
             return Some(name.to_string());
         }
-        #[cfg(feature = "sqlite")]
-        {
-            let path = std::path::Path::new(locator);
-            if path.exists() {
-                if let Ok(mut f) = std::fs::File::open(path) {
-                    use std::io::Read;
-                    let mut hdr = [0u8; 16];
-                    let n = f.read(&mut hdr).unwrap_or(0);
-                    if hdr[..n].starts_with(b"SQLite format 3\0") {
-                        return Some("sqlite".to_string());
-                    }
-                }
-            }
-        }
-        None
+        self.backends
+            .for_locator(locator)
+            .map(|f| f.name().to_string())
     }
 
     /// Updates `config.storage_backend` to match the backend inferred from
@@ -734,12 +723,6 @@ mod tests {
 
     fn make_sm() -> StoreManager {
         let mut registry = StoreRegistry::new();
-        #[cfg(feature = "sqlite")]
-        registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
-        // kanban-persistence-json is an unconditional dev-dependency of kanban-service (see
-        // KAN-1027-C, which removes its production feature gate entirely) — registering it
-        // unconditionally here, rather than behind `#[cfg(feature = "json")]`, avoids ever
-        // creating a gate that becomes permanently dead once that feature is deleted.
         registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
         let mut backends = kanban_backend::KanbanBackendRegistry::new();
         #[cfg(feature = "sqlite")]

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -854,5 +854,61 @@ mod tests {
             let boards = backend.list_boards().unwrap();
             assert!(boards.is_empty());
         }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_sqlite_locator_resolves_without_a_store_factory() {
+            let mut registry = StoreRegistry::new();
+            registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+            let mut backends = kanban_backend::KanbanBackendRegistry::new();
+            backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+            backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+            let sm = StoreManager::new(registry, backends);
+
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("test.db");
+            let cfg = AppConfig::default();
+            let backend = sm
+                .make_backend(path.to_str().unwrap(), &cfg)
+                .await
+                .expect("make_backend must resolve a sqlite locator without a store-level factory registered");
+            let boards = backend.list_boards().unwrap();
+            assert!(boards.is_empty());
+        }
+
+        #[test]
+        fn test_detect_backend_on_a_nonexistent_db_path_returns_sqlite() {
+            let sm = make_sm();
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("does_not_exist.db");
+            assert_eq!(
+                sm.detect_backend(path.to_str().unwrap()),
+                Some("sqlite".to_string())
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_detect_backend_on_an_existing_sqlite_file_still_returns_sqlite() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("existing.db");
+            kanban_persistence_sqlite::SqliteStore::open(path.to_str().unwrap())
+                .await
+                .unwrap();
+
+            let sm = make_sm();
+            assert_eq!(
+                sm.detect_backend(path.to_str().unwrap()),
+                Some("sqlite".to_string())
+            );
+        }
+
+        #[test]
+        fn test_detect_backend_without_the_sqlite_feature_returns_none_for_a_db_path() {
+            let sm = StoreManager::new(
+                StoreRegistry::new(),
+                kanban_backend::KanbanBackendRegistry::new(),
+            );
+
+            assert_eq!(sm.detect_backend("whatever.db"), None);
+        }
     }
 }

--- a/crates/kanban-service/tests/archived_card_sprint_reattach_sqlite.rs
+++ b/crates/kanban-service/tests/archived_card_sprint_reattach_sqlite.rs
@@ -21,7 +21,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -13,7 +13,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/tests/carry_over.rs
+++ b/crates/kanban-service/tests/carry_over.rs
@@ -6,7 +6,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/tests/create_card_from_spec.rs
+++ b/crates/kanban-service/tests/create_card_from_spec.rs
@@ -16,7 +16,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/tests/create_card_with_sprint.rs
+++ b/crates/kanban-service/tests/create_card_with_sprint.rs
@@ -7,7 +7,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/tests/export_to_sqlite_tests.rs
+++ b/crates/kanban-service/tests/export_to_sqlite_tests.rs
@@ -14,7 +14,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
@@ -70,7 +69,6 @@ async fn test_export_to_sqlite_preserves_full_archival_graph() {
 
     let mut stores = StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
@@ -181,9 +179,8 @@ async fn test_export_to_sqlite_rejects_an_existing_destination() {
         .to_string_lossy()
         .to_string();
 
-    let mut stores = StoreRegistry::new();
+    let stores = StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     let sm = StoreManager::new(stores, backends);
 

--- a/crates/kanban-service/tests/migrate.rs
+++ b/crates/kanban-service/tests/migrate.rs
@@ -13,7 +13,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
@@ -244,7 +243,6 @@ use uuid::Uuid;
 fn full_manager() -> StoreManager {
     let mut stores = StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/tests/open_context.rs
+++ b/crates/kanban-service/tests/open_context.rs
@@ -10,7 +10,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -6,7 +6,6 @@ async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanCo
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -14,7 +14,6 @@ async fn open_context(
     let mut config = config;
     let mut stores = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    stores.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-tui/src/app/types.rs
+++ b/crates/kanban-tui/src/app/types.rs
@@ -13,13 +13,13 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
-/// Builds a `StoreManager` that mirrors the default CLI registry: SQLite
-/// first (so content-sniffing prefers it) and JSON second as a catch-all
-/// fallback. Used by [`App::new`] as the default backend configuration.
+/// Builds a `StoreManager` that mirrors the default CLI registry. Backends
+/// are registered SQLite first (so locator-based content-sniffing prefers
+/// it) and JSON second as a catch-all fallback. Used by [`App::new`] as the
+/// default backend configuration.
 pub(in crate::app) fn default_store_manager() -> StoreManager {
     let mut registry = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-tui/tests/backend_selection_tests.rs
+++ b/crates/kanban-tui/tests/backend_selection_tests.rs
@@ -1,7 +1,6 @@
 fn test_store_manager() -> kanban_service::StoreManager {
     let mut registry = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -7,7 +7,6 @@ use tempfile::tempdir;
 fn test_store_manager() -> StoreManager {
     let mut registry = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-tui/tests/reload_tests.rs
+++ b/crates/kanban-tui/tests/reload_tests.rs
@@ -6,7 +6,6 @@ use tempfile::TempDir;
 fn test_store_manager() -> StoreManager {
     let mut registry = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-tui/tests/tui_context_sync.rs
+++ b/crates/kanban-tui/tests/tui_context_sync.rs
@@ -30,7 +30,6 @@ impl FetchPlan for CardListPlan {
 fn test_store_manager() -> StoreManager {
     let mut registry = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-tui/tests/undo_redo_tests.rs
+++ b/crates/kanban-tui/tests/undo_redo_tests.rs
@@ -6,7 +6,6 @@ use tempfile::TempDir;
 fn test_store_manager() -> StoreManager {
     let mut registry = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));

--- a/crates/kanban-tui/tests/wal_checkpoint_tests.rs
+++ b/crates/kanban-tui/tests/wal_checkpoint_tests.rs
@@ -6,7 +6,6 @@ use tempfile::TempDir;
 fn test_store_manager() -> StoreManager {
     let mut registry = kanban_persistence::StoreRegistry::new();
     let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    registry.register(Box::new(kanban_persistence_sqlite::SqliteStoreFactory));
     backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
     backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));


### PR DESCRIPTION
## Summary

- Delete `SqliteStoreFactory` (struct, `StoreFactory` impl, and its 5-test module) from `kanban-persistence-sqlite`, plus its README section. `KanbanBackendRegistry` already resolves sqlite locators through `SqliteBackendFactory` for both `make_backend` and content-sniffed detection, so the store-level factory was dead weight.
- Remove all 34 registration sites (4 production, 30 test), keeping every `backends.register(...SqliteBackendFactory)` call and its ordering untouched.
- Collapse `StoreManager::detect_backend`'s hardcoded `#[cfg(feature = "sqlite")]` magic-byte sniff into a delegate to the backend registry (`self.backends.for_locator(locator)`). This is a deliberate, tested behaviour change: a not-yet-created `.db` path now resolves to `Some("sqlite")` the same way an existing sqlite file does, instead of only the latter.
- Fix `StoreManager::backend_names`, which was reading the store registry (dropped to json-only by this change) instead of the backend registry. This feeds the `migrate` CLI's valid-backend-name arg validation, so left unfixed it would have silently rejected `sqlite` as a migrate target.
- Add `McpServer::register_backend_only` for registering a backend factory without a paired `StoreFactory`, needed by the mcp `tools/*.rs` test helpers that previously paired `SqliteStoreFactory` with `SqliteBackendFactory` via `register_backend`.

## Test plan

- [x] `test_sqlite_locator_resolves_without_a_store_factory` (proves the deletion's premise on unmodified code before the change)
- [x] `test_detect_backend_on_a_nonexistent_db_path_returns_sqlite` (red before the `detect_backend` refactor, green after)
- [x] `test_detect_backend_on_an_existing_sqlite_file_still_returns_sqlite` (regression guard, behaviour-preserving)
- [x] `test_detect_backend_without_the_sqlite_feature_returns_none_for_a_db_path`
- [x] `cargo test -p kanban-persistence-sqlite --all-features`
- [x] `cargo test -p kanban-service --all-features`
- [x] `cargo test -p kanban-cli --all-features` (includes the migrate CLI regression this PR fixes)
- [x] `cargo test -p kanban-mcp --all-features`
- [x] `cargo test -p kanban-server --all-features`
- [x] `cargo test -p kanban-tui --all-features`
- [x] `cargo test --workspace --no-run` compiles clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `grep -rn "SqliteStoreFactory" crates/` returns nothing
- [x] `grep -rn "SqliteBackendFactory" crates/` returns 53 (baseline 52 plus one new test registration)
