### PR TITLE
KAN-1374 feat(domain): name the shared control vocabulary as controller

### DIFF
--- a/.changeset/kan-1374-name-shared-control-surface-as.md
+++ b/.changeset/kan-1374-name-shared-control-surface-as.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain: adds a `controller` module that names and re-exports the shared control vocabulary (sort enums, filter/query types and functions) used by every application, disambiguated from `kanban_view::Controller`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ cargo tarpaulin        # Code coverage
 - `Card` - Task cards with priority, status, due dates
 - `Tag` - Categorization tags
 
-**Design Pattern**: Rich domain models with behavior, no infrastructure dependencies. The Model definition and its result vocabulary (`LoadState`, `Resolved`/`Collection`, `Invalidation`/`EntityIds`) live here; the fetch-planning vocabulary built on top of `LoadState` (`FetchPlan`, `FetchRound`, `FetchStatus`, `LoadedState`, `LoadedEntities`) lives in `kanban-service`
+**Design Pattern**: Rich domain models with behavior, no infrastructure dependencies. The Model definition and its result vocabulary (`LoadState`, `Resolved`/`Collection`, `Invalidation`/`EntityIds`) live here; the fetch-planning vocabulary built on top of `LoadState` (`FetchPlan`, `FetchRound`, `FetchStatus`, `LoadedState`, `LoadedEntities`) lives in `kanban-service`. The shared control vocabulary every application filters and sorts with (sort enums and filter/query types and functions) is named and re-exported from `controller`, disambiguated there from `kanban_view::Controller`; execution lives in `kanban-service` and per-application view state (mode, selection, focus) stays in each app.
 
 ### kanban-persistence
 **Purpose**: Persistence trait layer — defines `PersistenceStore`, `StoreFactory`, `StoreRegistry`, and shared types (errors, snapshots, conflict detection, file watching)

--- a/crates/kanban-domain/src/controller/mod.rs
+++ b/crates/kanban-domain/src/controller/mod.rs
@@ -1,0 +1,45 @@
+//! Shared control vocabulary: sort and filter types and functions used by
+//! every application on top of `kanban-domain`.
+//!
+//! Not to be confused with [`kanban_view::Controller`], the per-application
+//! render-loop struct that owns view state (mode, selection, focus) for
+//! `kanban-tui`; this module is the vocabulary those controllers filter and
+//! sort with, not a controller itself.
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_controller_reexports_match_the_shared_control_vocabulary() {
+        let _: fn() -> crate::controller::SortField = || crate::board::SortField::Priority;
+        let _: fn() -> crate::controller::BoardSortField =
+            || crate::board::BoardSortField::Name;
+        let _: fn() -> crate::controller::SortOrder = || crate::board::SortOrder::Ascending;
+
+        let _: fn() -> crate::controller::ArchivedFilter =
+            || crate::query::ArchivedFilter::default();
+        let _: fn() -> crate::controller::BoardListFilter =
+            || crate::query::BoardListFilter::default();
+        let _: fn() -> crate::controller::CardListFilter =
+            || crate::query::CardListFilter::default();
+
+        let _: fn(
+            crate::controller::CardQueryBuilder,
+        ) -> crate::controller::CardQueryBuilder = |b| b;
+
+        let _: fn(
+            &[crate::Board],
+            &crate::controller::BoardListFilter,
+            &std::collections::HashMap<uuid::Uuid, chrono::DateTime<chrono::Utc>>,
+            Option<(crate::controller::BoardSortField, crate::controller::SortOrder)>,
+        ) -> Vec<crate::Board> = crate::controller::filter_and_sort_boards;
+
+        let _: fn(
+            &[crate::Card],
+            &[crate::Column],
+            &[crate::Sprint],
+            Option<&crate::Board>,
+            &[crate::Board],
+            &crate::controller::CardListFilter,
+        ) -> Vec<crate::Card> = crate::controller::filter_and_sort_cards::<crate::Card>;
+    }
+}

--- a/crates/kanban-domain/src/controller/mod.rs
+++ b/crates/kanban-domain/src/controller/mod.rs
@@ -5,41 +5,80 @@
 //! render-loop struct that owns view state (mode, selection, focus) for
 //! `kanban-tui`; this module is the vocabulary those controllers filter and
 //! sort with, not a controller itself.
