### PR TITLE
KAN-1469 feat(domain,tui): live_boards_state replaces the collapsing live_boards

### DIFF
--- a/.changeset/kan-1469-live-boards-load-state.md
+++ b/.changeset/kan-1469-live-boards-load-state.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+kanban-domain, kanban-tui: replace the collapsing `Model::live_boards()` with `Model::live_boards_state()`, which reports `NotLoaded`/`Failed` instead of flattening every non-loaded state into an empty iterator. Every kanban-tui call site now distinguishes "not loaded yet" from "loaded and genuinely empty".

--- a/crates/kanban-domain/src/model/boards.rs
+++ b/crates/kanban-domain/src/model/boards.rs
@@ -291,6 +291,53 @@ mod tests {
     }
 
     #[test]
+    fn test_live_boards_state_on_an_unread_model_reports_not_loaded() {
+        let m = Model::default();
+        assert!(m.live_boards_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_live_boards_state_on_a_loaded_empty_collection_reports_loaded_empty() {
+        let mut m = Model::default();
+        let _ = m.load_from_snapshot(Snapshot::default());
+        let state = m.live_boards_state();
+        assert!(state.is_loaded());
+        assert!(state.loaded().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_live_boards_state_excludes_archived_heads_when_loaded() {
+        use crate::Archived;
+        let mut m = Model::default();
+        let live = Board::new("Live", None::<String>);
+        let archived = Board::new("Archived", None::<String>);
+        let live_id = live.id;
+        let archived_id = archived.id;
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![live, archived],
+            archived_boards: vec![Archived::now(archived_id)],
+            ..Default::default()
+        });
+        let state = m.live_boards_state();
+        let ids: Vec<Uuid> = state.loaded().unwrap().iter().map(|b| b.id).collect();
+        assert_eq!(ids, vec![live_id]);
+    }
+
+    #[test]
+    fn test_live_boards_state_propagates_failed_from_the_board_collection() {
+        let mut m = Model::default();
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        let _ = m.apply_resolved(Resolved {
+            boards: Collection {
+                all: LoadState::Failed(err),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        assert!(m.live_boards_state().is_failed());
+    }
+
+    #[test]
     fn test_board_by_id_state_is_loaded_for_an_archived_board() {
         use crate::Archived;
         let mut m = Model::default();

--- a/crates/kanban-domain/src/model/boards.rs
+++ b/crates/kanban-domain/src/model/boards.rs
@@ -6,15 +6,15 @@ impl Model {
     }
 
     /// The LIVE boards (unified collection minus the archived heads), in board
-    /// order. The live projects panel and every live-only quantity (first-board
-    /// default selection, new-board position, live counts) resolve through this,
-    /// so broadening `boards_state()` to the unified collection cannot leak
-    /// archived heads into live semantics.
-    pub fn live_boards(&self) -> impl Iterator<Item = &Board> {
-        self.boards_state()
-            .loaded_or_empty()
-            .iter()
-            .filter(|b| !self.archived_board_ids.contains(&b.id))
+    /// order, honest about load state: `NotLoaded`/`Failed` propagate rather
+    /// than collapsing to an empty collection.
+    pub fn live_boards_state(&self) -> LoadState<Vec<&Board>> {
+        self.boards_state().as_ref().map(|boards| {
+            boards
+                .iter()
+                .filter(|b| !self.archived_board_ids.contains(&b.id))
+                .collect()
+        })
     }
 
     pub fn archived_boards(&self) -> &[ArchivedBoard] {

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -178,7 +178,9 @@ impl Model {
     fn rebuild_card_index(&mut self) {
         self.card_index = self
             .cards
-            .loaded_or_empty()
+            .loaded()
+            .map(Vec::as_slice)
+            .unwrap_or_default()
             .iter()
             .enumerate()
             .map(|(i, c)| (c.id, i))
@@ -188,7 +190,9 @@ impl Model {
     fn rebuild_board_index(&mut self) {
         self.board_index = self
             .boards
-            .loaded_or_empty()
+            .loaded()
+            .map(Vec::as_slice)
+            .unwrap_or_default()
             .iter()
             .enumerate()
             .map(|(i, b)| (b.id, i))

--- a/crates/kanban-tui/src/app/export_import.rs
+++ b/crates/kanban-tui/src/app/export_import.rs
@@ -59,7 +59,7 @@ impl App {
     pub fn import_board_from_file(&mut self, filename: &str) -> io::Result<()> {
         let content = std::fs::read_to_string(filename)?;
 
-        let first_new_index = self.model.live_boards().count();
+        let first_new_index = self.model.live_boards_state().loaded().map_or(0, Vec::len);
         let default_sprint_prefix = Some(
             self.app_config
                 .effective_default_sprint_prefix()

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -107,7 +107,11 @@ impl App {
     }
 
     pub fn handle_export_all_key(&mut self) {
-        if self.focus.active == Focus::Boards && self.model.live_boards().next().is_some() {
+        let has_live_boards = matches!(
+            self.model.live_boards_state(),
+            LoadState::Loaded(boards) if !boards.is_empty()
+        );
+        if self.focus.active == Focus::Boards && has_live_boards {
             let filename = format!(
                 "kanban-all-{}.json",
                 chrono::Utc::now().format("%Y%m%d-%H%M%S")
@@ -208,7 +212,12 @@ impl App {
             return;
         };
         let idx = self.board_list.get_selected_index().unwrap_or(0);
-        let remaining_after = self.model.live_boards().count().saturating_sub(1);
+        let remaining_after = self
+            .model
+            .live_boards_state()
+            .loaded()
+            .map_or(0, Vec::len)
+            .saturating_sub(1);
 
         if let Err(e) = self.ctx.archive_board(board_id) {
             tracing::error!("Failed to archive board: {}", e);
@@ -481,7 +490,7 @@ impl App {
         let board_name = self.input.as_str().to_string();
 
         let board_id = uuid::Uuid::new_v4();
-        let position = self.model.live_boards().count() as i32;
+        let position = self.model.live_boards_state().loaded().map_or(0, Vec::len) as i32;
 
         let mut commands: Vec<Command> = vec![Command::Board(BoardCommand::Create(CreateBoard {
             id: board_id,

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -4,6 +4,7 @@ use crate::editor::edit_in_external_editor;
 use crate::events::EventHandler;
 use crossterm::event::KeyCode;
 use kanban_domain::export::BoardExporter;
+use kanban_domain::LoadState;
 use kanban_service::AppConfigDto;
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
@@ -288,9 +289,11 @@ impl App {
         // computed from that file's boards rather than the outgoing one's.
         self.reload_model();
 
-        self.selection.active_board_id = self.model.live_boards().next().map(|b| b.id);
-        let live_ids: Vec<uuid::Uuid> = self.model.live_boards().map(|b| b.id).collect();
-        self.board_list.update_boards(live_ids);
+        if let LoadState::Loaded(boards) = self.model.live_boards_state() {
+            self.selection.active_board_id = boards.first().map(|b| b.id);
+            let live_ids: Vec<uuid::Uuid> = boards.iter().map(|b| b.id).collect();
+            self.board_list.update_boards(live_ids);
+        }
         self.selection.active_card_id = None;
         self.selection.card_navigation_history.clear();
 
@@ -535,7 +538,12 @@ impl App {
     }
 
     fn trigger_export(&mut self) -> bool {
-        let live_ids: Vec<uuid::Uuid> = self.model.live_boards().map(|b| b.id).collect();
+        let live_ids: Vec<uuid::Uuid> = self
+            .model
+            .live_boards_state()
+            .loaded()
+            .map(|boards| boards.iter().map(|b| b.id).collect())
+            .unwrap_or_default();
         if live_ids.is_empty() {
             self.set_error("No boards to export".to_string());
             return false;
@@ -685,7 +693,12 @@ impl App {
     /// Open the export-all-boards dialog, or set an error if there are no
     /// live boards to export. Matches the direct `x` keypress's guard exactly.
     pub(crate) fn open_export_boards_dialog(&mut self) {
-        let live_ids: Vec<uuid::Uuid> = self.model.live_boards().map(|b| b.id).collect();
+        let live_ids: Vec<uuid::Uuid> = self
+            .model
+            .live_boards_state()
+            .loaded()
+            .map(|boards| boards.iter().map(|b| b.id).collect())
+            .unwrap_or_default();
         if live_ids.is_empty() {
             self.set_error("No boards to export".to_string());
             return;

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -69,7 +69,12 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
     // Sanity: the archived board head is hidden from the live list, present in
     // the archived-boards view.
     assert!(
-        app.model.live_boards().all(|b| b.id != arch_board.id),
+        app.model
+            .live_boards_state()
+            .loaded()
+            .unwrap()
+            .iter()
+            .all(|b| b.id != arch_board.id),
         "archived board must be hidden from live list before export"
     );
     assert!(
@@ -103,7 +108,12 @@ fn test_tui_export_all_round_trips_archived_board_with_subtree() {
     // Archived board head is back AND still archived (hidden from live list,
     // present in the archived view with its marker).
     assert!(
-        app2.model.live_boards().all(|b| b.id != arch_board.id),
+        app2.model
+            .live_boards_state()
+            .loaded()
+            .unwrap()
+            .iter()
+            .all(|b| b.id != arch_board.id),
         "archived board must remain hidden from live list after re-import"
     );
     assert!(

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -1,5 +1,6 @@
 use kanban_domain::KanbanOperations;
 use kanban_service::StoreManager;
+use kanban_tui::app::{AppMode, DialogMode, Focus};
 use kanban_tui::App;
 use std::fs;
 use tempfile::tempdir;
@@ -53,6 +54,29 @@ fn test_export_single_board() {
     assert_eq!(boards[0]["columns"].as_array().unwrap().len(), 1);
     assert_eq!(boards[0]["cards"].as_array().unwrap().len(), 1);
     assert_eq!(boards[0]["cards"][0]["title"], "Test Task");
+}
+
+#[test]
+fn test_export_all_is_refused_while_the_boards_are_not_loaded() {
+    let mut app = App::test_default();
+    app.focus.active = Focus::Boards;
+
+    app.handle_export_all_key();
+
+    assert_ne!(app.mode, AppMode::Dialog(DialogMode::ExportAll));
+}
+
+#[test]
+fn test_export_all_is_offered_once_the_boards_are_loaded_and_non_empty() {
+    let mut app = App::test_default();
+    app.ctx.create_board("Board 1".to_string(), None).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+    app.focus.active = Focus::Boards;
+
+    app.handle_export_all_key();
+
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::ExportAll));
 }
 
 #[test]

--- a/crates/kanban-tui/tests/settings_export_tests.rs
+++ b/crates/kanban-tui/tests/settings_export_tests.rs
@@ -283,7 +283,7 @@ fn test_execute_export_uses_explicit_board_ids_not_live_boards_snapshot_at_confi
     app.push_mode(AppMode::Dialog(DialogMode::ExportBoards));
 
     // A board is created AFTER the dialog was seeded, changing what
-    // `self.model.live_boards()` would return if `execute_export` re-derived
+    // `self.model.live_boards_state()` would return if `execute_export` re-derived
     // positions from it at confirm time instead of using the dialog's own
     // captured `board_ids`.
     app.ctx.create_board("BoardC".into(), None).unwrap();

--- a/crates/kanban-tui/tests/settings_storage_tests.rs
+++ b/crates/kanban-tui/tests/settings_storage_tests.rs
@@ -569,7 +569,12 @@ async fn test_migration_complete_populates_the_model_from_the_new_backend() {
     let old_config = app.app_config.clone();
     app.handle_migration_complete(old_config, Ok(true)).await;
 
-    let boards = app.model.live_boards().collect::<Vec<_>>();
+    let boards = app
+        .model
+        .live_boards_state()
+        .loaded()
+        .cloned()
+        .expect("boards must be loaded after migration completes");
     assert_eq!(
         boards.len(),
         1,


### PR DESCRIPTION
## Summary

- Add `Model::live_boards_state() -> LoadState<Vec<&Board>>` in `kanban-domain`, which reports `NotLoaded` and `Failed` honestly instead of collapsing every non-loaded state to an empty iterator, and delete the old `live_boards()` accessor entirely.
- Migrate every `kanban-tui` call site off `live_boards()` onto the new accessor: export/count operations now refuse while boards are not loaded, and selection/board-list state is left untouched across a not-yet-read-back backend swap rather than being cleared to empty.
- Rewrite the `rebuild_card_index`/`rebuild_board_index` index builders in domain's `mod.rs` to the non-collapsing `loaded().map(Vec::as_slice).unwrap_or_default()` pattern, dropping the last two non-definition uses of `loaded_or_empty`.

This drives the domain-wide census for the collapsing `loaded_or_empty` pattern down to exactly one hit: its own definition in `load_state.rs`.

## Test plan

- [x] `cargo test -p kanban-domain` (4 new state tests: not-loaded, loaded-empty, archived-head exclusion, failed propagation)
- [x] `cargo test -p kanban-tui` (2 new export-all gate tests, plus 3 pre-existing test-file call sites of the deleted accessor migrated)
- [x] `cargo clippy --all-targets --all-features -p kanban-domain -p kanban-tui -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Census: `fn live_boards\b` returns no hits under `crates/`; `live_boards()` under `crates/kanban-tui/src/` returns only the pre-existing unrelated test-name substring match in `navigation_handlers.rs`
