### PR TITLE
KAN-1497 feat(api,server,backend-http): serve archived-card markers over http

### DIFF
--- a/.changeset/kan-1497-archived-card-markers-over-http.md
+++ b/.changeset/kan-1497-archived-card-markers-over-http.md
@@ -1,0 +1,9 @@
+---
+bump: minor
+---
+
+api,server,backend-http: add `ArchivedCardResponse` and a
+`GET /v1/boards/{board_id}/archived-cards` route, then wire
+`HttpBackend::list_archived_cards_by_board` to call it so the remote
+backend can serve the board-scoped archived-card tier instead of
+returning `Unsupported`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,7 @@ dependencies = [
  "kanban-core",
  "kanban-domain",
  "kanban-server",
+ "kanban-service",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -5,11 +5,12 @@
 //! callers into an explicit version path.
 mod v1;
 pub use v1::{
-    ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
-    CardStatusDto, ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest,
-    CreateCardRequest, CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType,
-    ErrorCode, Page, PageParams, Patch, PrefixResponse, ReorderColumnRequest, ReplaceBoardRequest,
-    ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto,
-    SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest,
-    UpdateColumnRequest, UpdateSprintRequest,
+    ApiError, ArchivedCardResponse, ArchivedFilterDto, BoardResponse, CardGraphResponse,
+    CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame, ChangeKind, ColumnResponse,
+    CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
+    CreateSprintRequest, EntityType, ErrorCode, Page, PageParams, Patch, PrefixResponse,
+    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
+    ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
+    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
+    UpdateSprintRequest,
 };

--- a/crates/kanban-api/src/v1/cards/archived_response.rs
+++ b/crates/kanban-api/src/v1/cards/archived_response.rs
@@ -1,0 +1,63 @@
+use chrono::{DateTime, Utc};
+use kanban_domain::ArchivedCard;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Response body for a board-scoped archived-card marker. Mirrors
+/// `ArchivedCard`'s own flat wire shape: the card is never embedded, only
+/// referenced by `entity_id`, and there is no restore-position payload since
+/// an archived card stays live in place under the reference-marker model.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArchivedCardResponse {
+    pub entity_id: Uuid,
+    pub archived_at: DateTime<Utc>,
+    pub board_id: Uuid,
+}
+
+impl From<&ArchivedCard> for ArchivedCardResponse {
+    fn from(ac: &ArchivedCard) -> Self {
+        Self {
+            entity_id: ac.entity_id,
+            archived_at: ac.metadata.archived_at,
+            board_id: ac.context.board_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ArchivedCard {
+        ArchivedCard::new(Uuid::new_v4(), Uuid::new_v4())
+    }
+
+    #[test]
+    fn test_archived_card_response_round_trips_and_flattens_context() {
+        let ac = sample();
+        let resp = ArchivedCardResponse::from(&ac);
+
+        let value = serde_json::to_value(&resp).unwrap();
+        assert!(value.get("entity_id").is_some());
+        assert!(value.get("archived_at").is_some());
+        assert!(value.get("board_id").is_some());
+        assert!(value.get("context").is_none(), "context must not be nested");
+        assert!(
+            value.get("metadata").is_none(),
+            "metadata must not be nested"
+        );
+
+        let back: ArchivedCardResponse = serde_json::from_value(value).unwrap();
+        assert_eq!(back, resp);
+    }
+
+    #[test]
+    fn test_archived_card_response_from_archived_card_preserves_fields() {
+        let ac = sample();
+        let resp = ArchivedCardResponse::from(&ac);
+
+        assert_eq!(resp.entity_id, ac.entity_id);
+        assert_eq!(resp.archived_at, ac.metadata.archived_at);
+        assert_eq!(resp.board_id, ac.context.board_id);
+    }
+}

--- a/crates/kanban-api/src/v1/cards/mod.rs
+++ b/crates/kanban-api/src/v1/cards/mod.rs
@@ -1,5 +1,7 @@
+mod archived_response;
 mod conversions;
 mod requests;
 mod response;
+pub use archived_response::ArchivedCardResponse;
 pub use requests::{CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
 pub use response::CardResponse;

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -11,7 +11,9 @@ mod patch;
 mod prefixes;
 mod sprints;
 pub use boards::{BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
-pub use cards::{CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
+pub use cards::{
+    ArchivedCardResponse, CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest,
+};
 pub use columns::{
     ColumnResponse, CreateColumnRequest, ReorderColumnRequest, ReplaceColumnRequest,
     UpdateColumnRequest,

--- a/crates/kanban-backend-http/Cargo.toml
+++ b/crates/kanban-backend-http/Cargo.toml
@@ -28,4 +28,5 @@ chrono.workspace = true
 
 [dev-dependencies]
 kanban-server = { path = "../kanban-server", features = ["test-helpers"] }
+kanban-service = { path = "../kanban-service", version = "^0.9" }
 tempfile.workspace = true

--- a/crates/kanban-backend-http/Cargo.toml
+++ b/crates/kanban-backend-http/Cargo.toml
@@ -28,5 +28,5 @@ chrono.workspace = true
 
 [dev-dependencies]
 kanban-server = { path = "../kanban-server", features = ["test-helpers"] }
-kanban-service = { path = "../kanban-service", version = "^0.9" }
+kanban-service = { path = "../kanban-service" }
 tempfile.workspace = true

--- a/crates/kanban-backend-http/src/conversions.rs
+++ b/crates/kanban-backend-http/src/conversions.rs
@@ -1,5 +1,21 @@
-use kanban_api::{BoardResponse, CardResponse, ColumnResponse, PrefixResponse, SprintResponse};
-use kanban_domain::{Board, Card, Column, Prefix, Sprint};
+use kanban_api::{
+    ArchivedCardResponse, BoardResponse, CardResponse, ColumnResponse, PrefixResponse,
+    SprintResponse,
+};
+use kanban_domain::{
+    ArchiveMetadata, Archived, ArchivedCard, Board, Card, CardRestoreContext, Column, Prefix,
+    Sprint,
+};
+
+pub(crate) fn archived_card_from_response(resp: &ArchivedCardResponse) -> ArchivedCard {
+    Archived::with_context(
+        resp.entity_id,
+        CardRestoreContext {
+            board_id: resp.board_id,
+        },
+        ArchiveMetadata::at(resp.archived_at),
+    )
+}
 
 pub(crate) fn prefix_from_response(resp: &PrefixResponse) -> Prefix {
     let mut prefix = Prefix::new(&resp.name);

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -1,9 +1,12 @@
 use crate::conversions::{
-    board_from_response, card_from_response, column_from_response, prefix_from_response,
-    sprint_from_response,
+    archived_card_from_response, board_from_response, card_from_response, column_from_response,
+    prefix_from_response, sprint_from_response,
 };
 use crate::HttpBackend;
-use kanban_api::{BoardResponse, CardResponse, ColumnResponse, PrefixResponse, SprintResponse};
+use kanban_api::{
+    ArchivedCardResponse, BoardResponse, CardResponse, ColumnResponse, PrefixResponse,
+    SprintResponse,
+};
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
     KanbanResult, Prefix, Snapshot, Sprint,
@@ -193,6 +196,15 @@ impl DataStore for HttpBackend {
 
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         Err(KanbanError::unsupported("list_archived_cards"))
+    }
+
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.block_on(async {
+            let resp: Vec<ArchivedCardResponse> = self
+                .get_json_list(&format!("/v1/boards/{board_id}/archived-cards"))
+                .await?;
+            Ok(resp.iter().map(archived_card_from_response).collect())
+        })
     }
 
     fn insert_archived_card(&self, _ac: ArchivedCard) -> KanbanResult<()> {

--- a/crates/kanban-backend-http/tests/archived_cards.rs
+++ b/crates/kanban-backend-http/tests/archived_cards.rs
@@ -1,0 +1,138 @@
+use kanban_backend_http::HttpBackend;
+use kanban_domain::{ArchivedCard, DataStore, Model, NoProjections};
+use kanban_server::test_helpers::TestServer;
+use kanban_service::fetch_plan::{requestable, FetchPlan, FetchRound, LoadedEntities};
+use kanban_service::{AppConfig, KanbanContext, KanbanOperations};
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn blocking<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    tokio::task::spawn_blocking(f).await.unwrap()
+}
+
+fn seed_archived_card(ctx: &mut KanbanContext) -> (Uuid, Uuid) {
+    let board = ctx
+        .create_board("Archive Board".to_string(), Some("ARC".to_string()))
+        .unwrap();
+    let column = ctx
+        .create_column(board.id, "Col".to_string(), None)
+        .unwrap();
+    let card = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Archive me".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    ctx.archive_card(card.id).unwrap();
+    (board.id, card.id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_archived_cards_by_board_round_trips_over_http() {
+    let mut board_id = Uuid::nil();
+    let mut card_id = Uuid::nil();
+    let server = TestServer::start_with(|ctx| {
+        let (b, c) = seed_archived_card(ctx);
+        board_id = b;
+        card_id = c;
+    })
+    .await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let markers: Vec<ArchivedCard> =
+        blocking(move || backend.list_archived_cards_by_board(board_id).unwrap()).await;
+
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0].entity_id, card_id);
+    assert_eq!(markers[0].context.board_id, board_id);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_archived_cards_by_board_excludes_other_boards() {
+    let mut board_a = Uuid::nil();
+    let server = TestServer::start_with(|ctx| {
+        let (b, _c) = seed_archived_card(ctx);
+        board_a = b;
+        let other_board = ctx
+            .create_board("Other Board".to_string(), Some("OTH".to_string()))
+            .unwrap();
+        let other_col = ctx
+            .create_column(other_board.id, "Col".to_string(), None)
+            .unwrap();
+        let other_card = ctx
+            .create_card(
+                other_board.id,
+                other_col.id,
+                "Other archived".to_string(),
+                Default::default(),
+            )
+            .unwrap();
+        ctx.archive_card(other_card.id).unwrap();
+    })
+    .await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let markers: Vec<ArchivedCard> =
+        blocking(move || backend.list_archived_cards_by_board(board_a).unwrap()).await;
+
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0].context.board_id, board_a);
+
+    server.shutdown().await;
+}
+
+struct ArchivedCardsByBoardPlan {
+    board_id: Uuid,
+}
+
+impl FetchPlan for ArchivedCardsByBoardPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            archived_cards_by_board: if requestable(loaded.archived_cards_of_board(self.board_id)) {
+                vec![self.board_id]
+            } else {
+                Vec::new()
+            },
+            ..Default::default()
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_the_archived_card_tier_resolves_over_http() {
+    let mut board_id = Uuid::nil();
+    let mut card_id = Uuid::nil();
+    let server = TestServer::start_with(|ctx| {
+        let (b, c) = seed_archived_card(ctx);
+        board_id = b;
+        card_id = c;
+    })
+    .await;
+    let backend: Arc<dyn kanban_service::KanbanBackend> =
+        Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+
+    let model = blocking(move || {
+        let ctx = KanbanContext::open_deferred(backend, AppConfig::default());
+        let mut model = Model::default();
+        ctx.sync(
+            &ArchivedCardsByBoardPlan { board_id },
+            &mut model,
+            &mut NoProjections,
+        );
+        model
+    })
+    .await;
+
+    let state = model.board_archived_cards_state(board_id);
+    let markers = state
+        .loaded()
+        .expect("archived-card tier should resolve to Loaded over HTTP");
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0].entity_id, card_id);
+
+    server.shutdown().await;
+}

--- a/crates/kanban-backend-http/tests/archived_cards.rs
+++ b/crates/kanban-backend-http/tests/archived_cards.rs
@@ -10,7 +10,7 @@ async fn blocking<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> 
     tokio::task::spawn_blocking(f).await.unwrap()
 }
 
-fn seed_archived_card(ctx: &mut KanbanContext) -> (Uuid, Uuid) {
+fn seed_archived_card(ctx: &mut KanbanContext) -> (Uuid, Uuid, chrono::DateTime<chrono::Utc>) {
     let board = ctx
         .create_board("Archive Board".to_string(), Some("ARC".to_string()))
         .unwrap();
@@ -26,17 +26,20 @@ fn seed_archived_card(ctx: &mut KanbanContext) -> (Uuid, Uuid) {
         )
         .unwrap();
     ctx.archive_card(card.id).unwrap();
-    (board.id, card.id)
+    let seeded = ctx.list_archived_cards_by_board(board.id).unwrap();
+    (board.id, card.id, seeded[0].metadata.archived_at)
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_archived_cards_by_board_round_trips_over_http() {
     let mut board_id = Uuid::nil();
     let mut card_id = Uuid::nil();
+    let mut seeded_at = chrono::Utc::now();
     let server = TestServer::start_with(|ctx| {
-        let (b, c) = seed_archived_card(ctx);
+        let (b, c, at) = seed_archived_card(ctx);
         board_id = b;
         card_id = c;
+        seeded_at = at;
     })
     .await;
     let backend = HttpBackend::new(&server.base_url()).unwrap();
@@ -47,6 +50,7 @@ async fn test_list_archived_cards_by_board_round_trips_over_http() {
     assert_eq!(markers.len(), 1);
     assert_eq!(markers[0].entity_id, card_id);
     assert_eq!(markers[0].context.board_id, board_id);
+    assert_eq!(markers[0].metadata.archived_at, seeded_at);
 
     server.shutdown().await;
 }
@@ -55,7 +59,7 @@ async fn test_list_archived_cards_by_board_round_trips_over_http() {
 async fn test_list_archived_cards_by_board_excludes_other_boards() {
     let mut board_a = Uuid::nil();
     let server = TestServer::start_with(|ctx| {
-        let (b, _c) = seed_archived_card(ctx);
+        let (b, _c, _at) = seed_archived_card(ctx);
         board_a = b;
         let other_board = ctx
             .create_board("Other Board".to_string(), Some("OTH".to_string()))
@@ -107,7 +111,7 @@ async fn test_the_archived_card_tier_resolves_over_http() {
     let mut board_id = Uuid::nil();
     let mut card_id = Uuid::nil();
     let server = TestServer::start_with(|ctx| {
-        let (b, c) = seed_archived_card(ctx);
+        let (b, c, _at) = seed_archived_card(ctx);
         board_id = b;
         card_id = c;
     })

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -6,6 +6,7 @@ use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use kanban_domain::{Card, CardListFilter};
+use kanban_service::api::ArchivedCardResponse;
 use kanban_service::api::ArchivedFilterDto;
 use kanban_service::api::CardResponse;
 use kanban_service::api::{
@@ -60,10 +61,30 @@ async fn get_card(
     Ok(Json(CardResponse::from(&card)))
 }
 
+async fn list_archived_cards(
+    State(state): State<AppState>,
+    Path(board_id): Path<Uuid>,
+    Query(params): Query<PageParams>,
+) -> Result<Json<Page<ArchivedCardResponse>>, AppError> {
+    let ctx = state.ctx.lock().await;
+    ctx.require_board(board_id)
+        .map_err(|e| AppError::from(&e))?;
+    let markers = ctx
+        .list_archived_cards_by_board(board_id)
+        .map_err(|e| AppError::from(&e))?;
+    let responses: Vec<ArchivedCardResponse> =
+        markers.iter().map(ArchivedCardResponse::from).collect();
+    paginate_response(responses, &params)
+}
+
 pub fn read_router() -> Router<AppState> {
     Router::new()
         .route("/v1/boards/{board_id}/cards", get(list_cards))
         .route("/v1/boards/{board_id}/cards/{id}", get(get_card))
+        .route(
+            "/v1/boards/{board_id}/archived-cards",
+            get(list_archived_cards),
+        )
 }
 
 fn created_status(created: bool) -> StatusCode {

--- a/crates/kanban-server/src/test_helpers.rs
+++ b/crates/kanban-server/src/test_helpers.rs
@@ -65,10 +65,18 @@ impl TestServer {
     /// are valid the moment start() returns -- no race with a test hitting
     /// the port before bind completes).
     pub async fn start() -> Self {
+        Self::start_with(|_| {}).await
+    }
+
+    /// Like [`Self::start`], but runs `seed` against the fresh `KanbanContext`
+    /// before the router starts serving, so a test can put the context in a
+    /// state (e.g. an archived card) that no HTTP write route can reach.
+    pub async fn start_with(seed: impl FnOnce(&mut KanbanContext)) -> Self {
         let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
-        let ctx = KanbanContext::open(backend, AppConfig::default())
+        let mut ctx = KanbanContext::open(backend, AppConfig::default())
             .await
             .unwrap();
+        seed(&mut ctx);
         let state = AppState::new(ctx);
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/kanban-server/tests/archived_cards_read.rs
+++ b/crates/kanban-server/tests/archived_cards_read.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::http::StatusCode;
+use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_service::api::{ArchivedCardResponse, Page};
+use kanban_service::KanbanOperations;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_archived_cards_lists_only_that_boards_markers() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_a_id: Uuid;
+    let board_b_id: Uuid;
+    let archived_a_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_a_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        board_b_id = ctx
+            .create_board("Board B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+
+        let col_a_id = ctx
+            .create_column(board_a_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        let col_b_id = ctx
+            .create_column(board_b_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+
+        archived_a_id = ctx
+            .create_card(
+                board_a_id,
+                col_a_id,
+                "Archived in A".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let archived_b_id = ctx
+            .create_card(
+                board_b_id,
+                col_b_id,
+                "Archived in B".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+
+        ctx.archive_card(archived_a_id).unwrap();
+        ctx.archive_card(archived_b_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/archived-cards", board_a_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let page: Page<ArchivedCardResponse> = serde_json::from_value(json)
+        .expect("body should deserialize as Page<ArchivedCardResponse>");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].entity_id, archived_a_id);
+    assert_eq!(page.items[0].board_id, board_a_id);
+    assert!(page.items[0].archived_at <= chrono::Utc::now());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_archived_cards_unknown_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_board_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/archived-cards", random_board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

- Add `ArchivedCardResponse` to `kanban-api` (`entity_id`, `archived_at`, `board_id`), mirroring `ArchivedCard`'s own flat wire shape.
- Add `GET /v1/boards/{board_id}/archived-cards` to `kanban-server`, returning a paginated `Page<ArchivedCardResponse>` (consistent with every other collection route in `cards.rs`).
- Override `HttpBackend::list_archived_cards_by_board` in `kanban-backend-http` to call the new route and convert the response back into an `ArchivedCard`, preserving the wire `archived_at` instead of re-stamping `now()`.
- Add `TestServer::start_with(seed)` to `kanban-server::test_helpers` so an integration test can put a `KanbanContext` into an archived state before the router starts serving, since there is no HTTP write route for archiving a card.

This discharges the merged-tier follow-up so the remote (HTTP) backend can serve the board-scoped archived-card tier instead of failing every sync with `Unsupported`.

The plain (whole-store) `list_archived_cards` override stays an explicit `Unsupported` error; only the board-scoped read is implemented, matching `DECIDED-2` on the parent card.

## Test plan

- [x] `test_archived_card_response_round_trips_and_flattens_context` (kanban-api)
- [x] `test_get_board_archived_cards_lists_only_that_boards_markers` (kanban-server, red before the route existed)
- [x] `test_list_archived_cards_by_board_round_trips_over_http` (kanban-backend-http, red before the override existed)
- [x] `test_the_archived_card_tier_resolves_over_http` (kanban-backend-http, drives `KanbanContext::sync`/`resolve()` through a real `FetchPlan`, red before the override existed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -p kanban-api -p kanban-server -p kanban-backend-http -- -D warnings`
- [x] `cargo test -p kanban-api -p kanban-server -p kanban-backend-http --all-features`
- [x] Mutation check: reverted the route to call the whole-store `list_archived_cards` (no board scoping) and confirmed both the server test and the http round-trip test fail; restored the fix.
