### PR TITLE
KAN-1407 fix(tui): relationship dialogs and card detail must treat an unloaded graph as unavailable

### DIFF
--- a/.changeset/kan-1407-relationship-dialogs-must-treat-loaded.md
+++ b/.changeset/kan-1407-relationship-dialogs-must-treat-loaded.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: relationship dialogs (manage parents, manage children, manage children from list) now refuse to open and raise an error banner instead of silently treating an unloaded dependency graph as empty, which previously disabled cycle filtering and turned every checkbox press into an attach. The card detail view's relationship panel now shows a not-loaded/failed marker instead of a misleading "No parents"/"No children" when the graph tier hasn't loaded yet.

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -4,7 +4,6 @@ use kanban_domain::commands::{
     BoardCommand, CardCommand, ColumnCommand, Command, CreateCard, CreateColumn, RestoreCard,
     SetBoardTaskSort, UpdateCard,
 };
-use kanban_domain::Model;
 use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations, LoadState};
 use kanban_view::card_list::CardListId;
 use ratatui::{backend::CrosstermBackend, Terminal};
@@ -972,12 +971,10 @@ impl App {
             None => return,
         };
 
-        // Get ancestors to exclude (would create cycle)
-        let graph = self
-            .model
-            .graph_state()
-            .loaded()
-            .unwrap_or_else(|| Model::empty_graph());
+        let Some(graph) = self.model.graph_state().loaded() else {
+            self.set_error("Relationships are still loading. Try again in a moment.");
+            return;
+        };
         let ancestors = graph.ancestors(card_id);
 
         // Get cards from current board, excluding self and ancestors
@@ -1009,12 +1006,6 @@ impl App {
             .map(|c| c.id)
             .collect();
 
-        // Get current children (for checkbox display)
-        let graph = self
-            .model
-            .graph_state()
-            .loaded()
-            .unwrap_or_else(|| Model::empty_graph());
         let current_children: std::collections::HashSet<_> =
             graph.children(card_id).into_iter().collect();
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1177,12 +1177,11 @@ impl App {
             }
         };
 
-        let descendants = self
-            .model
-            .graph_state()
-            .loaded()
-            .unwrap_or_else(|| Model::empty_graph())
-            .descendants(card_id);
+        let Some(graph) = self.model.graph_state().loaded() else {
+            self.set_error("Relationships are still loading. Try again in a moment.");
+            return;
+        };
+        let descendants = graph.descendants(card_id);
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
@@ -1198,14 +1197,8 @@ impl App {
             .map(|c| c.id)
             .collect();
 
-        let current_parents: std::collections::HashSet<_> = self
-            .model
-            .graph_state()
-            .loaded()
-            .unwrap_or_else(|| Model::empty_graph())
-            .parents(card_id)
-            .into_iter()
-            .collect();
+        let current_parents: std::collections::HashSet<_> =
+            graph.parents(card_id).into_iter().collect();
 
         self.relationship.card_ids = eligible_cards;
         self.relationship.selected = current_parents;
@@ -1246,12 +1239,11 @@ impl App {
             }
         };
 
-        let ancestors = self
-            .model
-            .graph_state()
-            .loaded()
-            .unwrap_or_else(|| Model::empty_graph())
-            .ancestors(card_id);
+        let Some(graph) = self.model.graph_state().loaded() else {
+            self.set_error("Relationships are still loading. Try again in a moment.");
+            return;
+        };
+        let ancestors = graph.ancestors(card_id);
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
@@ -1267,14 +1259,8 @@ impl App {
             .map(|c| c.id)
             .collect();
 
-        let current_children: std::collections::HashSet<_> = self
-            .model
-            .graph_state()
-            .loaded()
-            .unwrap_or_else(|| Model::empty_graph())
-            .children(card_id)
-            .into_iter()
-            .collect();
+        let current_children: std::collections::HashSet<_> =
+            graph.children(card_id).into_iter().collect();
 
         self.relationship.card_ids = eligible_cards;
         self.relationship.selected = current_children;

--- a/crates/kanban-tui/src/ui/card_detail.rs
+++ b/crates/kanban-tui/src/ui/card_detail.rs
@@ -2,9 +2,10 @@ use crate::app::{App, CardFocus};
 use crate::components::*;
 use crate::theme::*;
 use crate::ui::load_state_body;
-use kanban_domain::{LoadState, Model};
+use kanban_domain::{DependencyGraph, LoadState};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
+    text::{Line, Span},
     widgets::Paragraph,
     Frame,
 };
