### PR TITLE
KAN-1453 test(service): cross-backend parity contract for resolve's scoped tiers

### DIFF
--- a/.changeset/kan-1453-cross-backend-parity-resolve-s.md
+++ b/.changeset/kan-1453-cross-backend-parity-resolve-s.md
@@ -1,5 +1,5 @@
 ---
-bump: patch
+bump: minor
 ---
 
 service: add cross-backend parity contract tests for `resolve`'s scoped tiers (columns-by-board, cards-by-column, sprints-by-board), pinning that every backend agrees on scoped-graph shape, archived-card exclusion, unknown-parent-is-empty, and failed-read-is-Failed-not-empty semantics

--- a/.changeset/kan-1453-cross-backend-parity-resolve-s.md
+++ b/.changeset/kan-1453-cross-backend-parity-resolve-s.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: add cross-backend parity contract tests for `resolve`'s scoped tiers (columns-by-board, cards-by-column, sprints-by-board), pinning that every backend agrees on scoped-graph shape, archived-card exclusion, unknown-parent-is-empty, and failed-read-is-Failed-not-empty semantics

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -603,3 +603,173 @@ pub async fn test_an_archived_card_restored_then_reread_is_absent_on_every_backe
         .unwrap();
     assert!(markers.is_empty());
 }
+
+pub async fn test_scoped_resolve_returns_the_same_graph_on_every_backend(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let col_a = ctx.create_column(board.id, "A".into(), None).unwrap();
+    let col_b = ctx.create_column(board.id, "B".into(), None).unwrap();
+    let card_a1 = ctx
+        .create_card(
+            board.id,
+            col_a.id,
+            "A1".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_a2 = ctx
+        .create_card(
+            board.id,
+            col_a.id,
+            "A2".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_b1 = ctx
+        .create_card(
+            board.id,
+            col_b.id,
+            "B1".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let sprint = ctx
+        .create_sprint(board.id, Some("SPR".into()), Some("Sprint".into()))
+        .unwrap();
+    let archived = ctx
+        .create_card(
+            board.id,
+            col_a.id,
+            "A-archived".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let _ = ctx.archive_card_impl(archived.id).unwrap();
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            columns_by_board: vec![board.id],
+            cards_by_column: vec![col_a.id, col_b.id],
+            sprints_by_board: vec![board.id],
+            ..Default::default()
+        }),
+        &Model::default(),
+    );
+
+    let columns_state = resolved
+        .columns
+        .by_parent
+        .get(&board.id)
+        .expect("board's columns requested");
+    assert!(columns_state.is_loaded());
+    let columns = columns_state.loaded().expect("columns loaded");
+    assert_eq!(
+        columns.iter().map(|c| c.id).collect::<Vec<_>>(),
+        vec![col_a.id, col_b.id]
+    );
+
+    let col_a_cards_state = resolved
+        .cards
+        .by_parent
+        .get(&col_a.id)
+        .expect("col_a's cards requested");
+    assert!(col_a_cards_state.is_loaded());
+    let col_a_cards = col_a_cards_state.loaded().expect("col_a cards loaded");
+    let mut col_a_ids: Vec<Uuid> = col_a_cards.iter().map(|c| c.id).collect();
+    col_a_ids.sort();
+    let mut expected_a_ids = vec![card_a1.id, card_a2.id];
+    expected_a_ids.sort();
+    assert_eq!(col_a_ids, expected_a_ids);
+    assert!(!col_a_cards.iter().any(|c| c.id == archived.id));
+
+    let col_b_cards_state = resolved
+        .cards
+        .by_parent
+        .get(&col_b.id)
+        .expect("col_b's cards requested");
+    assert!(col_b_cards_state.is_loaded());
+    let col_b_cards = col_b_cards_state.loaded().expect("col_b cards loaded");
+    assert_eq!(
+        col_b_cards.iter().map(|c| c.id).collect::<Vec<_>>(),
+        vec![card_b1.id]
+    );
+
+    let sprints_state = resolved
+        .sprints
+        .by_parent
+        .get(&board.id)
+        .expect("board's sprints requested");
+    assert!(sprints_state.is_loaded());
+    let sprints = sprints_state.loaded().expect("sprints loaded");
+    assert!(sprints.iter().any(|s| s.id == sprint.id));
+}
+
+pub async fn test_a_scope_on_an_unknown_parent_is_loaded_and_empty_on_every_backend(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+    let unknown = Uuid::new_v4();
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            columns_by_board: vec![unknown],
+            ..Default::default()
+        }),
+        &Model::default(),
+    );
+
+    let state = resolved
+        .columns
+        .by_parent
+        .get(&unknown)
+        .expect("unknown board's scope requested");
+    assert!(state.is_loaded());
+    assert!(state.loaded().expect("loaded").is_empty());
+}
+
+pub async fn test_a_failed_scoped_read_is_failed_not_empty_on_every_backend(
+    factory: BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let (factory, handles) = faultable(factory);
+    let backend = factory(&path);
+    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let _column = ctx.create_column(board.id, "Col".into(), None).unwrap();
+
+    handle.fail("list_columns_by_board");
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            columns_by_board: vec![board.id],
+            ..Default::default()
+        }),
+        &Model::default(),
+    );
+
+    let state = resolved
+        .columns
+        .by_parent
+        .get(&board.id)
+        .expect("board's columns requested");
+    assert!(state.is_failed());
+    assert!(!state.is_loaded());
+}

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -149,11 +149,8 @@ pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &
         .is_loaded());
     apply(&mut model, resolved);
     assert!(model.card_by_id_state(card.id).is_loaded());
