### PR TITLE
KAN-1438 feat(backend,persistence-json,service): a mark_dirty primitive so a backend can be flushed without a fake write

### DIFF
--- a/.changeset/kan-1438-mark-dirty-primitive-backend-can-flushed.md
+++ b/.changeset/kan-1438-mark-dirty-primitive-backend-can-flushed.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+backend,persistence-json,service: `KanbanBackend` gains a defaulted `mark_dirty()` method, so a backend can be marked dirty and later flushed without routing a fake empty snapshot through `apply_snapshot` just to trip the dirty flag. `JsonDataStore` overrides it to set its real dirty flag; `FaultInjectingBackend` delegates it to the wrapped backend.

--- a/crates/kanban-backend/README.md
+++ b/crates/kanban-backend/README.md
@@ -22,6 +22,7 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
     fn as_data_store(&self) -> &dyn DataStore;
     async fn flush(&self) -> KanbanResult<()> { Ok(()) }
     async fn reload(&self) -> KanbanResult<()> { Ok(()) }
+    fn mark_dirty(&self) {}
     fn needs_flush(&self) -> bool { false }
     fn needs_save_worker(&self) -> bool { false }
     fn instance_id(&self) -> Uuid { Uuid::nil() }

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -42,6 +42,12 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
         Ok(())
     }
 
+    /// Marks the backend dirty without performing a write, so a subsequent
+    /// `flush()` (or `needs_save_worker()`-driven background flush) picks it
+    /// up. No-op by default for write-through backends that have no dirty
+    /// flag to set.
+    fn mark_dirty(&self) {}
+
     /// Returns `true` when there are writes that have not been flushed yet.
     fn needs_flush(&self) -> bool {
         false

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -311,4 +311,11 @@ mod tests {
         let backend: &dyn KanbanBackend = &backend;
         assert!(backend.local_persistence().is_none());
     }
+
+    #[test]
+    fn test_mark_dirty_is_callable_on_a_backend_that_does_not_override_it() {
+        let backend = StubBackend;
+        let backend: &dyn KanbanBackend = &backend;
+        backend.mark_dirty();
+    }
 }

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -764,6 +764,36 @@ mod tests {
         assert!(jds.needs_flush(), "apply_snapshot must mark backend dirty");
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_mark_dirty_makes_a_never_mutated_backend_need_a_flush() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("t.json");
+        let jds = make_store(&path);
+        assert!(!jds.needs_flush());
+
+        jds.mark_dirty();
+        assert!(jds.needs_flush());
+
+        jds.flush().await.unwrap();
+        assert!(path.exists(), "flush after mark_dirty must write the file");
+        assert!(!jds.needs_flush(), "dirty flag cleared after flush");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_mark_dirty_on_an_already_dirty_backend_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let jds = make_store(&dir.path().join("t.json"));
+        jds.upsert_board(Board::new("B", None::<String>)).unwrap();
+        assert!(jds.needs_flush());
+
+        jds.mark_dirty();
+        jds.flush().await.unwrap();
+        assert!(!jds.needs_flush());
+
+        jds.flush().await.unwrap();
+        assert!(!jds.needs_flush(), "second flush must stay a no-op");
+    }
+
     // ─── F2 (KAN-871): JSON file seam round-trips the reference archival model ──
     //
     // After F1 an archived card stays LIVE in `cards` behind a marker. These

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -449,6 +449,11 @@ impl KanbanBackend for JsonDataStore {
         Ok(())
     }
 
+    fn mark_dirty(&self) {
+        let _ = self.ensure_loaded();
+        self.dirty.store(true, Ordering::Release);
+    }
+
     fn needs_flush(&self) -> bool {
         self.dirty.load(Ordering::Acquire)
     }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mark_dirty.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mark_dirty.rs
