### PR TITLE
KAN-1499 feat(service): the six remaining create/replace creators return their Invalidation

### DIFF
--- a/.changeset/kan-1499-service-creators-return-invalidation.md
+++ b/.changeset/kan-1499-service-creators-return-invalidation.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: create_card_from_spec, create_or_replace_card, create_column_from_spec, create_or_replace_column, create_sprint_from_spec and create_or_replace_sprint on `KanbanContext` now return `KanbanResult<(T, Invalidation)>` instead of `KanbanResult<T>`, mirroring the existing create_board_from_spec / create_or_replace_board precedent. Every caller in kanban-mcp, kanban-server and kanban-cli discards the invalidation explicitly for now.

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -204,15 +204,19 @@ impl CliContext {
                     None => column,
                 }
             }
-            None => self.inner.create_column_from_spec(
-                None,
-                NewColumn {
-                    board_id,
-                    name,
-                    wip_limit: None,
-                    default_status,
-                },
-            )?,
+            None => {
+                self.inner
+                    .create_column_from_spec(
+                        None,
+                        NewColumn {
+                            board_id,
+                            name,
+                            wip_limit: None,
+                            default_status,
+                        },
+                    )?
+                    .0
+            }
         };
         Ok(column)
     }

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -117,7 +117,7 @@ impl McpContext {
         id: Option<Uuid>,
         spec: kanban_domain::NewColumn,
     ) -> KanbanResult<kanban_domain::Column> {
-        self.inner.create_column_from_spec(id, spec)
+        Ok(self.inner.create_column_from_spec(id, spec)?.0)
     }
 
     /// Create a card from a full spec + optional client id, funneling through the
@@ -129,7 +129,7 @@ impl McpContext {
         id: Option<Uuid>,
         spec: kanban_domain::NewCard,
     ) -> KanbanResult<Card> {
-        self.inner.create_card_from_spec(id, spec)
+        Ok(self.inner.create_card_from_spec(id, spec)?.0)
     }
 
     /// Create a sprint from its create content + optional client id, funneling
