### PR TITLE
KAN-1437 feat(service): compose the whole-store export through read_full_snapshot

### DIFF
--- a/.changeset/kan-1437-compose-whole-store-export-atomic.md
+++ b/.changeset/kan-1437-compose-whole-store-export-atomic.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: route the whole-store export branch of `export_board(None)` through `read_full_snapshot` instead of `DataStore::snapshot`, and add a new `KanbanContext::export_all_boards()` that composes an `AllBoardsExport` directly, matching the two-step snapshot-then-convert flow callers previously had to do by hand.

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -358,7 +358,9 @@ impl KanbanContext {
             .map_err(|e| PersistenceError::Serialization(e.to_string()).into())
     }
 
-    /// Equivalent to `BoardImporter::convert_snapshot_to_export(self.snapshot()?)`.
+    /// Full-fidelity `AllBoardsExport` for every board, live and archived,
+    /// including archived subtrees and their markers. The dependency graph is
+    /// NOT part of `AllBoardsExport` and is dropped by the conversion.
     pub fn export_all_boards(&self) -> KanbanResult<AllBoardsExport> {
         let snapshot = crate::store_adapter::read_full_snapshot(self.backend.as_data_store())?;
         Ok(BoardImporter::convert_snapshot_to_export(snapshot))

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -1,6 +1,7 @@
 use super::KanbanContext;
 use kanban_core::{ClientId, KANBAN_VERSION};
 use kanban_domain::commands::{Command, SprintCommand};
+use kanban_domain::export::{AllBoardsExport, BoardImporter};
 use kanban_domain::{
     invalidation_from_inverse, Board, DataStore, FieldUpdate, Invalidation, KanbanError,
     KanbanResult, Snapshot, Sprint, SprintUpdate,
@@ -355,6 +356,10 @@ impl KanbanContext {
 
         serde_json::to_string_pretty(&snapshot)
             .map_err(|e| PersistenceError::Serialization(e.to_string()).into())
+    }
+
+    pub fn export_all_boards(&self) -> KanbanResult<AllBoardsExport> {
+        todo!()
     }
 
     pub fn import_board_impl(&mut self, data: &str) -> KanbanResult<(Board, Invalidation)> {

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -351,15 +351,17 @@ impl KanbanContext {
                 prefixes,
             }
         } else {
-            self.backend.snapshot()?
+            crate::store_adapter::read_full_snapshot(self.backend.as_data_store())?
         };
 
         serde_json::to_string_pretty(&snapshot)
             .map_err(|e| PersistenceError::Serialization(e.to_string()).into())
     }
 
+    /// Equivalent to `BoardImporter::convert_snapshot_to_export(self.snapshot()?)`.
     pub fn export_all_boards(&self) -> KanbanResult<AllBoardsExport> {
-        todo!()
+        let snapshot = crate::store_adapter::read_full_snapshot(self.backend.as_data_store())?;
+        Ok(BoardImporter::convert_snapshot_to_export(snapshot))
     }
 
     pub fn import_board_impl(&mut self, data: &str) -> KanbanResult<(Board, Invalidation)> {

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -7,7 +7,7 @@ use kanban_domain::card::CardPriority;
 use kanban_domain::{
     CardListFilter, CreateCardOptions, GraphOperations, KanbanOperations, Severity,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -1542,9 +1542,23 @@ pub async fn test_export_board_whole_store_includes_archived_board_and_card(
         "blocks edge between the live and archived card is present"
     );
 
-    let prefix_names: HashSet<String> = snapshot.prefixes.iter().map(|p| p.name.clone()).collect();
-    assert!(
-        !prefix_names.is_empty(),
-        "prefixes carried for the exported entities"
+    let prefixes_by_name: HashMap<&str, &kanban_domain::Prefix> = snapshot
+        .prefixes
+        .iter()
+        .map(|p| (p.name.as_str(), p))
+        .collect();
+    let task_prefix = prefixes_by_name
+        .get("task")
+        .expect("task prefix row present");
+    assert_eq!(
+        task_prefix.card_counter, 3,
+        "task prefix counter reflects all three created cards across both boards"
+    );
+    let sprint_prefix = prefixes_by_name
+        .get("sprint")
+        .expect("sprint prefix row present");
+    assert_eq!(
+        sprint_prefix.sprint_counter, 2,
+        "sprint prefix counter reflects both created sprints across both boards"
     );
 }

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -1436,3 +1436,120 @@ pub async fn test_list_archived_boards_round_trips_markers(factory: &BackendFact
     assert!(!ids.contains(&live.id));
     assert_eq!(markers.len(), 1);
 }
+
+pub async fn test_export_board_whole_store_includes_archived_board_and_card(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board_a = ctx.create_board("Board A".into(), None).unwrap();
+    let column_a = ctx
+        .create_column(board_a.id, "Todo".into(), None)
+        .unwrap();
+    let sprint_a = ctx.create_sprint(board_a.id, None, None).unwrap();
+    let live_card = ctx
+        .create_card(
+            board_a.id,
+            column_a.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let arch_card = ctx
+        .create_card(
+            board_a.id,
+            column_a.id,
+            "Arch".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.assign_card_to_sprint(live_card.id, sprint_a.id)
+        .unwrap();
+    ctx.block(live_card.id, arch_card.id, Severity::High)
+        .unwrap();
+    ctx.archive_card(arch_card.id).unwrap();
+
+    let board_b = ctx.create_board("Board B".into(), None).unwrap();
+    let column_b = ctx
+        .create_column(board_b.id, "Todo".into(), None)
+        .unwrap();
+    let sprint_b = ctx.create_sprint(board_b.id, None, None).unwrap();
+    let card_b = ctx
+        .create_card(
+            board_b.id,
+            column_b.id,
+            "B card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_board(board_b.id).unwrap();
+
+    let json = ctx.export_board(None).unwrap();
+    let snapshot: kanban_domain::Snapshot = serde_json::from_str(&json).unwrap();
+
+    let board_ids: HashSet<Uuid> = snapshot.boards.iter().map(|b| b.id).collect();
+    assert!(board_ids.contains(&board_a.id), "board A head present");
+    assert!(
+        board_ids.contains(&board_b.id),
+        "archived board B's head is still present in boards"
+    );
+
+    let archived_board_ids: HashSet<Uuid> = snapshot
+        .archived_boards
+        .iter()
+        .map(|m| m.entity_id())
+        .collect();
+    assert!(
+        archived_board_ids.contains(&board_b.id),
+        "board B's archived marker is present"
+    );
+
+    let column_ids: HashSet<Uuid> = snapshot.columns.iter().map(|c| c.id).collect();
+    assert!(column_ids.contains(&column_a.id), "board A column present");
+    assert!(
+        column_ids.contains(&column_b.id),
+        "board B's column present"
+    );
+
+    let card_ids: HashSet<Uuid> = snapshot.cards.iter().map(|c| c.id).collect();
+    assert!(card_ids.contains(&live_card.id), "live card present");
+    assert!(
+        card_ids.contains(&arch_card.id),
+        "archived card's live row present"
+    );
+    assert!(card_ids.contains(&card_b.id), "board B's card present");
+
+    let archived_card_ids: HashSet<Uuid> = snapshot
+        .archived_cards
+        .iter()
+        .map(|m| m.entity_id())
+        .collect();
+    assert!(
+        archived_card_ids.contains(&arch_card.id),
+        "archived card marker present"
+    );
+
+    let sprint_ids: HashSet<Uuid> = snapshot.sprints.iter().map(|s| s.id).collect();
+    assert!(sprint_ids.contains(&sprint_a.id), "board A sprint present");
+    assert!(sprint_ids.contains(&sprint_b.id), "board B sprint present");
+
+    assert!(
+        snapshot
+            .graph
+            .blocks_edges()
+            .iter()
+            .any(|e| e.base.source == live_card.id && e.base.target == arch_card.id),
+        "blocks edge between the live and archived card is present"
+    );
+
+    let prefix_names: HashSet<String> =
+        snapshot.prefixes.iter().map(|p| p.name.clone()).collect();
+    assert!(
+        !prefix_names.is_empty(),
+        "prefixes carried for the exported entities"
+    );
+}

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -1447,9 +1447,7 @@ pub async fn test_export_board_whole_store_includes_archived_board_and_card(
         .unwrap();
 
     let board_a = ctx.create_board("Board A".into(), None).unwrap();
-    let column_a = ctx
-        .create_column(board_a.id, "Todo".into(), None)
-        .unwrap();
+    let column_a = ctx.create_column(board_a.id, "Todo".into(), None).unwrap();
     let sprint_a = ctx.create_sprint(board_a.id, None, None).unwrap();
     let live_card = ctx
         .create_card(
@@ -1474,9 +1472,7 @@ pub async fn test_export_board_whole_store_includes_archived_board_and_card(
     ctx.archive_card(arch_card.id).unwrap();
 
     let board_b = ctx.create_board("Board B".into(), None).unwrap();
-    let column_b = ctx
-        .create_column(board_b.id, "Todo".into(), None)
-        .unwrap();
+    let column_b = ctx.create_column(board_b.id, "Todo".into(), None).unwrap();
     let sprint_b = ctx.create_sprint(board_b.id, None, None).unwrap();
     let card_b = ctx
         .create_card(
@@ -1546,8 +1542,7 @@ pub async fn test_export_board_whole_store_includes_archived_board_and_card(
         "blocks edge between the live and archived card is present"
     );
 
-    let prefix_names: HashSet<String> =
-        snapshot.prefixes.iter().map(|p| p.name.clone()).collect();
+    let prefix_names: HashSet<String> = snapshot.prefixes.iter().map(|p| p.name.clone()).collect();
     assert!(
         !prefix_names.is_empty(),
         "prefixes carried for the exported entities"

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -289,6 +289,10 @@ macro_rules! context_contract_tests {
             $crate::test_helpers::contract::archive::test_single_board_export_roundtrips_archived_board_marker(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
+        async fn test_export_board_whole_store_includes_archived_board_and_card() {
+            $crate::test_helpers::contract::archive::test_export_board_whole_store_includes_archived_board_and_card(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
         async fn test_delete_board_is_noop_on_archived_board() {
             $crate::test_helpers::contract::archive::test_delete_board_is_noop_on_archived_board(&$factory_fn()).await;
         }

--- a/crates/kanban-service/tests/export_all_boards.rs
+++ b/crates/kanban-service/tests/export_all_boards.rs
@@ -1,0 +1,137 @@
+//! `KanbanContext::export_all_boards` must compose the same `AllBoardsExport`
+//! as converting a full backend snapshot, atomically, without exposing the
+//! dependency graph and while carrying dangling-column archived cards.
+
+use kanban_domain::export::BoardImporter;
+use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, Severity};
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+async fn open_json(path: &std::path::Path) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_all_boards_matches_the_snapshot_based_composition() {
+    let dir = tempdir().unwrap();
+    let mut ctx = open_json(&dir.path().join("test.json")).await;
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let column = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let sprint = ctx.create_sprint(board.id, None, None).unwrap();
+    let live = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let arch = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Arch".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.assign_card_to_sprint(live.id, sprint.id).unwrap();
+    ctx.block(live.id, arch.id, Severity::High).unwrap();
+    ctx.archive_card(arch.id).unwrap();
+
+    let other_board = ctx.create_board("Other".into(), None).unwrap();
+    let other_column = ctx
+        .create_column(other_board.id, "Todo".into(), None)
+        .unwrap();
+    ctx.create_sprint(other_board.id, None, None).unwrap();
+    ctx.create_card(
+        other_board.id,
+        other_column.id,
+        "Other card".into(),
+        CreateCardOptions::default(),
+    )
+    .unwrap();
+    ctx.archive_board(other_board.id).unwrap();
+
+    let composed = ctx.export_all_boards().unwrap();
+    let expected = BoardImporter::convert_snapshot_to_export(ctx.snapshot().unwrap());
+
+    assert_eq!(
+        serde_json::to_value(&composed).unwrap(),
+        serde_json::to_value(&expected).unwrap(),
+        "export_all_boards must match converting the whole-store snapshot"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_all_boards_drops_the_dependency_graph() {
+    let dir = tempdir().unwrap();
+    let mut ctx = open_json(&dir.path().join("test.json")).await;
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let column = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let a = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "A".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let b = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "B".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.block(a.id, b.id, Severity::High).unwrap();
+
+    let export = ctx.export_all_boards().unwrap();
+    let value = serde_json::to_value(&export).unwrap();
+
+    assert!(
+        value.get("graph").is_none(),
+        "AllBoardsExport carries no graph field by construction (the inverse of \
+         transfer_state_to's contract); this pins that shape rather than \
+         asserting an edge was filtered out"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_all_boards_carries_a_dangling_column_archived_card() {
+    let dir = tempdir().unwrap();
+    let mut ctx = open_json(&dir.path().join("test.json")).await;
+
+    let board = ctx.create_board("Board".into(), None).unwrap();
+    let column = ctx.create_column(board.id, "Todo".into(), None).unwrap();
+    let card = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(card.id).unwrap();
+    ctx.delete_column(column.id).unwrap();
+
+    let export = ctx.export_all_boards().unwrap();
+    let board_export = export
+        .boards
+        .iter()
+        .find(|b| b.board.id == board.id)
+        .expect("board must be present");
+
+    assert!(
+        board_export.cards.iter().any(|c| c.id == card.id),
+        "an archived card whose column was deleted must still carry its live row"
+    );
+}


### PR DESCRIPTION
## Summary

- Swap the whole-store branch of `export_board(None)` (the `else` arm of `export_board_impl` in `crates/kanban-service/src/context/sprints.rs`) from `self.backend.snapshot()` to `store_adapter::read_full_snapshot`, matching the fidelity of the single-board export path (archived boards recovered via `get_board`, archived cards via `get_card`).
- Add a new `pub fn export_all_boards(&self) -> KanbanResult<AllBoardsExport>` on `KanbanContext`, composing `read_full_snapshot` + `BoardImporter::convert_snapshot_to_export` in one call, so callers (e.g. a future TUI auto-save/export-all path) no longer have to hand-roll the two-step conversion.
- No changes to `crates/kanban-tui`; it still builds its own export via `ctx.snapshot()` + `convert_snapshot_to_export`, unaffected by this swap.

## Tests

- `test_export_all_boards_matches_the_snapshot_based_composition`: asserts `export_all_boards()` matches `BoardImporter::convert_snapshot_to_export(ctx.snapshot())` for a rich two-board graph (live board with a sprint/live card/archived card/blocks edge, plus a second wholly-archived board).
- `test_export_all_boards_drops_the_dependency_graph`: pins that `AllBoardsExport` carries no `graph` key by construction.
- `test_export_all_boards_carries_a_dangling_column_archived_card`: an archived card whose column was later deleted still round-trips through `export_all_boards()`.
- `test_export_board_whole_store_includes_archived_board_and_card` (new contract test registered across `in_memory::`/`json::`/`sqlite::`): field-by-field assertion that `export_board(None)` carries a live board's full subtree plus a second, itself-archived board's head, marker, column, card, and sprint. This test already passes on unmodified `develop` (it is a characterisation test proving the existing `self.backend.snapshot()` path already had this fidelity); it stays green after the swap.

## Verification

- `cargo test -p kanban-service --features test-helpers`: green (all new and existing tests).
- `cargo clippy -p kanban-service --all-targets --features test-helpers -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Mutation check: reverted `export_all_boards` to call `self.backend.snapshot()` directly; the new tests still passed for the JSON backend (the two reads are equivalent there), consistent with the handoff's explicit decision to keep these three new tests JSON-only. Reverted the stub to `todo!()` first (the original Red state) to confirm all three panicked before implementation, then restored the real implementation.

## Changeset

`.changeset/kan-1437-compose-whole-store-export-atomic.md`, bump: minor (new public API on `KanbanContext`).
