### PR TITLE
KAN-1439 fix(cli): canonicalize paths in the populated-file init test for windows

### DIFF
--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -5109,9 +5109,11 @@ mod init_tests {
 
         let json = parse_json_output(&String::from_utf8_lossy(&output));
         assert!(json["success"].as_bool().unwrap());
+        let reported = std::fs::canonicalize(json["data"]["file"].as_str().unwrap())
+            .expect("reported path should exist");
         assert_eq!(
-            json["data"]["file"].as_str().unwrap(),
-            file_str,
+            reported,
+            std::fs::canonicalize(&file).expect("seeded path should exist"),
             "second init on a populated file should still report the same file path"
         );
 


### PR DESCRIPTION
The populated-file init regression test added by KAN-1439 compared the reported file path as a string. On the Windows CI runner the same temp path is spelled with the DOS 8.3 short name (RUNNER~1) on one run and the long name (runneradmin) on the other, so the assertion failed while both spellings name the same file. Compare the canonicalized paths instead.

Test-only change; the Linux job was and remains green. Fixes the develop Windows CI break introduced by #745.
