### PR TITLE
KAN-1434 feat(domain): delete Model::columns and Model::sprints collapsing accessors

### DIFF
--- a/.changeset/kan-1434-delete-model-columns-model-sprints.md
+++ b/.changeset/kan-1434-delete-model-columns-model-sprints.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain: deletes `Model::columns()` and `Model::sprints()`, the collapsing accessors that silently flattened `NotLoaded`/`Missing`/`Failed` states into an empty slice. Every caller now goes through `columns_state()`/`sprints_state()` (or `.loaded_or_empty()` directly), matching the pattern already established for `boards()`, `all_cards()`, and `graph()`. A source-text guard test pins both accessors' absence. tui: the fallout from the deletion is mechanical, replacing every `X.columns()`/`X.sprints()` call site (all of them in test code) with `X.columns_state().loaded_or_empty()`/`X.sprints_state().loaded_or_empty()`, with no assertion's expected value changed.

--- a/crates/kanban-domain/src/model/collections.rs
+++ b/crates/kanban-domain/src/model/collections.rs
@@ -1,16 +1,8 @@
 use super::*;
 
 impl Model {
-    pub fn columns(&self) -> &[Column] {
-        self.columns.loaded_or_empty()
-    }
-
     pub fn columns_state(&self) -> &LoadState<Vec<Column>> {
         &self.columns
-    }
-
-    pub fn sprints(&self) -> &[Sprint] {
-        self.sprints.loaded_or_empty()
     }
 
     pub fn sprints_state(&self) -> &LoadState<Vec<Sprint>> {
@@ -101,7 +93,7 @@ mod tests {
         let _ = m.load_from_snapshot(Snapshot::default());
         assert!(m.columns_state().is_loaded());
         assert!(m.columns_state().loaded().unwrap().is_empty());
-        assert!(m.columns().is_empty());
+        assert!(m.columns_state().loaded_or_empty().is_empty());
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -421,4 +421,17 @@ mod tests {
             "Model::card_by_id must be deleted; callers should use card_by_id_state(id).loaded().copied()"
         );
     }
+
+    #[test]
+    fn test_model_has_no_collapsing_column_or_sprint_accessors() {
+        let collections_src = include_str!("collections.rs");
+        assert!(
+            !collections_src.contains("pub fn columns(&self)"),
+            "Model::columns must be deleted; callers should use columns_state().loaded_or_empty()"
+        );
+        assert!(
+            !collections_src.contains("pub fn sprints(&self)"),
+            "Model::sprints must be deleted; callers should use sprints_state().loaded_or_empty()"
+        );
+    }
 }

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -216,9 +216,9 @@ mod tests {
     fn test_default_model_returns_empty_slices() {
         let m = Model::default();
         assert!(m.boards_state().loaded_or_empty().is_empty());
-        assert!(m.columns().is_empty());
+        assert!(m.columns_state().loaded_or_empty().is_empty());
         assert!(m.cards_state().loaded_or_empty().is_empty());
-        assert!(m.sprints().is_empty());
+        assert!(m.sprints_state().loaded_or_empty().is_empty());
         assert!(m.archived_card_markers().is_empty());
         assert!(m.archived_card_ids().is_empty());
     }
@@ -236,8 +236,8 @@ mod tests {
         });
         assert_eq!(m.boards_state().loaded_or_empty().len(), 1);
         assert_eq!(m.boards_state().loaded_or_empty()[0].id, board.id);
-        assert_eq!(m.columns().len(), 1);
-        assert_eq!(m.columns()[0].id, col.id);
+        assert_eq!(m.columns_state().loaded_or_empty().len(), 1);
+        assert_eq!(m.columns_state().loaded_or_empty()[0].id, col.id);
     }
 
     #[test]

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -110,7 +110,7 @@ mod active_card_index_regression {
         app.ctx.assign_card_to_sprint(fx.p_id, sprint_p.id).unwrap();
         load_with_card_order(&mut app, &[fx.a_id, fx.p_id, fx.b_id, fx.c_id, fx.d_id]);
 
-        let sprints = app.model.sprints().to_vec();
+        let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
         let entries = build_entries(&sprints, fx.board_id, chrono::Utc::now());
         let expected_idx = entries
             .iter()

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1159,7 +1159,8 @@ mod create_card_factory_tests {
         let board_id = app.selection.active_board_id.unwrap();
         let column_id = app
             .model
-            .columns()
+            .columns_state()
+            .loaded_or_empty()
             .iter()
             .find(|c| c.board_id == board_id)
             .unwrap()

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1702,7 +1702,7 @@ mod tests {
 
         // A second card, placed only in the Completed panel, distinct from the
         // Uncompleted panel's card set up by seed_sprint_with_card.
-        let column_id = app.model.columns()[0].id;
+        let column_id = app.model.columns_state().loaded_or_empty()[0].id;
         let completed_card = app
             .ctx
             .create_card(

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -808,7 +808,7 @@ mod tests {
         load_with_card_order(&mut app, &[fx.a_id, fx.p_id, fx.b_id, fx.c_id, fx.d_id]);
 
         // Prime the picker with the target sprint pre-checked.
-        let sprints = app.model.sprints().to_vec();
+        let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
         let board = app
             .model
             .boards_state()

--- a/crates/kanban-tui/tests/app_query_and_clipboard_decline_tests.rs
+++ b/crates/kanban-tui/tests/app_query_and_clipboard_decline_tests.rs
@@ -100,7 +100,7 @@ fn test_copy_branch_name_declines_when_the_sprint_tier_is_not_loaded() {
 fn test_get_current_sprint_selection_index_no_longer_reads_the_collapsing_sprints_accessor() {
     let source = include_str!("../src/app/query.rs");
     assert!(
-        !source.contains("self.model.sprints()"),
+        !source.contains("self.model.sprints_state().loaded_or_empty()"),
         "query.rs must read sprints via the state-preserving accessor, not the collapsing Model::sprints()"
     );
 }

--- a/crates/kanban-tui/tests/app_query_and_clipboard_decline_tests.rs
+++ b/crates/kanban-tui/tests/app_query_and_clipboard_decline_tests.rs
@@ -100,7 +100,7 @@ fn test_copy_branch_name_declines_when_the_sprint_tier_is_not_loaded() {
 fn test_get_current_sprint_selection_index_no_longer_reads_the_collapsing_sprints_accessor() {
     let source = include_str!("../src/app/query.rs");
     assert!(
-        !source.contains("self.model.sprints_state().loaded_or_empty()"),
+        !source.contains("self.model.sprints()"),
         "query.rs must read sprints via the state-preserving accessor, not the collapsing Model::sprints()"
     );
 }

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -146,12 +146,18 @@ fn test_archived_board_sprints_view_reachable() {
     assert_eq!(board.id, board_id);
     let sprint_count = app
         .model
-        .sprints()
+        .sprints_state()
+        .loaded_or_empty()
         .iter()
         .filter(|s| s.board_id == board_id)
         .count();
     assert_eq!(sprint_count, 1, "archived board's sprint is visible");
-    assert!(app.model.sprints().iter().any(|s| s.id == sprint_id));
+    assert!(app
+        .model
+        .sprints_state()
+        .loaded_or_empty()
+        .iter()
+        .any(|s| s.id == sprint_id));
 }
 
 #[test]
@@ -170,7 +176,8 @@ fn test_archived_board_columns_resolve() {
     assert_eq!(board.id, board_id);
     let column_count = app
         .model
-        .columns()
+        .columns_state()
+        .loaded_or_empty()
         .iter()
         .filter(|c| c.board_id == board_id)
         .count();

--- a/crates/kanban-tui/tests/column_default_status_tests.rs
+++ b/crates/kanban-tui/tests/column_default_status_tests.rs
@@ -29,10 +29,13 @@ fn setup_board_with_columns(app: &mut App) -> (uuid::Uuid, uuid::Uuid, uuid::Uui
 }
 
 fn board_columns(app: &App, board_id: uuid::Uuid) -> Vec<kanban_domain::Column> {
-    kanban_domain::card_lifecycle::sorted_board_columns(board_id, app.model.columns())
-        .into_iter()
-        .cloned()
-        .collect()
+    kanban_domain::card_lifecycle::sorted_board_columns(
+        board_id,
+        app.model.columns_state().loaded_or_empty(),
+    )
+    .into_iter()
+    .cloned()
+    .collect()
 }
 
 fn select_column(app: &mut App, board_id: uuid::Uuid, column_id: uuid::Uuid) {

--- a/crates/kanban-tui/tests/columnless_board_card_tests.rs
+++ b/crates/kanban-tui/tests/columnless_board_card_tests.rs
@@ -140,7 +140,8 @@ fn test_the_column_field_names_the_column_the_card_actually_lands_in() {
             .map(|l| l.id.clone()),
         Some(CardListId::Column(
             app.model
-                .columns()
+                .columns_state()
+                .loaded_or_empty()
                 .iter()
                 .find(|c| c.name == "Doing")
                 .unwrap()
@@ -172,7 +173,8 @@ fn test_the_column_field_names_the_column_the_card_actually_lands_in() {
         .clone();
     let col = app
         .model
-        .columns()
+        .columns_state()
+        .loaded_or_empty()
         .iter()
         .find(|c| c.id == card.column_id)
         .expect("column exists");
@@ -192,7 +194,7 @@ fn test_the_column_field_names_the_column_the_card_actually_lands_in() {
     }
     app2.handle_create_card_dialog(KeyCode::Enter);
     app2.reload_model();
-    let cols2 = app2.model.columns();
+    let cols2 = app2.model.columns_state().loaded_or_empty();
     assert_eq!(cols2.len(), 1);
     assert_eq!(cols2[0].name, snapshot2);
 }
@@ -278,7 +280,7 @@ fn test_creating_a_card_on_a_columnless_board_creates_the_template_named_column_
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
 
-    let cols = app.model.columns();
+    let cols = app.model.columns_state().loaded_or_empty();
     assert_eq!(cols.len(), 1);
     assert_eq!(cols[0].name, "TODO");
     assert_eq!(cols[0].default_status, Some(CardStatus::Todo));
@@ -308,7 +310,7 @@ fn test_an_edited_column_name_is_used_for_the_created_column() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
 
-    let cols = app.model.columns();
+    let cols = app.model.columns_state().loaded_or_empty();
     assert_eq!(cols.len(), 1);
     assert_eq!(cols[0].name, "Inbox");
     assert_eq!(cols[0].default_status, Some(CardStatus::Todo));
@@ -343,7 +345,7 @@ fn test_an_emptied_column_name_falls_back_to_the_template_name() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
 
-    let cols = app.model.columns();
+    let cols = app.model.columns_state().loaded_or_empty();
     assert_eq!(cols.len(), 1);
     assert_eq!(cols[0].name, "TODO");
     let card = app
@@ -368,13 +370,13 @@ fn test_undoing_the_card_create_also_removes_the_invented_column() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
     assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.columns().len(), 1);
+    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
 
     app.ctx.undo().unwrap();
     app.reload_model();
 
     assert!(app.model.cards_state().loaded_or_empty().is_empty());
-    assert!(app.model.columns().is_empty());
+    assert!(app.model.columns_state().loaded_or_empty().is_empty());
 }
 
 #[test]
@@ -569,7 +571,7 @@ fn test_a_board_with_existing_columns_gains_no_new_column() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
 
-    let cols = app.model.columns();
+    let cols = app.model.columns_state().loaded_or_empty();
     assert_eq!(cols.len(), 2);
     let card = app
         .model

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -385,7 +385,7 @@ fn test_create_card_does_not_carry_sprint_id_from_a_different_board() {
     app.prepare_frame();
 
     // Reset picker for board A.
-    let sprints = app.model.sprints().to_vec();
+    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
     let board_a_ref = app
         .model
         .boards_state()

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -180,7 +180,7 @@ fn test_import_valid_format() {
         app.model.boards_state().loaded_or_empty()[0].name,
         "Imported Board"
     );
-    assert_eq!(app.model.columns().len(), 1);
+    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
     assert_eq!(
         app.model.cards_state().loaded_or_empty()[0].title,
@@ -289,8 +289,11 @@ async fn test_async_load_initial_state_sqlite() {
         app.model.boards_state().loaded_or_empty()[0].name,
         "SQLite Board"
     );
-    assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.columns()[0].name, "Backlog");
+    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.columns_state().loaded_or_empty()[0].name,
+        "Backlog"
+    );
 }
 
 #[test]
@@ -373,9 +376,9 @@ fn test_export_import_sprint_and_card_prefixes() {
         app2.model.boards_state().loaded_or_empty()[0].card_prefix,
         Some("task".to_string())
     );
-    assert_eq!(app2.model.sprints().len(), 1);
+    assert_eq!(app2.model.sprints_state().loaded_or_empty().len(), 1);
     assert_eq!(
-        app2.model.sprints()[0].card_prefix,
+        app2.model.sprints_state().loaded_or_empty()[0].card_prefix,
         Some("hotfix".to_string())
     );
 }
@@ -513,6 +516,9 @@ fn test_import_column_missing_default_status_key_defaults_to_none() {
     app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.columns().len(), 1);
-    assert_eq!(app.model.columns()[0].default_status, None);
+    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model.columns_state().loaded_or_empty()[0].default_status,
+        None
+    );
 }

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -259,7 +259,7 @@ fn test_sprint_assignment_is_visible_in_model_without_a_further_redraw() {
         .assign_sprint_picker
         .reset_for_card_assignment(
             Some(sprint.id),
-            app.model.sprints(),
+            app.model.sprints_state().loaded_or_empty(),
             app.model
                 .board_by_id_state(board.id)
                 .loaded()

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -136,7 +136,7 @@ async fn test_v2_format_is_imported_correctly() {
         app.model.boards_state().loaded_or_empty()[0].name,
         "My Project"
     );
-    assert_eq!(app.model.columns().len(), 1);
+    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
     assert_eq!(
         app.model.cards_state().loaded_or_empty()[0].title,

--- a/crates/kanban-tui/tests/lifecycle_reload_tests.rs
+++ b/crates/kanban-tui/tests/lifecycle_reload_tests.rs
@@ -56,7 +56,7 @@ fn test_import_board_from_file_refreshes_the_whole_model_without_a_further_reloa
         app.model.boards_state().loaded_or_empty()[0].name,
         "Imported Board"
     );
-    assert_eq!(app.model.columns().len(), 1);
+    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
     assert_eq!(
         app.model.cards_state().loaded_or_empty()[0].title,

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -32,7 +32,7 @@ fn test_prepare_frame_populates_model_from_snapshot() {
 
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.boards_state().loaded_or_empty()[0].name, "Board");
-    assert_eq!(app.model.columns().len(), 1);
+    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
     assert_eq!(
         app.model

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -10,9 +10,9 @@ fn make_card(board: &Board, column_id: Uuid, title: &str, pos: i32) -> Card {
 fn test_empty_model_returns_empty_slices() {
     let model = Model::default();
     assert!(model.boards_state().loaded_or_empty().is_empty());
-    assert!(model.columns().is_empty());
+    assert!(model.columns_state().loaded_or_empty().is_empty());
     assert!(model.cards_state().loaded_or_empty().is_empty());
-    assert!(model.sprints().is_empty());
+    assert!(model.sprints_state().loaded_or_empty().is_empty());
     assert!(model.archived_card_markers().is_empty());
     assert_eq!(
         model
@@ -47,12 +47,12 @@ fn test_load_from_snapshot_populates_all_fields() {
 
     assert_eq!(model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(model.boards_state().loaded_or_empty()[0].name, "Board1");
-    assert_eq!(model.columns().len(), 1);
-    assert_eq!(model.columns()[0].name, "Col1");
+    assert_eq!(model.columns_state().loaded_or_empty().len(), 1);
+    assert_eq!(model.columns_state().loaded_or_empty()[0].name, "Col1");
     assert_eq!(model.cards_state().loaded_or_empty().len(), 1);
     assert_eq!(model.cards_state().loaded_or_empty()[0].title, "Card1");
-    assert_eq!(model.sprints().len(), 1);
-    assert_eq!(model.sprints()[0].sprint_number, 1);
+    assert_eq!(model.sprints_state().loaded_or_empty().len(), 1);
+    assert_eq!(model.sprints_state().loaded_or_empty()[0].sprint_number, 1);
 }
 
 #[test]

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -84,7 +84,7 @@ fn open_assign_dialog(app: &mut App) {
         .active_card_id
         .and_then(|id| app.model.card_by_id_state(id).loaded().copied())
         .and_then(|c| c.sprint_id);
-    let sprints = app.model.sprints().to_vec();
+    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
     let board = app
         .model
         .boards_state()
@@ -189,14 +189,16 @@ fn test_dialog_renders_completed_in_green_and_ended_in_red() {
     // Find the completed and ended sprint by their formatted names.
     let completed = app
         .model
-        .sprints()
+        .sprints_state()
+        .loaded_or_empty()
         .iter()
         .find(|s| s.id == fx.completed_id)
         .cloned()
         .unwrap();
     let ended = app
         .model
-        .sprints()
+        .sprints_state()
+        .loaded_or_empty()
         .iter()
         .find(|s| s.id == fx.ended_id)
         .cloned()
@@ -313,7 +315,7 @@ fn test_bulk_assign_bare_enter_is_a_no_op_and_does_not_mass_unassign() {
 
     // Pre-assign the card to a sprint so we can detect the regression
     // (unassign-on-open would clear sprint_id).
-    let sprints = app.model.sprints().to_vec();
+    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
     let board = app
         .model
         .boards_state()
@@ -356,7 +358,7 @@ fn test_bulk_assign_handler_supports_completed_sprint() {
     // Switch to bulk-assign flow with one selected card, with picker
     // primed (no single "current" sprint in bulk mode).
     app.multi_select.selected_cards.insert(card_id);
-    let sprints = app.model.sprints().to_vec();
+    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
     let board = app
         .model
         .boards_state()
@@ -420,7 +422,8 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
     let board = app.model.boards_state().loaded_or_empty()[0].clone();
     let completed = app
         .model
-        .sprints()
+        .sprints_state()
+        .loaded_or_empty()
         .iter()
         .find(|s| s.id == completed_id)
         .cloned()
@@ -487,7 +490,8 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
     // the bottom of the active section — guaranteed off-screen without scroll.
     let oldest_id = app
         .model
-        .sprints()
+        .sprints_state()
+        .loaded_or_empty()
         .iter()
         .min_by_key(|s| s.sprint_number)
         .map(|s| s.id)
@@ -498,7 +502,8 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
     let board_after = app.model.boards_state().loaded_or_empty()[0].clone();
     let oldest = app
         .model
-        .sprints()
+        .sprints_state()
+        .loaded_or_empty()
         .iter()
         .find(|s| s.id == oldest_id)
         .cloned()

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -167,7 +167,12 @@ fn test_for_card_assignment_initial_selection_is_zero_when_card_has_no_sprint() 
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -181,7 +186,7 @@ fn test_for_card_assignment_initial_selection_is_index_of_current_sprint() {
     let active = add_active_sprint(&mut app, board_id);
     add_planning_sprint(&mut app, board_id);
     let now = Utc::now();
-    let entries = build_entries(app.model.sprints(), board_id, now);
+    let entries = build_entries(app.model.sprints_state().loaded_or_empty(), board_id, now);
     let expected_idx = entries
         .iter()
         .position(|e| sprint_id_of(e) == Some(active))
@@ -194,8 +199,12 @@ fn test_for_card_assignment_initial_selection_is_index_of_current_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker =
-        SprintPickerView::for_card_assignment(app.model.sprints(), &board, Some(active), now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        Some(active),
+        now,
+    );
     assert_eq!(picker.initial_selection(), Some(expected_idx));
 }
 
@@ -214,8 +223,12 @@ fn test_for_card_assignment_render_shows_current_suffix_for_card_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker =
-        SprintPickerView::for_card_assignment(app.model.sprints(), &board, Some(active), now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        Some(active),
+        now,
+    );
     let out = render_picker_to_string(&picker, picker.initial_selection());
     assert!(
         out.contains("(current)"),
@@ -238,7 +251,8 @@ fn test_for_new_card_preselects_sole_active_non_ended_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_new_card(app.model.sprints(), &board, now);
+    let picker =
+        SprintPickerView::for_new_card(app.model.sprints_state().loaded_or_empty(), &board, now);
     let expected_idx = picker
         .index_of_sprint(Some(active))
         .expect("active sprint must appear in the new-card picker");
@@ -263,7 +277,8 @@ fn test_for_new_card_preselects_none_when_no_active_sprints() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_new_card(app.model.sprints(), &board, now);
+    let picker =
+        SprintPickerView::for_new_card(app.model.sprints_state().loaded_or_empty(), &board, now);
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -285,7 +300,8 @@ fn test_for_new_card_preselects_none_when_multiple_active_sprints() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_new_card(app.model.sprints(), &board, now);
+    let picker =
+        SprintPickerView::for_new_card(app.model.sprints_state().loaded_or_empty(), &board, now);
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -306,7 +322,12 @@ fn test_value_at_returns_none_uuid_for_none_row() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     assert_eq!(
         picker.value_at(0),
         Some(None),
@@ -319,7 +340,7 @@ fn test_value_at_returns_sprint_id_for_sprint_row() {
     let (mut app, board_id, _col) = make_app_with_board();
     let active = add_active_sprint(&mut app, board_id);
     let now = Utc::now();
-    let entries = build_entries(app.model.sprints(), board_id, now);
+    let entries = build_entries(app.model.sprints_state().loaded_or_empty(), board_id, now);
     let idx = entries
         .iter()
         .position(|e| sprint_id_of(e) == Some(active))
@@ -332,7 +353,12 @@ fn test_value_at_returns_sprint_id_for_sprint_row() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     assert_eq!(picker.value_at(idx), Some(Some(active)));
 }
 
@@ -350,9 +376,14 @@ fn test_index_of_sprint_returns_row_index_for_known_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let entries = build_entries(app.model.sprints(), board_id, now);
+    let entries = build_entries(app.model.sprints_state().loaded_or_empty(), board_id, now);
     let expected = entries.iter().position(|e| sprint_id_of(e) == Some(active));
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     assert_eq!(picker.index_of_sprint(Some(active)), expected);
 }
 
@@ -369,7 +400,12 @@ fn test_index_of_sprint_returns_none_entry_index_when_no_sprint_selected() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     assert_eq!(
         picker.index_of_sprint(None),
         Some(0),
@@ -390,7 +426,12 @@ fn test_index_of_sprint_returns_none_when_sprint_is_not_in_list() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     let unknown = uuid::Uuid::new_v4();
     assert_eq!(picker.index_of_sprint(Some(unknown)), None);
 }
@@ -403,7 +444,7 @@ fn test_value_at_indices_match_build_entries_order() {
     add_completed_sprint(&mut app, board_id);
     add_ended_sprint(&mut app, board_id);
     let now = Utc::now();
-    let entries = build_entries(app.model.sprints(), board_id, now);
+    let entries = build_entries(app.model.sprints_state().loaded_or_empty(), board_id, now);
     let board = app
         .model
         .boards_state()
@@ -412,7 +453,12 @@ fn test_value_at_indices_match_build_entries_order() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     assert_eq!(
         picker.len(),
         entries.len(),
@@ -447,7 +493,12 @@ fn test_render_emits_active_planned_header_with_yellow_color() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     let grid = render_picker_with_colors(&picker, Some(0));
     let color = line_color(&grid, "Active / Planned");
     assert_eq!(
@@ -474,7 +525,12 @@ fn test_render_with_none_selection_leaves_all_rows_unselected() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     let out = render_picker_to_string(&picker, None);
     assert!(
         !out.contains("> (None)"),
@@ -499,7 +555,12 @@ fn test_render_with_out_of_bounds_selected_does_not_panic() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker = SprintPickerView::for_card_assignment(app.model.sprints(), &board, None, now);
+    let picker = SprintPickerView::for_card_assignment(
+        app.model.sprints_state().loaded_or_empty(),
+        &board,
+        None,
+        now,
+    );
     let out_of_bounds = picker.len() + 100;
     // Test passes if this render call returns instead of panicking.
     let _ = render_picker_to_string(&picker, Some(out_of_bounds));

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -37,7 +37,7 @@ fn test_create_board_assigns_correct_id_to_columns() {
     assert_eq!(boards.len(), 1, "should have exactly one board");
     let board_id = boards[0].id;
 
-    let columns = app.model.columns();
+    let columns = app.model.columns_state().loaded_or_empty();
     let board_columns: Vec<_> = columns.iter().filter(|c| c.board_id == board_id).collect();
     assert_eq!(
         board_columns.len(),
@@ -196,7 +196,7 @@ fn test_create_sprint_selects_new_sprint() {
     app.create_sprint();
     app.prepare_frame();
 
-    let sprints = app.model.sprints();
+    let sprints = app.model.sprints_state().loaded_or_empty();
     assert_eq!(sprints.len(), 1, "should have one sprint");
 
     let selected = app.selection.sprint.get();
@@ -215,7 +215,8 @@ fn test_create_column_selects_new_column() {
 
     let columns_before = app
         .model
-        .columns()
+        .columns_state()
+        .loaded_or_empty()
         .iter()
         .filter(|c| c.board_id == app.model.boards_state().loaded_or_empty()[0].id)
         .count();
@@ -258,7 +259,7 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.create_sprint();
     app.prepare_frame();
 
-    let sprint_id = app.model.sprints()[0].id;
+    let sprint_id = app.model.sprints_state().loaded_or_empty()[0].id;
 
     // Create a card and assign it to the sprint
     app.focus.active = Focus::Cards;
@@ -321,8 +322,12 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     app.create_sprint();
     app.prepare_frame();
 
-    assert_eq!(app.model.sprints().len(), 2, "should have two sprints");
-    let sprint1_id = app.model.sprints()[0].id;
+    assert_eq!(
+        app.model.sprints_state().loaded_or_empty().len(),
+        2,
+        "should have two sprints"
+    );
+    let sprint1_id = app.model.sprints_state().loaded_or_empty()[0].id;
 
     // Activate sprint 1 so it can be completed
     app.selection.active_sprint_id = Some(sprint1_id);
@@ -515,7 +520,8 @@ fn test_delete_column_adjusts_selection() {
 
     let remaining = app
         .model
-        .columns()
+        .columns_state()
+        .loaded_or_empty()
         .iter()
         .filter(|c| c.board_id == board.id)
         .count();


### PR DESCRIPTION
## Summary

- Delete `Model::columns()` and `Model::sprints()` from `crates/kanban-domain/src/model/collections.rs`, the collapsing accessors that silently flattened `NotLoaded`/`Missing`/`Failed` into an empty slice.
- Add `test_model_has_no_collapsing_column_or_sprint_accessors`, a source-text guard test in `crates/kanban-domain/src/model/mod.rs` alongside its two siblings, pinning both accessors' absence.
- Repair the resulting compile fallout: 75 call sites across `kanban-domain`'s own test module and `kanban-tui` (4 inline `#[cfg(test)]` sites in production files, 66 sites across 14 integration test files). Every site is a mechanical rewrite from `X.columns()`/`X.sprints()` to `X.columns_state().loaded_or_empty()`/`X.sprints_state().loaded_or_empty()`; no assertion's expected value changed.
- All fallout is inside test code. Production census (`crates/*/src/` outside `#[cfg(test)]`) is zero.
- One documented exception: `crates/kanban-tui/tests/app_query_and_clipboard_decline_tests.rs:103` is a source-text guard asserting query.rs no longer calls the collapsing `Model::sprints()`. The mechanical rewrite's regex cannot distinguish that literal from a real call site and initially rewrote it too, inverting the guard. It has been restored to the original literal `self.model.sprints()`, so `census.py` correctly reports this one site under `tui_tests` rather than the previously claimed total of zero.

## Test plan

- [x] `cargo test -p kanban-domain test_model_has_no_collapsing_column_or_sprint_accessors` fails before the deletion (confirmed, red proof captured)
- [x] `cargo test -p kanban-domain -p kanban-tui -p kanban-view --all-features` green, no test deleted/renamed/ignored versus the merge base
- [x] `cargo clippy --all-targets --all-features -p kanban-domain -p kanban-tui -p kanban-view -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: reintroduced `Model::columns()` temporarily, confirmed the new guard test fails, reverted
- [x] Mutation check on the restored `app_query_and_clipboard_decline_tests.rs` guard: mutated query.rs to reintroduce the literal `self.model.sprints()` (as a comment, since the accessor no longer exists), confirmed the guard fails; reverted
- [x] `git grep -n 'pub fn columns(&self)\|pub fn sprints(&self)' -- crates/` returns only the guard test's string literals and the unrelated `KanbanContext::columns`/`sprints` in `kanban-service`