@@ -145,8 +145,10 @@ impl McpContext {
         name: Option<String>,
         prefix: Option<String>,
     ) -> KanbanResult<Sprint> {
-        self.inner
-            .create_sprint_from_spec(board_id, id, name, prefix, false)
+        Ok(self
+            .inner
+            .create_sprint_from_spec(board_id, id, name, prefix, false)?
+            .0)
     }
 
     pub fn clear_history(&mut self) -> KanbanResult<()> {

--- a/crates/kanban-server/src/handlers/cards.rs
+++ b/crates/kanban-server/src/handlers/cards.rs
@@ -29,7 +29,7 @@ pub fn create_card(
         .map_err(|e| ApiError::from(&e))?;
     let id = maybe_id.unwrap_or_else(Uuid::new_v4);
     require_card_in_column_if_present(ctx, id, column_id)?;
-    let outcome = ctx
+    let (outcome, _invalidation) = ctx
         .create_or_replace_card(id, spec)
         .map_err(|e| ApiError::from(&e))?;
     Ok((CardResponse::from(&outcome.card), outcome.created))
@@ -54,7 +54,7 @@ pub fn create_or_replace_card(
     let (_body_id, spec) = req
         .into_new_card(column_id)
         .map_err(|e| ApiError::from(&e))?;
-    let outcome = ctx
+    let (outcome, _invalidation) = ctx
         .create_or_replace_card(id, spec)
         .map_err(|e| ApiError::from(&e))?;
     Ok((CardResponse::from(&outcome.card), outcome.created))

--- a/crates/kanban-server/src/handlers/columns.rs
+++ b/crates/kanban-server/src/handlers/columns.rs
@@ -28,7 +28,7 @@ pub fn create_column(
         .map_err(|e| ApiError::from(&e))?;
     let id = maybe_id.unwrap_or_else(Uuid::new_v4);
     require_column_in_board_if_present(ctx, id, board_id)?;
-    let outcome = ctx
+    let (outcome, _invalidation) = ctx
         .create_or_replace_column(id, spec, None)
         .map_err(|e| ApiError::from(&e))?;
     Ok((ColumnResponse::from(&outcome.column), outcome.created))
@@ -52,7 +52,7 @@ pub fn create_or_replace_column(
     let (spec, position) = req
         .into_new_column(board_id)
         .map_err(|e| ApiError::from(&e))?;
-    let outcome = ctx
+    let (outcome, _invalidation) = ctx
         .create_or_replace_column(id, spec, Some(position))
         .map_err(|e| ApiError::from(&e))?;
     Ok((ColumnResponse::from(&outcome.column), outcome.created))

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -31,7 +31,7 @@ pub fn create_sprint(
     // already exists is a conflict (`AlreadyExists` -> 409), not a silent
     // replace. `create_sprint_from_spec` mints the id when absent and rejects a
     // collision before any side effect.
-    let sprint = ctx
+    let (sprint, _invalidation) = ctx
         .create_sprint_from_spec(board_id, req.id, req.name, req.prefix, false)
         .map_err(|e| ApiError::from(&e))?;
     project(ctx, sprint, true)
@@ -65,7 +65,7 @@ pub fn create_or_replace_sprint(
         prefix,
         card_prefix: _,
     } = req;
-    let outcome = ctx
+    let (outcome, _invalidation) = ctx
         .create_or_replace_sprint(board_id, id, name, prefix, false)
         .map_err(|e| ApiError::from(&e))?;
     project(ctx, outcome.sprint, outcome.created)

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -103,14 +103,6 @@ impl KanbanContext {
         &mut self,
         client_id: Option<Uuid>,
         spec: NewCard,
-    ) -> KanbanResult<Card> {
-        Ok(self.create_card_from_spec_returning(client_id, spec)?.0)
-    }
-
-    pub(super) fn create_card_from_spec_returning(
-        &mut self,
-        client_id: Option<Uuid>,
-        spec: NewCard,
     ) -> KanbanResult<(Card, Invalidation)> {
         // FK: column must exist; derive the owning board from it.
         let column = self.require_column(spec.column_id)?;
@@ -213,23 +205,29 @@ impl KanbanContext {
         &mut self,
         id: Uuid,
         spec: NewCard,
-    ) -> KanbanResult<CardCreateOutcome> {
+    ) -> KanbanResult<(CardCreateOutcome, Invalidation)> {
         if self.backend.get_card(id)?.is_none() {
-            let card = self.create_card_from_spec(Some(id), spec)?;
-            return Ok(CardCreateOutcome {
-                card,
-                created: true,
-            });
+            let (card, inv) = self.create_card_from_spec(Some(id), spec)?;
+            return Ok((
+                CardCreateOutcome {
+                    card,
+                    created: true,
+                },
+                inv,
+            ));
         }
         // FK (replace arm): the target column must exist before we dispatch the
         // update — a PUT-replace must not relocate a card to a non-existent
         // column. Routed through the canonical helper (KAN-248).
         self.require_column(spec.column_id)?;
-        let (card, _inv) = self.update_card_impl(id, replace_update_from_spec(spec))?;
-        Ok(CardCreateOutcome {
-            card,
-            created: false,
-        })
+        let (card, inv) = self.update_card_impl(id, replace_update_from_spec(spec))?;
+        Ok((
+            CardCreateOutcome {
+                card,
+                created: false,
+            },
+            inv,
+        ))
     }
 
     /// Thin shim over [`create_card_from_spec`](Self::create_card_from_spec)
@@ -253,7 +251,7 @@ impl KanbanContext {
             points: options.points,
             sprint_id: options.sprint_id,
         };
-        self.create_card_from_spec_returning(None, spec)
+        self.create_card_from_spec(None, spec)
     }
 
     pub(super) fn list_cards_impl(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {

--- a/crates/kanban-service/src/context/columns.rs
+++ b/crates/kanban-service/src/context/columns.rs
@@ -83,7 +83,8 @@ impl KanbanContext {
         // does not move a column across boards, but a board can be deleted
         // between reads, so the guard stays.
         self.require_board(spec.board_id)?;
-        let (column, inv) = self.update_column_impl(id, replace_update_from_spec(spec, position))?;
+        let (column, inv) =
+            self.update_column_impl(id, replace_update_from_spec(spec, position))?;
         Ok((
             ColumnCreateOutcome {
                 column,

--- a/crates/kanban-service/src/context/columns.rs
+++ b/crates/kanban-service/src/context/columns.rs
@@ -29,14 +29,6 @@ impl KanbanContext {
         &mut self,
         id: Option<Uuid>,
         spec: NewColumn,
-    ) -> KanbanResult<Column> {
-        Ok(self.create_column_from_spec_returning(id, spec)?.0)
-    }
-
-    pub(super) fn create_column_from_spec_returning(
-        &mut self,
-        id: Option<Uuid>,
-        spec: NewColumn,
     ) -> KanbanResult<(Column, Invalidation)> {
         self.require_board(spec.board_id)?;
         let id = id.unwrap_or_else(Uuid::new_v4);
@@ -75,25 +67,30 @@ impl KanbanContext {
         id: Uuid,
         spec: NewColumn,
         position: Option<i32>,
-    ) -> KanbanResult<ColumnCreateOutcome> {
+    ) -> KanbanResult<(ColumnCreateOutcome, Invalidation)> {
         if self.backend.get_column(id)?.is_none() {
-            let column = self.create_column_from_spec(Some(id), spec)?;
-            return Ok(ColumnCreateOutcome {
-                column,
-                created: true,
-            });
+            let (column, inv) = self.create_column_from_spec(Some(id), spec)?;
+            return Ok((
+                ColumnCreateOutcome {
+                    column,
+                    created: true,
+                },
+                inv,
+            ));
         }
         // FK (replace arm): the owning board must exist before we dispatch the
         // update, guarded via the canonical helper (KAN-248). The replace path
         // does not move a column across boards, but a board can be deleted
         // between reads, so the guard stays.
         self.require_board(spec.board_id)?;
-        let (column, _inv) =
-            self.update_column_impl(id, replace_update_from_spec(spec, position))?;
-        Ok(ColumnCreateOutcome {
-            column,
-            created: false,
-        })
+        let (column, inv) = self.update_column_impl(id, replace_update_from_spec(spec, position))?;
+        Ok((
+            ColumnCreateOutcome {
+                column,
+                created: false,
+            },
+            inv,
+        ))
     }
 
     pub fn create_column_impl(
@@ -122,7 +119,7 @@ impl KanbanContext {
                 })?;
                 Ok((column, invalidation))
             }
-            None => self.create_column_from_spec_returning(
+            None => self.create_column_from_spec(
                 None,
                 NewColumn {
                     board_id,

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -74,19 +74,6 @@ impl KanbanContext {
         name: Option<String>,
         prefix: Option<String>,
         auto_consume_name: bool,
-    ) -> KanbanResult<Sprint> {
-        Ok(self
-            .create_sprint_from_spec_returning(board_id, id, name, prefix, auto_consume_name)?
-            .0)
-    }
-
-    pub(super) fn create_sprint_from_spec_returning(
-        &mut self,
-        board_id: Uuid,
-        id: Option<Uuid>,
-        name: Option<String>,
-        prefix: Option<String>,
-        auto_consume_name: bool,
     ) -> KanbanResult<(Sprint, Invalidation)> {
         use kanban_domain::commands::CreateSprint;
 
@@ -140,14 +127,17 @@ impl KanbanContext {
         name: Option<String>,
         prefix: Option<String>,
         auto_consume_name: bool,
-    ) -> KanbanResult<SprintCreateOutcome> {
+    ) -> KanbanResult<(SprintCreateOutcome, Invalidation)> {
         if self.backend.get_sprint(id)?.is_none() {
-            let sprint =
+            let (sprint, inv) =
                 self.create_sprint_from_spec(board_id, Some(id), name, prefix, auto_consume_name)?;
-            return Ok(SprintCreateOutcome {
-                sprint,
-                created: true,
-            });
+            return Ok((
+                SprintCreateOutcome {
+                    sprint,
+                    created: true,
+                },
+                inv,
+            ));
         }
         let updates = SprintUpdate {
             name,
@@ -163,11 +153,14 @@ impl KanbanContext {
             start_date: FieldUpdate::NoChange,
             end_date: FieldUpdate::NoChange,
         };
-        let (sprint, _inv) = self.update_sprint_impl(id, updates)?;
-        Ok(SprintCreateOutcome {
-            sprint,
-            created: false,
-        })
+        let (sprint, inv) = self.update_sprint_impl(id, updates)?;
+        Ok((
+            SprintCreateOutcome {
+                sprint,
+                created: false,
+            },
+            inv,
+        ))
     }
 
     /// Thin shim over [`create_sprint_from_spec`](Self::create_sprint_from_spec)
@@ -180,7 +173,7 @@ impl KanbanContext {
         prefix: Option<String>,
         name: Option<String>,
     ) -> KanbanResult<(Sprint, Invalidation)> {
-        self.create_sprint_from_spec_returning(board_id, None, name, prefix, false)
+        self.create_sprint_from_spec(board_id, None, name, prefix, false)
     }
 
     pub(super) fn list_sprints_impl(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -248,7 +248,7 @@ fn test_card_get_by_id_zero_list_archived_cards_calls() {
     let (backend, mut ctx) = counting_context();
     let board = ctx.create_board("Board".into(), None).unwrap();
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
-    let card = ctx
+    let (card, _inv) = ctx
         .create_card_from_spec(
             None,
             kanban_domain::NewCard {
@@ -290,6 +290,7 @@ fn make_card(ctx: &mut KanbanContext, col_id: Uuid, title: &str) -> Card {
         },
     )
     .unwrap()
+    .0
 }
 
 #[test]

--- a/crates/kanban-service/tests/create_card_from_spec.rs
+++ b/crates/kanban-service/tests/create_card_from_spec.rs
@@ -50,7 +50,7 @@ async fn test_create_card_funnels_through_factory_seeds_defaults() {
     let board = ctx.create_board("Board".into(), None).unwrap();
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
-    let card = ctx
+    let (card, _inv) = ctx
         .create_card_from_spec(None, spec(col.id, "First"))
         .unwrap();
 
@@ -66,10 +66,10 @@ async fn test_create_card_mints_card_number_sequentially_across_creates() {
     let board = ctx.create_board("Board".into(), None).unwrap();
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
-    let first = ctx
+    let (first, _inv) = ctx
         .create_card_from_spec(None, spec(col.id, "First"))
         .unwrap();
-    let second = ctx
+    let (second, _inv) = ctx
         .create_card_from_spec(None, spec(col.id, "Second"))
         .unwrap();
 
@@ -83,8 +83,8 @@ async fn test_create_card_mints_id_when_not_supplied() {
     let board = ctx.create_board("Board".into(), None).unwrap();
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
-    let a = ctx.create_card_from_spec(None, spec(col.id, "A")).unwrap();
-    let b = ctx.create_card_from_spec(None, spec(col.id, "B")).unwrap();
+    let (a, _inv) = ctx.create_card_from_spec(None, spec(col.id, "A")).unwrap();
+    let (b, _inv) = ctx.create_card_from_spec(None, spec(col.id, "B")).unwrap();
 
     assert_ne!(a.id, Uuid::nil());
     assert_ne!(a.id, b.id, "two minted ids differ");
@@ -97,7 +97,7 @@ async fn test_create_card_uses_client_supplied_id() {
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
     let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-    let card = ctx
+    let (card, _inv) = ctx
         .create_card_from_spec(Some(id), spec(col.id, "Pinned"))
         .unwrap();
 
@@ -200,7 +200,7 @@ async fn test_create_card_with_sprint_seeds_sprint_log() {
 
     let mut s = spec(col.id, "Card");
     s.sprint_id = Some(sprint.id);
-    let card = ctx.create_card_from_spec(None, s).unwrap();
+    let (card, _inv) = ctx.create_card_from_spec(None, s).unwrap();
 
     assert_eq!(card.sprint_id, Some(sprint.id));
     assert_eq!(card.sprint_logs.len(), 1, "service-tier sprint-log seeding");
@@ -214,7 +214,7 @@ async fn test_create_card_applies_all_create_options_in_one_call() {
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
     let due = "2024-06-01T00:00:00Z".parse().unwrap();
 
-    let card = ctx
+    let (card, _inv) = ctx
         .create_card_from_spec(
             None,
             NewCard {
@@ -247,7 +247,7 @@ async fn test_put_create_card_is_idempotent_create_or_replace() {
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
     let id = Uuid::new_v4();
-    let first = ctx
+    let (first, _inv) = ctx
         .create_or_replace_card(id, spec(col.id, "Initial"))
         .unwrap();
     assert!(first.created, "absent id reports created");
@@ -263,7 +263,7 @@ async fn test_put_create_card_is_idempotent_create_or_replace() {
         points: Some(3),
         sprint_id: None,
     };
-    let second = ctx.create_or_replace_card(id, replacement).unwrap();
+    let (second, _inv) = ctx.create_or_replace_card(id, replacement).unwrap();
     assert!(!second.created, "present id reports replace");
     assert_eq!(second.card.id, id, "id stable across replace");
 

--- a/crates/kanban-service/tests/create_card_from_spec.rs
+++ b/crates/kanban-service/tests/create_card_from_spec.rs
@@ -112,7 +112,8 @@ async fn test_create_card_with_duplicate_client_id_returns_conflict() {
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
     let id = Uuid::new_v4();
-    ctx.create_card_from_spec(Some(id), spec(col.id, "Original"))
+    let (_card, _inv) = ctx
+        .create_card_from_spec(Some(id), spec(col.id, "Original"))
         .unwrap();
 
     let err = ctx
@@ -138,7 +139,8 @@ async fn test_create_card_with_duplicate_archived_id_returns_conflict() {
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
     let id = Uuid::new_v4();
-    ctx.create_card_from_spec(Some(id), spec(col.id, "ToArchive"))
+    let (_card, _inv) = ctx
+        .create_card_from_spec(Some(id), spec(col.id, "ToArchive"))
         .unwrap();
     ctx.archive_card(id).unwrap();
 
@@ -289,7 +291,8 @@ async fn test_create_or_replace_card_replace_with_missing_column_returns_not_fou
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
 
     let id = Uuid::new_v4();
-    ctx.create_or_replace_card(id, spec(col.id, "Initial"))
+    let (_outcome, _inv) = ctx
+        .create_or_replace_card(id, spec(col.id, "Initial"))
         .unwrap();
 
     let bad_column = Uuid::new_v4();

--- a/crates/kanban-service/tests/create_column_from_spec.rs
+++ b/crates/kanban-service/tests/create_column_from_spec.rs
@@ -60,7 +60,7 @@ async fn test_create_column_with_client_id_uses_it() {
     let bid = board_id(&mut ctx);
     let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
 
-    let column = ctx
+    let (column, _inv) = ctx
         .create_column_from_spec(Some(id), spec(bid, "To Do", None))
         .unwrap();
 
@@ -73,7 +73,7 @@ async fn test_create_column_carries_wip_limit_from_spec() {
     let (_dir, mut ctx) = ctx_for("wip");
     let bid = board_id(&mut ctx);
 
-    let column = ctx
+    let (column, _inv) = ctx
         .create_column_from_spec(None, spec(bid, "WIP", Some(2)))
         .unwrap();
 
@@ -90,7 +90,7 @@ async fn test_create_column_mints_id_when_absent() {
     let (_dir, mut ctx) = ctx_for("mint");
     let bid = board_id(&mut ctx);
 
-    let column = ctx
+    let (column, _inv) = ctx
         .create_column_from_spec(None, spec(bid, "Minted", None))
         .unwrap();
 
@@ -127,10 +127,10 @@ async fn test_create_column_appends_position() {
     let (_dir, mut ctx) = ctx_for("append");
     let bid = board_id(&mut ctx);
 
-    let first = ctx
+    let (first, _inv) = ctx
         .create_column_from_spec(None, spec(bid, "First", None))
         .unwrap();
-    let second = ctx
+    let (second, _inv) = ctx
         .create_column_from_spec(None, spec(bid, "Second", None))
         .unwrap();
 
@@ -146,7 +146,7 @@ async fn test_put_column_create_or_replace_is_idempotent() {
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    let first = ctx
+    let (first, _inv) = ctx
         .create_column_from_spec(Some(id), spec(bid, "Stable", Some(3)))
         .unwrap();
 
@@ -184,10 +184,10 @@ async fn test_create_column_shim_delegates_to_spec_path() {
 async fn test_reorder_column_still_updates_position() {
     let (_dir, mut ctx) = ctx_for("reorder");
     let bid = board_id(&mut ctx);
-    let a = ctx
+    let (a, _inv) = ctx
         .create_column_from_spec(None, spec(bid, "A", None))
         .unwrap();
-    let b = ctx
+    let (b, _inv) = ctx
         .create_column_from_spec(None, spec(bid, "B", None))
         .unwrap();
     assert_eq!(a.position, 0);
@@ -203,7 +203,7 @@ async fn test_create_or_replace_column_creates_when_absent() {
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    let ColumnCreateOutcome { column, created } = ctx
+    let (ColumnCreateOutcome { column, created }, _inv) = ctx
         .create_or_replace_column(id, spec(bid, "To Do", Some(2)), None)
         .unwrap();
 
@@ -224,7 +224,7 @@ async fn test_create_or_replace_column_replaces_when_present() {
         .unwrap();
     let position_before = ctx.get_column(id).unwrap().unwrap().position;
 
-    let ColumnCreateOutcome { column, created } = ctx
+    let (ColumnCreateOutcome { column, created }, _inv) = ctx
         .create_or_replace_column(id, spec(bid, "Renamed", None), None)
         .unwrap();
 
@@ -287,7 +287,7 @@ async fn test_create_column_with_default_status_persists_it() {
     let (_dir, mut ctx) = ctx_for("default_status");
     let bid = board_id(&mut ctx);
 
-    let column = ctx
+    let (column, _inv) = ctx
         .create_column_from_spec(
             None,
             NewColumn {

--- a/crates/kanban-service/tests/create_column_from_spec.rs
+++ b/crates/kanban-service/tests/create_column_from_spec.rs
@@ -104,7 +104,8 @@ async fn test_create_column_duplicate_id_returns_conflict() {
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    ctx.create_column_from_spec(Some(id), spec(bid, "Original", None))
+    let (_column, _inv) = ctx
+        .create_column_from_spec(Some(id), spec(bid, "Original", None))
         .unwrap();
 
     let err = ctx
@@ -220,7 +221,8 @@ async fn test_create_or_replace_column_replaces_when_present() {
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    ctx.create_or_replace_column(id, spec(bid, "Original", Some(5)), None)
+    let (_outcome, _inv) = ctx
+        .create_or_replace_column(id, spec(bid, "Original", Some(5)), None)
         .unwrap();
     let position_before = ctx.get_column(id).unwrap().unwrap().position;
 
@@ -248,7 +250,8 @@ async fn test_create_or_replace_column_replace_with_missing_board_returns_not_fo
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    ctx.create_or_replace_column(id, spec(bid, "Original", Some(5)), None)
+    let (_outcome, _inv) = ctx
+        .create_or_replace_column(id, spec(bid, "Original", Some(5)), None)
         .unwrap();
 
     let bad_board = Uuid::new_v4();
@@ -270,9 +273,11 @@ async fn test_create_or_replace_column_is_idempotent() {
     let bid = board_id(&mut ctx);
     let id = Uuid::new_v4();
 
-    ctx.create_or_replace_column(id, spec(bid, "X", None), None)
+    let (_outcome, _inv) = ctx
+        .create_or_replace_column(id, spec(bid, "X", None), None)
         .unwrap();
-    ctx.create_or_replace_column(id, spec(bid, "X", None), None)
+    let (_outcome, _inv) = ctx
+        .create_or_replace_column(id, spec(bid, "X", None), None)
         .unwrap();
 
     assert_eq!(

--- a/crates/kanban-service/tests/create_sprint_from_spec.rs
+++ b/crates/kanban-service/tests/create_sprint_from_spec.rs
@@ -120,7 +120,8 @@ async fn test_create_sprint_with_colliding_client_id_returns_conflict() {
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("collide.json"));
 
     let id = Uuid::new_v4();
-    ctx.create_sprint_from_spec(board_id, Some(id), None, None, false)
+    let (_sprint, _inv) = ctx
+        .create_sprint_from_spec(board_id, Some(id), None, None, false)
         .unwrap();
 
     let err = ctx
@@ -164,7 +165,8 @@ async fn test_create_sprint_bumps_board_counter_persisted_before_sprint() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("counter.json"));
 
-    ctx.create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
+    let (_sprint, _inv) = ctx
+        .create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
         .unwrap();
 
     // Board counter advanced (the dual-mint side effect persisted via upsert_board).

--- a/crates/kanban-service/tests/create_sprint_from_spec.rs
+++ b/crates/kanban-service/tests/create_sprint_from_spec.rs
@@ -30,10 +30,10 @@ async fn test_create_sprint_mints_sprint_number_from_board_counter() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("num.json"));
 
-    let first = ctx
+    let (first, _inv) = ctx
         .create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
         .unwrap();
-    let second = ctx
+    let (second, _inv) = ctx
         .create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
         .unwrap();
 
@@ -46,7 +46,7 @@ async fn test_create_sprint_with_explicit_name_allocates_name_index_from_board_p
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("name.json"));
 
-    let sprint = ctx
+    let (sprint, _inv) = ctx
         .create_sprint_from_spec(
             board_id,
             None,
@@ -72,7 +72,7 @@ async fn test_create_sprint_starts_in_planning_with_no_dates() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("planning.json"));
 
-    let sprint = ctx
+    let (sprint, _inv) = ctx
         .create_sprint_from_spec(board_id, None, None, None, false)
         .unwrap();
 
@@ -106,7 +106,7 @@ async fn test_create_sprint_with_client_supplied_id_uses_that_id() {
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("clientid.json"));
 
     let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-    let sprint = ctx
+    let (sprint, _inv) = ctx
         .create_sprint_from_spec(board_id, Some(id), None, None, false)
         .unwrap();
 
@@ -141,13 +141,13 @@ async fn test_put_create_sprint_is_idempotent() {
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("put.json"));
 
     let id = Uuid::new_v4();
-    let created = ctx
+    let (created, _inv) = ctx
         .create_or_replace_sprint(board_id, id, None, Some("SPR".to_string()), false)
         .unwrap();
     assert!(created.created, "absent id must report created");
     assert_eq!(created.sprint.id, id);
 
-    let replaced = ctx
+    let (replaced, _inv) = ctx
         .create_or_replace_sprint(board_id, id, None, Some("SPR".to_string()), false)
         .unwrap();
     assert!(
@@ -169,7 +169,7 @@ async fn test_create_sprint_bumps_board_counter_persisted_before_sprint() {
 
     // Board counter advanced (the dual-mint side effect persisted via upsert_board).
     let board = ctx.get_board(board_id).unwrap().unwrap();
-    let next = ctx
+    let (next, _inv) = ctx
         .create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
         .unwrap();
     assert_eq!(
@@ -183,10 +183,10 @@ async fn test_carry_over_still_requires_completed_source_and_planning_target() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("carry.json"));
 
-    let source = ctx
+    let (source, _inv) = ctx
         .create_sprint_from_spec(board_id, None, None, None, false)
         .unwrap();
-    let target = ctx
+    let (target, _inv) = ctx
         .create_sprint_from_spec(board_id, None, None, None, false)
         .unwrap();
 
@@ -213,7 +213,7 @@ async fn test_create_sprint_from_spec_sqlite_smoke() {
         .create_board("B".to_string(), Some("KAN".to_string()))
         .unwrap();
 
-    let sprint = ctx
+    let (sprint, _inv) = ctx
         .create_sprint_from_spec(
             board.id,
             None,

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -1,7 +1,8 @@
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
     BoardUpdate, Card, CardUpdate, DataStore, EntityIds, GraphOperations, Invalidation,
-    KanbanOperations, KanbanResult, Model, NewBoard, Prefix, RelatesKind, Severity, Sprint,
+    KanbanOperations, KanbanResult, Model, NewBoard, NewCard, NewColumn, Prefix, RelatesKind,
+    Severity, Sprint,
 };
 use kanban_service::{FetchPlan, FetchRound, KanbanContext, LoadedEntities};
 use std::collections::HashSet;
@@ -490,5 +491,212 @@ async fn test_create_or_replace_board_returns_the_update_invalidation_on_the_rep
 
     assert!(!outcome.created);
     assert_eq!(inv, Invalidation::Entities(EntityIds::boards([id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_card_from_spec_returns_an_invalidation_naming_the_card() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+
+    let (_card, inv) = ctx.create_card_from_spec(
+        None,
+        NewCard {
+            column_id: col.id,
+            title: "A".into(),
+            description: None,
+            priority: kanban_domain::CardPriority::Medium,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+    )?;
+
+    assert_eq!(inv, Invalidation::All);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_card_returns_the_create_invalidation_on_the_create_path(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let id = Uuid::new_v4();
+
+    let (outcome, inv) = ctx.create_or_replace_card(
+        id,
+        NewCard {
+            column_id: col.id,
+            title: "A".into(),
+            description: None,
+            priority: kanban_domain::CardPriority::Medium,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+    )?;
+
+    assert!(outcome.created);
+    assert_eq!(inv, Invalidation::All);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_card_returns_the_update_invalidation_on_the_replace_path(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let id = Uuid::new_v4();
+    let _ = ctx.create_or_replace_card(
+        id,
+        NewCard {
+            column_id: col.id,
+            title: "Original".into(),
+            description: None,
+            priority: kanban_domain::CardPriority::Medium,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+    )?;
+
+    let (outcome, inv) = ctx.create_or_replace_card(
+        id,
+        NewCard {
+            column_id: col.id,
+            title: "Replaced".into(),
+            description: None,
+            priority: kanban_domain::CardPriority::Medium,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        },
+    )?;
+
+    assert!(!outcome.created);
+    assert_eq!(inv, Invalidation::Entities(EntityIds::cards([id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_column_from_spec_returns_an_invalidation_naming_the_column(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+
+    let (column, inv) = ctx.create_column_from_spec(
+        None,
+        NewColumn {
+            board_id: board.id,
+            name: "C".into(),
+            wip_limit: None,
+            default_status: None,
+        },
+    )?;
+
+    assert_eq!(inv, Invalidation::Entities(EntityIds::columns([column.id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_column_returns_the_create_invalidation_on_the_create_path(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+    let id = Uuid::new_v4();
+
+    let (outcome, inv) = ctx.create_or_replace_column(
+        id,
+        NewColumn {
+            board_id: board.id,
+            name: "C".into(),
+            wip_limit: None,
+            default_status: None,
+        },
+        None,
+    )?;
+
+    assert!(outcome.created);
+    assert_eq!(inv, Invalidation::Entities(EntityIds::columns([id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_column_returns_the_update_invalidation_on_the_replace_path(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+    let id = Uuid::new_v4();
+    let _ = ctx.create_or_replace_column(
+        id,
+        NewColumn {
+            board_id: board.id,
+            name: "Original".into(),
+            wip_limit: None,
+            default_status: None,
+        },
+        None,
+    )?;
+
+    let (outcome, inv) = ctx.create_or_replace_column(
+        id,
+        NewColumn {
+            board_id: board.id,
+            name: "Renamed".into(),
+            wip_limit: None,
+            default_status: None,
+        },
+        None,
+    )?;
+
+    assert!(!outcome.created);
+    assert_eq!(inv, Invalidation::Entities(EntityIds::columns([id])));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_sprint_from_spec_returns_an_invalidation_naming_the_sprint(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+
+    let (_sprint, inv) =
+        ctx.create_sprint_from_spec(board.id, None, None, Some("SPR".into()), false)?;
+
+    assert_eq!(inv, Invalidation::All);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_sprint_returns_the_create_invalidation_on_the_create_path(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+    let id = Uuid::new_v4();
+
+    let (outcome, inv) =
+        ctx.create_or_replace_sprint(board.id, id, None, Some("SPR".into()), false)?;
+
+    assert!(outcome.created);
+    assert_eq!(inv, Invalidation::All);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_or_replace_sprint_returns_the_update_invalidation_on_the_replace_path(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), Some("KAN".into()))?;
+    let id = Uuid::new_v4();
+    let _ = ctx.create_or_replace_sprint(board.id, id, None, Some("SPR".into()), false)?;
+
+    let (outcome, inv) =
+        ctx.create_or_replace_sprint(board.id, id, None, Some("RENAMED".into()), false)?;
+
+    assert!(!outcome.created);
+    assert_eq!(inv, Invalidation::Entities(EntityIds::sprints([id])));
     Ok(())
 }

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -582,8 +582,8 @@ async fn test_create_or_replace_card_returns_the_update_invalidation_on_the_repl
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_create_column_from_spec_returns_an_invalidation_naming_the_column(
-) -> KanbanResult<()> {
+async fn test_create_column_from_spec_returns_an_invalidation_naming_the_column() -> KanbanResult<()>
+{
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), Some("KAN".into()))?;
 
@@ -658,8 +658,8 @@ async fn test_create_or_replace_column_returns_the_update_invalidation_on_the_re
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_create_sprint_from_spec_returns_an_invalidation_naming_the_sprint(
-) -> KanbanResult<()> {
+async fn test_create_sprint_from_spec_returns_an_invalidation_naming_the_sprint() -> KanbanResult<()>
+{
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), Some("KAN".into()))?;
 

--- a/crates/kanban-service/tests/sprint_name_resolution.rs
+++ b/crates/kanban-service/tests/sprint_name_resolution.rs
@@ -29,7 +29,7 @@ async fn test_resolve_sprint_name_returns_the_owning_boards_pool_name() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("get.json"));
 
-    let sprint = ctx
+    let (sprint, _inv) = ctx
         .create_sprint_from_spec(
             board_id,
             None,
@@ -48,7 +48,7 @@ async fn test_resolve_sprint_name_returns_none_when_sprint_has_no_name_index() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("no_name.json"));
 
-    let sprint = ctx
+    let (sprint, _inv) = ctx
         .create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
         .unwrap();
 

--- a/crates/kanban-service/tests/sprint_name_resolution.rs
+++ b/crates/kanban-service/tests/sprint_name_resolution.rs
@@ -74,24 +74,27 @@ async fn test_resolve_sprint_names_maps_each_sprint_to_its_own_pool_name() {
     let dir = tempdir().unwrap();
     let (mut ctx, board_id) = ctx_with_board(&dir.path().join("list.json"));
 
-    ctx.create_sprint_from_spec(
-        board_id,
-        None,
-        Some("Alpha".to_string()),
-        Some("SPR".to_string()),
-        false,
-    )
-    .unwrap();
-    ctx.create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
+    let (_sprint, _inv) = ctx
+        .create_sprint_from_spec(
+            board_id,
+            None,
+            Some("Alpha".to_string()),
+            Some("SPR".to_string()),
+            false,
+        )
         .unwrap();
-    ctx.create_sprint_from_spec(
-        board_id,
-        None,
-        Some("Gamma".to_string()),
-        Some("SPR".to_string()),
-        false,
-    )
-    .unwrap();
+    let (_sprint, _inv) = ctx
+        .create_sprint_from_spec(board_id, None, None, Some("SPR".to_string()), false)
+        .unwrap();
+    let (_sprint, _inv) = ctx
+        .create_sprint_from_spec(
+            board_id,
+            None,
+            Some("Gamma".to_string()),
+            Some("SPR".to_string()),
+            false,
+        )
+        .unwrap();
 
     let sprints = ctx.list_sprints(board_id).unwrap();
     let names = resolve_sprint_names(&ctx, board_id, &sprints).unwrap();

--- a/crates/kanban-service/tests/update_column_default_status.rs
+++ b/crates/kanban-service/tests/update_column_default_status.rs
@@ -37,6 +37,7 @@ fn board_with_column(ctx: &mut KanbanContext, default_status: Option<CardStatus>
         },
     )
     .unwrap()
+    .0
     .id
 }
 


### PR DESCRIPTION
## Summary

Widens the six remaining creator/replacer methods on `KanbanContext` to return `KanbanResult<(T, Invalidation)>`, mirroring the existing `create_board_from_spec` / `create_or_replace_board` precedent:

- `create_card_from_spec`, `create_or_replace_card`
- `create_column_from_spec`, `create_or_replace_column`
- `create_sprint_from_spec`, `create_or_replace_sprint`

Each method collapses its former `pub(super)` `_returning` twin into the public method itself and repoints its own internal callers (`create_or_replace_*`'s create arm, and the `*_impl` legacy shims).

## Changes

- `crates/kanban-service/src/context/{cards,columns,sprints}.rs`: widened return types; internal callers updated in the same commit so the crate never sits in a half-migrated state.
- `crates/kanban-service/tests/mutation_invalidation.rs`: nine new tests asserting the invalidation content for each method on both the create and replace arms. Two of these (card create, sprint create) assert `Invalidation::All` rather than a scoped `Entities(...)` set. Verified empirically: the inverse of `CreateCard`/`CreateSprint` is `DeleteCard`/`DeleteSprint`, and both report `touched_entities() -> None` (they also touch the dependency graph / sprint-log cascade), so `invalidation_from_inverse` falls back to `All`. This matches existing behaviour for every other card/sprint create path in this file, not a new gap.
- `crates/kanban-service/tests/{create_card_from_spec,create_column_from_spec,create_sprint_from_spec,sprint_name_resolution,update_column_default_status,card_archived_at_scan}.rs`: adapted every existing call site to destructure the pair instead of the bare entity.
- Downstream compile fallout fixed with an explicit, named discard (`let (x, _invalidation) = ...`) rather than a bare `.0`, except where mirroring the board precedent's existing `?.0` shorthand:
  - `crates/kanban-mcp/src/context.rs`: the three `McpContext` forwarders (`create_column_from_spec`, `create_card_from_spec`, `create_sprint_from_spec`) discard via `?.0`, matching `create_board_from_spec`'s existing style. Their public signatures are unchanged, so no MCP tool file needed touching.
  - `crates/kanban-server/src/handlers/{cards,columns,sprints}.rs`: each handler now destructures `(outcome, _invalidation)` before projecting onto its wire response.
  - `crates/kanban-cli/src/context.rs`: `create_column_with_default_status`'s append-path arm discards the invalidation with `.0`.
- `.changeset/kan-1499-service-creators-return-invalidation.md`: `bump: minor` (breaking public-signature change on a published, pre-1.0 crate).

`create_board_from_spec` / `create_or_replace_board` are byte-unchanged (confirmed via `git diff origin/develop -- crates/kanban-service/src/context/boards.rs`).

## Discard census

```
crates/kanban-server/src/handlers/boards.rs:21:    let (board, _inv) = ctx
crates/kanban-server/src/handlers/boards.rs:36:    let (outcome, _inv) = ctx
crates/kanban-server/src/handlers/cards.rs:32:    let (outcome, _invalidation) = ctx
crates/kanban-server/src/handlers/cards.rs:57:    let (outcome, _invalidation) = ctx
crates/kanban-server/src/handlers/columns.rs:31:    let (outcome, _invalidation) = ctx
crates/kanban-server/src/handlers/columns.rs:55:    let (outcome, _invalidation) = ctx
crates/kanban-server/src/handlers/sprints.rs:34:    let (sprint, _invalidation) = ctx
crates/kanban-server/src/handlers/sprints.rs:68:    let (outcome, _invalidation) = ctx
```
(kanban-mcp has no matching `let (x, _...)` discard sites. Its three forwarders use the board precedent's `?.0` shorthand instead.)

## Test plan

- [x] `cargo test -p kanban-service --test mutation_invalidation`: confirmed the nine new tests fail to compile before the Green commit (E0308, tuple vs bare struct)
- [x] `cargo test -p kanban-service -p kanban-mcp -p kanban-server -p kanban-cli -p kanban-tui --all-features` green
- [x] `cargo clippy -p kanban-service -p kanban-mcp -p kanban-server -p kanban-cli -p kanban-tui --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: temporarily replaced `create_column_from_spec`'s returned invalidation with `Invalidation::All`, confirmed `test_create_column_from_spec_returns_an_invalidation_naming_the_column` fails, then reverted
