### PR TITLE
KAN-1462 refactor(persistence-json,persistence-sqlite,persistence): rewire backend snapshot test callers, widen snapshot_async to pub

### DIFF
--- a/.changeset/kan-1462-rewire-backend-snapshot-test-callers.md
+++ b/.changeset/kan-1462-rewire-backend-snapshot-test-callers.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+kanban-persistence-json, kanban-persistence-sqlite, kanban-persistence: rewire the test call sites off `DataStore::snapshot`/`apply_snapshot` onto their backend-specific replacements (`snapshot_async`/`apply_snapshot_async`, `read_full_snapshot`/`write_full_snapshot`, `snapshot_impl`), and widen `SqliteStore::snapshot_async`/`apply_snapshot_async` from `pub(crate)` to `pub` so a separate crate's tests can call them directly.

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -765,8 +765,11 @@ mod tests {
     async fn test_apply_snapshot_sets_dirty_flag() {
         let dir = tempdir().unwrap();
         let jds = make_store(&dir.path().join("t.json"));
-        jds.apply_snapshot(Snapshot::new()).unwrap();
-        assert!(jds.needs_flush(), "apply_snapshot must mark backend dirty");
+        kanban_service::write_full_snapshot(&jds, Snapshot::new()).unwrap();
+        assert!(
+            jds.needs_flush(),
+            "write_full_snapshot must mark backend dirty"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -986,7 +989,7 @@ mod tests {
         }))
         .unwrap();
 
-        let before = jds.snapshot().unwrap();
+        let before = kanban_service::read_full_snapshot(&jds).unwrap();
 
         let result = jds.with_transaction(Box::new(|| {
             jds.upsert_board(Board::new("Injected", None::<String>))?;
@@ -997,7 +1000,7 @@ mod tests {
 
         assert!(result.is_err(), "the batch's own error must propagate");
 
-        let after = jds.snapshot().unwrap();
+        let after = kanban_service::read_full_snapshot(&jds).unwrap();
         assert_eq!(
             after, before,
             "entire graph must be restored byte-identical after a failed batch"

--- a/crates/kanban-persistence-json/tests/prefix_write_enforcement.rs
+++ b/crates/kanban-persistence-json/tests/prefix_write_enforcement.rs
@@ -60,7 +60,7 @@ async fn test_a_rejected_batch_leaves_the_store_unchanged() {
     }))
     .unwrap();
 
-    let before = jds.snapshot().unwrap();
+    let before = kanban_service::read_full_snapshot(&jds).unwrap();
 
     let injected = Board::new("Injected", None::<String>);
     let injected_id = injected.id;
@@ -75,7 +75,7 @@ async fn test_a_rejected_batch_leaves_the_store_unchanged() {
     }));
 
     assert!(result.is_err());
-    assert_eq!(jds.snapshot().unwrap(), before);
+    assert_eq!(kanban_service::read_full_snapshot(&jds).unwrap(), before);
     assert!(jds.get_card(offender_id).unwrap().is_none());
     assert!(jds.get_board(injected_id).unwrap().is_none());
 }

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/snapshot.rs
@@ -70,7 +70,7 @@ impl SqliteStore {
         Ok(())
     }
 
-    pub(crate) async fn snapshot_async(&self) -> KanbanResult<Snapshot> {
+    pub async fn snapshot_async(&self) -> KanbanResult<Snapshot> {
         // Reference-marker model: carry ALL board heads (live + archived) so an
         // archived board's row survives the round-trip; archived-ness rides on the
         // separate `archived_boards` markers.
@@ -94,7 +94,7 @@ impl SqliteStore {
         Ok(snap)
     }
 
-    pub(crate) async fn apply_snapshot_async(&self, snapshot: Snapshot) -> KanbanResult<()> {
+    pub async fn apply_snapshot_async(&self, snapshot: Snapshot) -> KanbanResult<()> {
         let mut tx = self.pool.begin().await.map_err(db_err)?;
 
         sqlx::query("PRAGMA defer_foreign_keys = ON")

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/board_archival.rs
@@ -198,7 +198,7 @@ fn test_snapshot_and_apply_round_trip_archived_boards() {
         src.insert_archived_board(Archived::now(archived_id))
             .unwrap();
 
-        let snap = src.snapshot().unwrap();
+        let snap = src.snapshot_async().await.unwrap();
         assert_eq!(
             snap.boards.len(),
             2,
@@ -215,7 +215,7 @@ fn test_snapshot_and_apply_round_trip_archived_boards() {
         let dir2 = TempDir::new().unwrap();
         let path2 = dir2.path().join("dst.sqlite3");
         let dst = SqliteStore::open(&path2).await.unwrap();
-        dst.apply_snapshot(snap).unwrap();
+        dst.apply_snapshot_async(snap).await.unwrap();
 
         assert_eq!(dst.list_boards().unwrap().len(), 1);
         let restored = dst.list_archived_boards().unwrap();

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/prefix_fk_enforcement.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/prefix_fk_enforcement.rs
@@ -212,7 +212,7 @@ fn test_apply_snapshot_reports_an_unbacked_namespace_as_a_domain_error() {
         snapshot.cards = vec![card];
         assert!(snapshot.prefixes.is_empty());
 
-        let result = store.apply_snapshot(snapshot);
+        let result = store.apply_snapshot_async(snapshot).await;
         match result {
             Err(KanbanError::Domain(DomainError::PrefixNotBacked {
                 card_number,

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_atomicity.rs
@@ -27,12 +27,12 @@ fn test_apply_snapshot_failure_leaves_existing_data_untouched() {
         store.upsert_column(column).unwrap();
         store.upsert_card(card).unwrap();
 
-        let mut bad_snapshot = store.snapshot().unwrap();
+        let mut bad_snapshot = store.snapshot_async().await.unwrap();
         let mut broken_card = bad_snapshot.cards[0].clone();
         broken_card.sprint_id = Some(Uuid::new_v4());
         bad_snapshot.cards = vec![broken_card];
 
-        let result = store.apply_snapshot(bad_snapshot);
+        let result = store.apply_snapshot_async(bad_snapshot).await;
         assert!(
             result.is_err(),
             "a dangling sprint_id must fail at commit, not silently succeed"

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_prefix_ordering.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/tests/snapshot_prefix_ordering.rs
@@ -37,7 +37,7 @@ fn test_apply_snapshot_never_deletes_a_prefix_row_while_a_card_names_it() {
             .insert_archived_card(ArchivedCard::new(second.id, board.id))
             .unwrap();
 
-        let snap = store.snapshot().unwrap();
+        let snap = store.snapshot_async().await.unwrap();
 
         sqlx::query(
             "CREATE TRIGGER prefix_delete_restrict_probe \
@@ -59,7 +59,7 @@ fn test_apply_snapshot_never_deletes_a_prefix_row_while_a_card_names_it() {
         .await
         .unwrap();
 
-        let result = store.apply_snapshot(snap);
+        let result = store.apply_snapshot_async(snap).await;
         assert!(
             result.is_ok(),
             "apply_snapshot must not delete a prefix row while a card still \

--- a/crates/kanban-persistence-sqlite/tests/data_store.rs
+++ b/crates/kanban-persistence-sqlite/tests/data_store.rs
@@ -329,7 +329,7 @@ async fn test_sqlite_snapshot_roundtrip() {
     let card = make_card(&board, col.id, "Card", 0);
     store.upsert_card(card).unwrap();
 
-    let snap = store.snapshot().unwrap();
+    let snap = store.snapshot_async().await.unwrap();
     assert_eq!(snap.boards.len(), 1);
     assert_eq!(snap.columns.len(), 1);
     assert_eq!(snap.cards.len(), 1);
@@ -352,7 +352,7 @@ async fn test_sqlite_apply_snapshot_replaces_existing_data() {
         vec![],
         DependencyGraph::new(),
     );
-    store.apply_snapshot(snap).unwrap();
+    store.apply_snapshot_async(snap).await.unwrap();
 
     let boards = store.list_boards().unwrap();
     assert_eq!(boards.len(), 1);
@@ -486,7 +486,7 @@ async fn test_sqlite_concurrent_reads_and_writes_no_panic() {
                 let _ = s.list_boards();
                 let _ = s.list_all_columns();
                 let _ = s.list_all_cards();
-                let _ = s.snapshot();
+                let _ = s.snapshot_async().await;
             }
         }));
     }

--- a/crates/kanban-persistence/tests/snapshot_serde_archived_marker.rs
+++ b/crates/kanban-persistence/tests/snapshot_serde_archived_marker.rs
@@ -27,7 +27,7 @@ fn test_snapshot_serde_carries_archived_card_as_live_plus_marker() {
         .insert_archived_card(ArchivedCard::new(archived_id, board.id))
         .unwrap();
 
-    let snapshot = store.snapshot().unwrap();
+    let snapshot = store.snapshot_impl().unwrap();
     let bytes = snapshot_to_json_bytes(&snapshot).unwrap();
     let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
 


### PR DESCRIPTION
Pure mechanical rewire of the 16 test call sites in kanban-persistence-json, kanban-persistence-sqlite and kanban-persistence off `DataStore::snapshot`/`apply_snapshot` onto their backend-specific replacements. No behavior change. One commit.

## Changes

- Widened `SqliteStore::snapshot_async`/`apply_snapshot_async` from `pub(crate)` to `pub` (needed because kanban-persistence-sqlite's own `tests/` binaries live in a separate crate from `src/`).
- Rewired 10 SQLite test call sites onto `.snapshot_async().await` / `.apply_snapshot_async(...).await`.
- Rewired 1 kanban-persistence test site onto `InMemoryStore::snapshot_impl()`.
- Rewired 4 JSON whole-graph rollback/round-trip test sites onto `kanban_service::read_full_snapshot`/`kanban_service::write_full_snapshot`.
- Rewired 1 JSON dirty-flag test to trigger via `kanban_service::write_full_snapshot`, empirically confirmed to still set the dirty flag (see row 16 below).

This leaf must land before KAN-1444 (which deletes `DataStore::snapshot`/`apply_snapshot`); leaving any site unrewired breaks that branch's compile.

## Census (before)

```
git grep -n -E '\.snapshot\(\)|\.apply_snapshot\(' -- crates/kanban-persistence-json crates/kanban-persistence-sqlite crates/kanban-persistence | grep -vE 'snapshot_async|snapshot_impl|\.md:'
```
returned exactly 20 hits (16 test call sites + the 4 impl-body lines that route the trait method).

## Census (after)

```
git grep -n -E '\.snapshot\(\)|\.apply_snapshot\(' -- crates/kanban-persistence-json crates/kanban-persistence-sqlite crates/kanban-persistence | grep -vE 'snapshot_async|snapshot_impl|\.md:'
```
returns exactly 4 lines, all impl-body: `json_backend.rs:396`, `json_backend.rs:400`, `sqlite_backend.rs:242`, `sqlite_backend.rs:245`.

```
git grep -n 'pub(crate) async fn snapshot_async\|pub(crate) async fn apply_snapshot_async' -- crates/kanban-persistence-sqlite/src
```
returns 0 lines.

```
git grep -n 'pub async fn snapshot_async\|pub async fn apply_snapshot_async' -- crates/kanban-persistence-sqlite/src
```
returns exactly 2 lines (`sqlite_store/snapshot.rs:73`, `:97`).

## Audit table

| # | File | Enclosing fn | Current shape | Asserts today | Planned rewrite | Asserts after | Backends exercised | Mutation performed |
|---|---|---|---|---|---|---|---|---|
| 1 | sqlite_store/tests/board_archival.rs:201 | test_snapshot_and_apply_round_trip_archived_boards | `src.snapshot().unwrap()` | boards.len()==2, archived_boards.len()==1, archived id matches | rename to `snapshot_async().await` | unchanged | SQLite | none (round-trip, no rollback path) |
| 2 | sqlite_store/tests/board_archival.rs:218 | test_snapshot_and_apply_round_trip_archived_boards | `dst.apply_snapshot(snap).unwrap()` | boards restored, archived board restored | rename to `apply_snapshot_async(...).await` | unchanged | SQLite | none |
| 3 | sqlite_store/tests/prefix_fk_enforcement.rs:215 | test_apply_snapshot_reports_an_unbacked_namespace_as_a_domain_error | `store.apply_snapshot(snapshot)` | returns `DomainError::PrefixNotBacked` for an unbacked card prefix | rename to `apply_snapshot_async(...).await` | unchanged | SQLite | none |
| 4 | sqlite_store/tests/snapshot_atomicity.rs:30 | test_apply_snapshot_failure_leaves_existing_data_untouched | `store.snapshot().unwrap()` | captures a snapshot to corrupt | rename to `snapshot_async().await` | unchanged | SQLite | none |
| 5 | sqlite_store/tests/snapshot_atomicity.rs:35 | test_apply_snapshot_failure_leaves_existing_data_untouched | `store.apply_snapshot(bad_snapshot)` | dangling `sprint_id` fails at commit, not silently | rename to `apply_snapshot_async(...).await` | unchanged | SQLite | none |
| 6 | sqlite_store/tests/snapshot_prefix_ordering.rs:40 | test_apply_snapshot_never_deletes_a_prefix_row_while_a_card_names_it | `store.snapshot().unwrap()` | captures a snapshot to replay against DB-level restrict triggers | rename to `snapshot_async().await` | unchanged | SQLite | none |
| 7 | sqlite_store/tests/snapshot_prefix_ordering.rs:62 | test_apply_snapshot_never_deletes_a_prefix_row_while_a_card_names_it | `store.apply_snapshot(snap)` | apply succeeds without ever tripping the DELETE-then-INSERT ordering triggers | rename to `apply_snapshot_async(...).await` | unchanged | SQLite | none |
| 8 | tests/data_store.rs:332 | test_sqlite_snapshot_roundtrip | `store.snapshot().unwrap()` | boards/columns/cards/sprints lens all 1 | rename to `snapshot_async().await` | unchanged | SQLite | none |
| 9 | tests/data_store.rs:355 | test_sqlite_apply_snapshot_replaces_existing_data | `store.apply_snapshot(snap).unwrap()` | old board replaced by the snapshot's board | rename to `apply_snapshot_async(...).await` | unchanged | SQLite | none |
| 10 | tests/data_store.rs:489 | test_sqlite_concurrent_reads_and_writes_no_panic | `let _ = s.snapshot();` inside a tokio::spawn'd closure over `Arc<SqliteStore>` | no panic under concurrent read/write | rename to `let _ = s.snapshot_async().await;` | unchanged | SQLite | none |
| 11 | kanban-persistence/tests/snapshot_serde_archived_marker.rs:30 | test_snapshot_serde_carries_archived_card_as_live_plus_marker | `store.snapshot().unwrap()` (InMemoryStore) | archived card appears once under `cards`, once under `archived_cards` marker | rename to `snapshot_impl().unwrap()` | unchanged | in-memory | none |
| 12 | json_backend.rs:989 (fn @ :949) | test_json_with_transaction_failed_batch_rolls_back_full_graph | `jds.snapshot().unwrap()` | captures full-graph "before" state | `kanban_service::read_full_snapshot(&jds).unwrap()` | unchanged | JSON | dropped `state.sprints` restoration in `InMemoryStore::apply_snapshot_impl` -> test FAILED (rolled-back sprint list mismatched "before"); reverted |
| 13 | json_backend.rs:1000 (fn @ :949) | test_json_with_transaction_failed_batch_rolls_back_full_graph | `jds.snapshot().unwrap()` | captures full-graph "after" state, asserted `==` before | `kanban_service::read_full_snapshot(&jds).unwrap()` | unchanged | JSON | same mutation as row 12, same run |
| 14 | prefix_write_enforcement.rs:63 | test_a_rejected_batch_leaves_the_store_unchanged | `jds.snapshot().unwrap()` | captures full-graph "before" state | `kanban_service::read_full_snapshot(&jds).unwrap()` | unchanged | JSON | dropped `state.boards` restoration in `InMemoryStore::apply_snapshot_impl` -> test FAILED (injected board survived rollback); reverted |
| 15 | prefix_write_enforcement.rs:78 | test_a_rejected_batch_leaves_the_store_unchanged | `jds.snapshot().unwrap()` | asserted `== before` after a rejected batch | `kanban_service::read_full_snapshot(&jds).unwrap()` | unchanged | JSON | same mutation as row 14, same run |
| 16 | json_backend.rs:768 (fn @ :765) | test_apply_snapshot_sets_dirty_flag | `jds.apply_snapshot(Snapshot::new()).unwrap()` | `needs_flush()` is true after applying an empty snapshot | `kanban_service::write_full_snapshot(&jds, Snapshot::new()).unwrap()` | unchanged, message reworded to name `write_full_snapshot` | JSON | none; empirical finding: `write_full_snapshot` unconditionally calls `set_graph`, which routes through `with_mutate`, which unconditionally marks the backend dirty regardless of whether the passed snapshot is empty. Ran the rewritten test and confirmed `needs_flush()` is still true, so Branch 1 from the card holds; no substitute per-entity write was needed. |

Rows 1-11 are pure renames with identical assertions before and after. Rows 12-16 additionally needed the `kanban_service::read_full_snapshot`/`write_full_snapshot` free functions because `jds` (`JsonDataStore`) no longer exposes `DataStore::snapshot`/`apply_snapshot` directly from these call sites; both mutation-checks (rows 12/13 and 14/15) confirmed the rewritten assertions still catch a real rollback defect, and both sabotages were reverted before committing (`git diff` on `kanban-backend-memory` is clean in the final commit).

## Verification

```
nix develop --command cargo fmt --all -- --check
nix develop --command cargo clippy --all-targets --all-features -- -D warnings
nix develop --command cargo test -p kanban-persistence-json -p kanban-persistence-sqlite -p kanban-persistence --all-features
```
All green. `cargo test ... -- --list` before and after the rewire produced the identical test name set (732 lines, diff only in build-timing/dirty-tree noise).

## Changeset

`minor` bump. Widening `SqliteStore::snapshot_async`/`apply_snapshot_async` from `pub(crate)` to `pub` is new public API on a published crate (`.changeset/README.md`: any published crate's new public item is `minor` pre-1.0), not a bug fix.