@@ -1,0 +1,37 @@
+use kanban_backend::KanbanBackend;
+use kanban_domain::data_store::DataStore;
+use tempfile::TempDir;
+
+use crate::SqliteBackend;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mark_dirty_on_a_write_through_backend_does_not_disturb_it() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.sqlite3");
+
+    let backend = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
+
+    let board = kanban_domain::Board::new("B", None::<String>);
+    let board_id = board.id;
+    let column = kanban_domain::Column::new(board.id, "Col", 0);
+    let column_id = column.id;
+    let card = kanban_domain::Card::new(board.id, column.id, "Task", 0);
+    let card_id = card.id;
+    backend.upsert_board(board).unwrap();
+    backend.upsert_column(column).unwrap();
+    backend.upsert_card(card).unwrap();
+
+    backend.mark_dirty();
+    assert!(!backend.needs_flush());
+
+    backend.flush().await.unwrap();
+    drop(backend);
+
+    let reopened = SqliteBackend::open(path.to_str().unwrap()).await.unwrap();
+    assert_eq!(reopened.get_board(board_id).unwrap().unwrap().id, board_id);
+    assert_eq!(
+        reopened.get_column(column_id).unwrap().unwrap().id,
+        column_id
+    );
+    assert_eq!(reopened.get_card(card_id).unwrap().unwrap().id, card_id);
+}

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/mod.rs
@@ -14,6 +14,7 @@ mod filtered_reads;
 mod graph;
 mod init;
 mod instance_id;
+mod mark_dirty;
 mod metadata;
 mod migration_coverage;
 mod migration_v11_to_v12;

--- a/crates/kanban-service/src/test_helpers/fault.rs
+++ b/crates/kanban-service/src/test_helpers/fault.rs
@@ -425,6 +425,9 @@ impl KanbanBackend for FaultInjectingBackend {
     fn needs_save_worker(&self) -> bool {
         self.inner.needs_save_worker()
     }
+    fn mark_dirty(&self) {
+        self.inner.mark_dirty();
+    }
     fn instance_id(&self) -> Uuid {
         self.inner.instance_id()
     }


### PR DESCRIPTION
## Changes

- Add a defaulted `fn mark_dirty(&self) {}` to the `KanbanBackend` trait (`crates/kanban-backend/src/lib.rs`), placed between `reload` and `needs_flush`, with a doc comment describing the no-op-by-default contract.
- Override it on `JsonDataStore` (`crates/kanban-persistence-json/src/json_backend.rs`): ensures the inner store is loaded, then stores the dirty flag with `Ordering::Release`, matching the ordering used by every other store to that field in the file.
- Delegate it on `FaultInjectingBackend` (`crates/kanban-service/src/test_helpers/fault.rs`) so a fault-injection wrapper around a real backend stays transparent instead of silently swallowing the call.
- Document the new method in `crates/kanban-backend/README.md`'s trait sketch.
- This unblocks a follow-up (KAN-1439, out of scope here) that replaces the CLI's hack of routing an empty `Snapshot` through `apply_snapshot` just to trip the dirty flag.

## Tests

- `test_mark_dirty_is_callable_on_a_backend_that_does_not_override_it` (kanban-backend): smoke test against `StubBackend` proving the default is inert and callable.
- `test_mark_dirty_makes_a_never_mutated_backend_need_a_flush` (kanban-persistence-json): a never-mutated `JsonDataStore` reports `needs_flush() == false`, `mark_dirty()` flips it to `true`, and the following `flush()` actually writes the file to disk.
- `test_mark_dirty_on_an_already_dirty_backend_is_idempotent` (kanban-persistence-json): calling `mark_dirty()` on top of an already-dirty backend does not disturb the normal flush/no-op-on-clean-flush cycle.
- `test_mark_dirty_on_a_write_through_backend_does_not_disturb_it` (kanban-persistence-sqlite): seeds a board/column/card, calls `mark_dirty()` on a real `SqliteBackend`, asserts `needs_flush()` stays `false` (SqliteBackend never overrides it), flushes, drops the backend, reopens a fresh `SqliteBackend` on the same path, and asserts the whole graph survived the round trip.

## Verification

- `cargo test -p kanban-backend -p kanban-persistence-json -p kanban-persistence-sqlite -p kanban-service --all-features`: green
- `cargo clippy -p kanban-backend -p kanban-persistence-json -p kanban-persistence-sqlite -p kanban-service --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Mutation check: reverted `JsonDataStore::mark_dirty` to a no-op body, confirmed `test_mark_dirty_makes_a_never_mutated_backend_need_a_flush` fails, then restored the fix.
- `git diff origin/develop -- crates/kanban-cli` is empty (no CLI changes in this PR).
- `git grep -n 'impl .*KanbanBackend for' -- crates/` still shows 12 impl blocks; only `JsonDataStore` and `FaultInjectingBackend` gained a `mark_dirty` body; `SqliteBackend`, `InMemoryStore`, and `HttpBackend` have no override.