@@ -13,6 +14,24 @@ use uuid::Uuid;
 const RELATIONSHIP_BOX_HEIGHT: u16 = 7;
 const RELATIONSHIP_VIEWPORT_BORDER_HEIGHT: usize = 2;
 
+fn graph_load_marker(state: &LoadState<DependencyGraph>) -> Option<Line<'static>> {
+    match state {
+        LoadState::Loaded(_) => None,
+        LoadState::NotLoaded => Some(Line::from(Span::styled(
+            "  Relationships not loaded yet",
+            label_text(),
+        ))),
+        LoadState::Missing => Some(Line::from(Span::styled(
+            "  Relationships not found",
+            label_text(),
+        ))),
+        LoadState::Failed(e) => Some(Line::from(Span::styled(
+            format!("  Relationships failed to load: {e}"),
+            error_text(),
+        ))),
+    }
+}
+
 pub(super) fn render_relationship_boxes(
     app: &App,
     frame: &mut Frame,
@@ -20,7 +39,15 @@ pub(super) fn render_relationship_boxes(
     parents: &[Uuid],
     children: &[Uuid],
     child_count: usize,
+    graph_marker: Option<Line<'static>>,
 ) {
+    if let Some(marker) = graph_marker {
+        let config = FieldSectionConfig::new("Relationships");
+        let widget = Paragraph::new(vec![marker]).block(config.block());
+        frame.render_widget(widget, area);
+        return;
+    }
+
     let relationship_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
@@ -73,19 +100,12 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                 let has_sprint_logs = !card.sprint_logs.is_empty();
                 let card_id = card.id;
 
-                // Get parent and child information
-                let parents = app
-                    .model
-                    .graph_state()
-                    .loaded()
-                    .unwrap_or_else(|| Model::empty_graph())
-                    .parents(card_id);
-                let children = app
-                    .model
-                    .graph_state()
-                    .loaded()
-                    .unwrap_or_else(|| Model::empty_graph())
-                    .children(card_id);
+                let graph_state = app.model.graph_state();
+                let graph_marker = graph_load_marker(graph_state);
+                let (parents, children) = match graph_state.loaded() {
+                    Some(graph) => (graph.parents(card_id), graph.children(card_id)),
+                    None => (Vec::new(), Vec::new()),
+                };
                 let child_count = children.len();
 
                 let constraints = vec![
@@ -141,6 +161,7 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                         &parents,
                         &children,
                         child_count,
+                        graph_marker.clone(),
                     );
                 } else {
                     // Render metadata section
@@ -162,6 +183,7 @@ pub(super) fn render_card_detail_view(app: &App, frame: &mut Frame, area: Rect) 
                         &parents,
                         &children,
                         child_count,
+                        graph_marker,
                     );
                 }
             }

--- a/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
@@ -248,6 +248,7 @@ fn test_handle_manage_parents_still_opens_the_dialog_when_everything_is_loaded()
         ModelLoadStates {
             cards: LoadState::Loaded(vec![card, other_card]),
             columns: LoadState::Loaded(vec![column.clone()]),
+            graph: LoadState::Loaded(kanban_domain::DependencyGraph::default()),
             ..Default::default()
         },
     );
@@ -331,6 +332,7 @@ fn test_handle_manage_children_still_opens_the_dialog_when_everything_is_loaded(
         ModelLoadStates {
             cards: LoadState::Loaded(vec![card, other_card]),
             columns: LoadState::Loaded(vec![column.clone()]),
+            graph: LoadState::Loaded(kanban_domain::DependencyGraph::default()),
             ..Default::default()
         },
     );

--- a/crates/kanban-tui/tests/load_state_render_tests.rs
+++ b/crates/kanban-tui/tests/load_state_render_tests.rs
@@ -83,6 +83,31 @@ fn app_with_card_and_sprint_state(state: LoadState<Vec<Sprint>>) -> (App, Board,
     (app, board, card)
 }
 
