### PR TITLE
KAN-1463 test(service): rewire contract and integration snapshot callers onto read/write_full_snapshot

### DIFF
--- a/.changeset/kan-1463-rewire-contract-integration-test-callers.md
+++ b/.changeset/kan-1463-rewire-contract-integration-test-callers.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: rewire kanban-service's cross-backend contract tests and integration tests off `DataStore::snapshot`/`apply_snapshot` onto `read_full_snapshot`/`write_full_snapshot`, and onto scoped per-collection reads where that is what the test already asserts. Test-only change; `KanbanContext::snapshot`/`apply_snapshot` and the `prefix.rs` contract are untouched.

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -1,6 +1,6 @@
 use super::super::BackendFactory;
 use super::assert_card_eq;
-use crate::KanbanContext;
+use crate::{read_full_snapshot, KanbanContext};
 use kanban_core::AppConfig;
 use kanban_domain::archival::ArchivedEntity;
 use kanban_domain::card::CardPriority;
@@ -510,7 +510,7 @@ pub async fn test_delete_board_is_noop_on_archived_board(factory: &BackendFactor
         "archived marker must still be present after bare delete_board"
     );
     // Subtree must be intact.
-    let snap = ctx.data_store().snapshot().unwrap();
+    let snap = read_full_snapshot(ctx.data_store()).unwrap();
     assert_eq!(
         snap.columns.len(),
         1,
@@ -567,7 +567,7 @@ pub async fn test_board_delete_undo_full_graph_roundtrip(factory: &BackendFactor
     ctx.delete_board(s.board).unwrap();
 
     // Everything gone after permanent delete.
-    let empty = ctx.data_store().snapshot().unwrap();
+    let empty = read_full_snapshot(ctx.data_store()).unwrap();
     assert!(empty.cards.is_empty(), "all card rows gone after delete");
     assert!(empty.columns.is_empty(), "columns gone after delete");
     assert!(empty.sprints.is_empty(), "sprints gone after delete");
@@ -582,7 +582,7 @@ pub async fn test_board_delete_undo_full_graph_roundtrip(factory: &BackendFactor
     ctx.save().await.unwrap();
     let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
 
-    let snap = ctx.data_store().snapshot().unwrap();
+    let snap = read_full_snapshot(ctx.data_store()).unwrap();
     assert_eq!(snap.archived_boards.len(), 1, "board restored as archived");
     assert_eq!(snap.columns.len(), 1, "column restored after undo");
     assert_eq!(snap.cards.len(), 2, "both card rows restored after undo");
@@ -787,13 +787,13 @@ pub async fn test_single_board_export_roundtrips_archived_board_marker(factory: 
     dst.save().await.unwrap();
     let dst = KanbanContext::open_deferred(factory(&dst_path), AppConfig::default());
 
-    let imported = dst.data_store().snapshot().unwrap();
+    let imported = dst.data_store().list_archived_boards().unwrap();
     assert_eq!(
-        imported.archived_boards.len(),
+        imported.len(),
         1,
         "imported board stays archived (marker survives the round-trip)"
     );
-    assert_eq!(imported.archived_boards[0].entity_id(), board.id);
+    assert_eq!(imported[0].entity_id(), board.id);
     assert!(
         !dst.list_boards().unwrap().iter().any(|b| b.id == board.id),
         "archived board is hidden from the live board list after round-trip"
@@ -1060,7 +1060,7 @@ pub async fn test_board_archive_restore_full_graph_roundtrip(factory: &BackendFa
     ctx.save().await.unwrap();
     let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
 
-    let snap = ctx.data_store().snapshot().unwrap();
+    let snap = read_full_snapshot(ctx.data_store()).unwrap();
     assert_eq!(snap.boards.len(), 1, "board is live after restore");
     assert!(snap.archived_boards.is_empty(), "no archived-board marker");
     assert_eq!(snap.columns.len(), 1, "column survived archive/restore");

--- a/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
+++ b/crates/kanban-service/src/test_helpers/contract/lifecycle.rs
@@ -1,6 +1,6 @@
 use super::super::helpers::fully_populated_snapshot;
 use super::super::BackendFactory;
-use crate::KanbanContext;
+use crate::{read_full_snapshot, write_full_snapshot, KanbanContext};
 use kanban_core::{AppConfig, EdgeBase};
 use kanban_domain::board::{SortField, SortOrder};
 use kanban_domain::card::{CardPriority, CardStatus};
@@ -374,12 +374,16 @@ pub async fn test_full_roundtrip_preserves_all_fields(factory: &BackendFactory) 
 
     {
         let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
-        ctx.apply_snapshot(original.clone()).unwrap();
+        let store = ctx.data_store();
+        let seed = original.clone();
+        ctx.backend()
+            .with_transaction(Box::new(move || write_full_snapshot(store, seed)))
+            .unwrap();
         ctx.save().await.unwrap();
     }
 
     let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
-    let loaded = ctx.snapshot().unwrap();
+    let loaded = read_full_snapshot(ctx.data_store()).unwrap();
     assert_eq!(original, loaded);
 }
 

--- a/crates/kanban-service/tests/board_archive.rs
+++ b/crates/kanban-service/tests/board_archive.rs
@@ -1,6 +1,6 @@
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{KanbanOperations, KanbanResult};
-use kanban_service::KanbanContext;
+use kanban_service::{read_full_snapshot, KanbanContext};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -43,7 +43,7 @@ async fn test_archive_board_hides_from_boards_and_lists_in_archived() -> KanbanR
         ctx.list_all_columns()?.is_empty(),
         "archived board's columns hidden from live view"
     );
-    let snap = ctx.snapshot()?;
+    let snap = read_full_snapshot(ctx.data_store())?;
     assert_eq!(snap.columns.len(), 1, "subtree preserved in snapshot");
     assert_eq!(snap.cards.len(), 1);
     Ok(())
@@ -109,7 +109,7 @@ async fn test_delete_archived_board_undo_restores_as_archived() -> KanbanResult<
         ctx.list_all_columns()?.is_empty(),
         "still archived: subtree hidden from live view"
     );
-    let snap = ctx.snapshot()?;
+    let snap = read_full_snapshot(ctx.data_store())?;
     assert_eq!(snap.columns.len(), 1, "subtree preserved");
     assert_eq!(snap.cards.len(), 1);
     Ok(())

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -53,7 +53,11 @@ async fn test_archive_hides_from_live_lists_and_persists_across_reload() -> Kanb
             ctx.list_all_columns()?.is_empty(),
             "subtree hidden from live view (C3b)"
         );
-        assert_eq!(ctx.snapshot()?.columns.len(), 1, "subtree stays in place");
+        assert_eq!(
+            ctx.data_store().list_all_columns()?.len(),
+            1,
+            "subtree stays in place"
+        );
         ctx.save().await?;
         board_id
     };
@@ -68,7 +72,11 @@ async fn test_archive_hides_from_live_lists_and_persists_across_reload() -> Kanb
         ctx.list_all_columns()?.is_empty(),
         "subtree hidden from live view"
     );
