### PR TITLE
KAN-1440 feat(tui): route board export through TuiContext::export_all_boards

### DIFF
--- a/.changeset/kan-1440-route-board-export-through-kanbancontext.md
+++ b/.changeset/kan-1440-route-board-export-through-kanbancontext.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+tui: adds `TuiContext::export_all_boards`, a pass-through to `KanbanContext::export_all_boards`, and points board export (single-board, export-all, and auto-save) at it instead of building the export from a raw `DataStore::snapshot` call.

--- a/crates/kanban-tui/src/app/export_import.rs
+++ b/crates/kanban-tui/src/app/export_import.rs
@@ -13,9 +13,9 @@ impl App {
     }
 
     /// Export ALL boards (live + archived) with their full subtrees. Routes
-    /// through the backend snapshot so an archived board's HEAD, its columns/
-    /// cards/sprints (which live in the flat collections under the archived
-    /// board_id), AND its `archived_boards` marker all round-trip. The
+    /// through `KanbanContext::export_all_boards` so an archived board's HEAD,
+    /// its columns/cards/sprints (which live in the flat collections under the
+    /// archived board_id), AND its `archived_boards` marker all round-trip. The
     /// live-scoped model accessors omit archived boards and their subtrees, so
     /// they must NOT be used here (KAN-895 regression).
     pub fn export_all_boards_with_filename(&self) -> io::Result<()> {
@@ -32,21 +32,20 @@ impl App {
         Ok(())
     }
 
-    /// Build a full-fidelity `AllBoardsExport` from the backend snapshot
-    /// (`convert_snapshot_to_export`), which includes archived board heads and
-    /// their subtrees plus `archived_boards` markers, and handles dangling-column
-    /// archived cards.
+    /// Build a full-fidelity `AllBoardsExport` through
+    /// `KanbanContext::export_all_boards`, which includes archived board heads
+    /// and their subtrees plus `archived_boards` markers, and handles
+    /// dangling-column archived cards.
     fn build_all_boards_export(&self) -> io::Result<AllBoardsExport> {
-        let snapshot = self
-            .ctx
-            .snapshot()
-            .map_err(|e| io::Error::other(e.to_string()))?;
-        Ok(BoardImporter::convert_snapshot_to_export(snapshot))
+        self.ctx
+            .export_all_boards()
+            .map_err(|e| io::Error::other(e.to_string()))
     }
 
-    /// Build an `AllBoardsExport` from the backend snapshot, keeping only the
-    /// boards in `board_ids` (preserving their order). Uses the snapshot path so
-    /// each board's archived-card live rows and markers round-trip correctly.
+    /// Build an `AllBoardsExport` through `KanbanContext::export_all_boards`,
+    /// keeping only the boards in `board_ids` (preserving their order). Uses
+    /// that path so each board's archived-card live rows and markers
+    /// round-trip correctly.
     pub(crate) fn build_boards_export(&self, board_ids: &[Uuid]) -> io::Result<AllBoardsExport> {
         let full = self.build_all_boards_export()?;
         let selected: Vec<_> = board_ids

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -650,8 +650,8 @@ impl App {
             return;
         }
 
-        // Route through the snapshot so each selected board's archived-card live
-        // rows and markers round-trip.
+        // Route through KanbanContext::export_all_boards so each selected
+        // board's archived-card live rows and markers round-trip.
         let export = match self.build_boards_export(&selected_board_ids) {
             Ok(export) => export,
             Err(e) => {

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -98,6 +98,10 @@ impl TuiContext {
         self.inner.snapshot()
     }
 
+    pub fn export_all_boards(&self) -> KanbanResult<kanban_domain::export::AllBoardsExport> {
+        self.inner.export_all_boards()
+    }
+
     pub fn migrate_sprint_logs(&mut self) -> KanbanResult<usize> {
         let (result, _invalidation) = self.inner.migrate_sprint_logs()?;
         if result > 0 && self.save_coordinator.has_save_channel() {

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -11,8 +11,12 @@
 //! tests drive the ACTUAL TUI export entry point (not the snapshot path
 //! directly).
 
-use kanban_domain::KanbanOperations;
+mod helpers;
+
+use helpers::{FailingSnapshotBackend, SnapshotCountingBackend};
+use kanban_domain::{GraphOperations, KanbanOperations};
 use kanban_tui::App;
+use std::sync::atomic::Ordering;
 use tempfile::tempdir;
 
 #[test]
@@ -220,5 +224,220 @@ fn test_tui_auto_save_round_trips_archived_board_with_subtree() {
             .iter()
             .any(|ab| ab.entity_id == arch_board.id),
         "archived_boards marker must not be orphaned after auto_save round-trip"
+    );
+}
+
+#[test]
+fn test_export_does_not_call_the_whole_store_trait_method() {
+    let dir = tempdir().unwrap();
+
+    let mut counted_app = App::test_default();
+    counted_app
+        .ctx
+        .create_board("Board".to_string(), None)
+        .unwrap();
+    let (backend, snapshot_reads) = SnapshotCountingBackend::wrap(counted_app.ctx.backend());
+    counted_app.ctx.replace_backend(backend);
+
+    let counted_path = dir.path().join("counted.json");
+    counted_app
+        .input
+        .set(counted_path.to_str().unwrap().to_string());
+    counted_app.export_all_boards_with_filename().unwrap();
+    assert_eq!(
+        snapshot_reads.load(Ordering::SeqCst),
+        0,
+        "export must not read the whole-store snapshot"
+    );
+
+    let mut failing_app = App::test_default();
+    failing_app
+        .ctx
+        .create_board("Board".to_string(), None)
+        .unwrap();
+    let failing_backend = FailingSnapshotBackend::wrap(failing_app.ctx.backend());
+    failing_app.ctx.replace_backend(failing_backend);
+
+    let failing_path = dir.path().join("failing.json");
+    failing_app
+        .input
+        .set(failing_path.to_str().unwrap().to_string());
+    assert!(
+        failing_app.export_all_boards_with_filename().is_ok(),
+        "export must succeed even when the whole-store snapshot fails"
+    );
+}
+
+#[test]
+fn test_export_all_boards_round_trips_an_archived_board_subtree() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("export_all_full_graph.json");
+
+    let mut app = App::test_default();
+
+    let live_board = app
+        .ctx
+        .create_board("Live Board".to_string(), None)
+        .unwrap();
+    let live_col = app
+        .ctx
+        .create_column(live_board.id, "Todo".to_string(), None)
+        .unwrap();
+    let live_card = app
+        .ctx
+        .create_card(
+            live_board.id,
+            live_col.id,
+            "Live Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    let child_card = app
+        .ctx
+        .create_card(
+            live_board.id,
+            live_col.id,
+            "Child Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    app.ctx.attach_child(live_card.id, child_card.id).unwrap();
+
+    let archived_on_live_card = app
+        .ctx
+        .create_card(
+            live_board.id,
+            live_col.id,
+            "Archived On Live".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(archived_on_live_card.id).unwrap();
+
+    let arch_board = app
+        .ctx
+        .create_board("Archived Board".to_string(), None)
+        .unwrap();
+    let arch_col = app
+        .ctx
+        .create_column(arch_board.id, "Backlog".to_string(), None)
+        .unwrap();
+    let arch_card = app
+        .ctx
+        .create_card(
+            arch_board.id,
+            arch_col.id,
+            "Archived Board Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    let arch_sprint = app
+        .ctx
+        .create_sprint(arch_board.id, Some("S".to_string()), None)
+        .unwrap();
+    app.ctx.archive_board(arch_board.id).unwrap();
+    app.reload_model();
+    app.prepare_frame();
+
+    app.input.set(file_path.to_str().unwrap().to_string());
+    app.export_all_boards_with_filename().unwrap();
+
+    let mut app2 = App::test_default();
+    app2.import_board_from_file(file_path.to_str().unwrap())
+        .unwrap();
+    app2.reload_model();
+    app2.prepare_frame();
+
+    assert!(
+        app2.model
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .any(|b| b.id == live_board.id),
+        "live board head must round-trip"
+    );
+    assert!(
+        app2.model
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .any(|b| b.id == arch_board.id),
+        "archived board head must round-trip"
+    );
+
+    let snap = app2.ctx.snapshot().unwrap();
+
+    let re_live_col = snap
+        .columns
+        .iter()
+        .find(|c| c.id == live_col.id)
+        .expect("live board column must round-trip");
+    assert_eq!(re_live_col.position, live_col.position, "column position");
+    assert_eq!(re_live_col.wip_limit, live_col.wip_limit, "column wip_limit");
+
+    let re_arch_col = snap
+        .columns
+        .iter()
+        .find(|c| c.id == arch_col.id)
+        .expect("archived board column must round-trip");
+    assert_eq!(re_arch_col.position, arch_col.position, "archived column position");
+    assert_eq!(
+        re_arch_col.wip_limit, arch_col.wip_limit,
+        "archived column wip_limit"
+    );
+
+    let re_live_card = snap
+        .cards
+        .iter()
+        .find(|c| c.id == live_card.id)
+        .expect("live card must round-trip");
+    assert_eq!(re_live_card.position, live_card.position, "card position");
+    assert_eq!(re_live_card.prefix, live_card.prefix, "card prefix");
+    assert_eq!(
+        re_live_card.card_number, live_card.card_number,
+        "card card_number"
+    );
+
+    let re_arch_card = snap
+        .cards
+        .iter()
+        .find(|c| c.id == arch_card.id)
+        .expect("archived board card must round-trip");
+    assert_eq!(
+        re_arch_card.position, arch_card.position,
+        "archived board card position"
+    );
+
+    assert!(
+        snap.cards.iter().any(|c| c.id == archived_on_live_card.id),
+        "archived card's live row must round-trip"
+    );
+    assert!(
+        snap.archived_cards
+            .iter()
+            .any(|ac| ac.entity_id == archived_on_live_card.id),
+        "archived card's marker must round-trip"
+    );
+
+    let re_arch_sprint = snap
+        .sprints
+        .iter()
+        .find(|s| s.id == arch_sprint.id)
+        .expect("archived board sprint must round-trip");
+    assert_eq!(
+        re_arch_sprint.sprint_number, arch_sprint.sprint_number,
+        "sprint sprint_number"
+    );
+
+    assert!(
+        snap.archived_boards
+            .iter()
+            .any(|ab| ab.entity_id == arch_board.id),
+        "archived_boards marker must round-trip"
+    );
+
+    assert!(
+        app2.ctx.list_children_of(live_card.id).unwrap().is_empty(),
+        "AllBoardsExport carries no graph field, so dependency edges do not round-trip"
     );
 }

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -373,14 +373,20 @@ fn test_export_all_boards_round_trips_an_archived_board_subtree() {
         .find(|c| c.id == live_col.id)
         .expect("live board column must round-trip");
     assert_eq!(re_live_col.position, live_col.position, "column position");
-    assert_eq!(re_live_col.wip_limit, live_col.wip_limit, "column wip_limit");
+    assert_eq!(
+        re_live_col.wip_limit, live_col.wip_limit,
+        "column wip_limit"
+    );
 
     let re_arch_col = snap
         .columns
         .iter()
         .find(|c| c.id == arch_col.id)
         .expect("archived board column must round-trip");
-    assert_eq!(re_arch_col.position, arch_col.position, "archived column position");
+    assert_eq!(
+        re_arch_col.position, arch_col.position,
+        "archived column position"
+    );
     assert_eq!(
         re_arch_col.wip_limit, arch_col.wip_limit,
         "archived column wip_limit"

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -57,6 +57,50 @@ fn test_export_single_board() {
 }
 
 #[test]
+fn test_export_selected_board_still_filters_to_that_board() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("test_export_selected.json");
+
+    let mut app = App::test_default();
+
+    let first_board = app
+        .ctx
+        .create_board("First Board".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_board("Second Board".to_string(), None)
+        .unwrap();
+
+    app.reload_model();
+    app.prepare_frame();
+    let selected_index = app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .iter()
+        .position(|b| b.id == first_board.id)
+        .unwrap();
+    app.board_list
+        .inner_mut()
+        .set_selected_index(Some(selected_index));
+    app.input.set(file_path.to_str().unwrap().to_string());
+    app.reload_model();
+    app.prepare_frame();
+
+    app.export_board_with_filename().unwrap();
+
+    let content = fs::read_to_string(&file_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let boards = parsed["boards"].as_array().unwrap();
+    assert_eq!(
+        boards.len(),
+        1,
+        "export must contain only the selected board"
+    );
+    assert_eq!(boards[0]["board"]["name"], "First Board");
+}
+
+#[test]
 fn test_export_all_is_refused_while_the_boards_are_not_loaded() {
     let mut app = App::test_default();
     app.focus.active = Focus::Boards;


### PR DESCRIPTION
## Summary

Points the TUI's export path at `KanbanContext::export_all_boards` instead of building the export from a raw `DataStore::snapshot()` call, so `export_board_with_filename`, `export_all_boards_with_filename`, and `auto_save` all share the same composed read.

- Adds `TuiContext::export_all_boards`, a one-line pass-through to `KanbanContext::export_all_boards`.
- `build_all_boards_export` now calls `self.ctx.export_all_boards()` instead of `self.ctx.snapshot()` plus `BoardImporter::convert_snapshot_to_export`.
- Updates the three mechanism comments that referenced "the backend snapshot" (in `export_import.rs` and `settings_handlers.rs`) to describe the new path, keeping the KAN-895 regression note intact.
- Adds `.changeset/kan-1440-route-board-export-through-kanbancontext.md` (minor: new public `TuiContext::export_all_boards`).

## Tests

- `test_export_does_not_call_the_whole_store_trait_method` (new, Red before the fix): proves export no longer calls `DataStore::snapshot` (via `SnapshotCountingBackend`) and survives a snapshot failure (via `FailingSnapshotBackend`).
- `test_export_all_boards_round_trips_an_archived_board_subtree` (new, characterisation baseline): green both before and after the change; seeds a live board, an archived card on it, a dependency edge, and a separate archived board with its own column/card/sprint, exports all boards, re-imports, and asserts each entity type plus wip_limit/position/sprint_number individually. Also asserts `list_children_of` is empty post-import since `AllBoardsExport` carries no graph field.
- `test_export_selected_board_still_filters_to_that_board` (new, regression guard): seeds two boards, exports only the selected one, asserts the file contains exactly that board.

Ran pre-fix: `test_export_does_not_call_the_whole_store_trait_method` failed with `left: 1, right: 0` (snapshot was called once); mutation-checked post-fix by reverting `build_all_boards_export` back to the snapshot path, confirming the same test fails again, then restoring the fix.

## Verification

```
nix develop --command cargo fmt --all -- --check
nix develop --command cargo clippy -p kanban-tui --all-targets --all-features -- -D warnings
nix develop --command cargo test -p kanban-tui
```

All clean; 315+ tests passing across the crate's test binaries, zero failures.

## AC checks

```
git grep -nF '.snapshot()' -- crates/kanban-tui/src/app/export_import.rs   # empty
git grep -n "self.model" -- crates/kanban-tui/src/app/export_import.rs    # only inside import_board_from_file
git grep -n "KAN-895" -- crates/kanban-tui/src/app/export_import.rs       # present
git grep -n AlwaysFailsSnapshotBackend -- crates/kanban-tui/tests         # empty
git diff origin/develop -- crates/kanban-tui/src/app/lifecycle.rs         # empty
git diff origin/develop -- crates/kanban-tui/src/handlers/settings_handlers.rs  # comment-only
```