+fn app_with_card_and_graph_state(state: LoadState<DependencyGraph>) -> (App, Board, Card) {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let column = Column::new(board.id, "Backlog", 0);
+    let card = Card::new(board.id, column.id, "Task", 0);
+    let mut resolved = base_resolved(&board);
+    resolved.cards = Collection {
+        all: LoadState::Loaded(vec![card.clone()]),
+        ..Default::default()
+    };
+    resolved.columns = Collection {
+        all: LoadState::Loaded(vec![column.clone()]),
+        ..Default::default()
+    };
+    resolved.sprints = Collection {
+        all: LoadState::Loaded(vec![]),
+        ..Default::default()
+    };
+    resolved.graph = state;
+    let _ = app.model.apply_resolved(resolved);
+    app.selection.active_board_id = Some(board.id);
+    app.selection.active_card_id = Some(card.id);
+    (app, board, card)
+}
+
 fn app_with_asymmetric_column_tier(board_columns_state: LoadState<Vec<Column>>) -> App {
     let mut app = App::test_default();
     let board = Board::new("TestBoard", None::<String>);
@@ -425,4 +450,43 @@ fn test_multi_panel_column_name_lookup_renders_failed_distinctly() {
     });
     assert!(!output.contains("Unknown"));
     assert!(output.contains("Failed"));
+}
+
+#[test]
+fn test_a_not_loaded_graph_tier_does_not_render_no_parents_or_no_children() {
+    let (mut app, _board, _card) = app_with_card_and_graph_state(LoadState::NotLoaded);
+    app.push_mode(AppMode::CardDetail);
+    let output = helpers::render_widget_to_string(120, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(!output.contains("No parents"));
+    assert!(!output.contains("No children"));
+    assert!(output.contains("not loaded yet"));
+    assert!(output.contains("Relationships"));
+}
+
+#[test]
+fn test_a_failed_graph_tier_renders_the_error_inline_in_the_relationship_panel() {
+    let (mut app, _board, _card) = app_with_card_and_graph_state(LoadState::Failed(Arc::new(
+        KanbanError::unsupported("boom"),
+    )));
+    app.push_mode(AppMode::CardDetail);
+    let output = helpers::render_widget_to_string(120, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("failed to load"));
+    assert!(output.contains("boom"));
+    assert!(!output.contains("No parents"));
+}
+
+#[test]
+fn test_a_loaded_but_genuinely_empty_graph_still_renders_no_parents_and_no_children() {
+    let (mut app, _board, _card) =
+        app_with_card_and_graph_state(LoadState::Loaded(DependencyGraph::default()));
+    app.push_mode(AppMode::CardDetail);
+    let output = helpers::render_widget_to_string(120, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(output.contains("No parents"));
+    assert!(output.contains("No children"));
 }

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -1,10 +1,19 @@
 mod helpers;
 
 use kanban_domain::Model;
-use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations};
+use kanban_domain::{
+    CreateCardOptions, EntityIds, GraphOperations, Invalidation, KanbanOperations,
+};
+use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::components::resolve_relationship_cards;
 use kanban_tui::App;
 use uuid::Uuid;
+
+fn invalidate_graph(app: &mut App) {
+    let _ = app
+        .model
+        .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+}
 
 fn create_board_and_column(app: &mut App, board_title: &str) -> (Uuid, Uuid) {
     let board = app.ctx.create_board(board_title.into(), None).unwrap();
@@ -235,4 +244,127 @@ fn test_card_detail_children_box_shows_cross_board_child_title() {
 
     assert!(output.contains("CrossBoardChildXYZ"));
     assert!(!output.contains("UnrelatedDecoyABC"));
+}
+
+#[test]
+fn test_manage_parents_refuses_to_open_when_the_graph_is_not_loaded() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+    let subject = create_card(&mut app, board_id, column_id, "Subject");
+    app.reload_model();
+    app.selection.active_card_id = Some(subject);
+
+    invalidate_graph(&mut app);
+
+    app.handle_manage_parents();
+
+    let banner = app.ui_state.banner.expect("expected an error banner");
+    let message = banner.message.to_lowercase();
+    assert!(message.contains("relationship") || message.contains("loading"));
+    assert_ne!(app.mode, AppMode::Dialog(DialogMode::ManageParents));
+}
+
+#[test]
+fn test_manage_children_refuses_to_open_when_the_graph_is_not_loaded() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+    let subject = create_card(&mut app, board_id, column_id, "Subject");
+    app.reload_model();
+    app.selection.active_card_id = Some(subject);
+
+    invalidate_graph(&mut app);
+
+    app.handle_manage_children();
+
+    let banner = app.ui_state.banner.expect("expected an error banner");
+    let message = banner.message.to_lowercase();
+    assert!(message.contains("relationship") || message.contains("loading"));
+    assert_ne!(app.mode, AppMode::Dialog(DialogMode::ManageChildren));
+}
+
+#[test]
+fn test_manage_children_from_list_refuses_to_open_when_the_graph_is_not_loaded() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+    let subject = create_card(&mut app, board_id, column_id, "Subject");
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.push_mode(AppMode::Normal);
+    app.prepare_frame();
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+    assert_eq!(
+        app.get_selected_card_in_context().map(|c| c.id),
+        Some(subject),
+        "fixture must select the card before the graph is invalidated"
+    );
+
+    invalidate_graph(&mut app);
+
+    app.handle_manage_children_from_list();
+
+    let banner = app.ui_state.banner.expect("expected an error banner");
+    let message = banner.message.to_lowercase();
+    assert!(message.contains("relationship") || message.contains("loading"));
+    assert_ne!(app.mode, AppMode::Dialog(DialogMode::ManageChildren));
+}
+
+#[test]
+fn test_manage_parents_does_not_offer_a_descendant_when_the_graph_is_not_loaded() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+    let a = create_card(&mut app, board_id, column_id, "A");
+    let b = create_card(&mut app, board_id, column_id, "B");
+    app.ctx.attach_child(a, b).unwrap();
+    app.reload_model();
+    app.selection.active_card_id = Some(a);
+
+    app.relationship.card_ids = vec![Uuid::new_v4()];
+
+    invalidate_graph(&mut app);
+
+    app.handle_manage_parents();
+
+    assert_ne!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageParents),
+        "the dialog must refuse to open on an unloaded graph"
+    );
+    assert!(
+        !app.relationship.card_ids.contains(&b),
+        "descendant B must never be offered as a legal parent of A"
+    );
+}
+
+#[test]
+fn test_an_existing_parent_is_pre_selected_so_toggling_it_detaches() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+    let p = create_card(&mut app, board_id, column_id, "Parent");
+    let c = create_card(&mut app, board_id, column_id, "Child");
+    app.ctx.attach_child(p, c).unwrap();
+    app.reload_model();
+    app.selection.active_card_id = Some(c);
+
+    app.handle_manage_parents();
+
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::ManageParents));
+    assert!(app.relationship.selected.contains(&p));
+}
+
+#[test]
+fn test_manage_parents_still_opens_and_filters_when_the_graph_is_loaded() {
+    let mut app = App::test_default();
+    let (board_id, column_id) = create_board_and_column(&mut app, "Board");
+    let a = create_card(&mut app, board_id, column_id, "A");
+    let b = create_card(&mut app, board_id, column_id, "B");
+    app.ctx.attach_child(a, b).unwrap();
+    app.reload_model();
+    app.selection.active_card_id = Some(a);
+
+    app.handle_manage_parents();
+
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::ManageParents));
+    assert!(!app.relationship.card_ids.contains(&b));
 }


