### PR TITLE
KAN-1204 refactor(service): move json migration legs onto the store adapter

### DIFF
--- a/.changeset/kan-1204-move-json-migration-legs-store.md
+++ b/.changeset/kan-1204-move-json-migration-legs-store.md
@@ -1,0 +1,12 @@
+---
+bump: minor
+---
+
+service: adds `StoreManager::make_backend_named` for resolving a
+`KanbanBackend` by exact name, bypassing header/extension sniffing (a
+migration destination never exists yet, so there is nothing to sniff).
+`migrate_store`'s JSON-side source and destination now route through
+`make_backend`/`make_backend_named` and a typed `Snapshot` via the
+`store_adapter` module instead of `PersistenceStore`/`StoreSnapshot`;
+FK repair moves with it as `store_adapter::repair_fks`, replacing the
+old JSON-level `repair_snapshot_fks`/`fix_card_fks` pair.

--- a/crates/kanban-cli/tests/migrate.rs
+++ b/crates/kanban-cli/tests/migrate.rs
@@ -359,10 +359,20 @@ async fn seed_full_graph(path: &std::path::Path) -> FullGraph {
     let col_other = ctx.create_column(board.id, "Done".into(), None).unwrap();
 
     let blocker = ctx
-        .create_card(board.id, col_lowest.id, "Blocker".into(), Default::default())
+        .create_card(
+            board.id,
+            col_lowest.id,
+            "Blocker".into(),
+            Default::default(),
+        )
         .unwrap();
     let blocked = ctx
-        .create_card(board.id, col_lowest.id, "Blocked".into(), Default::default())
+        .create_card(
+            board.id,
+            col_lowest.id,
+            "Blocked".into(),
+            Default::default(),
+        )
         .unwrap();
     ctx.block(blocker.id, blocked.id, Severity::High).unwrap();
 
@@ -440,12 +450,17 @@ fn assert_full_graph_present(ctx: &KanbanContext, g: &FullGraph) {
 
     let archived_cards = ctx.list_archived_cards().unwrap();
     assert!(
-        archived_cards.iter().any(|ac| ac.entity_id == g.archived_card),
+        archived_cards
+            .iter()
+            .any(|ac| ac.entity_id == g.archived_card),
         "archived-card marker must survive"
     );
 
     let sprints = ctx.list_all_sprints().unwrap();
-    assert!(sprints.iter().any(|s| s.id == g.sprint), "sprint must survive");
+    assert!(
+        sprints.iter().any(|s| s.id == g.sprint),
+        "sprint must survive"
+    );
 
     let blocker_card = ctx.get_card(g.blocker).unwrap().unwrap();
     assert_eq!(

--- a/crates/kanban-cli/tests/migrate.rs
+++ b/crates/kanban-cli/tests/migrate.rs
@@ -6,6 +6,7 @@ use kanban_persistence_sqlite::SqliteStore;
 use kanban_service::KanbanContext;
 use std::sync::Arc;
 use tempfile::TempDir;
+use uuid::Uuid;
 
 async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanContext> {
     let mut config = config;
@@ -316,6 +317,307 @@ async fn test_migrate_cli_default_output_path() {
         expected_output.exists(),
         "Expected default output at {}",
         expected_output.display()
+    );
+}
+
+fn make_store_manager() -> kanban_service::StoreManager {
+    let mut stores = kanban_persistence::StoreRegistry::new();
+    let mut backends = kanban_backend::KanbanBackendRegistry::new();
+    backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+    stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+    backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+    kanban_service::StoreManager::new(stores, backends)
+}
+
+struct FullGraph {
+    board: Uuid,
+    other_board: Uuid,
+    col_lowest: Uuid,
+    col_other: Uuid,
+    blocker: Uuid,
+    blocked: Uuid,
+    sprint: Uuid,
+    archived_card: Uuid,
+    archived_board: Uuid,
+}
+
+/// Seeds a non-trivial entity graph through the real `KanbanContext` API: two
+/// boards (one archived), two columns, a live card that blocks another, a
+/// sprint with a bound card, and an archived card. `path`'s extension picks
+/// the source backend the same way the CLI's own backend detection does.
+async fn seed_full_graph(path: &std::path::Path) -> FullGraph {
+    use kanban_domain::{GraphOperations, Severity};
+
+    let mut ctx = open_context(path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx
+        .create_board("Board One".into(), Some("B1".into()))
+        .unwrap();
+    let col_lowest = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let col_other = ctx.create_column(board.id, "Done".into(), None).unwrap();
+
+    let blocker = ctx
+        .create_card(board.id, col_lowest.id, "Blocker".into(), Default::default())
+        .unwrap();
+    let blocked = ctx
+        .create_card(board.id, col_lowest.id, "Blocked".into(), Default::default())
+        .unwrap();
+    ctx.block(blocker.id, blocked.id, Severity::High).unwrap();
+
+    let sprint = ctx
+        .create_sprint(board.id, Some("SPR".into()), Some("Sprint 1".into()))
+        .unwrap();
+    ctx.assign_card_to_sprint(blocker.id, sprint.id).unwrap();
+
+    let to_archive = ctx
+        .create_card(
+            board.id,
+            col_other.id,
+            "Will archive".into(),
+            Default::default(),
+        )
+        .unwrap();
+    ctx.archive_card(to_archive.id).unwrap();
+
+    let other_board = ctx
+        .create_board("Board Two".into(), Some("B2".into()))
+        .unwrap();
+    ctx.archive_board(other_board.id).unwrap();
+
+    ctx.save().await.unwrap();
+
+    FullGraph {
+        board: board.id,
+        other_board: other_board.id,
+        col_lowest: col_lowest.id,
+        col_other: col_other.id,
+        blocker: blocker.id,
+        blocked: blocked.id,
+        sprint: sprint.id,
+        archived_card: to_archive.id,
+        archived_board: other_board.id,
+    }
+}
+
+fn assert_full_graph_present(ctx: &KanbanContext, g: &FullGraph) {
+    use kanban_domain::GraphOperations;
+
+    let boards = ctx.list_boards().unwrap();
+    assert!(
+        boards.iter().any(|b| b.id == g.board),
+        "live board must survive"
+    );
+    let archived_boards = ctx.list_archived_boards().unwrap();
+    assert!(
+        archived_boards
+            .iter()
+            .any(|ab| ab.entity_id == g.archived_board),
+        "archived board marker must survive"
+    );
+    assert!(
+        ctx.get_board(g.other_board).unwrap().is_some(),
+        "archived board head must survive"
+    );
+
+    let columns = ctx.list_all_columns().unwrap();
+    assert!(
+        columns.iter().any(|c| c.id == g.col_lowest),
+        "lowest-position column must survive"
+    );
+    assert!(
+        columns.iter().any(|c| c.id == g.col_other),
+        "second column must survive"
+    );
+
+    assert!(ctx.get_card(g.blocker).unwrap().is_some(), "blocker card");
+    assert!(ctx.get_card(g.blocked).unwrap().is_some(), "blocked card");
+    assert!(
+        ctx.get_card(g.archived_card).unwrap().is_some(),
+        "archived card's live row must survive"
+    );
+
+    let archived_cards = ctx.list_archived_cards().unwrap();
+    assert!(
+        archived_cards.iter().any(|ac| ac.entity_id == g.archived_card),
+        "archived-card marker must survive"
+    );
+
+    let sprints = ctx.list_all_sprints().unwrap();
+    assert!(sprints.iter().any(|s| s.id == g.sprint), "sprint must survive");
+
+    let blocker_card = ctx.get_card(g.blocker).unwrap().unwrap();
+    assert_eq!(
+        blocker_card.sprint_id,
+        Some(g.sprint),
+        "sprint binding on the card must survive"
+    );
+
+    assert_eq!(
+        ctx.list_blockers_of(g.blocked).unwrap(),
+        vec![g.blocker],
+        "the dependency edge must survive"
+    );
+}
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_to_sqlite_migration_preserves_full_graph() {
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("source.json");
+    let dst_path = dir.path().join("dest.db");
+
+    let graph = seed_full_graph(&src_path).await;
+
+    let sm = make_store_manager();
+    sm.migrate_store(
+        "json",
+        src_path.to_str().unwrap(),
+        "sqlite",
+        dst_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let loaded = open_context(dst_path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    assert_full_graph_present(&loaded, &graph);
+}
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_to_json_migration_preserves_full_graph() {
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("source.db");
+    let dst_path = dir.path().join("dest.json");
+
+    let graph = seed_full_graph(&src_path).await;
+
+    let sm = make_store_manager();
+    sm.migrate_store(
+        "sqlite",
+        src_path.to_str().unwrap(),
+        "json",
+        dst_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let loaded = open_context(dst_path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    assert_full_graph_present(&loaded, &graph);
+}
+
+// multi_thread: sqlx connection pool spawns background tasks that deadlock on single-threaded runtime
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migration_round_trip_is_identity_over_the_entity_graph() {
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("source.json");
+    let mid_path = dir.path().join("mid.db");
+    let dst_path = dir.path().join("dest.json");
+
+    let graph = seed_full_graph(&src_path).await;
+
+    let sm = make_store_manager();
+    sm.migrate_store(
+        "json",
+        src_path.to_str().unwrap(),
+        "sqlite",
+        mid_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
+    sm.migrate_store(
+        "sqlite",
+        mid_path.to_str().unwrap(),
+        "json",
+        dst_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let loaded = open_context(dst_path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    assert_full_graph_present(&loaded, &graph);
+
+    let blocker_card = loaded.get_card(graph.blocker).unwrap().unwrap();
+    let blocked_card = loaded.get_card(graph.blocked).unwrap().unwrap();
+    assert_eq!(blocker_card.column_id, graph.col_lowest);
+    assert_eq!(blocked_card.column_id, graph.col_lowest);
+
+    let columns = loaded.list_all_columns().unwrap();
+    let lowest = columns.iter().find(|c| c.id == graph.col_lowest).unwrap();
+    let other = columns.iter().find(|c| c.id == graph.col_other).unwrap();
+    assert_eq!(
+        lowest.position, 0,
+        "column ordering must survive the round trip"
+    );
+    assert!(other.position > lowest.position);
+}
+
+/// A live card whose column has since disappeared cannot be reconstructed
+/// through the normal API (deleting a non-empty column is refused), so the
+/// dangling reference is planted directly in the JSON snapshot after seeding
+/// through the real context.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_orphaned_card_survives_json_leg_and_is_rehomed_to_the_lowest_column() {
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("source.json");
+    let dst_path = dir.path().join("dest.db");
+
+    let mut ctx = open_context(src_path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col_lowest = ctx.create_column(board.id, "Backlog".into(), None).unwrap();
+    let col_other = ctx.create_column(board.id, "Doing".into(), None).unwrap();
+    let orphan = ctx
+        .create_card(board.id, col_other.id, "Orphan".into(), Default::default())
+        .unwrap();
+    ctx.save().await.unwrap();
+    drop(ctx);
+
+    let json_store = Arc::new(JsonFileStore::new(&src_path));
+    let (snap, _) = json_store.load().await.unwrap();
+    let mut snapshot: kanban_domain::Snapshot = serde_json::from_slice(&snap.data).unwrap();
+    for card in snapshot.cards.iter_mut() {
+        if card.id == orphan.id {
+            card.column_id = uuid::Uuid::new_v4();
+        }
+    }
+    let data = serde_json::to_vec(&snapshot).unwrap();
+    json_store
+        .save(kanban_persistence::StoreSnapshot {
+            data,
+            metadata: kanban_persistence::PersistenceMetadata::new(uuid::Uuid::new_v4()),
+        })
+        .await
+        .unwrap();
+
+    let sm = make_store_manager();
+    sm.migrate_store(
+        "json",
+        src_path.to_str().unwrap(),
+        "sqlite",
+        dst_path.to_str().unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let loaded = open_context(dst_path.to_str().unwrap(), AppConfig::default())
+        .await
+        .unwrap();
+    let migrated = loaded
+        .get_card(orphan.id)
+        .unwrap()
+        .expect("orphaned card must survive migration");
+    assert_eq!(
+        migrated.column_id, col_lowest.id,
+        "orphaned card must be rehomed to the lowest-position column"
     );
 }
 

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -89,6 +89,13 @@ pub(crate) fn write_full_snapshot(store: &dyn DataStore, snapshot: Snapshot) -> 
     store.set_graph(snapshot.graph)
 }
 
+/// `read_full_snapshot` reads flat per collection precisely so a card that
+/// outlived its column is carried across rather than dropped; this is where
+/// such a card is given a column again. A card whose `sprint_id` names no
+/// sprint has it cleared. A live card whose `column_id` names no column is
+/// moved to the lowest-`position` column, and the migration fails rather than
+/// writing an unreachable card when there is no column to move it to. An
+/// archived card's column reference is historical and may dangle.
 pub(crate) fn repair_fks(snapshot: &mut Snapshot) -> KanbanResult<()> {
     let valid_columns: HashSet<Uuid> = snapshot.columns.iter().map(|c| c.id).collect();
     let valid_sprints: HashSet<Uuid> = snapshot.sprints.iter().map(|s| s.id).collect();

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -1,5 +1,5 @@
 use kanban_domain::data_store::DataStore;
-use kanban_domain::{KanbanResult, Snapshot};
+use kanban_domain::{KanbanError, KanbanResult, Snapshot};
 use std::collections::HashSet;
 use uuid::Uuid;
 
@@ -87,6 +87,43 @@ pub(crate) fn write_full_snapshot(store: &dyn DataStore, snapshot: Snapshot) -> 
         store.insert_archived_board(ab)?;
     }
     store.set_graph(snapshot.graph)
+}
+
+pub(crate) fn repair_fks(snapshot: &mut Snapshot) -> KanbanResult<()> {
+    let valid_columns: HashSet<Uuid> = snapshot.columns.iter().map(|c| c.id).collect();
+    let valid_sprints: HashSet<Uuid> = snapshot.sprints.iter().map(|s| s.id).collect();
+    let fallback_column: Option<Uuid> = snapshot
+        .columns
+        .iter()
+        .min_by_key(|c| c.position)
+        .map(|c| c.id);
+
+    for card in snapshot.cards.iter_mut() {
+        if let Some(sprint_id) = card.sprint_id {
+            if !valid_sprints.contains(&sprint_id) {
+                card.sprint_id = None;
+            }
+        }
+        if !valid_columns.contains(&card.column_id) {
+            if let Some(fb) = fallback_column {
+                card.column_id = fb;
+            }
+        }
+    }
+
+    let orphaned = snapshot
+        .cards
+        .iter()
+        .filter(|card| !valid_columns.contains(&card.column_id))
+        .count();
+    if orphaned > 0 {
+        return Err(KanbanError::validation(format!(
+            "cannot migrate: {orphaned} live card(s) reference a column that does not \
+             exist and there is no column to reassign them to"
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -750,6 +787,70 @@ mod tests {
             }) if prefix == "KAN"
         ));
         assert_eq!(probe.unbacked_at_write(), vec![(7, "KAN".to_string())]);
+    }
+
+    #[test]
+    fn test_repair_snapshot_fks_repairs_live_row_of_archived_card() -> KanbanResult<()> {
+        let valid_col = Column::new(Uuid::new_v4(), "Todo", 0);
+        let card_id = Uuid::new_v4();
+        let board_id = Uuid::new_v4();
+        let mut card = Card::new(board_id, Uuid::new_v4(), "Archived card", 0);
+        card.id = card_id;
+
+        let mut snapshot = Snapshot::new();
+        snapshot.columns = vec![valid_col.clone()];
+        snapshot.cards = vec![card];
+        snapshot.archived_cards = vec![ArchivedCard::new(card_id, board_id)];
+
+        repair_fks(&mut snapshot)?;
+
+        assert_eq!(
+            snapshot.cards[0].column_id, valid_col.id,
+            "live card row must be reassigned to fallback column"
+        );
+        let marker = &snapshot.archived_cards[0];
+        assert_eq!(marker.entity_id, card_id);
+        assert_eq!(marker.context.board_id, board_id);
+        Ok(())
+    }
+
+    #[test]
+    fn test_repair_snapshot_fks_marker_archived_cards_pass_through_unchanged() -> KanbanResult<()> {
+        let col = Column::new(Uuid::new_v4(), "Todo", 0);
+        let card_id = Uuid::new_v4();
+        let board_id = Uuid::new_v4();
+        let mut card = Card::new(board_id, col.id, "C", 0);
+        card.id = card_id;
+        let marker = ArchivedCard::new(card_id, board_id);
+
+        let mut snapshot = Snapshot::new();
+        snapshot.columns = vec![col];
+        snapshot.cards = vec![card];
+        snapshot.archived_cards = vec![marker];
+
+        repair_fks(&mut snapshot)?;
+
+        let marker_after = &snapshot.archived_cards[0];
+        assert_eq!(marker_after.entity_id, marker.entity_id);
+        assert_eq!(marker_after.context.board_id, marker.context.board_id);
+        Ok(())
+    }
+
+    #[test]
+    fn test_repair_fks_fails_when_there_is_no_column_to_rehome_to() {
+        let board_id = Uuid::new_v4();
+        let mut card = Card::new(board_id, Uuid::new_v4(), "Orphan", 0);
+        card.id = Uuid::new_v4();
+
+        let mut snapshot = Snapshot::new();
+        snapshot.cards = vec![card];
+
+        let err = repair_fks(&mut snapshot).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot migrate") && msg.contains("live card"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -102,6 +102,23 @@ impl StoreManager {
         factory.create(locator, config).await
     }
 
+    /// Creates a [`KanbanBackend`] for `locator` by exact backend name,
+    /// bypassing header/extension sniffing entirely.
+    pub async fn make_backend_named(
+        &self,
+        backend: &str,
+        locator: &str,
+        config: &AppConfig,
+    ) -> Result<std::sync::Arc<dyn crate::backend::KanbanBackend>, KanbanError> {
+        let factory = self.backends.for_name(backend).ok_or_else(|| {
+            KanbanError::Internal(format!(
+                "no registered backend named '{backend}'; registered: {:?}",
+                self.backends.names()
+            ))
+        })?;
+        factory.create(locator, config).await
+    }
+
     /// Creates a `PersistenceStore` for the named `backend` at `locator`.
     /// Returns an error if `backend` is not registered in this manager.
     pub fn make_store(
@@ -892,6 +909,29 @@ mod tests {
             );
 
             assert_eq!(sm.detect_backend("whatever.db"), None);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_make_backend_named_ignores_the_locator_header() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("dest.db");
+            let sm = make_sm();
+            let cfg = AppConfig::default();
+
+            let named = sm
+                .make_backend_named("json", path.to_str().unwrap(), &cfg)
+                .await
+                .unwrap();
+            assert!(
+                named.needs_save_worker(),
+                "make_backend_named(\"json\", ...) must build a JSON backend regardless of the .db extension"
+            );
+
+            let sniffed = sm.make_backend(path.to_str().unwrap(), &cfg).await.unwrap();
+            assert!(
+                !sniffed.needs_save_worker(),
+                "make_backend on the same nonexistent .db path sniffs sqlite by extension"
+            );
         }
 
         #[test]

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -272,8 +272,11 @@ impl StoreManager {
     /// any dangling foreign keys in the process. Rolls back (deletes the
     /// partial destination file) on failure.
     ///
-    /// SQLite source/destination are handled directly via `SqliteStore`;
-    /// JSON and other registry-backed backends go through the `StoreRegistry`.
+    /// Both legs produce and consume a typed `kanban_domain::Snapshot`.
+    /// SQLite ends are handled directly via `SqliteBackend`; JSON and other
+    /// registry-backed ends go through the `KanbanBackendRegistry`
+    /// (`make_backend` for the source, whose header is authoritative, and
+    /// `make_backend_named` for the destination, which does not exist yet).
     pub async fn migrate_store(
         &self,
         from_backend: &str,

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -1,10 +1,7 @@
 use crate::config;
 use crate::AppConfig;
 use kanban_domain::{DataStore, KanbanError};
-use kanban_persistence::{
-    snapshot_from_json_bytes, PersistenceStore, StoreRegistry, StoreSnapshot,
-};
-use std::collections::HashSet;
+use kanban_persistence::{snapshot_from_json_bytes, PersistenceStore, StoreRegistry};
 use std::sync::Arc;
 
 /// Owns the `StoreRegistry` and `KanbanBackendRegistry` and exposes the
@@ -328,47 +325,35 @@ impl StoreManager {
             return Err(KanbanError::validation("sqlite feature not compiled in"));
         }
 
-        // Every other leg has JSON on one end, so a StoreSnapshot exists and FK
-        // repair applies to it.
-        let mut store_snapshot: StoreSnapshot = if source_is_sqlite {
+        // Every other leg has JSON on one end, so `Snapshot`-level FK repair
+        // applies to it.
+        let mut snapshot: kanban_domain::Snapshot = if source_is_sqlite {
             #[cfg(feature = "sqlite")]
             {
-                use kanban_persistence::PersistenceMetadata;
-                let snapshot = self.read_sqlite_source(from_path).await?;
-                StoreSnapshot {
-                    data: kanban_persistence::snapshot_to_json_bytes(&snapshot)?,
-                    metadata: PersistenceMetadata::new(uuid::Uuid::new_v4()),
-                }
+                self.read_sqlite_source(from_path).await?
             }
             #[cfg(not(feature = "sqlite"))]
             return Err(KanbanError::validation("sqlite feature not compiled in"));
         } else {
-            let source = self.make_store(from_backend, from_path)?;
-            let (snap, _) = source.load().await?;
-            snap
+            let backend = self.make_backend(from_path, &AppConfig::default()).await?;
+            let snap = crate::store_adapter::read_full_snapshot(backend.as_data_store());
+            drop(backend);
+            snap?
         };
 
-        repair_snapshot_fks(&mut store_snapshot)?;
+        crate::store_adapter::repair_fks(&mut snapshot)?;
 
         if dest_is_sqlite {
             #[cfg(feature = "sqlite")]
             {
-                let repaired = snapshot_from_json_bytes(&store_snapshot.data)?;
-                return self.write_sqlite_destination(to_path, repaired).await;
+                return self.write_sqlite_destination(to_path, snapshot).await;
             }
             #[cfg(not(feature = "sqlite"))]
             return Err(KanbanError::validation("sqlite feature not compiled in"));
         }
 
-        let target = self.make_store(to_backend, to_path)?;
-        let outcome = target.save(store_snapshot).await;
-        target.close().await;
-        drop(target);
-        if let Err(e) = outcome {
-            cleanup_destination_files(to_path).await;
-            return Err(e.into());
-        }
-        Ok(())
+        self.write_registry_destination(to_backend, to_path, snapshot)
+            .await
     }
 
     /// Reads a SQLite source into a `Snapshot` through per-entity `DataStore`
@@ -416,6 +401,36 @@ impl StoreManager {
             crate::store_adapter::write_full_snapshot(backend.as_data_store(), snapshot)
         }));
         backend.close().await;
+        drop(backend);
+        if let Err(e) = outcome {
+            if created_here {
+                cleanup_destination_files(to_path).await;
+            }
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Writes a whole workspace into a registry-backed (non-SQLite)
+    /// destination via `make_backend_named`, flushing before drop since these
+    /// backends may buffer writes in memory until told to persist.
+    async fn write_registry_destination(
+        &self,
+        to_backend: &str,
+        to_path: &str,
+        snapshot: kanban_domain::Snapshot,
+    ) -> Result<(), KanbanError> {
+        let created_here = !std::path::Path::new(to_path).exists();
+
+        let backend = self
+            .make_backend_named(to_backend, to_path, &AppConfig::default())
+            .await?;
+        let outcome = match backend.with_transaction(Box::new(|| {
+            crate::store_adapter::write_full_snapshot(backend.as_data_store(), snapshot)
+        })) {
+            Ok(()) => backend.flush().await,
+            Err(e) => Err(e),
+        };
         drop(backend);
         if let Err(e) = outcome {
             if created_here {
@@ -506,106 +521,11 @@ async fn cleanup_destination_files(to_path: &str) {
     remove_file_with_windows_retry(std::path::Path::new(&shm)).await;
 }
 
-fn repair_snapshot_fks(snapshot: &mut StoreSnapshot) -> Result<(), KanbanError> {
-    let mut data: serde_json::Value = serde_json::from_slice(&snapshot.data).map_err(|e| {
-        KanbanError::validation(format!("Failed to parse snapshot for FK repair: {e}"))
-    })?;
-
-    let valid_columns: HashSet<String> = data["columns"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|c| c["id"].as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let valid_sprints: HashSet<String> = data["sprints"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|s| s["id"].as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let fallback_column: Option<String> = data["columns"].as_array().and_then(|arr| {
-        arr.iter()
-            .min_by_key(|c| c["position"].as_i64().unwrap_or(i64::MAX))
-            .and_then(|c| c["id"].as_str())
-            .map(String::from)
-    });
-
-    if let Some(cards) = data["cards"].as_array_mut() {
-        for card in cards.iter_mut() {
-            fix_card_fks(
-                card,
-                &valid_columns,
-                &valid_sprints,
-                fallback_column.as_deref(),
-            );
-        }
-        // Live cards must land in a real column. The SQLite `cards.column_id`
-        // FK used to reject an orphan on save; it was dropped (KAN-832) so an
-        // archived card can keep a dangling historical column, which also
-        // removed that backstop for LIVE cards. `fix_card_fks` moved every
-        // fixable card to the fallback column, so a card still pointing outside
-        // `valid_columns` had no column to reassign to and is unrepairable —
-        // fail explicitly (archived cards are intentionally exempt: their
-        // column reference is historical and may dangle).
-        let orphaned = cards
-            .iter()
-            .filter(|card| {
-                card["column_id"]
-                    .as_str()
-                    .is_some_and(|c| !valid_columns.contains(c))
-            })
-            .count();
-        if orphaned > 0 {
-            return Err(KanbanError::validation(format!(
-                "cannot migrate: {orphaned} live card(s) reference a column that does not \
-                 exist and there is no column to reassign them to"
-            )));
-        }
-    }
-
-    // Archived cards are pure markers ({ entity_id, archived_at, board_id }); the
-    // archived card's live row is repaired by the `cards` loop above. There is no
-    // embedded `card` to fix here since the V10 migration ran before FK repair.
-
-    snapshot.data = serde_json::to_vec(&data).map_err(|e| {
-        KanbanError::validation(format!("Failed to serialize repaired snapshot: {e}"))
-    })?;
-
-    Ok(())
-}
-
-fn fix_card_fks(
-    card: &mut serde_json::Value,
-    valid_columns: &HashSet<String>,
-    valid_sprints: &HashSet<String>,
-    fallback_column: Option<&str>,
-) {
-    if let Some(sprint_id) = card["sprint_id"].as_str() {
-        if !valid_sprints.contains(sprint_id) {
-            card["sprint_id"] = serde_json::Value::Null;
-        }
-    }
-    if let Some(col_id) = card["column_id"].as_str() {
-        if !valid_columns.contains(col_id) {
-            if let Some(fb) = fallback_column {
-                card["column_id"] = serde_json::Value::String(fb.to_string());
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kanban_persistence::{PersistenceMetadata, StoreRegistry};
+    use kanban_persistence::StoreRegistry;
     use tempfile::tempdir;
-    use uuid::Uuid;
 
     #[test]
     fn test_sqlite_to_sqlite_leg_does_not_round_trip_through_json() {
@@ -638,104 +558,6 @@ mod tests {
                 "{from} -> {to} carries a StoreSnapshot, so FK repair applies"
             );
         }
-    }
-
-    fn make_snapshot_with_json(data: serde_json::Value) -> StoreSnapshot {
-        StoreSnapshot {
-            data: serde_json::to_vec(&data).unwrap(),
-            metadata: PersistenceMetadata::new(Uuid::new_v4()),
-        }
-    }
-
-    /// Drift guard: verifies that an archived card whose live row has a dangling
-    /// column_id gets the live row repaired (moved to fallback column) without
-    /// erroring, and the marker entry is left unchanged with no `card` key.
-    #[test]
-    fn test_repair_snapshot_fks_repairs_live_row_of_archived_card() {
-        let valid_col_id = Uuid::new_v4().to_string();
-        let dangling_col_id = Uuid::new_v4().to_string();
-        let card_id = Uuid::new_v4().to_string();
-        let board_id = Uuid::new_v4().to_string();
-
-        let data = serde_json::json!({
-            "boards": [{"id": board_id}],
-            "columns": [{"id": valid_col_id, "position": 0}],
-            "sprints": [],
-            "cards": [{
-                "id": card_id,
-                "column_id": dangling_col_id,
-                "sprint_id": null
-            }],
-            "archived_cards": [{
-                "entity_id": card_id,
-                "board_id": board_id,
-                "archived_at": "2024-01-01T00:00:00Z"
-            }]
-        });
-
-        let mut snapshot = make_snapshot_with_json(data);
-        repair_snapshot_fks(&mut snapshot)
-            .expect("repair must succeed for archived card with dangling column");
-
-        let repaired: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
-
-        assert_eq!(
-            repaired["cards"][0]["column_id"].as_str().unwrap(),
-            valid_col_id,
-            "live card row must be reassigned to fallback column"
-        );
-        let marker = &repaired["archived_cards"][0];
-        assert!(
-            marker.get("card").is_none(),
-            "marker must have no embedded `card` key (pure marker shape)"
-        );
-        assert_eq!(marker["entity_id"].as_str().unwrap(), card_id);
-        assert_eq!(marker["board_id"].as_str().unwrap(), board_id);
-    }
-
-    /// Drift guard: verifies that a marker-only archived_cards entry passes
-    /// through repair_snapshot_fks byte-identical. Pins the marker-shape contract
-    /// so a future reader cannot silently re-add an embed-handling branch.
-    #[test]
-    fn test_repair_snapshot_fks_marker_archived_cards_pass_through_unchanged() {
-        let col_id = Uuid::new_v4().to_string();
-        let card_id = Uuid::new_v4().to_string();
-        let board_id = Uuid::new_v4().to_string();
-
-        let archived_entry = serde_json::json!({
-            "entity_id": card_id,
-            "board_id": board_id,
-            "archived_at": "2024-01-01T00:00:00Z"
-        });
-
-        let data = serde_json::json!({
-            "boards": [],
-            "columns": [{"id": col_id, "position": 0}],
-            "sprints": [],
-            "cards": [{"id": card_id, "column_id": col_id, "sprint_id": null}],
-            "archived_cards": [archived_entry.clone()]
-        });
-
-        let mut snapshot = make_snapshot_with_json(data);
-        repair_snapshot_fks(&mut snapshot).expect("repair must succeed");
-
-        let repaired: serde_json::Value = serde_json::from_slice(&snapshot.data).unwrap();
-        let marker_after = &repaired["archived_cards"][0];
-
-        assert_eq!(
-            marker_after["entity_id"].as_str().unwrap(),
-            card_id,
-            "entity_id must be unchanged"
-        );
-        assert_eq!(
-            marker_after["board_id"].as_str().unwrap(),
-            board_id,
-            "board_id must be unchanged"
-        );
-        assert!(
-            marker_after.get("card").is_none(),
-            "no `card` embed must be present before or after repair"
-        );
     }
 
     fn make_sm() -> StoreManager {

--- a/crates/kanban-service/tests/migrate.rs
+++ b/crates/kanban-service/tests/migrate.rs
@@ -6,7 +6,10 @@ use kanban_service::{KanbanContext, StoreManager};
 fn manager() -> StoreManager {
     let mut registry = StoreRegistry::new();
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
-    StoreManager::new(registry, kanban_backend::KanbanBackendRegistry::new())
+    let mut backends = kanban_backend::KanbanBackendRegistry::new();
+    backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+    backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+    StoreManager::new(registry, backends)
 }
 
 async fn open_context(locator: &str, config: AppConfig) -> KanbanResult<KanbanContext> {


### PR DESCRIPTION
## Summary

Collapses `migrate_store`'s JSON leg from `PersistenceStore`/`StoreSnapshot`
onto the same `DataStore`/`store_adapter` path the SQLite leg already uses.

- Adds `StoreManager::make_backend_named` for resolving a `KanbanBackend` by
  exact name via `KanbanBackendRegistry::for_name`, bypassing header/extension
  sniffing. A migration destination never exists yet, so there is nothing for
  the sniffing `for_locator` path to detect.
- `migrate_store`'s JSON-side source now reads through `make_backend` +
  `store_adapter::read_full_snapshot`; the JSON-side (or other registry-backed)
  destination now writes through the new `write_registry_destination`, which
  calls `make_backend_named` + `store_adapter::write_full_snapshot` inside
  `with_transaction`, then flushes before drop since these backends may buffer
  writes until told to persist.
- Moves FK repair from JSON-level `repair_snapshot_fks`/`fix_card_fks` (over
  `serde_json::Value`) to a typed `store_adapter::repair_fks(&mut Snapshot)`.
  The two prior drift-guard tests were ported to the typed shape under their
  original names, plus a new test for the no-fallback-column failure case.
- Updates the `StoreManager` fixture in `kanban-service`'s `migrate.rs`
  integration tests to register backend factories alongside its store
  factory, since the JSON leg now needs the `KanbanBackendRegistry` too.
- Adds four characterization tests to `kanban-cli`'s `migrate.rs` seeding a
  non-trivial entity graph (two boards incl. one archived, two columns, a
  blocking edge, a sprint-bound card, an archived card, and a deliberately
  orphaned card), committed first and seen green against the tree
  unmodified by this PR's production edits, then re-verified green
  unedited after the refactor.

## Test plan

- [x] `cargo test -p kanban-service --all-features` (173 lib tests + all
      integration suites, including the 17 in `tests/migrate.rs`)
- [x] `cargo test -p kanban-cli --all-features` (331 integration tests,
      including the 14 in `tests/migrate.rs`)
- [x] `cargo clippy -p kanban-service -p kanban-cli --all-targets
      --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Mutation check: broke `repair_fks`'s column-reassignment branch,
      confirmed `test_orphaned_card_survives_json_leg_and_is_rehomed_to_the_lowest_column`
      failed, reverted.