-    assert_eq!(ctx.snapshot()?.columns.len(), 1, "subtree persisted");
+    assert_eq!(
+        ctx.data_store().list_all_columns()?.len(),
+        1,
+        "subtree persisted"
+    );
     Ok(())
 }
 
@@ -162,6 +170,10 @@ async fn test_delete_works_on_archived_board_and_undo_restores_as_archived() -> 
         ctx.list_all_columns()?.is_empty(),
         "still archived: hidden from live"
     );
-    assert_eq!(ctx.snapshot()?.columns.len(), 1, "subtree restored");
+    assert_eq!(
+        ctx.data_store().list_all_columns()?.len(),
+        1,
+        "subtree restored"
+    );
     Ok(())
 }

--- a/crates/kanban-service/tests/board_query_audit.rs
+++ b/crates/kanban-service/tests/board_query_audit.rs
@@ -4,7 +4,7 @@
 
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{CardListFilter, GraphOperations, KanbanOperations, KanbanResult, RelatesKind};
-use kanban_service::{AppConfig, KanbanContext};
+use kanban_service::{read_full_snapshot, AppConfig, KanbanContext};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -76,7 +76,7 @@ async fn test_snapshot_and_export_still_carry_archived_board_subtree() -> Kanban
     let mut c = ctx().await;
     let (_a, a_card, _b) = seed(&mut c)?;
     // FIDELITY: snapshot keeps the archived board's card (no data loss).
