### PR TITLE
KAN-1457 feat(service): add InvalidationPlan, a FetchPlan derived from an Invalidation

### DIFF
--- a/.changeset/kan-1457-invalidation-plan.md
+++ b/.changeset/kan-1457-invalidation-plan.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+kanban-service adds `InvalidationPlan`, a `FetchPlan` built from an `Invalidation` plus a pre-invalidation `LoadedState` snapshot. It re-requests exactly the tiers `Model::invalidate` is about to blank, restricted to tiers the model had already read, so a mutation only refetches what was actually visible before it ran.

--- a/crates/kanban-service/src/invalidation_plan.rs
+++ b/crates/kanban-service/src/invalidation_plan.rs
@@ -1,6 +1,8 @@
-use kanban_domain::Invalidation;
+use kanban_domain::{EntityIds, Invalidation};
 
-use crate::fetch_plan::{FetchPlan, FetchRound, LoadedEntities, LoadedState};
+use crate::fetch_plan::{
+    requestable, FetchPlan, FetchRound, FetchStatus, LoadedEntities, LoadedState,
+};
 
 /// A [`FetchPlan`] built from an [`Invalidation`] plus a pre-invalidation
 /// [`LoadedState`] snapshot. Construct it *before* calling
@@ -13,12 +15,57 @@ pub struct InvalidationPlan {
     round: FetchRound,
 }
 