-    assert!(model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .any(|c| c.id == card.id));
+    let cards = model.cards_state().loaded().expect("card list loaded");
+    assert!(cards.iter().any(|c| c.id == card.id));
 
     let _invalidation = ctx.delete_card_impl(card.id).unwrap();
 
@@ -171,11 +168,11 @@ pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &
         .is_missing());
     apply(&mut model, resolved2);
     assert!(model.card_by_id_state(card.id).is_missing());
-    assert!(!model
+    let cards = model
         .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .any(|c| c.id == card.id));
+        .loaded()
+        .expect("card list still loaded after the delete");
+    assert!(!cards.iter().any(|c| c.id == card.id));
 }
 
 pub async fn test_a_backend_read_error_resolves_failed_not_missing(factory: BackendFactory) {
@@ -652,6 +649,11 @@ pub async fn test_scoped_resolve_returns_the_same_graph_on_every_backend(factory
         )
         .unwrap();
     let _ = ctx.archive_card_impl(archived.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
 
     let resolved = ctx.resolve(
         &StaticPlan(FetchRound {

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -509,5 +509,17 @@ macro_rules! cache_contract_tests {
         async fn test_an_archived_card_restored_then_reread_is_absent_on_every_backend() {
             $crate::test_helpers::contract::cache::test_an_archived_card_restored_then_reread_is_absent_on_every_backend(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_scoped_resolve_returns_the_same_graph_on_every_backend() {
+            $crate::test_helpers::contract::cache::test_scoped_resolve_returns_the_same_graph_on_every_backend(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_scope_on_an_unknown_parent_is_loaded_and_empty_on_every_backend() {
+            $crate::test_helpers::contract::cache::test_a_scope_on_an_unknown_parent_is_loaded_and_empty_on_every_backend(&$factory_fn()).await;
+        }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_failed_scoped_read_is_failed_not_empty_on_every_backend() {
+            $crate::test_helpers::contract::cache::test_a_failed_scoped_read_is_failed_not_empty_on_every_backend($factory_fn()).await;
+        }
     };
 }


### PR DESCRIPTION
## Summary

Adds three cross-backend parity contract functions for `resolve`'s scoped tiers to `crates/kanban-service/src/test_helpers/contract/cache.rs`, registered in `cache_contract_tests!` (invoked for in-memory, JSON, and SQLite in `archival_contract.rs`, and for JSON again in `kanban-persistence-json/tests/contract.rs`).

- `test_scoped_resolve_returns_the_same_graph_on_every_backend` (`&BackendFactory`) - seeds a board with two columns, three live cards (two in one column, one in the other), a sprint, and an archived card, saves and reopens the context from disk, then resolves `columns_by_board` + `cards_by_column` + `sprints_by_board` in a single round. Asserts columns come back in position order, each column's live cards match exactly (archived card excluded), and the sprint is present, all as `Loaded`.
- `test_a_scope_on_an_unknown_parent_is_loaded_and_empty_on_every_backend` (`&BackendFactory`) - resolving `columns_by_board` for an id that does not exist yields `Loaded(vec![])`, never an error or a missing/not-loaded state.
- `test_a_failed_scoped_read_is_failed_not_empty_on_every_backend` (`BackendFactory` by value, via `faultable`) - injecting a fault on `list_columns_by_board` makes the scoped resolve surface `Failed`, never a silently-empty `Loaded`.

## Fixes from the prior review round

- `test_a_deleted_card_resolves_missing_on_a_second_resolve` collapsed both its list-state checks through `LoadState::loaded_or_empty()`, which maps `NotLoaded`/`Failed` to an empty slice, so the negative assertion (`!cards.iter().any(...)`) passed vacuously whenever the list state was anything other than `Loaded`. Both sites now bind `model.cards_state().loaded()` explicitly first (`.expect(...)`), so a non-`Loaded` state fails the test outright before the content assertion runs.
- `test_scoped_resolve_returns_the_same_graph_on_every_backend` resolved against the same in-process `ctx` it wrote through, so the JSON backend's read (served from its in-RAM mirror) could pass even if nothing was ever flushed to disk. The test now calls `ctx.save().await.unwrap()` after the archive and reopens a fresh `KanbanContext` over `factory(&path)` before resolving, so the JSON arm actually exercises its durability path.
- The changeset bump was `patch`; it is now `minor`, since this diff adds new public `pub async fn`s to a published crate's `test_helpers` module plus new macro arms, matching the same-epic precedent set by KAN-1426 (which created this file at `minor`) and KAN-1425's review correction.

## Mutation checks (all reverted before commit)

**JSON's `flush` no-op'd** (`JsonDataStore::flush` replaced with `Ok(())`, run against the reopen-from-disk version of the graph test):

```
test in_memory::test_scoped_resolve_returns_the_same_graph_on_every_backend ... ok
test json::test_scoped_resolve_returns_the_same_graph_on_every_backend ... FAILED
test sqlite::test_scoped_resolve_returns_the_same_graph_on_every_backend ... ok
test result: FAILED. 2 passed; 1 failed
```

Only the JSON arm went red, confirming the reopen step actually catches a JSON flush that never happened.

**SQLite's archival exclusion clause removed** (`fetch_cards_with_filter`'s `WHERE NOT EXISTS (...)` replaced with `WHERE 1=1`), re-run against the reopen-from-disk version:

```
test in_memory::test_scoped_resolve_returns_the_same_graph_on_every_backend ... ok
test json::test_scoped_resolve_returns_the_same_graph_on_every_backend ... ok
test sqlite::test_scoped_resolve_returns_the_same_graph_on_every_backend ... FAILED
test result: FAILED. 2 passed; 1 failed
```

Only the SQLite arm went red, as expected.

**`resolve.rs`'s `columns_by_board` `Err` arm changed from `LoadState::Failed(Arc::new(e))` to `LoadState::Loaded(vec![])`**:

```
test in_memory::test_a_failed_scoped_read_is_failed_not_empty_on_every_backend ... FAILED
test json::test_a_failed_scoped_read_is_failed_not_empty_on_every_backend ... FAILED
test sqlite::test_a_failed_scoped_read_is_failed_not_empty_on_every_backend ... FAILED
test result: FAILED. 0 passed; 3 failed
```

All three backends went red, confirming the test pins the Failed-not-empty distinction rather than passing vacuously.

`git diff origin/develop -- crates/kanban-service/src/resolve.rs crates/kanban-backend-memory crates/kanban-persistence-json crates/kanban-persistence-sqlite` is empty; all three mutations were reverted before commit.

## Counts

```
$ git grep -c '^pub async fn test_' -- crates/kanban-service/src/test_helpers/contract/cache.rs
crates/kanban-service/src/test_helpers/contract/cache.rs:16
```

16 total functions in `cache.rs` (13 pre-existing + 3 new).

The `factory: BackendFactory)` single-line grep pattern only catches 4 by-value functions because rustfmt wraps some signatures across lines (`factory: BackendFactory,` on its own line), so it undercounts. Counting the macro arms directly is reliable: `cache_contract_tests!` has 16 arms total, 9 by-reference (`&$factory_fn()`) and 7 by-value (`$factory_fn()`), matching the 16 functions one-for-one.

## HttpBackend coverage gap

`git grep -n 'impl DataStore for' | grep -v '    impl'` currently returns 13 lines: `HttpBackend`, `InMemoryStore`, `PrefixWriteOrderStore`, `JsonDataStore`, `SqliteBackend`, `SqliteStore`, `MockBackend`, `RecordingStore`, `FaultInjectingBackend`, `CountingBackend` (x2), `SnapshotCountingBackend`, `FailingSnapshotBackend`.

Of these, only `InMemoryStore`, `JsonDataStore`, and `SqliteBackend`/`SqliteStore` are exercised by `cache_contract_tests!` (via `archival_contract.rs` and `kanban-persistence-json/tests/contract.rs`). `HttpBackend` has no independent archival/scoped-read semantics of its own to be at parity with here since it delegates to a remote `kanban-server`, so it is out of scope for this contract suite. `FaultInjectingBackend` is a decorator over another backend rather than an independent implementation, so it also does not need its own parity coverage; the other entries are per-test doubles used elsewhere in the suite, not production backends.

## Verification

- `cargo test -p kanban-service --features test-helpers` - all green (9 new tests: 3 functions x 3 backends)
- `cargo test -p kanban-service --all-features` - all green
- `cargo test -p kanban-persistence-json --all-features` - all green (macro also invoked there)
- `cargo clippy -p kanban-service --all-targets --all-features -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean

## Changeset

`.changeset/kan-1453-cross-backend-parity-resolve-s.md`, bump `minor`. This diff adds new public library API (`pub async fn`s and macro arms) under the `test-helpers` feature of a published crate. Per `.changeset/README.md`, a new backwards-compatible feature is a `minor` bump; being feature-gated makes the addition opt-in, not internal. This matches the KAN-1426 precedent (which created this file at `minor`) and the review correction applied to KAN-1425 for the same reasoning.
