### PR TITLE
KAN-1461 refactor(backend-memory): rewire in-memory test callers onto snapshot_impl/apply_snapshot_impl

### DIFF
--- a/.changeset/kan-1461-rewire-in-memory-test-callers.md
+++ b/.changeset/kan-1461-rewire-in-memory-test-callers.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+backend-memory: rewire the 14 test-only callers of `InMemoryStore::snapshot`/`apply_snapshot` onto the already-public inherent methods `snapshot_impl`/`apply_snapshot_impl`, so the tests no longer depend on the `DataStore` trait methods slated for removal.

--- a/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
@@ -88,10 +88,10 @@ mod tests {
         store.upsert_card(card).unwrap();
         store.upsert_sprint(sprint).unwrap();
 
-        let snap = store.snapshot().unwrap();
+        let snap = store.snapshot_impl().unwrap();
 
         let store2 = InMemoryStore::new();
-        store2.apply_snapshot(snap).unwrap();
+        store2.apply_snapshot_impl(snap).unwrap();
 
         assert_eq!(store2.list_boards().unwrap().len(), 1);
         assert_eq!(store2.list_all_columns().unwrap().len(), 1);
@@ -112,7 +112,7 @@ mod tests {
             .insert_archived_board(Archived::now(archived_id))
             .unwrap();
 
-        let snap = store.snapshot().unwrap();
+        let snap = store.snapshot_impl().unwrap();
         // Reference-marker model: BOTH board heads live in `.boards` (the archived
         // one is the marker's referenced entity); `.archived_boards` holds the
         // pure marker.
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(snap.archived_boards.len(), 1);
 
         let store2 = InMemoryStore::new();
-        store2.apply_snapshot(snap).unwrap();
+        store2.apply_snapshot_impl(snap).unwrap();
 
         // list_boards is live-scoped: only the non-archived board.
         assert_eq!(store2.list_boards().unwrap().len(), 1);
@@ -156,7 +156,7 @@ mod tests {
         store.upsert_sprint(s2).unwrap();
         store.upsert_sprint(s1).unwrap();
 
-        let snap = store.snapshot().unwrap();
+        let snap = store.snapshot_impl().unwrap();
 
         assert_eq!(
             snap.boards[0].name, "A",
@@ -196,7 +196,7 @@ mod tests {
         }
 
         let names: Vec<String> = store
-            .snapshot()
+            .snapshot_impl()
             .unwrap()
             .boards
             .iter()
@@ -223,7 +223,7 @@ mod tests {
         }
 
         let names: Vec<String> = store
-            .snapshot()
+            .snapshot_impl()
             .unwrap()
             .columns
             .iter()
@@ -251,7 +251,7 @@ mod tests {
         }
 
         let titles: Vec<String> = store
-            .snapshot()
+            .snapshot_impl()
             .unwrap()
             .cards
             .iter()
@@ -281,7 +281,7 @@ mod tests {
             vec![],
             DependencyGraph::new(),
         );
-        let err = store.apply_snapshot(snap).unwrap_err();
+        let err = store.apply_snapshot_impl(snap).unwrap_err();
         assert!(
             matches!(
                 &err,
@@ -317,7 +317,7 @@ mod tests {
             vec![],
             DependencyGraph::new(),
         );
-        store.apply_snapshot(snap).unwrap();
+        store.apply_snapshot_impl(snap).unwrap();
 
         let boards = store.list_boards().unwrap();
         assert_eq!(boards.len(), 1);

--- a/crates/kanban-backend-memory/src/in_memory_store/state.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/state.rs
@@ -121,8 +121,8 @@ mod tests {
         assert!(store.list_all_sprints().is_ok());
         assert!(store.get_graph().is_ok());
         assert!(store.set_graph(DependencyGraph::new()).is_ok());
-        assert!(store.snapshot().is_ok());
-        assert!(store.apply_snapshot(Snapshot::new()).is_ok());
+        assert!(store.snapshot_impl().is_ok());
+        assert!(store.apply_snapshot_impl(Snapshot::new()).is_ok());
         assert!(store.delete_card(card.id).is_ok());
         assert!(store.delete_cards_by_columns(&[col.id]).is_ok());
         assert!(store.delete_column(col.id).is_ok());
@@ -157,7 +157,7 @@ mod tests {
                     let _ = s.list_boards();
                     let _ = s.list_all_columns();
                     let _ = s.list_all_cards();
-                    let _ = s.snapshot();
+                    let _ = s.snapshot_impl();
                 }
             }));
         }

--- a/crates/kanban-backend-memory/src/in_memory_store/tests/cards.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/tests/cards.rs
@@ -222,7 +222,7 @@ fn test_column_index_apply_snapshot_rebuilds_from_snapshot_cards() {
         DependencyGraph::new(),
     );
 
-    store.apply_snapshot(snapshot).unwrap();
+    store.apply_snapshot_impl(snapshot).unwrap();
 
     assert_eq!(
         store.count_cards_in_column(col_a.id).unwrap(),


### PR DESCRIPTION
## Summary

Pure mechanical rewire, no behavior change. Renames all 14 test-only call sites of `DataStore::snapshot`/`apply_snapshot` on `InMemoryStore` onto the already-public inherent methods `snapshot_impl`/`apply_snapshot_impl` defined in `crates/kanban-backend-memory/src/in_memory_store/snapshot.rs`. This unblocks the later deletion of the `DataStore::snapshot`/`apply_snapshot` trait methods, since the crate's own tests would otherwise still depend on them.

Files touched:
- `crates/kanban-backend-memory/src/in_memory_store/snapshot.rs` (10 sites)
- `crates/kanban-backend-memory/src/in_memory_store/state.rs` (3 sites)
- `crates/kanban-backend-memory/src/in_memory_store/tests/cards.rs` (1 site)

No new tests were added by design: this is a rewire of already-passing tests onto already-existing pub inherent methods, with no new behavior to characterize. The discriminator is the audit table below plus a mutation check on the two rows whose subject narrows from the trait method to the inherent method.

## Audit table (14 call sites)

| File:line | Enclosing fn | Current shape | Asserts today | Rewrite | Asserts after | Backends exercised | Notes |
|---|---|---|---|---|---|---|---|
| snapshot.rs:91 | test_snapshot_roundtrip | `store.snapshot()` | roundtrip via 4 list_* counts == 1 | `store.snapshot_impl()` | identical | in-memory | none |
| snapshot.rs:94 | test_snapshot_roundtrip | `store2.apply_snapshot(snap)` | as above | `store2.apply_snapshot_impl(snap)` | identical | in-memory | none |
| snapshot.rs:115 | test_snapshot_round_trips_archived_boards | `store.snapshot()` | board head + archived marker counts | `store.snapshot_impl()` | identical | in-memory | none |
| snapshot.rs:123 | test_snapshot_round_trips_archived_boards | `store2.apply_snapshot(snap)` | as above | `store2.apply_snapshot_impl(snap)` | identical | in-memory | none |
| snapshot.rs:159 | test_snapshot_sorts_entities_by_position | `store.snapshot()` | boards/columns/cards/sprints sort order | `store.snapshot_impl()` | identical | in-memory | none |
| snapshot.rs:199 | test_snapshot_orders_boards_with_equal_position_by_created_at | `.snapshot()` (chained, own line) | equal-position boards ordered by created_at | `.snapshot_impl()` | identical | in-memory | bare receiver on its own line from a rustfmt-split chain |
| snapshot.rs:226 | test_snapshot_orders_columns_with_equal_position_by_created_at | `.snapshot()` (chained, own line) | equal-position columns ordered by created_at | `.snapshot_impl()` | identical | in-memory | bare receiver on its own line from a rustfmt-split chain |
| snapshot.rs:254 | test_snapshot_orders_cards_with_equal_position_by_created_at | `.snapshot()` (chained, own line) | equal-position cards ordered by created_at | `.snapshot_impl()` | identical | in-memory | bare receiver on its own line from a rustfmt-split chain |
| snapshot.rs:284 | test_apply_snapshot_rejects_a_snapshot_whose_cards_outrun_its_prefix_rows | `store.apply_snapshot(snap)` | rejects with `PrefixNotBacked`, no card/prefix written | `store.apply_snapshot_impl(snap)` | identical | in-memory | none |
| snapshot.rs:320 | test_apply_snapshot_replaces_existing_data | `store.apply_snapshot(snap)` | old board replaced by new | `store.apply_snapshot_impl(snap)` | identical | in-memory | none |
| state.rs:124 | test_all_data_store_methods_return_ok_not_panic | `store.snapshot().is_ok()` | trait method returns Ok | `store.snapshot_impl().is_ok()` | inherent method returns Ok | in-memory | subject narrows from trait method to inherent method (expected, no trait method exists post-KAN-1444); mutation-checked below |
| state.rs:125 | test_all_data_store_methods_return_ok_not_panic | `store.apply_snapshot(Snapshot::new()).is_ok()` | trait method returns Ok | `store.apply_snapshot_impl(Snapshot::new()).is_ok()` | inherent method returns Ok | in-memory | subject narrows from trait method to inherent method (expected) |
| state.rs:160 | test_concurrent_reads_and_writes_no_panic | `s.snapshot()` inside `thread::spawn` closure over `Arc<InMemoryStore>` | no panic under concurrent read/write | `s.snapshot_impl()` | identical | in-memory | `s` is `Arc<InMemoryStore>`, not `&dyn DataStore`; no retype needed |
| tests/cards.rs:225 | test_column_index_apply_snapshot_rebuilds_from_snapshot_cards | `store.apply_snapshot(snapshot)` | column index rebuilt from snapshot cards | `store.apply_snapshot_impl(snapshot)` | identical | in-memory | none |

## Mutation check (state.rs:124)

Temporarily made `snapshot_impl` return `Err(...)` at the top of its body, re-ran `test_all_data_store_methods_return_ok_not_panic`, confirmed the rewritten `assert!(store.snapshot_impl().is_ok())` failed with:

```
thread '...test_all_data_store_methods_return_ok_not_panic' panicked at crates/kanban-backend-memory/src/in_memory_store/state.rs:124:9:
assertion failed: store.snapshot_impl().is_ok()
```

Reverted the mutation exactly; re-ran green (84 passed, 0 failed).

## Verification

- `cargo test -p kanban-backend-memory --all-features -- --list` before and after: identical test name list (85 total across lib + integration test).
- `cargo test -p kanban-backend-memory --all-features`: green, 84 lib tests + 1 integration test passed.
- `cargo clippy -p kanban-backend-memory --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `git diff --name-only origin/develop -- crates/kanban-domain` empty; `git grep -n 'kanban-service' -- crates/kanban-backend-memory/Cargo.toml` returns nothing (no coupling introduced or crossed).

Changeset added at `.changeset/kan-1461-rewire-in-memory-test-callers.md` with `bump: patch` (internal test-code rename only, no public API surface touched).