-    let snap = c.snapshot()?;
+    let snap = read_full_snapshot(c.data_store())?;
     assert!(
         snap.cards.iter().any(|x| x.id == a_card),
         "snapshot must preserve the archived board's card"

--- a/crates/kanban-service/tests/command_replay.rs
+++ b/crates/kanban-service/tests/command_replay.rs
@@ -7,7 +7,7 @@ use kanban_backend_memory::InMemoryStore;
 use kanban_domain::commands::CommandContext;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{KanbanOperations, KanbanResult, Snapshot};
-use kanban_service::KanbanContext;
+use kanban_service::{read_full_snapshot, write_full_snapshot, KanbanContext};
 use std::sync::Arc;
 
 async fn make_ctx() -> KanbanContext {
@@ -32,13 +32,13 @@ async fn test_replay_from_baseline_reproduces_state() -> KanbanResult<()> {
     let sprint = ctx.create_sprint(board.id, None, None)?;
     ctx.assign_card_to_sprint(card1.id, sprint.id)?;
 
-    let original = ctx.snapshot()?;
+    let original = read_full_snapshot(ctx.data_store())?;
     let backend = ctx.backend();
     let (batches, count) = backend.load_all_batches()?;
     assert!(count > 0, "should have recorded at least one command batch");
 
     let replay_backend = Arc::new(InMemoryStore::new());
-    replay_backend.apply_snapshot(Snapshot::new())?;
+    write_full_snapshot(replay_backend.as_ref(), Snapshot::new())?;
     {
         let cmd_ctx = CommandContext {
             store: replay_backend.as_ref() as &dyn DataStore,
@@ -49,7 +49,7 @@ async fn test_replay_from_baseline_reproduces_state() -> KanbanResult<()> {
             }
         }
     }
-    let replayed = replay_backend.snapshot()?;
+    let replayed = read_full_snapshot(replay_backend.as_ref())?;
 
     assert_eq!(
         original.boards.len(),

--- a/crates/kanban-service/tests/create_card_replay_prefix_row.rs
+++ b/crates/kanban-service/tests/create_card_replay_prefix_row.rs
@@ -9,7 +9,7 @@ use kanban_domain::{
 };
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
-use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use kanban_service::{write_full_snapshot, AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -33,7 +33,7 @@ async fn fresh_destination(backend: &Backend, path: &std::path::Path) -> Arc<dyn
         Backend::Json => Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path)))),
         Backend::Sqlite => Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap()),
     };
-    store.apply_snapshot(Snapshot::new()).unwrap();
+    write_full_snapshot(store.as_ref(), Snapshot::new()).unwrap();
     store
 }
 

--- a/crates/kanban-service/tests/export_all_boards.rs
+++ b/crates/kanban-service/tests/export_all_boards.rs
@@ -5,7 +5,7 @@
 use kanban_domain::export::BoardImporter;
 use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, Severity};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