+//!
+//! [`count_filtered_cards`](crate::query::count_filtered_cards) and
+//! [`resolve_board_sort`](crate::query::resolve_board_sort) are lower-level
+//! helpers behind [`filter_and_sort_cards`] and [`filter_and_sort_boards`]
+//! respectively; they are implementation details of the vocabulary above and
+//! are intentionally not re-exported here, callers reach them via
+//! `crate::query` directly.
+
+pub use crate::board::{BoardSortField, SortField, SortOrder};
+pub use crate::query::{
+    filter_and_sort_boards, filter_and_sort_cards, ArchivedFilter, BoardListFilter, CardListFilter,
+    CardQueryBuilder,
+};
 
 #[cfg(test)]
 mod tests {
+    type BoardArchivedAt = std::collections::HashMap<uuid::Uuid, chrono::DateTime<chrono::Utc>>;
+    type BoardSortOverride = Option<(super::BoardSortField, super::SortOrder)>;
+
+    fn accepts_board_sort_vocabulary(
+        _: super::SortField,
+        _: super::BoardSortField,
+        _: super::SortOrder,
+    ) {
+    }
+
+    fn accepts_board_filter_vocabulary(
+        _: super::ArchivedFilter,
+        _: super::BoardListFilter,
+        _: super::CardListFilter,
+    ) {
+    }
+
+    fn identity_filter_and_sort_boards(
+        boards: &[crate::Board],
+        filter: &super::BoardListFilter,
+        archived_at: &BoardArchivedAt,
+        default: BoardSortOverride,
+    ) -> Vec<crate::Board> {
+        super::filter_and_sort_boards(boards, filter, archived_at, default)
+    }
+
+    fn identity_filter_and_sort_cards(
+        cards: &[crate::Card],
+        columns: &[crate::Column],
+        sprints: &[crate::Sprint],
+        board: Option<&crate::Board>,
+        boards: &[crate::Board],
+        filter: &super::CardListFilter,
+    ) -> Vec<crate::Card> {
+        super::filter_and_sort_cards(cards, columns, sprints, board, boards, filter)
+    }
+
+    fn identity_card_query_builder(
+        builder: super::CardQueryBuilder<'_>,
+    ) -> super::CardQueryBuilder<'_> {
+        builder
+    }
+
     #[test]
     fn test_controller_reexports_match_the_shared_control_vocabulary() {
-        let _: fn() -> crate::controller::SortField = || crate::board::SortField::Priority;
-        let _: fn() -> crate::controller::BoardSortField =
-            || crate::board::BoardSortField::Name;
-        let _: fn() -> crate::controller::SortOrder = || crate::board::SortOrder::Ascending;
+        accepts_board_sort_vocabulary(
+            crate::board::SortField::Priority,
+            crate::board::BoardSortField::Name,
+            crate::board::SortOrder::Ascending,
+        );
+        accepts_board_filter_vocabulary(
+            crate::query::ArchivedFilter::default(),
+            crate::query::BoardListFilter::default(),
+            crate::query::CardListFilter::default(),
+        );
 
-        let _: fn() -> crate::controller::ArchivedFilter =
-            || crate::query::ArchivedFilter::default();
-        let _: fn() -> crate::controller::BoardListFilter =
-            || crate::query::BoardListFilter::default();
-        let _: fn() -> crate::controller::CardListFilter =
-            || crate::query::CardListFilter::default();
-
-        let _: fn(
-            crate::controller::CardQueryBuilder,
-        ) -> crate::controller::CardQueryBuilder = |b| b;
-
-        let _: fn(
-            &[crate::Board],
-            &crate::controller::BoardListFilter,
-            &std::collections::HashMap<uuid::Uuid, chrono::DateTime<chrono::Utc>>,
-            Option<(crate::controller::BoardSortField, crate::controller::SortOrder)>,
-        ) -> Vec<crate::Board> = crate::controller::filter_and_sort_boards;
-
-        let _: fn(
-            &[crate::Card],
-            &[crate::Column],
-            &[crate::Sprint],
-            Option<&crate::Board>,
-            &[crate::Board],
-            &crate::controller::CardListFilter,
-        ) -> Vec<crate::Card> = crate::controller::filter_and_sort_cards::<crate::Card>;
+        let _ = identity_filter_and_sort_boards;
+        let _ = identity_filter_and_sort_cards;
+        let _ = identity_card_query_builder;
     }
 }

