### PR TITLE
KAN-1496 feat(domain,service): give archived boards a flat fetch tier

### DIFF
--- a/.changeset/kan-1496-archived-boards-fetch-tier.md
+++ b/.changeset/kan-1496-archived-boards-fetch-tier.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain,service: add an archived-boards fetch tier mirroring the archived-card tier: `FetchRound.archived_board_list`, `Resolved.archived_boards`, a resolve arm over `DataStore::list_archived_boards`, and an `apply_resolved` path that feeds `Model::archived_boards`/`archived_board_ids` on load and records a Failed read without disturbing previously loaded markers. Also applies the flat `resolved.archived_cards.all` tier into the Model, which was previously fetched but silently dropped, and removes the permissive `Ok(Vec::new())` default on `DataStore::list_archived_boards`, making every backend implement it explicitly.

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -249,6 +249,9 @@ mod tests {
         fn delete_archived_card(&self, _card_id: Uuid) -> KanbanResult<()> {
             unimplemented!()
         }
+        fn list_archived_boards(&self) -> KanbanResult<Vec<kanban_domain::ArchivedBoard>> {
+            unimplemented!()
+        }
         fn get_sprint(&self, _id: Uuid) -> KanbanResult<Option<Sprint>> {
             unimplemented!()
         }

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -763,8 +763,7 @@ impl ImportEntities {
         // Include archived boards: `list_boards` is now live-only (archived
         // boards live in a discrete collection), so dedup must also read the
         // archived set or an import could silently collide with an archived
-        // board id. Safe across backends — the `list_archived_boards` default
-        // returns empty (no bricking).
+        // board id.
         let existing_board_ids: HashSet<Uuid> = context
             .store
             .list_boards()?

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -227,13 +227,15 @@ pub trait DataStore: Send + Sync {
 
     // Archived board (C2/C3a). A board is a scoping root: archive moves its head
     // out of the live `boards` set into a discrete archived collection as
-    // `Archived<Board>`; the subtree stays in the flat collections. These four
-    // ship FUNCTIONAL DEFAULTS so every backend stays green between C2 and the
-    // persistence overrides (C4/C5). `InMemoryStore` overrides all four; the
-    // JSON backend inherits them via its inner `InMemoryStore`; SQLite overrides
-    // in C5. The defaults are chosen so no core path bricks on a not-yet-migrated
+    // `Archived<Board>`; the subtree stays in the flat collections. `get_archived_board`
+    // and `insert_archived_board` ship FUNCTIONAL DEFAULTS so every backend stays
+    // green between C2 and the persistence overrides (C4/C5); `list_archived_boards`
+    // is REQUIRED because a defaulted-empty read is indistinguishable from a
+    // genuinely empty archived collection, and every backend implements it. The
+    // defaults that remain are chosen so no core path bricks on a not-yet-migrated
     // backend:
-    //   - reads default empty (a backend with no archived collection has none);
+    //   - `get_archived_board` defaults to `None` (a backend with no archived
+    //     collection has none);
     //   - `delete` defaults to a no-op — deleting from an absent collection is
     //     vacuously successful, and the collection-agnostic `DeleteBoard` calls
     //     it on EVERY board delete (incl. live boards), so it must not error;
@@ -244,9 +246,7 @@ pub trait DataStore: Send + Sync {
     fn get_archived_board(&self, _board_id: Uuid) -> KanbanResult<Option<crate::ArchivedBoard>> {
         Ok(None)
     }
-    fn list_archived_boards(&self) -> KanbanResult<Vec<crate::ArchivedBoard>> {
-        Ok(Vec::new())
-    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<crate::ArchivedBoard>>;
     fn insert_archived_board(&self, _ab: crate::ArchivedBoard) -> KanbanResult<()> {
         Err(crate::KanbanError::unsupported("insert_archived_board"))
     }
@@ -434,6 +434,9 @@ mod tests {
             unimplemented!()
         }
         fn delete_archived_card(&self, _card_id: Uuid) -> KanbanResult<()> {
+            unimplemented!()
+        }
+        fn list_archived_boards(&self) -> KanbanResult<Vec<crate::ArchivedBoard>> {
             unimplemented!()
         }
         fn get_sprint(&self, _id: Uuid) -> KanbanResult<Option<Sprint>> {

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -1001,6 +1001,40 @@ mod tests {
     }
 
     #[test]
+    fn test_applying_a_flat_archived_card_list_feeds_the_marker_set() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Col", 0);
+        let card = Card::new(board.id, column.id, "task", 0);
+        let marker = ArchivedCard::new(card.id, board.id);
+
+        let _ = m.apply_resolved(Resolved {
+            archived_cards: Collection {
+                all: LoadState::Loaded(vec![marker]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(m.archived_card_ids().contains(&card.id));
+
+        let mut m2 = Model::default();
+        let mut by_parent = HashMap::new();
+        by_parent.insert(
+            board.id,
+            LoadState::Loaded(vec![ArchivedCard::new(card.id, board.id)]),
+        );
+        let _ = m2.apply_resolved(Resolved {
+            archived_cards: Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        assert!(m2.archived_card_ids().is_empty());
+    }
+
+    #[test]
     fn test_a_failed_archived_read_is_readable_as_failed() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -48,6 +48,27 @@ fn apply_scopes<T>(
     }
 }
 
+fn apply_flat_archival<T>(
+    target: &mut Option<Vec<T>>,
+    error: &mut Option<Arc<KanbanError>>,
+    ids: &mut HashSet<Uuid>,
+    all: LoadState<Vec<T>>,
+    id_of: impl Fn(&T) -> Uuid,
+) {
+    match all {
+        LoadState::NotLoaded => {}
+        LoadState::Loaded(v) => {
+            *ids = v.iter().map(&id_of).collect();
+            *target = Some(v);
+            *error = None;
+        }
+        LoadState::Failed(e) => {
+            *error = Some(e);
+        }
+        LoadState::Missing => {}
+    }
+}
+
 impl Model {
     /// Applies one resolve pass across the three independent tiers per
     /// entity kind: `all`, then `by_id`, then `by_parent`. A tier left
@@ -125,6 +146,20 @@ impl Model {
         apply_scopes(
             &mut self.archived_cards_by_board,
             resolved.archived_cards.by_parent,
+        );
+        apply_flat_archival(
+            &mut self.archived_cards,
+            &mut self.archived_cards_error,
+            &mut self.archived_card_ids,
+            resolved.archived_cards.all,
+            |ac| ac.entity_id,
+        );
+        apply_flat_archival(
+            &mut self.archived_boards,
+            &mut self.archived_boards_error,
+            &mut self.archived_board_ids,
+            resolved.archived_boards.all,
+            |ab| ab.entity_id,
         );
 
         if !resolved.graph.is_not_loaded() {

--- a/crates/kanban-domain/src/model/boards.rs
+++ b/crates/kanban-domain/src/model/boards.rs
@@ -21,6 +21,21 @@ impl Model {
         self.archived_boards.as_deref().unwrap_or(&[])
     }
 
+    /// The whole-store archived-board-marker tier, `Loaded` exactly when a
+    /// snapshot or resolve pass has supplied it, `Failed` when the last
+    /// attempt errored without a subsequent successful one. Independent of
+    /// `archived_boards()`, which returns `&[]` for both `NotLoaded` and a
+    /// genuinely empty `Loaded`.
+    pub fn archived_boards_state(&self) -> LoadState<&[ArchivedBoard]> {
+        if let Some(err) = &self.archived_boards_error {
+            return LoadState::Failed(std::sync::Arc::clone(err));
+        }
+        match &self.archived_boards {
+            Some(markers) => LoadState::Loaded(markers.as_slice()),
+            None => LoadState::NotLoaded,
+        }
+    }
+
     /// Distinguishes a genuinely empty archived-boards tier from one that has
     /// never been absorbed (`archived_boards()` returns `&[]` for both).
     pub fn archived_boards_absorbed(&self) -> bool {

--- a/crates/kanban-domain/src/model/boards.rs
+++ b/crates/kanban-domain/src/model/boards.rs
@@ -54,7 +54,9 @@ impl Model {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Board, Snapshot};
+    use crate::resolved::Collection;
+    use crate::{ArchivedBoard, Board, KanbanError, Resolved, Snapshot};
+    use std::sync::Arc;
 
     #[test]
     fn test_default_model_returns_empty_archived_board_slices() {
@@ -66,6 +68,42 @@ mod tests {
             .loaded()
             .copied()
             .is_none());
+    }
+
+    #[test]
+    fn test_archived_boards_state_is_not_loaded_by_default() {
+        let m = Model::default();
+        assert!(m.archived_boards_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_a_failed_archived_board_read_leaves_the_marker_sets_alone() {
+        let mut m = Model::default();
+        let board = Board::new("Archived", None::<String>);
+        let marker = ArchivedBoard::now(board.id);
+
+        let _ = m.apply_resolved(Resolved {
+            archived_boards: Collection {
+                all: LoadState::Loaded(vec![marker]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        assert!(m.archived_boards_state().is_loaded());
+        assert!(m.archived_board_ids().contains(&board.id));
+
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        let _ = m.apply_resolved(Resolved {
+            archived_boards: Collection {
+                all: LoadState::Failed(err),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(m.archived_boards_state().is_failed());
+        assert!(m.archived_board_ids().contains(&board.id));
+        assert_eq!(m.archived_boards().len(), 1);
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -92,6 +92,9 @@ impl Model {
     /// The whole-store archived-marker tier, `Loaded` exactly when a snapshot
     /// has supplied it. Independent of `board_archived_cards_state`.
     pub fn archived_cards_state(&self) -> LoadState<&[ArchivedCard]> {
+        if let Some(err) = &self.archived_cards_error {
+            return LoadState::Failed(std::sync::Arc::clone(err));
+        }
         match &self.archived_cards {
             Some(markers) => LoadState::Loaded(markers.as_slice()),
             None => LoadState::NotLoaded,

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -1,7 +1,9 @@
 use crate::{
-    ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, LoadState, Snapshot, Sprint,
+    ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, KanbanError, LoadState,
+    Snapshot, Sprint,
 };
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// The unified, per-Model view of every entity kind's flat, per-id and
@@ -21,8 +23,10 @@ pub struct Model {
     board_index: HashMap<Uuid, usize>,
     sprints: LoadState<Vec<Sprint>>,
     archived_cards: Option<Vec<ArchivedCard>>,
+    archived_cards_error: Option<Arc<KanbanError>>,
     archived_card_ids: HashSet<Uuid>,
     archived_boards: Option<Vec<ArchivedBoard>>,
+    archived_boards_error: Option<Arc<KanbanError>>,
     archived_board_ids: HashSet<Uuid>,
     graph: LoadState<DependencyGraph>,
     /// The per-id tier beside each unified collection. Not a second row
@@ -59,8 +63,10 @@ impl Default for Model {
             board_index: HashMap::new(),
             sprints: LoadState::NotLoaded,
             archived_cards: None,
+            archived_cards_error: None,
             archived_card_ids: HashSet::new(),
             archived_boards: None,
+            archived_boards_error: None,
             archived_board_ids: HashSet::new(),
             graph: LoadState::NotLoaded,
             boards_by_id: HashMap::new(),
@@ -164,7 +170,9 @@ impl Model {
         self.archived_card_ids = cards.iter().flatten().map(|ac| ac.entity_id).collect();
         self.archived_board_ids = boards.iter().flatten().map(|ab| ab.entity_id).collect();
         self.archived_cards = cards;
+        self.archived_cards_error = None;
         self.archived_boards = boards;
+        self.archived_boards_error = None;
     }
 
     fn rebuild_card_index(&mut self) {

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use uuid::Uuid;
 
+use crate::archived_board::ArchivedBoard;
 use crate::archived_card::ArchivedCard;
 use crate::board::Board;
 use crate::card::Card;
@@ -82,6 +83,10 @@ pub struct Resolved {
     /// Archival markers, not cards. `by_id` stays permanently empty: no
     /// `FetchRound` tier requests a single marker.
     pub archived_cards: Collection<ArchivedCard>,
+    /// Archival markers, not boards. `by_id` and `by_parent` stay
+    /// permanently empty: no `FetchRound` tier requests a single marker or a
+    /// board-scoped one, only the whole list.
+    pub archived_boards: Collection<ArchivedBoard>,
     pub graph: LoadState<DependencyGraph>,
 }
 

--- a/crates/kanban-domain/src/resolved.rs
+++ b/crates/kanban-domain/src/resolved.rs
@@ -103,6 +103,7 @@ mod tests {
         assert!(resolved.columns.is_untouched());
         assert!(resolved.cards.is_untouched());
         assert!(resolved.sprints.is_untouched());
+        assert!(resolved.archived_boards.is_untouched());
     }
 
     #[test]

--- a/crates/kanban-service/src/context/sync.rs
+++ b/crates/kanban-service/src/context/sync.rs
@@ -61,6 +61,26 @@ mod tests {
         }
     }
 
+    struct ArchivedBoardListPlan;
+    impl FetchPlan for ArchivedBoardListPlan {
+        fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+            FetchRound {
+                archived_board_list: requestable(loaded.archived_board_list()),
+                ..Default::default()
+            }
+        }
+    }
+
+    struct ForceArchivedBoardListPlan;
+    impl FetchPlan for ForceArchivedBoardListPlan {
+        fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+            FetchRound {
+                archived_board_list: true,
+                ..Default::default()
+            }
+        }
+    }
+
     struct CardListPlan;
     impl FetchPlan for CardListPlan {
         fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
@@ -246,5 +266,40 @@ mod tests {
 
         assert!(model.boards_state().is_failed());
         assert!(!model.boards_state().is_loaded());
+    }
+
+    #[cfg(feature = "test-helpers")]
+    #[test]
+    fn test_a_failed_archived_board_read_leaves_the_marker_sets_alone() {
+        use crate::test_helpers::FaultInjectingBackend;
+        use crate::KanbanBackend;
+        use kanban_domain::Archived;
+
+        let store = InMemoryStore::new();
+        let board = Board::new("Archived", None::<String>);
+        store.upsert_board(board.clone()).unwrap();
+        store
+            .insert_archived_board(Archived::now(board.id))
+            .unwrap();
+        let backend = Arc::new(FaultInjectingBackend::new(
+            Arc::new(store) as Arc<dyn KanbanBackend>
+        ));
+
+        let ctx = KanbanContext::open_deferred(
+            backend.clone() as Arc<dyn KanbanBackend>,
+            AppConfig::default(),
+        );
+        let mut model = Model::default();
+
+        ctx.sync(&ArchivedBoardListPlan, &mut model, &mut NoProjections);
+        assert!(model.archived_boards_state().is_loaded());
+        assert!(model.archived_board_ids().contains(&board.id));
+
+        backend.fail("list_archived_boards");
+        ctx.sync(&ForceArchivedBoardListPlan, &mut model, &mut NoProjections);
+
+        assert!(model.archived_boards_state().is_failed());
+        assert!(model.archived_board_ids().contains(&board.id));
+        assert_eq!(model.archived_boards().len(), 1);
     }
 }

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -186,6 +186,9 @@ mod tests {
         fn archived_cards_of_board(&self, _board_id: Uuid) -> FetchStatus {
             FetchStatus::NotLoaded
         }
+        fn archived_board_list(&self) -> FetchStatus {
+            FetchStatus::NotLoaded
+        }
     }
 
     impl LoadedEntities for StubLoaded {
@@ -328,6 +331,15 @@ mod tests {
             ..Default::default()
         };
         assert!(!scoped_round.is_empty());
+    }
+
+    #[test]
+    fn test_an_archived_board_round_is_not_empty() {
+        let round = FetchRound {
+            archived_board_list: true,
+            ..Default::default()
+        };
+        assert!(!round.is_empty());
     }
 
     #[test]

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -57,6 +57,7 @@ pub trait LoadedState {
     fn sprints_of_board(&self, board_id: Uuid) -> FetchStatus;
     fn archived_card_list(&self) -> FetchStatus;
     fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus;
+    fn archived_board_list(&self) -> FetchStatus;
 }
 
 /// The `*_list` flags request a whole collection, the `*_by_*` vectors
@@ -81,6 +82,7 @@ pub struct FetchRound {
     pub archived_card_list: bool,
     /// Board ids whose archived-card markers are wanted.
     pub archived_cards_by_board: Vec<Uuid>,
+    pub archived_board_list: bool,
 }
 
 impl FetchRound {
@@ -98,6 +100,7 @@ impl FetchRound {
             && self.sprints_by_board.is_empty()
             && !self.archived_card_list
             && self.archived_cards_by_board.is_empty()
+            && !self.archived_board_list
     }
 }
 

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -61,6 +61,10 @@ impl LoadedState for Model {
     fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus {
         (&self.board_archived_cards_state(board_id)).into()
     }
+
+    fn archived_board_list(&self) -> FetchStatus {
+        (&self.archived_boards_state()).into()
+    }
 }
 
 impl LoadedEntities for Model {

--- a/crates/kanban-service/src/read_recorder.rs
+++ b/crates/kanban-service/src/read_recorder.rs
@@ -224,6 +224,8 @@ impl DataStore for RecordingStore {
         self.inner.get_archived_board(board_id)
     }
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.record("list_archived_boards", vec![]);
+        self.check("list_archived_boards")?;
         self.inner.list_archived_boards()
     }
     fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -82,6 +82,12 @@ impl LoadedState for Overlay<'_> {
             None => self.base.archived_cards_of_board(board_id),
         }
     }
+    fn archived_board_list(&self) -> FetchStatus {
+        overlay_status(
+            &self.pass.archived_boards.all,
+            self.base.archived_board_list(),
+        )
+    }
 }
 
 impl LoadedEntities for Overlay<'_> {
@@ -109,6 +115,7 @@ struct Fetched {
     sprints_by_board: HashSet<Uuid>,
     archived_card_list: bool,
     archived_cards_by_board: HashSet<Uuid>,
+    archived_board_list: bool,
 }
 
 impl Fetched {
@@ -130,6 +137,7 @@ impl Fetched {
         self.archived_card_list |= round.archived_card_list;
         self.archived_cards_by_board
             .extend(round.archived_cards_by_board.iter().copied());
+        self.archived_board_list |= round.archived_board_list;
     }
 }
 
@@ -172,6 +180,7 @@ fn narrow_to_outstanding(
             round.archived_cards_by_board,
             &fetched.archived_cards_by_board,
         ),
+        archived_board_list: round.archived_board_list && !fetched.archived_board_list,
     }
 }
 
@@ -208,6 +217,12 @@ fn fetch_round(round: &FetchRound, store: &dyn DataStore, resolved: &mut Resolve
     }
     if round.archived_card_list {
         resolved.archived_cards.all = match store.list_archived_cards() {
+            Ok(v) => LoadState::Loaded(v),
+            Err(e) => LoadState::Failed(Arc::new(e)),
+        };
+    }
+    if round.archived_board_list {
+        resolved.archived_boards.all = match store.list_archived_boards() {
             Ok(v) => LoadState::Loaded(v),
             Err(e) => LoadState::Failed(Arc::new(e)),
         };

--- a/crates/kanban-service/src/resolve/tests/archived_board.rs
+++ b/crates/kanban-service/src/resolve/tests/archived_board.rs
@@ -1,0 +1,98 @@
+use crate::fetch_plan::FetchRound;
+
+use super::{seed_archived_board, seed_board, store, FixedPlan, StubLoaded};
+use crate::read_recorder::{assert_ops, ReadOp};
+use crate::resolve::resolve;
+
+#[test]
+fn test_a_flat_archived_board_round_resolves_every_marker() {
+    let store = store();
+    let live = seed_board(&store, "live");
+    let archived_a = seed_board(&store, "a");
+    seed_archived_board(&store, &archived_a);
+    let archived_b = seed_board(&store, "b");
+    seed_archived_board(&store, &archived_b);
+
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        archived_board_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert_ops(
+        &store.ops(),
+        &[ReadOp {
+            method: "list_archived_boards",
+            ids: vec![],
+        }],
+    );
+    let all = resolved.archived_boards.all.loaded().unwrap();
+    assert_eq!(all.len(), 2);
+    assert!(resolved.archived_boards.by_parent.is_empty());
+    assert!(resolved.archived_boards.by_id.is_empty());
+    let _ = live;
+}
+
+#[test]
+fn test_an_unrequested_archived_board_tier_stays_not_loaded() {
+    let store = store();
+    let board = seed_board(&store, "b");
+    seed_archived_board(&store, &board);
+
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        board_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.boards.all.is_loaded());
+    assert!(resolved.archived_boards.is_untouched());
+}
+
+#[test]
+fn test_an_archived_board_read_error_resolves_failed_not_empty() {
+    let store = store();
+    let board = seed_board(&store, "b");
+    seed_archived_board(&store, &board);
+    store.fail_method("list_archived_boards");
+
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        archived_board_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    let state = &resolved.archived_boards.all;
+    assert!(state.is_failed());
+    assert!(!state.is_loaded());
+}
+
+#[test]
+fn test_a_plan_that_repeats_the_archived_board_list_fetches_it_once_and_halts() {
+    let store = store();
+    let board = seed_board(&store, "b");
+    seed_archived_board(&store, &board);
+    let loaded = StubLoaded::default();
+    let plan = FixedPlan(FetchRound {
+        archived_board_list: true,
+        ..Default::default()
+    });
+
+    let resolved = resolve(&plan, &loaded, &store);
+
+    assert!(resolved.archived_boards.all.is_loaded());
+    let ops = store.ops();
+    let ops = ops.lock().unwrap();
+    assert_eq!(
+        ops.iter()
+            .filter(|op| op.method == "list_archived_boards")
+            .count(),
+        1
+    );
+}

--- a/crates/kanban-service/src/resolve/tests/mod.rs
+++ b/crates/kanban-service/src/resolve/tests/mod.rs
@@ -4,7 +4,7 @@ use std::cell::{Cell, RefCell};
 
 use kanban_domain::resolved::Collection;
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, LoadState, Sprint,
+    ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, LoadState, Sprint,
 };
 use uuid::Uuid;
 
@@ -15,6 +15,7 @@ use crate::fetch_plan::{
 use crate::read_recorder::RecordingStore;
 
 mod archived;
+mod archived_board;
 mod multi_round;
 mod overlay;
 mod resolve;
@@ -29,6 +30,7 @@ pub(super) struct StubLoaded {
     cards: Collection<Card>,
     sprints: Collection<Sprint>,
     archived_cards: Collection<ArchivedCard>,
+    archived_boards: Collection<ArchivedBoard>,
     graph: LoadState<DependencyGraph>,
 }
 
@@ -100,6 +102,9 @@ impl LoadedStateTrait for StubLoaded {
             .map(FetchStatus::from)
             .unwrap_or(FetchStatus::NotLoaded)
     }
+    fn archived_board_list(&self) -> FetchStatus {
+        (&self.archived_boards.all).into()
+    }
 }
 
 impl LoadedEntities for StubLoaded {
@@ -131,6 +136,7 @@ impl StubLoaded {
         apply_collection(&mut self.cards, resolved.cards);
         apply_collection(&mut self.sprints, resolved.sprints);
         apply_collection(&mut self.archived_cards, resolved.archived_cards);
+        apply_collection(&mut self.archived_boards, resolved.archived_boards);
         if !matches!(resolved.graph, LoadState::NotLoaded) {
             self.graph = resolved.graph;
         }
@@ -225,6 +231,12 @@ pub(super) fn seed_archived_card(
 ) -> ArchivedCard {
     let marker = ArchivedCard::new(card.id, board.id);
     store.insert_archived_card(marker).unwrap();
+    marker
+}
+
+pub(super) fn seed_archived_board(store: &RecordingStore, board: &Board) -> ArchivedBoard {
+    let marker = ArchivedBoard::now(board.id);
+    store.insert_archived_board(marker).unwrap();
     marker
 }
 

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -1413,3 +1413,26 @@ pub async fn test_list_boards_liveonly_does_not_fetch_archived_markers(factory: 
         "LiveOnly == list_boards() even with archived boards present (no marker fetch needed)"
     );
 }
+
+pub async fn test_list_archived_boards_round_trips_markers(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let live = ctx.create_board("Live".into(), Some("L".into())).unwrap();
+    let archived = ctx
+        .create_board("Archived".into(), Some("A".into()))
+        .unwrap();
+    ctx.archive_board(archived.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let markers = ctx.list_archived_boards().unwrap();
+    let ids: HashSet<Uuid> = markers.iter().map(|m| m.entity_id).collect();
+    assert!(ids.contains(&archived.id));
+    assert!(!ids.contains(&live.id));
+    assert_eq!(markers.len(), 1);
+}

--- a/crates/kanban-service/src/test_helpers/fault.rs
+++ b/crates/kanban-service/src/test_helpers/fault.rs
@@ -336,6 +336,7 @@ impl DataStore for FaultInjectingBackend {
         self.inner.get_archived_board(board_id)
     }
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.check("list_archived_boards", vec![])?;
         self.inner.list_archived_boards()
     }
     fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {

--- a/crates/kanban-service/src/test_helpers/fault.rs
+++ b/crates/kanban-service/src/test_helpers/fault.rs
@@ -44,6 +44,7 @@ pub const FAULTABLE_READS: &[&str] = &[
     "get_graph",
     "list_archived_cards",
     "list_archived_cards_by_board",
+    "list_archived_boards",
     "list_prefixes",
 ];
 

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -325,6 +325,10 @@ macro_rules! context_contract_tests {
             $crate::test_helpers::contract::archive::test_list_boards_archived_only_default_is_recency(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_archived_boards_round_trips_markers() {
+            $crate::test_helpers::contract::archive::test_list_archived_boards_round_trips_markers(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
         async fn test_list_boards_live_default_is_position() {
             $crate::test_helpers::contract::archive::test_list_boards_live_default_is_position(&$factory_fn()).await;
         }

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -168,6 +168,7 @@ mod tests {
         loaded_columns: HashMap<Uuid, Vec<Column>>,
         archived_card_list: FetchStatus,
         archived_cards_of_board: FetchStatus,
+        archived_board_list: FetchStatus,
     }
 
     impl Default for StubLoaded {
@@ -186,6 +187,7 @@ mod tests {
                 loaded_columns: HashMap::new(),
                 archived_card_list: FetchStatus::NotLoaded,
                 archived_cards_of_board: FetchStatus::NotLoaded,
+                archived_board_list: FetchStatus::NotLoaded,
             }
         }
     }
@@ -235,6 +237,9 @@ mod tests {
         }
         fn archived_cards_of_board(&self, _board_id: Uuid) -> FetchStatus {
             self.archived_cards_of_board
+        }
+        fn archived_board_list(&self) -> FetchStatus {
+            self.archived_board_list
         }
     }
 


### PR DESCRIPTION
## Summary

Gives archived boards a fetch tier mirroring the existing archived-card tier.

- `FetchRound.archived_board_list` (flat only, no board-scoped variant, since a board has no parent) and the matching `LoadedState::archived_board_list()` trait method, threaded through `Overlay`, `Fetched`, `narrow_to_outstanding`, and `fetch_round` in `resolve.rs`.
- `Resolved.archived_boards: Collection<ArchivedBoard>`, with `by_id`/`by_parent` permanently empty (only the whole-list tier is ever requested).
- `Model::archived_boards_state()` mirroring `archived_cards_state()`, backed by a companion `archived_boards_error` field so a Failed read can be represented on the `Option<Vec<_>>`-backed marker set without disturbing previously loaded `archived_boards()`/`archived_board_ids()`.
- `apply_resolved` now applies `resolved.archived_boards.all` (Loaded feeds the marker set and ids, Failed sets the error field, both leave prior state alone on repeat).

## Related fix

`apply_resolved` fetched `resolved.archived_cards.all` (the flat archived-card list) but never applied it into the Model, so a whole-list archived-card round silently never populated `archived_card_ids()`. Fixed the same way as boards, with a matching `archived_cards_error` field so `archived_cards_state()` can also report Failed.

## Breaking change

Removed the permissive `Ok(Vec::new())` default on `DataStore::list_archived_boards`, making it a required trait method. Every production backend already implemented it explicitly; the only fixtures relying on the default were `StubBackend` (kanban-backend), `FloorStore` (kanban-domain test), and `StubLoaded` (kanban-tui), which now get explicit overrides.

## Testing

- New unit tests in `fetch_plan.rs`, `resolved.rs`, `model/apply.rs`, `model/boards.rs`, `resolve/tests/archived_board.rs`, and `context/sync.rs` covering the flat round, the resolve pass, the apply path, and a Failed read leaving previously loaded markers alone.
- New contract test `test_list_archived_boards_round_trips_markers`, run against in-memory, JSON, and SQLite via the existing `context_contract_tests!` macro.
- Fixed two plumbing gaps discovered along the way that would otherwise have made these tests unreliable: `RecordingStore::list_archived_boards` wasn't recording/faultable, and `FaultInjectingBackend::list_archived_boards` wasn't checking for an injected fault.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` (whole workspace)
- `cargo test -p kanban-domain -p kanban-service -p kanban-backend -p kanban-tui --all-features`
- Confirmed the red commit alone fails to compile (18 errors), and mutation-tested the central assertions (breaking each production wire individually reproduced the corresponding test failure, then restored).

`crates/kanban-backend-http/` is untouched.