-use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use kanban_service::{read_full_snapshot, AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -60,7 +60,8 @@ async fn test_export_all_boards_matches_the_snapshot_based_composition() {
     ctx.archive_board(other_board.id).unwrap();
 
     let composed = ctx.export_all_boards().unwrap();
-    let expected = BoardImporter::convert_snapshot_to_export(ctx.snapshot().unwrap());
+    let expected =
+        BoardImporter::convert_snapshot_to_export(read_full_snapshot(ctx.data_store()).unwrap());
 
     assert_eq!(
         serde_json::to_value(&composed).unwrap(),

--- a/crates/kanban-service/tests/export_import_archived_roundtrip.rs
+++ b/crates/kanban-service/tests/export_import_archived_roundtrip.rs
@@ -14,7 +14,9 @@ use kanban_domain::{
 };
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
-use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use kanban_service::{
+    read_full_snapshot, write_full_snapshot, AppConfig, KanbanBackend, KanbanContext,
+};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -101,11 +103,10 @@ fn assert_full_graph(ctx: &KanbanContext, ids: &SeedIds) -> KanbanResult<()> {
         "archived_boards marker entity_id"
     );
 
-    // Archived board HEAD reachable from raw snapshot (apply_snapshot stores it)
-    let snap = ctx.snapshot()?;
+    // Archived board HEAD reachable from raw storage (apply_snapshot stores it)
     assert!(
-        snap.boards.iter().any(|b| b.id == ids.archived_board_id),
-        "archived board head must be in snapshot.boards"
+        ctx.data_store().get_board(ids.archived_board_id)?.is_some(),
+        "archived board head must be reachable via get_board"
     );
 
     // Column present in live view
@@ -164,7 +165,7 @@ fn assert_full_graph(ctx: &KanbanContext, ids: &SeedIds) -> KanbanResult<()> {
 /// This includes archived board heads (snapshot.boards has all board heads) and
 /// archived_boards markers, and correctly handles dangling-column archived cards.
 fn export_snapshot_to_json(ctx: &KanbanContext, export_path: &str) -> KanbanResult<()> {
-    let snapshot = ctx.snapshot()?;
+    let snapshot = read_full_snapshot(ctx.data_store())?;
     let export = BoardImporter::convert_snapshot_to_export(snapshot);
     BoardExporter::export_to_file(&export, export_path)
         .map_err(|e| kanban_domain::KanbanError::Internal(format!("export_to_file failed: {e}")))
@@ -197,7 +198,7 @@ fn import_into_context(ctx: &KanbanContext, export_path: &str) -> KanbanResult<(
         graph: DependencyGraph::default(),
         prefixes,
     };
-    ctx.apply_snapshot(snapshot)
+    write_full_snapshot(ctx.data_store(), snapshot)
 }
 
 // ── JSON backend test ─────────────────────────────────────────────────────────

--- a/crates/kanban-service/tests/export_import_prefix_counters.rs
+++ b/crates/kanban-service/tests/export_import_prefix_counters.rs
@@ -12,7 +12,7 @@
 use kanban_domain::{CreateCardOptions, KanbanOperations, KanbanResult, Prefix};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
-use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use kanban_service::{read_full_snapshot, AppConfig, KanbanBackend, KanbanContext};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -476,7 +476,8 @@ async fn test_export_to_sqlite_carries_the_prefix_counters() {
     let mut src = open_json(&dir.path().join("src.json")).await;
     seed_and_export(&mut src, "TASK", 3).unwrap();
 
-    let export = BoardImporter::convert_snapshot_to_export(src.snapshot().unwrap());
+    let export =
+        BoardImporter::convert_snapshot_to_export(read_full_snapshot(src.data_store()).unwrap());
 
     let mut registry = StoreRegistry::new();
     registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -16,7 +16,7 @@ use kanban_domain::{
     BoardUpdate, CardPriority, CardStatus, CardUpdate, ColumnUpdate, FieldUpdate, KanbanOperations,
     KanbanResult, SortField, SortOrder, SprintStatus, SprintUpdate, TaskListView,
 };
-use kanban_service::KanbanContext;
+use kanban_service::{read_full_snapshot, KanbanContext};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -1140,7 +1140,7 @@ async fn test_composite_round_trip_undo_returns_to_baseline() -> KanbanResult<()
 
     // Baseline snapshot — what we expect to see after undoing the
     // round-trip sequence below.
-    let baseline = ctx.snapshot()?;
+    let baseline = read_full_snapshot(ctx.data_store())?;
     let baseline_card_count = baseline.cards.len();
     let baseline_archived = baseline.archived_cards.len();
     let baseline_card_columns: std::collections::HashMap<_, _> =
@@ -1191,7 +1191,7 @@ async fn test_composite_round_trip_undo_returns_to_baseline() -> KanbanResult<()
     // Structural assertions: counts, column membership, sprint
     // bindings, priorities. updated_at drift is out of scope (see the
     // module docstring on command_replay.rs).
-    let restored = ctx.snapshot()?;
+    let restored = read_full_snapshot(ctx.data_store())?;
     assert_eq!(restored.boards.len(), baseline.boards.len());
     assert_eq!(restored.columns.len(), baseline.columns.len());
     assert_eq!(restored.cards.len(), baseline_card_count);
@@ -1244,7 +1244,7 @@ async fn test_composite_round_trip_redo_restores_forward_state() -> KanbanResult
         },
     )?;
 
-    let forward_snapshot = ctx.snapshot()?;
+    let forward_snapshot = read_full_snapshot(ctx.data_store())?;
 
     // Undo all
     while ctx.can_undo() {
@@ -1258,7 +1258,7 @@ async fn test_composite_round_trip_redo_restores_forward_state() -> KanbanResult
         );
     }
 
-    let replayed = ctx.snapshot()?;
+    let replayed = read_full_snapshot(ctx.data_store())?;
     assert_eq!(replayed.cards.len(), forward_snapshot.cards.len());
     let replayed_c1 = replayed.cards.iter().find(|c| c.id == c1.id).unwrap();
     let forward_c1 = forward_snapshot
@@ -1440,7 +1440,7 @@ async fn test_inverse_delete_board_restores_full_cascade() -> KanbanResult<()> {
     ctx.backend().set_graph(graph)?;
     ctx.clear_history()?;
 
-    let baseline = ctx.snapshot()?;
+    let baseline = read_full_snapshot(ctx.data_store())?;
     let baseline_board_ids: std::collections::HashSet<_> =
         baseline.boards.iter().map(|b| b.id).collect();
     let baseline_column_ids: std::collections::HashSet<_> =
@@ -1468,7 +1468,7 @@ async fn test_inverse_delete_board_restores_full_cascade() -> KanbanResult<()> {
 
     assert!(ctx.undo()?.is_some(), "cascade undo must succeed");
 
-    let restored = ctx.snapshot()?;
+    let restored = read_full_snapshot(ctx.data_store())?;
     let restored_board_ids: std::collections::HashSet<_> =
         restored.boards.iter().map(|b| b.id).collect();
     let restored_column_ids: std::collections::HashSet<_> =

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -3,8 +3,8 @@ use kanban_domain::commands::{
     BoardCommand, CardCommand, Command, CompactColumnPositions, CreateBoard, ImportEntities,
     UpdateBoard,
 };
-use kanban_domain::{BoardUpdate, CardUpdate, KanbanOperations, KanbanResult, Snapshot};
-use kanban_service::KanbanContext;
+use kanban_domain::{BoardUpdate, CardUpdate, KanbanOperations, KanbanResult};
+use kanban_service::{read_full_snapshot, write_full_snapshot, KanbanContext};
 use std::sync::Arc;
 
 async fn open_context(
@@ -41,12 +41,12 @@ async fn test_snapshot_roundtrip_preserves_all_fields() -> KanbanResult<()> {
     let col_id = ctx.columns()?[0].id;
     ctx.create_card(board_id, col_id, "Card".into(), Default::default())?;
 
-    let snap = ctx.snapshot()?;
-    ctx.apply_snapshot(Snapshot::new())?;
+    let snap = read_full_snapshot(ctx.data_store())?;
+    ctx.delete_board(board_id)?;
     assert!(ctx.boards()?.is_empty());
 
-    ctx.apply_snapshot(snap.clone())?;
-    assert_eq!(ctx.snapshot()?, snap);
+    write_full_snapshot(ctx.data_store(), snap.clone())?;
+    assert_eq!(read_full_snapshot(ctx.data_store())?, snap);
     Ok(())
 }
 

--- a/crates/kanban-service/tests/with_transaction.rs
+++ b/crates/kanban-service/tests/with_transaction.rs
@@ -5,6 +5,7 @@ use kanban_backend_memory::InMemoryStore;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{Board, KanbanError, KanbanResult};
 use kanban_service::backend::KanbanBackend;
+use kanban_service::read_full_snapshot;
 use std::sync::Arc;
 
 #[test]
@@ -100,7 +101,7 @@ fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
         graph.set_block(blocker_id, blocked_id)
     }))?;
 
-    let before = backend.snapshot()?;
+    let before = read_full_snapshot(backend.as_data_store())?;
 
     let backend_for_closure = Arc::clone(&backend);
     let result = backend.with_transaction(Box::new(move || {
@@ -155,7 +156,7 @@ fn test_in_memory_with_transaction_rolls_back_full_graph() -> KanbanResult<()> {
     // not think to enumerate. Its failure output is a whole-Snapshot diff, so
     // running it first would bury the readable diagnosis.
     assert_eq!(
-        backend.snapshot()?,
+        read_full_snapshot(backend.as_data_store())?,
         before,
         "the whole store must come back identical"
     );


### PR DESCRIPTION
## Summary

Rewires kanban-service's cross-backend contract tests and integration tests off `DataStore::snapshot`/`apply_snapshot` onto `read_full_snapshot`/`write_full_snapshot` (per-entity `DataStore` reads/writes, added in KAN-1461/-1460), and onto scoped single-collection `DataStore` reads where that is all a site actually asserts. Test-only change: `KanbanContext::snapshot`/`apply_snapshot` and the `prefix.rs` contract are untouched.

## Finding: a forward-referencing seed needs an explicit transaction, not a pass-through

`test_helpers/contract/lifecycle.rs:377`/`:382` (`test_full_roundtrip_preserves_all_fields`) seeds `fully_populated_snapshot()`, whose `board.active_sprint_id` forward-references a sprint that `write_full_snapshot` has not written yet at the point it upserts the board (it writes boards, then columns, then sprints, then cards). On SQLite each per-entity write is its own immediately-checked statement, so the board's `active_sprint_id` foreign key fails before the sprint row exists:

```
thread 'sqlite::test_full_roundtrip_preserves_all_fields' panicked at
crates/kanban-service/src/test_helpers/contract/lifecycle.rs:379:42:
called `Result::unwrap()` on an `Err` value:
Database("error returned from database: (code: 787) FOREIGN KEY constraint failed")
```

`write_full_snapshot`'s own doc comment states the contract: "Writes a whole workspace ... The caller supplies the transaction." SQLite's foreign keys are declared `DEFERRABLE INITIALLY DEFERRED` (`crates/kanban-persistence-sqlite/src/sqlite_store/init.rs:605`), so inside one explicit transaction the check is deferred to commit, by which point the sprint row exists. `KanbanBackend::with_transaction` is reachable from the test through `ctx.backend()`, so the fix stays entirely inside this leaf's scope: wrap the seed write in `ctx.backend().with_transaction(...)` and keep reading through `read_full_snapshot`. Confirmed green on all three backends (in_memory, json, sqlite) after the rewrite; mutation-checked by reverting to an untransacted write and confirming the same SQLite FK failure reappears, then restoring the fix.

Net effect on the ACs: the `crates/kanban-service` (excluding `tests/`) raw count is **15**, matching the card's target. `tests/` raw is unaffected (still 2, both `card_archived_at_scan.rs`).

## A second semantic gap, worked around without touching `write_full_snapshot`

`write_full_snapshot` only upserts/inserts; it never deletes, so `write_full_snapshot(store, Snapshot::new())` is a no-op on a non-empty store, unlike `apply_snapshot(Snapshot::new())` which replaces the whole store wholesale. Confirmed empirically: the naive substitution in `undo_redo.rs::test_snapshot_roundtrip_preserves_all_fields` left the seeded board in place and failed `assert!(ctx.boards()?.is_empty())`.

Fix: keep the round-trip's read/write halves on `read_full_snapshot`/`write_full_snapshot`, but replace the "clear the store" step with `ctx.delete_board(board_id)` (the one board in the fixture; deleting it cascades its subtree, matching how every other archive/delete contract test clears a graph). Verified green.

The two other `Snapshot::new()` sites this leaf touches (`command_replay.rs:41`, `create_card_replay_prefix_row.rs:36`) are safe as a direct swap because both write into a **freshly constructed** store (`InMemoryStore::new()` / a brand-new `JsonDataStore`/`SqliteBackend`), where "upsert nothing" and "replace with nothing" are equivalent. Both re-verified green, JSON and SQLite included.

## Drift found: a 34th site not in the card's table

`tests/export_all_boards.rs:63` (`BoardImporter::convert_snapshot_to_export(ctx.snapshot().unwrap())`, in `test_export_all_boards_matches_the_snapshot_based_composition`) was added by KAN-1437's landed commit and is absent from the card's 33-row table. Same shape as `export_import_prefix_counters.rs:479` (feeds `convert_snapshot_to_export`), rewired the same way, treated as whole-graph per its own hazard note (it diffs two full exports).

## Audit table (34 rows: 33 card-named + 1 drift-found)

| File:line | Shape | Resolution |
|---|---|---|
| `contract/archive.rs:513` | 2 collections read | `read_full_snapshot` |
| `contract/archive.rs:570` | 5 collections read | `read_full_snapshot` |
| `contract/archive.rs:585` | 6 collections read | `read_full_snapshot` |
| `contract/archive.rs:790` | 1 collection read | scoped `list_archived_boards()` |
| `contract/archive.rs:1063` | 7 collections read | `read_full_snapshot` (mutation-checked, see below) |
| `contract/lifecycle.rs:377` | whole-store write, `active_sprint_id` forward-refs a sprint | `write_full_snapshot` inside `ctx.backend().with_transaction(...)` (see finding above) |
| `contract/lifecycle.rs:382` | whole-store read, paired with the above | `read_full_snapshot` |
| `tests/board_archive.rs:46` | 2 collections read | `read_full_snapshot` |
| `tests/board_archive.rs:112` | 2 collections read | `read_full_snapshot` |
| `tests/board_archive_sqlite.rs:56` | 1 collection read | scoped `list_all_columns()` (SQLite run empirically) |
| `tests/board_archive_sqlite.rs:71` | 1 collection read | scoped `list_all_columns()` (SQLite run empirically) |
| `tests/board_archive_sqlite.rs:165` | 1 collection read | scoped `list_all_columns()` (SQLite run empirically) |
| `tests/board_query_audit.rs:79` | 2 collections read | `read_full_snapshot` |
| `tests/command_replay.rs:35` | whole-graph read | `read_full_snapshot` |
| `tests/command_replay.rs:41` | write into a fresh store | `write_full_snapshot` |
| `tests/command_replay.rs:52` | whole-graph read | `read_full_snapshot` |
| `tests/create_card_replay_prefix_row.rs:36` | write into a fresh store | `write_full_snapshot` |
| `tests/export_all_boards.rs:63` | drift-found; feeds `convert_snapshot_to_export` | `read_full_snapshot` |
| `tests/export_import_archived_roundtrip.rs:105` | 1 field checked (`boards`) | scoped `get_board(id)` |
| `tests/export_import_archived_roundtrip.rs:167` | feeds `convert_snapshot_to_export` | `read_full_snapshot` |
| `tests/export_import_archived_roundtrip.rs:200` | write into a fresh dest store | `write_full_snapshot` |
| `tests/export_import_prefix_counters.rs:479` | feeds `convert_snapshot_to_export` | `read_full_snapshot` |
| `tests/inverse_commands.rs:1143` | whole-graph read | `read_full_snapshot` |
| `tests/inverse_commands.rs:1194` | whole-graph read | `read_full_snapshot` |
| `tests/inverse_commands.rs:1247` | whole-graph read | `read_full_snapshot` |
| `tests/inverse_commands.rs:1261` | whole-graph read | `read_full_snapshot` |
| `tests/inverse_commands.rs:1443` | whole-graph read | `read_full_snapshot` |
| `tests/inverse_commands.rs:1471` | whole-graph read | `read_full_snapshot` |
| `tests/undo_redo.rs:44` | whole-graph read (baseline) | `read_full_snapshot` |
| `tests/undo_redo.rs:45` | clear-the-store step | `ctx.delete_board(board_id)` (see semantic gap above) |
| `tests/undo_redo.rs:48` | write into now-empty store | `write_full_snapshot` |
| `tests/undo_redo.rs:49` | whole-graph read (compare) | `read_full_snapshot` |
| `tests/with_transaction.rs:103` | whole-graph read (backstop baseline) | `read_full_snapshot(backend.as_data_store())` |
| `tests/with_transaction.rs:158` | whole-graph read (backstop compare) | `read_full_snapshot(backend.as_data_store())` |

No row narrows a whole-graph comparison to fewer collections than it originally checked.

## Mutation checks

`test_board_archive_restore_full_graph_roundtrip` (`contract/archive.rs:1048`): temporarily cleared `snap.columns` after the `read_full_snapshot` call, confirmed the rewritten assertion fails on all three backends (in-memory, JSON, SQLite), then reverted:

```
failures:
    in_memory::test_board_archive_restore_full_graph_roundtrip
    json::test_board_archive_restore_full_graph_roundtrip
    sqlite::test_board_archive_restore_full_graph_roundtrip
```

`test_full_roundtrip_preserves_all_fields` (`contract/lifecycle.rs:370`): temporarily dropped the `with_transaction` wrapper around the seed write, confirmed the SQLite backend fails with the FK error quoted above while in_memory and json still pass, then restored the wrapper. Re-ran all three backends green.

## Verification

- `cargo test -p kanban-service --all-features`: green, 0 failed across every test binary.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `git diff --stat origin/develop`: touches only `crates/kanban-service/src/test_helpers/`, `crates/kanban-service/tests/`, and the new changeset.