--- a/crates/kanban-domain/src/controller/mod.rs
+++ b/crates/kanban-domain/src/controller/mod.rs
@@ -1,17 +1,24 @@
 //! Shared control vocabulary: sort and filter types and functions used by
 //! every application on top of `kanban-domain`.
 //!
-//! Not to be confused with [`kanban_view::Controller`], the per-application
-//! render-loop struct that owns view state (mode, selection, focus) for
-//! `kanban-tui`; this module is the vocabulary those controllers filter and
-//! sort with, not a controller itself.
+//! Not to be confused with `kanban_view::Controller`, one application's
+//! presentation state derived from a `Model` plus session-scoped choices
+//! (cached live/archived partitions of that application's cards and boards,
+//! and its board sort field/order). It does not own `mode`, `selection` or
+//! `focus`; those stay on `kanban-tui`'s `App`. This module is the
+//! vocabulary a `kanban_view::Controller` filters and sorts with, not a
+//! controller itself.
+//!
+//! The sort enums (`SortField`, `BoardSortField`, `SortOrder`) are
+//! re-exported from `crate::board` rather than `crate::query` because they
+//! live with `Board` for historical reasons.
 //!
 //! [`count_filtered_cards`](crate::query::count_filtered_cards) and
-//! [`resolve_board_sort`](crate::query::resolve_board_sort) are lower-level
-//! helpers behind [`filter_and_sort_cards`] and [`filter_and_sort_boards`]
-//! respectively; they are implementation details of the vocabulary above and
-//! are intentionally not re-exported here, callers reach them via
-//! `crate::query` directly.
+//! [`resolve_board_sort`](crate::query::resolve_board_sort) are part of the
+//! same vocabulary and remain reachable as `kanban_domain::count_filtered_cards`
+//! / `kanban_domain::resolve_board_sort` (or via `crate::query`); they are
+//! omitted from this module's re-export list to keep the named surface to
+//! the primary filter/sort entry points.
 
 pub use crate::board::{BoardSortField, SortField, SortOrder};
 pub use crate::query::{

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -14,6 +14,7 @@ pub mod command_batch;
 pub mod command_store;
 pub mod commands;
 pub mod completion_derivation;
+pub mod controller;
 pub mod counter_derivation;
 pub mod data_store;
 pub mod dependencies;


### PR DESCRIPTION
## Summary

- Adds `crates/kanban-domain/src/controller/mod.rs`, a doc-only module that re-exports the shared control vocabulary used by every application: `SortField`, `BoardSortField`, `SortOrder` from `board`, and `ArchivedFilter`, `BoardListFilter`, `CardListFilter`, `CardQueryBuilder`, `filter_and_sort_boards`, `filter_and_sort_cards` from `query`.
- The module doc disambiguates `kanban_domain::controller` from `kanban_view::Controller` (the per-application render-loop struct), and explicitly rules that `count_filtered_cards`/`resolve_board_sort` stay unexported here, reachable via `crate::query` directly.
- Adds a compile-time test proving each re-exported name matches its real home, so the module cannot silently drift from `board`/`query`.
- One line added to `lib.rs` (`pub mod controller;`), placed alphabetically between `completion_derivation` and `counter_derivation`.
- CLAUDE.md's kanban-domain section gets one sentence naming `controller` and the vocabulary/execution/per-app-view-state split.

No call sites change; nothing becomes newly reachable since the crate root already re-exports every one of these types.

## Test plan

- `cargo test -p kanban-domain controller` (Red: failed to compile with E0433/E0425 before the `pub use` blocks were added; Green after)
- `cargo test -p kanban-domain --all-features` (full crate suite green)
- `cargo clippy -p kanban-domain --all-targets --all-features -- -D warnings` (clean)
- `cargo fmt --all -- --check` (clean)
- Mutation check: removed the `pub use` blocks, confirmed the test fails to compile again, restored them
