### PR TITLE
KAN-1439 refactor(cli): seed the empty storage file via mark_dirty

### DIFF
--- a/.changeset/kan-1439-seed-empty-storage-file-mark-dirty.md
+++ b/.changeset/kan-1439-seed-empty-storage-file-mark-dirty.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+cli: seed a freshly created storage file's dirty flag via the `KanbanBackend::mark_dirty` primitive instead of a `needs_save_worker`-guarded `apply_snapshot(Snapshot::new())` call, so every backend gets the same unconditional write on `kanban init`.

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -124,13 +124,8 @@ async fn create_empty_storage_file(
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     // `flush()` alone is a no-op here: a never-mutated backend's dirty flag
-    // starts false, so nothing would land on disk without seeding a write.
-    if backend.needs_save_worker() {
-        backend
-            .as_data_store()
-            .apply_snapshot(kanban_domain::Snapshot::new())
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-    }
+    // starts false, so nothing would land on disk without marking it dirty.
+    backend.mark_dirty();
     backend.flush().await.map_err(|e| anyhow::anyhow!("{e}"))?;
     Ok(())
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5045,6 +5045,113 @@ mod init_tests {
         });
         assert_eq!(boards.len(), 0);
     }
+
+    #[test]
+    fn test_init_on_an_existing_populated_file_is_a_successful_no_op() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("boards.json");
+        let file_str = file.to_str().unwrap().to_string();
+
+        kanban().args([&file_str, "init"]).assert().success();
+
+        let bjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file_str,
+                    "board",
+                    "create",
+                    "--name",
+                    "B",
+                    "--card-prefix",
+                    "B",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let board_id = extract_id(&bjson);
+        let cjson = parse_json_output(&String::from_utf8_lossy(
+            &kanban()
+                .args([
+                    &file_str, "column", "create", "--board", &board_id, "--name", "TODO",
+                ])
+                .assert()
+                .success()
+                .get_output()
+                .stdout,
+        ));
+        let column_id = extract_id(&cjson);
+        kanban()
+            .args([
+                &file_str,
+                "card",
+                "create",
+                "--board",
+                &board_id,
+                "--column",
+                &column_id,
+                "--title",
+                "Populated",
+            ])
+            .assert()
+            .success();
+
+        let before = std::fs::read(&file).expect("file should exist after seeding");
+
+        let output = kanban()
+            .args([&file_str, "init"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let json = parse_json_output(&String::from_utf8_lossy(&output));
+        assert!(json["success"].as_bool().unwrap());
+        assert_eq!(
+            json["data"]["file"].as_str().unwrap(),
+            file_str,
+            "second init on a populated file should still report the same file path"
+        );
+
+        let after = std::fs::read(&file).expect("file should still exist after second init");
+        assert_eq!(
+            before, after,
+            "init on an existing populated file must not rewrite it"
+        );
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let boards = rt.block_on(async {
+            let store = std::sync::Arc::new(kanban_persistence_json::JsonFileStore::new(&file));
+            let backend = kanban_persistence_json::JsonDataStore::new(store);
+            kanban_domain::DataStore::list_boards(&backend)
+                .expect("list_boards should succeed after the no-op init")
+        });
+        assert_eq!(boards.len(), 1);
+        assert_eq!(boards[0].name, "B");
+
+        let columns = rt.block_on(async {
+            let store = std::sync::Arc::new(kanban_persistence_json::JsonFileStore::new(&file));
+            let backend = kanban_persistence_json::JsonDataStore::new(store);
+            kanban_domain::DataStore::list_columns_by_board(&backend, boards[0].id)
+                .expect("list_columns_by_board should succeed after the no-op init")
+        });
+        assert_eq!(columns.len(), 1);
+        assert_eq!(columns[0].name, "TODO");
+
+        let cards = rt.block_on(async {
+            let store = std::sync::Arc::new(kanban_persistence_json::JsonFileStore::new(&file));
+            let backend = kanban_persistence_json::JsonDataStore::new(store);
+            kanban_domain::DataStore::list_cards_by_column(&backend, columns[0].id)
+                .expect("list_cards_by_column should succeed after the no-op init")
+        });
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].title, "Populated");
+    }
 }
 
 mod relation_tests {


### PR DESCRIPTION
## Summary

- Replaced the `needs_save_worker`-guarded `apply_snapshot(Snapshot::new())` poke in `create_empty_storage_file` (crates/kanban-cli/src/app.rs) with an unconditional `backend.mark_dirty()` call, per the `KanbanBackend::mark_dirty` primitive added in KAN-1438.
- Removed the now-unused `kanban_domain::Snapshot` usage from app.rs; this purges the last production `apply_snapshot` call site in kanban-cli. The only remaining reference is a `CountingBackend` test double in `handlers/card.rs`, reserved for a later deletion pass.
- Added `test_init_on_an_existing_populated_file_is_a_successful_no_op`, seeding a board/column/card then asserting a second `kanban init` on the same file is a byte-for-byte no-op and the full entity graph is still readable. This passes unmodified against current develop, since the change is behavior-preserving; it is a regression pin rather than a Red test, in line with the card's own framing.
- Corrected a stale claim on KAN-1079's board card (superseded, retained for provenance) that kanban-cli had no production `apply_snapshot` call sites.
- Added `.changeset/kan-1439-seed-empty-storage-file-mark-dirty.md` (patch bump; no public API changed).

## Test plan

- [x] `cargo test -p kanban-cli --all-features` green, including the new test and the three pre-existing `init_tests` pins (fresh JSON, fresh SQLite, empty-file idempotence)
- [x] `cargo clippy -p kanban-cli --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: removed `mark_dirty()` without restoring the old guard, confirmed 5 `init_tests` failed (including the new test), then restored the fix and confirmed the tree matches the committed diff exactly
- [x] `git grep -n 'apply_snapshot' -- crates/kanban-cli/src` returns only the `#[cfg(test)]` double in `handlers/card.rs`
- [x] `git grep -n 'Snapshot' -- crates/kanban-cli/src/app.rs` returns nothing
- [x] All three `create_empty_storage_file` call sites remain preceded by an `exists()` guard