### PR DESCRIPTION
## Changes

- `handle_manage_parents`, `handle_manage_children`, and `handle_manage_children_from_list` now refuse to open when the dependency graph tier is `NotLoaded`, raising an error banner instead of silently falling back to an empty graph. That fallback previously disabled cycle filtering (any card could be offered as a legal parent/child, including descendants) and turned every checkbox press into an attach, since an empty `selected` set never matched an existing relationship.
- `render_card_detail_view` no longer collapses a `NotLoaded`/`Failed`/`Missing` graph tier into an empty graph either. The relationship panel now renders a dedicated "not loaded yet" / "failed to load" / "not found" marker across the shared box area in those cases, and only falls back to the normal Parents/Children boxes once the graph is genuinely `Loaded` (including the loaded-but-empty case, which still renders "No parents"/"No children" as before).
- `get_current_card_parents`/`get_current_card_children` are left unchanged: their only consumers are pagination-count seeding and list navigation, never text rendering or an attach/detach decision, so their existing NotLoaded-collapses-to-empty-Vec behavior is presentational and correct.
- Updated an existing fixture (`detail_view_handlers_collapsing_accessor_tests.rs`) whose "everything is loaded" setup left the graph tier implicitly `NotLoaded`; it now loads the graph explicitly so it continues to exercise the still-opens-when-loaded path under the stricter check.

## Test plan

- [x] `cargo test -p kanban-tui --all-features`
- [x] `cargo clippy -p kanban-tui --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Mutation check: reverted the `handle_manage_parents` fix, confirmed the new Red tests fail for the expected reason, restored the fix.