+fn was_read(status: FetchStatus) -> bool {
+    matches!(status, FetchStatus::Loaded)
+}
+
+fn already_read(
+    ids: &std::collections::HashSet<uuid::Uuid>,
+    status_of: impl Fn(uuid::Uuid) -> FetchStatus,
+) -> Vec<uuid::Uuid> {
+    let mut ids: Vec<uuid::Uuid> = ids
+        .iter()
+        .copied()
+        .filter(|id| was_read(status_of(*id)))
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+fn outstanding(
+    ids: &[uuid::Uuid],
+    status_of: impl Fn(uuid::Uuid) -> FetchStatus,
+) -> Vec<uuid::Uuid> {
+    ids.iter()
+        .copied()
+        .filter(|id| requestable(status_of(*id)))
+        .collect()
+}
+
 impl InvalidationPlan {
-    pub fn for_invalidation(
-        _invalidation: &Invalidation,
-        _loaded: &dyn LoadedState,
-    ) -> Option<Self> {
-        todo!()
+    pub fn for_invalidation(invalidation: &Invalidation, loaded: &dyn LoadedState) -> Option<Self> {
+        let round = match invalidation {
+            Invalidation::All => FetchRound {
+                board_list: was_read(loaded.board_list()),
+                column_list: was_read(loaded.column_list()),
+                card_list: was_read(loaded.card_list()),
+                sprint_list: was_read(loaded.sprint_list()),
+                graph: was_read(loaded.graph()),
+                columns: Vec::new(),
+                cards: Vec::new(),
+                sprints: Vec::new(),
+                columns_by_board: Vec::new(),
+                cards_by_column: Vec::new(),
+                sprints_by_board: Vec::new(),
+                archived_card_list: was_read(loaded.archived_card_list()),
+                archived_cards_by_board: Vec::new(),
+                archived_board_list: was_read(loaded.archived_board_list()),
+            },
+            Invalidation::Entities(ids) if ids.is_empty() => return None,
+            Invalidation::Entities(ids) => build_entities_round(ids, loaded),
+        };
+
+        (!round.is_empty()).then_some(Self { round })
     }
 
     pub fn round(&self) -> &FetchRound {
@@ -26,9 +73,47 @@ impl InvalidationPlan {
     }
 }
 
+fn build_entities_round(ids: &EntityIds, loaded: &dyn LoadedState) -> FetchRound {
+    FetchRound {
+        board_list: (!ids.boards.is_empty() || ids.prefixes) && was_read(loaded.board_list()),
+        column_list: !ids.columns.is_empty() && was_read(loaded.column_list()),
+        card_list: !ids.cards.is_empty() && was_read(loaded.card_list()),
+        sprint_list: !ids.sprints.is_empty() && was_read(loaded.sprint_list()),
+        graph: ids.graph && was_read(loaded.graph()),
+        columns: already_read(&ids.columns, |id| loaded.column(id)),
+        cards: already_read(&ids.cards, |id| loaded.card(id)),
+        sprints: already_read(&ids.sprints, |id| loaded.sprint(id)),
+        columns_by_board: Vec::new(),
+        cards_by_column: Vec::new(),
+        sprints_by_board: Vec::new(),
+        // `Model::invalidate`'s `Entities` path never blanks either flat
+        // archival tier; only `load_from_snapshot` recomputes them.
+        archived_card_list: false,
+        archived_cards_by_board: Vec::new(),
+        archived_board_list: false,
+    }
+}
+
 impl FetchPlan for InvalidationPlan {
-    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
-        todo!()
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            board_list: self.round.board_list && requestable(loaded.board_list()),
+            column_list: self.round.column_list && requestable(loaded.column_list()),
+            card_list: self.round.card_list && requestable(loaded.card_list()),
+            sprint_list: self.round.sprint_list && requestable(loaded.sprint_list()),
+            graph: self.round.graph && requestable(loaded.graph()),
+            columns: outstanding(&self.round.columns, |id| loaded.column(id)),
+            cards: outstanding(&self.round.cards, |id| loaded.card(id)),
+            sprints: outstanding(&self.round.sprints, |id| loaded.sprint(id)),
+            columns_by_board: Vec::new(),
+            cards_by_column: Vec::new(),
+            sprints_by_board: Vec::new(),
+            archived_card_list: self.round.archived_card_list
+                && requestable(loaded.archived_card_list()),
+            archived_cards_by_board: Vec::new(),
+            archived_board_list: self.round.archived_board_list
+                && requestable(loaded.archived_board_list()),
+        }
     }
 }
 

--- a/crates/kanban-service/src/invalidation_plan.rs
+++ b/crates/kanban-service/src/invalidation_plan.rs
@@ -15,8 +15,11 @@ pub struct InvalidationPlan {
     round: FetchRound,
 }
 
+/// `NotLoaded` is precisely "nobody ever asked". `Loaded`, `Failed` and
+/// `Missing` all mean a fetch was attempted, and `Model::invalidate` clears a
+/// cached `Missing` by removing the entry, so all three count as "was read".
 fn was_read(status: FetchStatus) -> bool {
-    matches!(status, FetchStatus::Loaded)
+    !matches!(status, FetchStatus::NotLoaded)
 }
 
 fn already_read(
@@ -43,6 +46,11 @@ fn outstanding(
 }
 
 impl InvalidationPlan {
+    /// `loaded` must be the `Model`'s state *before* `Model::invalidate` is
+    /// applied. Never substitute an empty plan for `None`: `None` means
+    /// nothing invalidated needs re-fetching, while `Some` with an
+    /// all-`false`/all-empty round would be a distinct, wrong signal to
+    /// callers that check `is_none()` to skip a refetch cycle.
     pub fn for_invalidation(invalidation: &Invalidation, loaded: &dyn LoadedState) -> Option<Self> {
         let round = match invalidation {
             Invalidation::All => FetchRound {
@@ -95,6 +103,13 @@ fn build_entities_round(ids: &EntityIds, loaded: &dyn LoadedState) -> FetchRound
 }
 
 impl FetchPlan for InvalidationPlan {
+    /// Both `FetchRound` literals in this file are exhaustive, deliberately
+    /// against the usual plan convention. A tier `Model::invalidate` blanks
+    /// and this plan silently defaults to "not requested" is exactly the
+    /// defect this type exists to close, so a new tier must break the build
+    /// here. Never repair such a break with `..Default::default()`; that
+    /// trades the compile error for the silent gap. Add the field by name
+    /// and decide it.
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         FetchRound {
             board_list: self.round.board_list && requestable(loaded.board_list()),

--- a/crates/kanban-service/src/invalidation_plan.rs
+++ b/crates/kanban-service/src/invalidation_plan.rs
@@ -1,0 +1,36 @@
+use kanban_domain::Invalidation;
+
+use crate::fetch_plan::{FetchPlan, FetchRound, LoadedEntities, LoadedState};
+
+/// A [`FetchPlan`] built from an [`Invalidation`] plus a pre-invalidation
+/// [`LoadedState`] snapshot. Construct it *before* calling
+/// [`kanban_domain::Model::invalidate`]: it re-requests exactly the tiers
+/// `invalidate` is about to blank, restricted to tiers the snapshot shows
+/// were already read, so it never asks for something the caller never
+/// wanted in the first place.
+#[derive(Debug, Clone)]
+pub struct InvalidationPlan {
+    round: FetchRound,
+}
+
+impl InvalidationPlan {
+    pub fn for_invalidation(
+        _invalidation: &Invalidation,
+        _loaded: &dyn LoadedState,
+    ) -> Option<Self> {
+        todo!()
+    }
+
+    pub fn round(&self) -> &FetchRound {
+        &self.round
+    }
+}
+
+impl FetchPlan for InvalidationPlan {
+    fn next_round(&self, _loaded: &dyn LoadedEntities) -> FetchRound {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -333,7 +333,13 @@ fn test_the_plan_never_emits_a_scoped_tier() {
     ];
 
     for ids in shapes {
-        let world = all_loaded();
+        let world = StubWorld {
+            columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            cards_of_column: HashMap::from([(column, FetchStatus::Loaded)]),
+            sprints_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            archived_cards_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            ..all_loaded()
+        };
         let Some(plan) = InvalidationPlan::for_invalidation(&Invalidation::Entities(ids), &world)
         else {
             continue;

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -278,6 +278,36 @@ fn test_only_the_loaded_ids_of_a_mixed_invalidation_are_requested() {
 }
 
 #[test]
+fn test_a_failed_card_list_is_still_re_requested_because_it_was_read() {
+    let a = Uuid::new_v4();
+    let world = StubWorld {
+        card_list: FetchStatus::Failed,
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
+            .expect("card_list was read, even though it failed");
+
+    assert!(plan.round().card_list);
+}
+
+#[test]
+fn test_a_missing_card_id_is_still_re_requested_because_it_was_read() {
+    let a = Uuid::new_v4();
+    let world = StubWorld {
+        cards: HashMap::from([(a, FetchStatus::Missing)]),
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
+            .expect("card a was read, even though it came back missing");
+
+    assert_eq!(plan.round().cards, vec![a]);
+}
+
+#[test]
 fn test_the_plan_never_emits_a_scoped_tier() {
     let a = Uuid::new_v4();
     let b = Uuid::new_v4();

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -1,0 +1,457 @@
+use std::collections::HashMap;
+
+use kanban_domain::{Column, EntityIds};
+use uuid::Uuid;
+
+use super::*;
+
+struct StubWorld {
+    board_list: FetchStatus,
+    column_list: FetchStatus,
+    card_list: FetchStatus,
+    sprint_list: FetchStatus,
+    graph: FetchStatus,
+    columns: HashMap<Uuid, FetchStatus>,
+    cards: HashMap<Uuid, FetchStatus>,
+    sprints: HashMap<Uuid, FetchStatus>,
+    columns_of_board: HashMap<Uuid, FetchStatus>,
+    cards_of_column: HashMap<Uuid, FetchStatus>,
+    sprints_of_board: HashMap<Uuid, FetchStatus>,
+    archived_card_list: FetchStatus,
+    archived_cards_of_board: HashMap<Uuid, FetchStatus>,
+    archived_board_list: FetchStatus,
+}
+
+impl Default for StubWorld {
+    fn default() -> Self {
+        StubWorld {
+            board_list: FetchStatus::NotLoaded,
+            column_list: FetchStatus::NotLoaded,
+            card_list: FetchStatus::NotLoaded,
+            sprint_list: FetchStatus::NotLoaded,
+            graph: FetchStatus::NotLoaded,
+            columns: HashMap::new(),
+            cards: HashMap::new(),
+            sprints: HashMap::new(),
+            columns_of_board: HashMap::new(),
+            cards_of_column: HashMap::new(),
+            sprints_of_board: HashMap::new(),
+            archived_card_list: FetchStatus::NotLoaded,
+            archived_cards_of_board: HashMap::new(),
+            archived_board_list: FetchStatus::NotLoaded,
+        }
+    }
+}
+
+impl LoadedState for StubWorld {
+    fn board_list(&self) -> FetchStatus {
+        self.board_list
+    }
+    fn column_list(&self) -> FetchStatus {
+        self.column_list
+    }
+    fn card_list(&self) -> FetchStatus {
+        self.card_list
+    }
+    fn sprint_list(&self) -> FetchStatus {
+        self.sprint_list
+    }
+    fn graph(&self) -> FetchStatus {
+        self.graph
+    }
+    fn column(&self, id: Uuid) -> FetchStatus {
+        self.columns
+            .get(&id)
+            .copied()
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn card(&self, id: Uuid) -> FetchStatus {
+        self.cards
+            .get(&id)
+            .copied()
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn sprint(&self, id: Uuid) -> FetchStatus {
+        self.sprints
+            .get(&id)
+            .copied()
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn columns_of_board(&self, board_id: Uuid) -> FetchStatus {
+        self.columns_of_board
+            .get(&board_id)
+            .copied()
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn cards_of_column(&self, column_id: Uuid) -> FetchStatus {
+        self.cards_of_column
+            .get(&column_id)
+            .copied()
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn sprints_of_board(&self, board_id: Uuid) -> FetchStatus {
+        self.sprints_of_board
+            .get(&board_id)
+            .copied()
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn archived_card_list(&self) -> FetchStatus {
+        self.archived_card_list
+    }
+    fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus {
+        self.archived_cards_of_board
+            .get(&board_id)
+            .copied()
+            .unwrap_or(FetchStatus::NotLoaded)
+    }
+    fn archived_board_list(&self) -> FetchStatus {
+        self.archived_board_list
+    }
+}
+
+impl LoadedEntities for StubWorld {
+    fn loaded_columns_of_board(&self, _board_id: Uuid) -> Option<&[Column]> {
+        None
+    }
+}
+
+fn all_loaded() -> StubWorld {
+    StubWorld {
+        board_list: FetchStatus::Loaded,
+        column_list: FetchStatus::Loaded,
+        card_list: FetchStatus::Loaded,
+        sprint_list: FetchStatus::Loaded,
+        graph: FetchStatus::Loaded,
+        columns: HashMap::new(),
+        cards: HashMap::new(),
+        sprints: HashMap::new(),
+        columns_of_board: HashMap::new(),
+        cards_of_column: HashMap::new(),
+        sprints_of_board: HashMap::new(),
+        archived_card_list: FetchStatus::Loaded,
+        archived_cards_of_board: HashMap::new(),
+        archived_board_list: FetchStatus::Loaded,
+    }
+}
+
+#[test]
+fn test_an_invalidated_card_that_was_never_loaded_is_not_requested() {
+    let world = StubWorld::default();
+    let a = Uuid::new_v4();
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world);
+
+    assert!(plan.is_none());
+}
+
+#[test]
+fn test_an_invalidated_card_that_was_loaded_is_requested_by_id() {
+    let a = Uuid::new_v4();
+    let world = StubWorld {
+        cards: HashMap::from([(a, FetchStatus::Loaded)]),
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
+            .expect("card was loaded");
+
+    assert_eq!(plan.round().cards, vec![a]);
+    assert!(plan.round().columns.is_empty());
+    assert!(plan.round().sprints.is_empty());
+    assert!(!plan.round().board_list);
+    assert!(!plan.round().column_list);
+    assert!(!plan.round().card_list);
+    assert!(!plan.round().sprint_list);
+    assert!(!plan.round().graph);
+}
+
+#[test]
+fn test_a_loaded_card_list_is_re_requested_when_any_card_is_invalidated() {
+    let a = Uuid::new_v4();
+    let world = StubWorld {
+        card_list: FetchStatus::Loaded,
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
+            .expect("card_list was loaded");
+
+    assert!(plan.round().card_list);
+    assert!(plan.round().cards.is_empty());
+}
+
+#[test]
+fn test_a_named_board_is_re_requested_as_the_board_list() {
+    let b = Uuid::new_v4();
+    let world = StubWorld {
+        board_list: FetchStatus::Loaded,
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::boards([b])), &world)
+            .expect("board_list was loaded");
+
+    assert!(plan.round().board_list);
+    assert!(plan.round().columns.is_empty());
+    assert!(plan.round().cards.is_empty());
+    assert!(plan.round().sprints.is_empty());
+    assert!(!plan.round().graph);
+}
+
+#[test]
+fn test_a_prefix_only_invalidation_re_requests_a_loaded_board_list() {
+    let world = StubWorld {
+        board_list: FetchStatus::Loaded,
+        ..Default::default()
+    };
+
+    let plan = InvalidationPlan::for_invalidation(
+        &Invalidation::Entities(EntityIds::default().with_prefixes()),
+        &world,
+    )
+    .expect("board_list was loaded");
+
+    assert!(plan.round().board_list);
+    assert!(plan.round().columns.is_empty());
+    assert!(plan.round().cards.is_empty());
+    assert!(plan.round().sprints.is_empty());
+    assert!(!plan.round().graph);
+    assert!(!plan.round().column_list);
+    assert!(!plan.round().card_list);
+    assert!(!plan.round().sprint_list);
+}
+
+#[test]
+fn test_a_prefix_bump_over_an_unread_board_list_yields_no_plan() {
+    let world = StubWorld::default();
+
+    let plan = InvalidationPlan::for_invalidation(
+        &Invalidation::Entities(EntityIds::default().with_prefixes()),
+        &world,
+    );
+
+    assert!(plan.is_none());
+}
+
+#[test]
+fn test_a_graph_invalidation_requests_the_graph_alongside_its_loaded_cards() {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let world = StubWorld {
+        graph: FetchStatus::Loaded,
+        cards: HashMap::from([(a, FetchStatus::Loaded), (b, FetchStatus::Loaded)]),
+        ..Default::default()
+    };
+
+    let plan = InvalidationPlan::for_invalidation(
+        &Invalidation::Entities(EntityIds::cards([a, b]).with_graph()),
+        &world,
+    )
+    .expect("graph and cards were loaded");
+
+    assert!(plan.round().graph);
+    let mut expected = vec![a, b];
+    expected.sort_unstable();
+    assert_eq!(plan.round().cards, expected);
+}
+
+#[test]
+fn test_only_the_loaded_ids_of_a_mixed_invalidation_are_requested() {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let world = StubWorld {
+        cards: HashMap::from([(a, FetchStatus::Loaded), (b, FetchStatus::NotLoaded)]),
+        ..Default::default()
+    };
+
+    let plan = InvalidationPlan::for_invalidation(
+        &Invalidation::Entities(EntityIds::cards([a, b])),
+        &world,
+    )
+    .expect("card a was loaded");
+
+    assert_eq!(plan.round().cards, vec![a]);
+}
+
+#[test]
+fn test_the_plan_never_emits_a_scoped_tier() {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let board = Uuid::new_v4();
+    let column = Uuid::new_v4();
+    let sprint = Uuid::new_v4();
+
+    let shapes = vec![
+        EntityIds::boards([board]),
+        EntityIds::columns([column]),
+        EntityIds::cards([a, b]),
+        EntityIds::sprints([sprint]),
+        EntityIds::default().with_graph(),
+        EntityIds::default().with_prefixes(),
+        EntityIds {
+            boards: [board].into(),
+            columns: [column].into(),
+            cards: [a, b].into(),
+            sprints: [sprint].into(),
+            graph: true,
+            prefixes: true,
+        },
+    ];
+
+    for ids in shapes {
+        let world = all_loaded();
+        let Some(plan) = InvalidationPlan::for_invalidation(&Invalidation::Entities(ids), &world)
+        else {
+            continue;
+        };
+
+        assert!(plan.round().columns_by_board.is_empty());
+        assert!(plan.round().cards_by_column.is_empty());
+        assert!(plan.round().sprints_by_board.is_empty());
+        assert!(plan.round().archived_cards_by_board.is_empty());
+
+        let next = plan.next_round(&world);
+        assert!(next.columns_by_board.is_empty());
+        assert!(next.cards_by_column.is_empty());
+        assert!(next.sprints_by_board.is_empty());
+        assert!(next.archived_cards_by_board.is_empty());
+    }
+}
+
+#[test]
+fn test_an_empty_entities_invalidation_yields_no_plan() {
+    let world = all_loaded();
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::default()), &world);
+
+    assert!(plan.is_none());
+}
+
+#[test]
+fn test_all_repairs_every_read_tier_including_the_archival_markers() {
+    let world = StubWorld {
+        board_list: FetchStatus::Loaded,
+        column_list: FetchStatus::Loaded,
+        card_list: FetchStatus::Loaded,
+        sprint_list: FetchStatus::Loaded,
+        graph: FetchStatus::Loaded,
+        archived_card_list: FetchStatus::Loaded,
+        archived_board_list: FetchStatus::Loaded,
+        ..Default::default()
+    };
+
+    let plan = InvalidationPlan::for_invalidation(&Invalidation::All, &world)
+        .expect("everything was loaded");
+
+    let round = plan.round();
+    assert!(round.board_list);
+    assert!(round.column_list);
+    assert!(round.card_list);
+    assert!(round.sprint_list);
+    assert!(round.graph);
+    assert!(round.archived_card_list);
+    assert!(round.archived_board_list);
+    assert!(round.columns.is_empty());
+    assert!(round.cards.is_empty());
+    assert!(round.sprints.is_empty());
+    assert!(round.columns_by_board.is_empty());
+    assert!(round.cards_by_column.is_empty());
+    assert!(round.sprints_by_board.is_empty());
+    assert!(round.archived_cards_by_board.is_empty());
+}
+
+#[test]
+fn test_an_invalidated_archived_card_list_is_not_requested_because_invalidate_does_not_blank_it() {
+    let a = Uuid::new_v4();
+    let world = StubWorld {
+        cards: HashMap::from([(a, FetchStatus::Loaded)]),
+        archived_card_list: FetchStatus::Loaded,
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
+            .expect("card a was loaded");
+
+    assert_eq!(plan.round().cards, vec![a]);
+    assert!(!plan.round().archived_card_list);
+}
+
+#[test]
+fn test_an_invalidated_board_never_repairs_the_archived_board_list_because_invalidate_does_not_blank_it(
+) {
+    let b = Uuid::new_v4();
+    let world = StubWorld {
+        board_list: FetchStatus::Loaded,
+        archived_board_list: FetchStatus::Loaded,
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::boards([b])), &world)
+            .expect("board_list was loaded");
+
+    assert!(plan.round().board_list);
+    assert!(!plan.round().archived_board_list);
+}
+
+#[test]
+fn test_next_round_is_empty_once_everything_it_asked_for_is_loaded() {
+    let a = Uuid::new_v4();
+    let world = StubWorld {
+        cards: HashMap::from([(a, FetchStatus::Loaded)]),
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
+            .expect("card a was loaded");
+
+    let still_missing = StubWorld {
+        cards: HashMap::from([(a, FetchStatus::NotLoaded)]),
+        ..Default::default()
+    };
+    assert_eq!(plan.next_round(&still_missing).cards, vec![a]);
+
+    let now_loaded = StubWorld {
+        cards: HashMap::from([(a, FetchStatus::Loaded)]),
+        ..Default::default()
+    };
+    assert!(plan.next_round(&now_loaded).is_empty());
+}
+
+#[test]
+fn test_a_multi_id_round_is_deterministic() {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    let world = all_loaded_with_cards(&[a, b, c]);
+
+    let plan_one = InvalidationPlan::for_invalidation(
+        &Invalidation::Entities(EntityIds::cards([a, b, c])),
+        &world,
+    )
+    .expect("cards were loaded");
+    let plan_two = InvalidationPlan::for_invalidation(
+        &Invalidation::Entities(EntityIds::cards([c, b, a])),
+        &world,
+    )
+    .expect("cards were loaded");
+
+    let mut expected = vec![a, b, c];
+    expected.sort_unstable();
+    assert_eq!(plan_one.round().cards, expected);
+    assert_eq!(plan_one.round().cards, plan_two.round().cards);
+}
+
+fn all_loaded_with_cards(ids: &[Uuid]) -> StubWorld {
+    StubWorld {
+        cards: ids.iter().map(|id| (*id, FetchStatus::Loaded)).collect(),
+        ..all_loaded()
+    }
+}

--- a/crates/kanban-service/src/lib.rs
+++ b/crates/kanban-service/src/lib.rs
@@ -18,6 +18,7 @@ mod cascade;
 pub mod config;
 mod context;
 pub mod fetch_plan;
+pub mod invalidation_plan;
 mod model_loaded;
 mod path;
 #[cfg(test)]
@@ -35,6 +36,7 @@ pub use context::{
 pub use fetch_plan::{
     requestable, FetchPlan, FetchRound, FetchStatus, LoadedEntities, LoadedState,
 };
+pub use invalidation_plan::InvalidationPlan;
 pub use kanban_backend::KanbanBackend;
 pub use kanban_backend::RemoteWrites;
 pub use kanban_backend::TransactionFn;


### PR DESCRIPTION
## Summary

- Adds `InvalidationPlan` to `kanban-service`: a `FetchPlan` built from an `Invalidation` plus a pre-invalidation `LoadedState` snapshot.
- `for_invalidation` re-requests exactly the tiers `Model::invalidate` is about to blank, restricted to tiers the model had already read (`FetchStatus::Loaded`). It returns `None` when nothing that was actually read would be affected, so a caller never pays for an empty round.
- `Invalidation::All` repairs every flat tier the snapshot shows was read, including both flat archival tiers (`archived_card_list`, `archived_board_list`), matching `Model::invalidate`'s full reset on that path.
- `Invalidation::Entities(ids)` never repairs the two flat archival tiers, because `Model::invalidate`'s `Entities` branch never blanks them (only `load_from_snapshot` recomputes those).
- The plan never emits any of the four parent-scoped tiers (`columns_by_board`, `cards_by_column`, `sprints_by_board`, `archived_cards_by_board`), since a parent key is not recoverable from the id-keyed `LoadedState` interface.
- `next_round` (the `FetchPlan` impl) re-masks every tier against a fresh `LoadedEntities` snapshot at resolve time, so anything that got loaded in the meantime drops out.
- Pure new type with 15 unit tests; zero consumer wiring in this PR (a follow-up wires it into the mutation paths) and zero change to `kanban-domain`.

## Test plan

- `cargo test -p kanban-service --all-features`: all green (194 lib tests including 15 new `invalidation_plan` tests, plus the full integration suite).
- `cargo clippy -p kanban-service --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Mutation check: reverted the hardcoded `archived_card_list: false` under the `Entities` arm to a `was_read`-gated version, confirmed `test_an_invalidated_archived_card_list_is_not_requested_because_invalidate_does_not_blank_it` fails, then restored the fix.
