### PR TITLE
KAN-1460 feat(service): expose read_full_snapshot/write_full_snapshot under test-helpers feature

### DIFF
--- a/.changeset/kan-1460-expose-read-full-snapshot-write-full-snapshot-under-test.md
+++ b/.changeset/kan-1460-expose-read-full-snapshot-write-full-snapshot-under-test.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: expose `read_full_snapshot` and `write_full_snapshot` as public functions, re-exported from the crate root under the existing `test-helpers` feature, so integration-test crates outside `kanban-service` can seed and read a full workspace snapshot directly.

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -45,6 +45,8 @@ pub use store_manager::StoreManager;
 
 #[cfg(feature = "test-helpers")]
 pub mod test_helpers;
+#[cfg(feature = "test-helpers")]
+pub use crate::store_adapter::{read_full_snapshot, write_full_snapshot};
 
 pub use kanban_core::{AppConfig, AppType};
 

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 /// Archived boards are absent from `list_boards`, so their heads are recovered
 /// individually through the unfiltered `get_board`. Archived cards are likewise
 /// absent from `list_all_cards` and are fetched by id.
-pub(crate) fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot> {
+pub fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot> {
     // Flat, per-collection reads rather than a walk down boards -> columns ->
     // cards. Cards carry no foreign key on `column_id` or `board_id`, so a card
     // can outlive its column; a hierarchical read could only reach cards through
@@ -62,7 +62,7 @@ pub(crate) fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot
 /// each row lands: sprints precede cards because `cards.sprint_id` references
 /// them, and both follow boards. Archival markers reference the rows they mark,
 /// so they come last.
-pub(crate) fn write_full_snapshot(store: &dyn DataStore, snapshot: Snapshot) -> KanbanResult<()> {
+pub fn write_full_snapshot(store: &dyn DataStore, snapshot: Snapshot) -> KanbanResult<()> {
     // Before the boards: these carry all card and sprint numbering, and a
     // snapshot written without them restarts every namespace at 1.
     for prefix in snapshot.prefixes {

--- a/crates/kanban-service/tests/store_adapter_reachability.rs
+++ b/crates/kanban-service/tests/store_adapter_reachability.rs
@@ -1,0 +1,17 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::data_store::DataStore;
+use kanban_domain::{Board, KanbanResult};
+
+#[test]
+fn test_read_full_snapshot_is_reachable_from_an_integration_test() -> KanbanResult<()> {
+    let store = InMemoryStore::new();
+    let board = Board::new("B", None::<String>);
+    let board_id = board.id;
+    store.upsert_board(board)?;
+
+    let snap = kanban_service::read_full_snapshot(&store)?;
+
+    assert_eq!(snap.boards.len(), 1);
+    assert_eq!(snap.boards[0].id, board_id);
+    Ok(())
+}

--- a/crates/kanban-service/tests/store_adapter_reachability.rs
+++ b/crates/kanban-service/tests/store_adapter_reachability.rs
@@ -1,3 +1,7 @@
+//! Requires the `test-helpers` feature; run with
+//! `cargo test -p kanban-service --features test-helpers`.
+#![cfg(feature = "test-helpers")]
+
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{Board, KanbanResult};


### PR DESCRIPTION
## Summary

- Widens `read_full_snapshot` and `write_full_snapshot` in `kanban-service::store_adapter` from `pub(crate)` to `pub`.
- Re-exports both from the crate root, gated behind the existing `test-helpers` feature (mirrors the pattern used for `test_helpers`), so integration-test crates outside `kanban-service` can reach them.
- The `store_adapter` module itself stays private (`mod store_adapter;`); the re-export line is the only door.
- Purely additive: no call site is rewired, `store_manager.rs` keeps calling both functions through their crate-relative paths unchanged.

## Red -> Green

Wrote `crates/kanban-service/tests/store_adapter_reachability.rs` first, seeding an `InMemoryStore` with one board and calling `kanban_service::read_full_snapshot`. It failed with an unresolved-import style error (E0425, `cannot find function read_full_snapshot in crate kanban_service`), confirming the gap was exactly the missing public surface, not a missing feature flag or dependency. No self-referential dev-dependency on `kanban-service` was needed to reproduce the failure or reach green.

Widened the two function signatures and added the feature-gated re-export in `lib.rs`; the same test then passed.

Mutation-checked by reverting one signature back to `pub(crate)`: the crate fails to build with the expected unused-import / privacy error, then reverted.

## Changeset

Added `.changeset/kan-1460-expose-read-full-snapshot-write-full-snapshot-under-test.md` with `bump: minor`, since this adds new public API surface (feature-gated) per the pre-1.0 rule in `.changeset/README.md`.

## Verification

- `cargo test -p kanban-service --features test-helpers --test store_adapter_reachability` passes
- `cargo test -p kanban-service --all-features` passes, 0 failed
- `cargo test -p kanban-service --features test-helpers -- --list` reports 1138 tests total
- `cargo build -p kanban-service --no-default-features` succeeds
- `cargo fmt --all -- --check` clean
- `cargo clippy -p kanban-service --all-targets --features test-helpers -- -D warnings` clean
- AC greps: 0 `pub(crate)` hits on the two functions, 2 `pub fn` hits, 1 re-export line preceded by the `test-helpers` cfg attribute, 0 `pub mod store_adapter` hits

## Note on commit shape

The card's AC calls for exactly one commit. That held for the first commit (test + implementation together), but review found the new test file was missing its `#![cfg(feature = "test-helpers")]` gate, so `cargo test -p kanban-service` failed to compile at default features (a regression, since CI only runs `--all-features` and could not catch it). A second commit adds the gate, mirroring `fault_injection.rs` and `archival_contract.rs` in the same directory. The branch already being pushed rules out amending in place, so the one-commit AC is superseded by this fix commit.

Re-verified both configurations after the fix:
- `cargo test -p kanban-service --test store_adapter_reachability --no-run` (default features) now succeeds, running 0 tests
- `cargo test -p kanban-service --features test-helpers --test store_adapter_reachability` still reports 1 passed
- `cargo clippy -p kanban-service --all-targets --all-features -- -D warnings` is clean. `cargo clippy -p kanban-service --all-targets -- -D warnings` (default features) fails on a pre-existing, unrelated dead-code lint in `context/sync.rs` that is also present on `origin/develop` before this branch's changes (confirmed via a throwaway worktree at f904be65); it is not caused by this change.

This leaf rewires nothing and unblocks KAN-1461 through KAN-1464.
