### PR TITLE
KAN-1498 feat(tui): migrate cards/boards tier reads off loaded_or_empty

### DIFF
--- a/.changeset/kan-1498-tui-cards-boards-tier-decline.md
+++ b/.changeset/kan-1498-tui-cards-boards-tier-decline.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: the 19 remaining `loaded_or_empty()` reads on the cards/boards tiers in kanban-tui's handlers and app modules now handle `LoadState` explicitly. Acting handlers decline with a "not loaded yet" banner and leave state unchanged when their cards or boards tier is not loaded; per-frame and read-only search paths skip silently; the shared test fixture that seeds `active_board_id` now panics loudly instead of silently producing `None` if boards were never loaded.

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -1,5 +1,5 @@
 use super::{animation, App};
-use kanban_domain::AnimationType;
+use kanban_domain::{AnimationType, LoadState};
 use std::time::Instant;
 
 impl App {
@@ -147,5 +147,79 @@ impl App {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{animation, App};
+    use crate::app::CardAnimation;
+    use kanban_domain::{CreateCardOptions, EntityIds, Invalidation, KanbanOperations, Snapshot};
+    use std::time::{Duration, Instant};
+
+    fn refresh(app: &mut App) {
+        let snap = Snapshot {
+            archived_boards: Vec::new(),
+            boards: app.ctx.data_store().list_boards().unwrap(),
+            columns: app.ctx.data_store().list_all_columns().unwrap(),
+            cards: app.ctx.data_store().list_all_cards().unwrap(),
+            archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+            sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+            graph: app.ctx.data_store().get_graph().unwrap(),
+            prefixes: Vec::new(),
+        };
+        app.load_snapshot(snap);
+    }
+
+    #[test]
+    fn test_handle_animation_tick_with_a_not_loaded_cards_tier_skips_the_archive_without_a_banner()
+    {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "Todo".into(), None)
+            .unwrap();
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Card".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        refresh(&mut app);
+
+        app.animation.animating.insert(
+            card.id,
+            CardAnimation {
+                animation_type: kanban_domain::AnimationType::Archiving,
+                start_time: Instant::now()
+                    - Duration::from_millis(animation::ANIMATION_DURATION_MS as u64 + 50),
+            },
+        );
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::cards([
+                uuid::Uuid::new_v4(),
+            ])));
+
+        app.handle_animation_tick();
+
+        assert!(
+            app.ui_state.banner.is_none(),
+            "a NotLoaded cards tier on the per-frame archive path must degrade silently, not bannering every tick"
+        );
+        assert!(
+            !app.animation.animating.contains_key(&card.id),
+            "the completed animation entry must still be removed"
+        );
+        let stored = app.ctx.data_store().get_card(card.id).unwrap();
+        assert!(
+            stored.is_some(),
+            "the card must not be archived while the cards tier is not loaded, since it was silently skipped"
+        );
     }
 }

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -24,13 +24,14 @@ impl App {
             self.animation.animating.remove(&card_id);
             match animation_type {
                 AnimationType::Archiving => {
-                    let cards = self.model.cards_state().loaded_or_empty();
-                    if let Some(card_pos) = cards.iter().position(|c| c.id == card_id) {
-                        let card = &cards[card_pos];
-                        if !affected_columns.contains(&card.column_id) {
-                            affected_columns.push(card.column_id);
+                    if let LoadState::Loaded(cards) = self.model.cards_state() {
+                        if let Some(card_pos) = cards.iter().position(|c| c.id == card_id) {
+                            let card = &cards[card_pos];
+                            if !affected_columns.contains(&card.column_id) {
+                                affected_columns.push(card.column_id);
+                            }
+                            archive_cards.push(card_id);
                         }
-                        archive_cards.push(card_id);
                     }
                 }
                 AnimationType::Restoring => {

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -54,7 +54,10 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::App;
-    use kanban_domain::{FieldUpdate, KanbanOperations, LoadState, SprintStatus, SprintUpdate};
+    use kanban_domain::{
+        EntityIds, FieldUpdate, Invalidation, KanbanOperations, LoadState, SprintStatus,
+        SprintUpdate,
+    };
 
     fn seed_ended_sprint(app: &mut App) -> uuid::Uuid {
         let board = app.ctx.create_board("Board".into(), None).unwrap();
@@ -96,5 +99,28 @@ mod tests {
         let ended = app.check_ended_sprints();
 
         assert_eq!(ended, Some(vec![sprint_id]));
+    }
+
+    #[test]
+    fn test_check_ended_sprints_with_a_not_loaded_boards_tier_skips_the_board_name_lookup() {
+        let mut app = App::test_default();
+        let sprint_id = seed_ended_sprint(&mut app);
+        let _ = app.model.load_from_snapshot(app.ctx.snapshot().unwrap());
+        assert!(matches!(app.model.sprints_state(), LoadState::Loaded(_)));
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::boards([
+                uuid::Uuid::new_v4(),
+            ])));
+        assert!(matches!(app.model.boards_state(), LoadState::NotLoaded));
+
+        let ended = app.check_ended_sprints();
+
+        assert_eq!(
+            ended,
+            Some(vec![sprint_id]),
+            "the sprint-tier scan must be unaffected by a NotLoaded boards tier"
+        );
     }
 }

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -17,22 +17,18 @@ impl App {
                 "Found {} ended sprint(s) that need attention:",
                 ended_sprints.len()
             );
-            for sprint in &ended_sprints {
-                if let Some(board) = self
-                    .model
-                    .boards_state()
-                    .loaded_or_empty()
-                    .iter()
-                    .find(|b| b.id == sprint.board_id)
-                {
-                    tracing::warn!(
-                        "  - {} (ended: {})",
-                        sprint.formatted_name(board, None),
-                        sprint
-                            .end_date
-                            .map(|d| d.format("%Y-%m-%d %H:%M UTC").to_string())
-                            .unwrap_or_else(|| "unknown".to_string())
-                    );
+            if let LoadState::Loaded(boards) = self.model.boards_state() {
+                for sprint in &ended_sprints {
+                    if let Some(board) = boards.iter().find(|b| b.id == sprint.board_id) {
+                        tracing::warn!(
+                            "  - {} (ended: {})",
+                            sprint.formatted_name(board, None),
+                            sprint
+                                .end_date
+                                .map(|d| d.format("%Y-%m-%d %H:%M UTC").to_string())
+                                .unwrap_or_else(|| "unknown".to_string())
+                        );
+                    }
                 }
             }
         }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1491,6 +1491,16 @@ mod cards_tier_decline_tests {
         KanbanOperations, NoProjections, Snapshot,
     };
 
+    fn assert_error_banner(app: &App, expected_message: &str) {
+        let banner = app
+            .ui_state
+            .banner
+            .as_ref()
+            .expect("expected an error banner to be set");
+        assert_eq!(banner.variant, crate::components::BannerVariant::Error);
+        assert_eq!(banner.message, expected_message);
+    }
+
     fn refresh(app: &mut App) {
         let snap = Snapshot {
             archived_boards: Vec::new(),
@@ -1574,10 +1584,7 @@ mod cards_tier_decline_tests {
 
         app.handle_toggle_card_completion();
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         let card = app.ctx.get_card(card_id).unwrap().unwrap();
         assert_eq!(
             card.status,
@@ -1599,10 +1606,7 @@ mod cards_tier_decline_tests {
         app.create_card();
         app.input.clear();
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         let cards = app.ctx.data_store().list_all_cards().unwrap();
         assert!(
             !cards.iter().any(|c| c.title == "New card"),
@@ -1627,10 +1631,7 @@ mod cards_tier_decline_tests {
 
         app.handle_move_card_right();
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         let card = app.ctx.get_card(card_id).unwrap().unwrap();
         assert_eq!(
             card.column_id, column_id,
@@ -1655,10 +1656,7 @@ mod cards_tier_decline_tests {
 
         app.handle_move_card_right();
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         let card = app.ctx.get_card(card_id).unwrap().unwrap();
         assert_eq!(
             card.column_id, column_id,
@@ -1699,10 +1697,7 @@ mod cards_tier_decline_tests {
 
         app.start_delete_animation(card_id);
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         assert!(
             !app.animation.animating.contains_key(&card_id),
             "the card must not be queued for archive animation while the cards tier is not loaded"
@@ -1723,10 +1718,7 @@ mod cards_tier_decline_tests {
 
         app.handle_manage_children_from_list();
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         assert_ne!(
             app.mode,
             crate::app::AppMode::Dialog(crate::app::DialogMode::ManageChildren),

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -340,16 +340,12 @@ impl App {
         let card_ids: Vec<uuid::Uuid> = self.multi_select.selected_cards.iter().copied().collect();
         let first_card_id = card_ids.first().copied();
 
+        let all_cards = self.model.cards_state().loaded_or_empty();
+
         let updates: Vec<(uuid::Uuid, CardUpdate)> = card_ids
             .iter()
             .filter_map(|card_id| {
-                let card = self
-                    .model
-                    .cards_state()
-                    .loaded_or_empty()
-                    .iter()
-                    .find(|c| c.id == *card_id)?
-                    .clone();
+                let card = all_cards.iter().find(|c| c.id == *card_id)?.clone();
                 let new_status = if card.status == CardStatus::Done {
                     CardStatus::Todo
                 } else {
@@ -727,13 +723,8 @@ impl App {
         use kanban_domain::AnimationType;
         use std::time::Instant;
 
-        if self
-            .model
-            .cards_state()
-            .loaded_or_empty()
-            .iter()
-            .any(|c| c.id == card_id)
-        {
+        let cards = self.model.cards_state().loaded_or_empty();
+        if cards.iter().any(|c| c.id == card_id) {
             self.animation.animating.insert(
                 card_id,
                 CardAnimation {
@@ -1468,6 +1459,259 @@ mod create_card_factory_tests {
         assert!(
             board_row.map(|row| row.card_counter == 0).unwrap_or(true),
             "the board's own namespace must not advance for a sprint-prefixed card"
+        );
+    }
+}
+
+#[cfg(test)]
+mod cards_tier_decline_tests {
+    use crate::app::Focus;
+    use crate::App;
+    use kanban_domain::{
+        CardStatus, CreateCardOptions, DerivedProjections, EntityIds, Invalidation,
+        KanbanOperations, NoProjections, Snapshot,
+    };
+
+    fn refresh(app: &mut App) {
+        let snap = Snapshot {
+            archived_boards: Vec::new(),
+            boards: app.ctx.data_store().list_boards().unwrap(),
+            columns: app.ctx.data_store().list_all_columns().unwrap(),
+            cards: app.ctx.data_store().list_all_cards().unwrap(),
+            archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+            sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+            graph: app.ctx.data_store().get_graph().unwrap(),
+            prefixes: Vec::new(),
+        };
+        app.load_snapshot(snap);
+    }
+
+    fn invalidate_cards_tier(app: &mut App) {
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::cards([
+                uuid::Uuid::new_v4(),
+            ])));
+    }
+
+    /// Sets `card_by_id_state(card_id)` to `Loaded` via the `by_id` tier
+    /// without touching the flat `cards` tier, which stays `NotLoaded`.
+    fn pin_card_by_id(app: &mut App, card_id: uuid::Uuid) {
+        let card = app.ctx.get_card(card_id).unwrap().unwrap();
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            cards: kanban_domain::resolved::Collection {
+                by_id: [(card_id, kanban_domain::LoadState::Loaded(card))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        NoProjections.resync(&app.model, changed);
+    }
+
+    fn select_card_in_active_task_list(app: &mut App, card_id: uuid::Uuid) {
+        app.prepare_frame();
+        let list = app
+            .view
+            .strategy
+            .get_active_task_list_mut()
+            .expect("active task list");
+        let idx = list
+            .cards
+            .iter()
+            .position(|&id| id == card_id)
+            .expect("card present in active task list");
+        list.set_selected_index(Some(idx));
+    }
+
+    fn seed_board_column_card(app: &mut App) -> (uuid::Uuid, uuid::Uuid, uuid::Uuid) {
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "Todo".into(), None)
+            .unwrap();
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Card".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        (board.id, column.id, card.id)
+    }
+
+    #[test]
+    fn test_toggle_selected_cards_completion_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+        app.focus.active = Focus::Cards;
+        app.multi_select.selected_cards.insert(card_id);
+        app.multi_select.selection_mode_active = true;
+
+        invalidate_cards_tier(&mut app);
+
+        app.handle_toggle_card_completion();
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        let card = app.ctx.get_card(card_id).unwrap().unwrap();
+        assert_eq!(
+            card.status,
+            CardStatus::Todo,
+            "status must be unchanged when the handler declines"
+        );
+    }
+
+    #[test]
+    fn test_create_card_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let (board_id, _column_id, _card_id) = seed_board_column_card(&mut app);
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+
+        invalidate_cards_tier(&mut app);
+
+        app.input.set("New card".to_string());
+        app.create_card();
+        app.input.clear();
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        let cards = app.ctx.data_store().list_all_cards().unwrap();
+        assert!(
+            !cards.iter().any(|c| c.title == "New card"),
+            "no card should have been created while the cards tier is not loaded"
+        );
+    }
+
+    #[test]
+    fn test_handle_move_card_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let (board_id, column_id, card_id) = seed_board_column_card(&mut app);
+        app.ctx
+            .create_column(board_id, "Doing".into(), None)
+            .unwrap();
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+        app.focus.active = Focus::Cards;
+        select_card_in_active_task_list(&mut app, card_id);
+
+        invalidate_cards_tier(&mut app);
+        pin_card_by_id(&mut app, card_id);
+
+        app.handle_move_card_right();
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        let card = app.ctx.get_card(card_id).unwrap().unwrap();
+        assert_eq!(
+            card.column_id, column_id,
+            "card's column must be unchanged when the handler declines"
+        );
+    }
+
+    #[test]
+    fn test_move_selected_cards_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let (board_id, column_id, card_id) = seed_board_column_card(&mut app);
+        app.ctx
+            .create_column(board_id, "Doing".into(), None)
+            .unwrap();
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+        app.focus.active = Focus::Cards;
+        app.multi_select.selected_cards.insert(card_id);
+        app.multi_select.selection_mode_active = true;
+
+        invalidate_cards_tier(&mut app);
+
+        app.handle_move_card_right();
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        let card = app.ctx.get_card(card_id).unwrap().unwrap();
+        assert_eq!(
+            card.column_id, column_id,
+            "selected card's column must be unchanged when the handler declines"
+        );
+    }
+
+    #[test]
+    fn test_cursor_archive_anchor_with_a_not_loaded_cards_tier_returns_none() {
+        let mut app = App::test_default();
+        let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+        app.focus.active = Focus::Cards;
+        select_card_in_active_task_list(&mut app, card_id);
+
+        invalidate_cards_tier(&mut app);
+
+        assert_eq!(
+            app.cursor_archive_anchor(),
+            None,
+            "a NotLoaded cards tier must return None, not a stale Some"
+        );
+        assert!(
+            app.ui_state.banner.is_none(),
+            "cursor_archive_anchor is a caller-declines helper, not a user-facing banner"
+        );
+    }
+
+    #[test]
+    fn test_start_delete_animation_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+
+        invalidate_cards_tier(&mut app);
+
+        app.start_delete_animation(card_id);
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        assert!(
+            !app.animation.animating.contains_key(&card_id),
+            "the card must not be queued for archive animation while the cards tier is not loaded"
+        );
+    }
+
+    #[test]
+    fn test_handle_manage_children_from_list_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+        app.focus.active = Focus::Cards;
+        select_card_in_active_task_list(&mut app, card_id);
+
+        invalidate_cards_tier(&mut app);
+        pin_card_by_id(&mut app, card_id);
+
+        app.handle_manage_children_from_list();
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        assert_ne!(
+            app.mode,
+            crate::app::AppMode::Dialog(crate::app::DialogMode::ManageChildren),
+            "the ManageChildren dialog must not open while the cards tier is not loaded"
         );
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -340,7 +340,10 @@ impl App {
         let card_ids: Vec<uuid::Uuid> = self.multi_select.selected_cards.iter().copied().collect();
         let first_card_id = card_ids.first().copied();
 
-        let all_cards = self.model.cards_state().loaded_or_empty();
+        let LoadState::Loaded(all_cards) = self.model.cards_state() else {
+            self.set_error("Cards are not loaded yet");
+            return;
+        };
 
         let updates: Vec<(uuid::Uuid, CardUpdate)> = card_ids
             .iter()
@@ -402,7 +405,10 @@ impl App {
                 let (column_id, position, mark_as_complete, new_column_cmd) = match existing_column
                 {
                     Some(col) => {
-                        let cards = self.model.cards_state().loaded_or_empty();
+                        let LoadState::Loaded(cards) = self.model.cards_state() else {
+                            self.set_error("Cards are not loaded yet");
+                            return;
+                        };
                         let position =
                             kanban_domain::card_lifecycle::next_position_in_column(cards, col.id);
                         let LoadState::Loaded(columns) = self.model.columns_state() else {
@@ -555,7 +561,10 @@ impl App {
                 self.set_error("Columns are not loaded yet");
                 return;
             };
-            let cards = self.model.cards_state().loaded_or_empty();
+            let LoadState::Loaded(cards) = self.model.cards_state() else {
+                self.set_error("Cards are not loaded yet");
+                return;
+            };
             let move_result = kanban_domain::card_lifecycle::compute_card_column_move(
                 &card, board, columns, cards, direction,
             );
@@ -633,7 +642,10 @@ impl App {
             self.set_error("Columns are not loaded yet");
             return;
         };
-        let cards = self.model.cards_state().loaded_or_empty();
+        let LoadState::Loaded(cards) = self.model.cards_state() else {
+            self.set_error("Cards are not loaded yet");
+            return;
+        };
         let updates: Vec<(uuid::Uuid, CardUpdate)> = card_ids
             .iter()
             .filter_map(|card_id| {
@@ -701,9 +713,10 @@ impl App {
     /// inferring it from whichever archived card lands last in HashMap order.
     fn cursor_archive_anchor(&self) -> Option<(uuid::Uuid, i32)> {
         let card_id = self.get_selected_card_id()?;
-        self.model
-            .cards_state()
-            .loaded_or_empty()
+        let LoadState::Loaded(cards) = self.model.cards_state() else {
+            return None;
+        };
+        cards
             .iter()
             .find(|c| c.id == card_id)
             .map(|c| (c.column_id, c.position))
@@ -723,7 +736,10 @@ impl App {
         use kanban_domain::AnimationType;
         use std::time::Instant;
 
-        let cards = self.model.cards_state().loaded_or_empty();
+        let LoadState::Loaded(cards) = self.model.cards_state() else {
+            self.set_error("Cards are not loaded yet");
+            return;
+        };
         if cards.iter().any(|c| c.id == card_id) {
             self.animation.animating.insert(
                 card_id,
@@ -987,7 +1003,10 @@ impl App {
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
-        let cards = self.model.cards_state().loaded_or_empty();
+        let LoadState::Loaded(cards) = self.model.cards_state() else {
+            self.set_error("Cards are not loaded yet");
+            return;
+        };
         let eligible_cards: Vec<_> = cards
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1040,53 +1040,47 @@ impl App {
                             }
                         }
                         CardListAction::MoveColumn(card_id, is_right) => {
-                            if !self.model.cards_state().is_loaded() {
+                            let LoadState::Loaded(cards) = self.model.cards_state() else {
                                 self.set_error("Cards are not loaded yet");
-                            } else if let Some(card) = self
-                                .model
-                                .cards_state()
-                                .loaded()
-                                .and_then(|cards| cards.iter().find(|c| c.id == card_id))
-                                .cloned()
-                            {
-                                let direction = if is_right {
-                                    kanban_domain::card_lifecycle::MoveDirection::Right
-                                } else {
-                                    kanban_domain::card_lifecycle::MoveDirection::Left
-                                };
+                                return;
+                            };
+                            let Some(card) = cards.iter().find(|c| c.id == card_id).cloned() else {
+                                return;
+                            };
 
-                                let board = self.active_board().cloned();
-                                let move_result = match board {
-                                    Some(board) => match self.model.columns_state() {
-                                        LoadState::Loaded(columns) => {
-                                            let cards = match self.model.cards_state() {
-                                                LoadState::Loaded(cards) => cards.as_slice(),
-                                                _ => &[],
-                                            };
-                                            kanban_domain::card_lifecycle::compute_card_column_move(
-                                                &card, &board, columns, cards, direction,
-                                            )
-                                        }
-                                        _ => {
-                                            self.set_error("Columns are not loaded yet");
-                                            None
-                                        }
-                                    },
-                                    None => None,
-                                };
+                            let direction = if is_right {
+                                kanban_domain::card_lifecycle::MoveDirection::Right
+                            } else {
+                                kanban_domain::card_lifecycle::MoveDirection::Left
+                            };
 
-                                if let Some(result) = move_result {
-                                    use kanban_domain::KanbanOperations;
-                                    // Service layer chains the status flip when the
-                                    // move crosses the completion-column boundary.
-                                    if let Err(e) =
-                                        self.ctx.move_card(card_id, result.target_column_id, None)
-                                    {
-                                        tracing::error!("Failed to move card: {}", e);
-                                        self.set_error(format!("Failed to move card: {}", e));
-                                    } else {
-                                        self.reload_model();
+                            let board = self.active_board().cloned();
+                            let move_result = match board {
+                                Some(board) => match self.model.columns_state() {
+                                    LoadState::Loaded(columns) => {
+                                        kanban_domain::card_lifecycle::compute_card_column_move(
+                                            &card, &board, columns, cards, direction,
+                                        )
                                     }
+                                    _ => {
+                                        self.set_error("Columns are not loaded yet");
+                                        None
+                                    }
+                                },
+                                None => None,
+                            };
+
+                            if let Some(result) = move_result {
+                                use kanban_domain::KanbanOperations;
+                                // Service layer chains the status flip when the
+                                // move crosses the completion-column boundary.
+                                if let Err(e) =
+                                    self.ctx.move_card(card_id, result.target_column_id, None)
+                                {
+                                    tracing::error!("Failed to move card: {}", e);
+                                    self.set_error(format!("Failed to move card: {}", e));
+                                } else {
+                                    self.reload_model();
                                 }
                             }
                         }
@@ -2371,13 +2365,14 @@ mod tests {
         assert_eq!(app.mode, AppMode::SprintDetail);
     }
 
-    fn assert_error_banner(app: &App) {
+    fn assert_error_banner(app: &App, expected_message: &str) {
         let banner = app
             .ui_state
             .banner
             .as_ref()
             .expect("expected an error banner to be set");
         assert_eq!(banner.variant, crate::components::BannerVariant::Error);
+        assert_eq!(banner.message, expected_message);
     }
 
     fn assert_no_banner(app: &App) {
@@ -2406,7 +2401,7 @@ mod tests {
         app.handle_board_detail_navigation_key(KeyCode::Char('j'));
 
         assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
-        assert_error_banner(&app);
+        assert_error_banner(&app, "Columns are not loaded yet");
     }
 
     #[test]
@@ -2456,7 +2451,7 @@ mod tests {
             app.mode,
             AppMode::Dialog(DialogMode::AssignCardToSprint)
         ));
-        assert_error_banner(&app);
+        assert_error_banner(&app, "Sprints are not loaded yet");
     }
 
     #[test]
@@ -2521,10 +2516,7 @@ mod tests {
 
         app.handle_sprint_detail_key(KeyCode::Char('L'));
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         let card_after = app.ctx.get_card(card_id).unwrap().unwrap();
         assert_eq!(
             card_after.column_id, card_before.column_id,
@@ -2544,10 +2536,7 @@ mod tests {
 
         app.handle_manage_parents();
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         assert_ne!(
             app.mode,
             AppMode::Dialog(DialogMode::ManageParents),
@@ -2567,10 +2556,7 @@ mod tests {
 
         app.handle_manage_children();
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         assert_ne!(
             app.mode,
             AppMode::Dialog(DialogMode::ManageChildren),
@@ -2587,10 +2573,7 @@ mod tests {
 
         app.toggle_completion_for_card_ids(vec![card_id]);
 
-        assert!(
-            app.ui_state.banner.is_some(),
-            "must decline with a banner when the cards tier is not loaded"
-        );
+        assert_error_banner(&app, "Cards are not loaded yet");
         let card = app.ctx.get_card(card_id).unwrap().unwrap();
         assert_eq!(
             card.status,

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1185,10 +1185,8 @@ impl App {
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
-        let eligible_cards: Vec<_> = self
-            .model
-            .cards_state()
-            .loaded_or_empty()
+        let cards = self.model.cards_state().loaded_or_empty();
+        let eligible_cards: Vec<_> = cards
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))
             .filter(|c| c.id != card_id)
@@ -1247,10 +1245,8 @@ impl App {
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
-        let eligible_cards: Vec<_> = self
-            .model
-            .cards_state()
-            .loaded_or_empty()
+        let cards = self.model.cards_state().loaded_or_empty();
+        let eligible_cards: Vec<_> = cards
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))
             .filter(|c| c.id != card_id)
@@ -1373,16 +1369,12 @@ impl App {
     pub fn toggle_completion_for_card_ids(&mut self, ids: Vec<uuid::Uuid>) {
         use kanban_domain::{CardStatus, CardUpdate, KanbanOperations};
 
+        let all_cards = self.model.cards_state().loaded_or_empty();
+
         let updates: Vec<(uuid::Uuid, CardUpdate)> = ids
             .iter()
             .filter_map(|card_id| {
-                let card = self
-                    .model
-                    .cards_state()
-                    .loaded_or_empty()
-                    .iter()
-                    .find(|c| c.id == *card_id)?
-                    .clone();
+                let card = all_cards.iter().find(|c| c.id == *card_id)?.clone();
                 let new_status = if card.status == CardStatus::Done {
                     CardStatus::Todo
                 } else {
@@ -1415,7 +1407,10 @@ mod tests {
     use crate::app::{AppMode, BoardFocus, CardFocus, DialogMode};
     use crate::App;
     use crossterm::event::KeyCode;
-    use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, Snapshot};
+    use kanban_domain::{
+        CardStatus, CreateCardOptions, DerivedProjections, EntityIds, GraphOperations,
+        Invalidation, KanbanOperations, LoadState, NoProjections, Snapshot,
+    };
 
     /// Seeds a board with exactly `total_columns` columns (via `create_column`,
     /// not the TUI's default-seeding `create_board` handler) and opens it in
@@ -2483,5 +2478,113 @@ mod tests {
             AppMode::Dialog(DialogMode::AssignCardToSprint)
         ));
         assert_no_banner(&app);
+    }
+
+    fn invalidate_cards_tier(app: &mut App) {
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::cards([
+                uuid::Uuid::new_v4(),
+            ])));
+    }
+
+    fn pin_card_by_id(app: &mut App, card_id: uuid::Uuid) {
+        let card = app.ctx.get_card(card_id).unwrap().unwrap();
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            cards: kanban_domain::resolved::Collection {
+                by_id: [(card_id, LoadState::Loaded(card))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        NoProjections.resync(&app.model, changed);
+    }
+
+    #[test]
+    fn test_card_list_action_move_column_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let card_id = seed_sprint_with_card(&mut app, "task");
+        let card_before = app.ctx.get_card(card_id).unwrap().unwrap();
+
+        invalidate_cards_tier(&mut app);
+
+        app.handle_sprint_detail_key(KeyCode::Char('L'));
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        let card_after = app.ctx.get_card(card_id).unwrap().unwrap();
+        assert_eq!(
+            card_after.column_id, card_before.column_id,
+            "card's column must be unchanged when the handler declines"
+        );
+    }
+
+    #[test]
+    fn test_handle_manage_parents_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let ids = seed_chain(&mut app, &["Parent", "Child"]);
+        let card_id = ids[1];
+        app.selection.active_card_id = Some(card_id);
+
+        invalidate_cards_tier(&mut app);
+        pin_card_by_id(&mut app, card_id);
+
+        app.handle_manage_parents();
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ManageParents),
+            "the ManageParents dialog must not open while the cards tier is not loaded"
+        );
+    }
+
+    #[test]
+    fn test_handle_manage_children_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let ids = seed_chain(&mut app, &["Parent", "Child"]);
+        let card_id = ids[0];
+        app.selection.active_card_id = Some(card_id);
+
+        invalidate_cards_tier(&mut app);
+        pin_card_by_id(&mut app, card_id);
+
+        app.handle_manage_children();
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        assert_ne!(
+            app.mode,
+            AppMode::Dialog(DialogMode::ManageChildren),
+            "the ManageChildren dialog must not open while the cards tier is not loaded"
+        );
+    }
+
+    #[test]
+    fn test_toggle_completion_for_card_ids_with_a_not_loaded_cards_tier_declines() {
+        let mut app = App::test_default();
+        let card_id = seed_sprint_with_card(&mut app, "task");
+
+        invalidate_cards_tier(&mut app);
+
+        app.toggle_completion_for_card_ids(vec![card_id]);
+
+        assert!(
+            app.ui_state.banner.is_some(),
+            "must decline with a banner when the cards tier is not loaded"
+        );
+        let card = app.ctx.get_card(card_id).unwrap().unwrap();
+        assert_eq!(
+            card.status,
+            CardStatus::Todo,
+            "status must be unchanged when the handler declines"
+        );
     }
 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -975,36 +975,34 @@ impl App {
                             }
                         }
                         CardListAction::Complete(card_id) => {
-                            if let Some(card) = self
-                                .model
-                                .cards_state()
-                                .loaded_or_empty()
-                                .iter()
-                                .find(|c| c.id == card_id)
-                            {
-                                use kanban_domain::{CardStatus, CardUpdate, KanbanOperations};
-                                let new_status = if card.status == CardStatus::Done {
-                                    CardStatus::Todo
-                                } else {
-                                    CardStatus::Done
-                                };
+                            if let LoadState::Loaded(cards) = self.model.cards_state() {
+                                if let Some(card) = cards.iter().find(|c| c.id == card_id) {
+                                    use kanban_domain::{CardStatus, CardUpdate, KanbanOperations};
+                                    let new_status = if card.status == CardStatus::Done {
+                                        CardStatus::Todo
+                                    } else {
+                                        CardStatus::Done
+                                    };
 
-                                // Service layer chains the column move automatically.
-                                if let Err(e) = self.ctx.update_card(
-                                    card_id,
-                                    CardUpdate {
-                                        status: Some(new_status),
-                                        ..Default::default()
-                                    },
-                                ) {
-                                    tracing::error!("Failed to toggle card completion: {}", e);
-                                    self.set_error(format!(
-                                        "Failed to toggle card completion: {}",
-                                        e
-                                    ));
-                                } else {
-                                    self.reload_model();
+                                    // Service layer chains the column move automatically.
+                                    if let Err(e) = self.ctx.update_card(
+                                        card_id,
+                                        CardUpdate {
+                                            status: Some(new_status),
+                                            ..Default::default()
+                                        },
+                                    ) {
+                                        tracing::error!("Failed to toggle card completion: {}", e);
+                                        self.set_error(format!(
+                                            "Failed to toggle card completion: {}",
+                                            e
+                                        ));
+                                    } else {
+                                        self.reload_model();
+                                    }
                                 }
+                            } else {
+                                self.set_error("Cards are not loaded yet");
                             }
                         }
                         CardListAction::TogglePriority(card_id) => {
@@ -1042,12 +1040,13 @@ impl App {
                             }
                         }
                         CardListAction::MoveColumn(card_id, is_right) => {
-                            if let Some(card) = self
+                            if !self.model.cards_state().is_loaded() {
+                                self.set_error("Cards are not loaded yet");
+                            } else if let Some(card) = self
                                 .model
                                 .cards_state()
-                                .loaded_or_empty()
-                                .iter()
-                                .find(|c| c.id == card_id)
+                                .loaded()
+                                .and_then(|cards| cards.iter().find(|c| c.id == card_id))
                                 .cloned()
                             {
                                 let direction = if is_right {
@@ -1060,7 +1059,10 @@ impl App {
                                 let move_result = match board {
                                     Some(board) => match self.model.columns_state() {
                                         LoadState::Loaded(columns) => {
-                                            let cards = self.model.cards_state().loaded_or_empty();
+                                            let cards = match self.model.cards_state() {
+                                                LoadState::Loaded(cards) => cards.as_slice(),
+                                                _ => &[],
+                                            };
                                             kanban_domain::card_lifecycle::compute_card_column_move(
                                                 &card, &board, columns, cards, direction,
                                             )
@@ -1185,7 +1187,10 @@ impl App {
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
-        let cards = self.model.cards_state().loaded_or_empty();
+        let LoadState::Loaded(cards) = self.model.cards_state() else {
+            self.set_error("Cards are not loaded yet");
+            return;
+        };
         let eligible_cards: Vec<_> = cards
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))
@@ -1245,7 +1250,10 @@ impl App {
 
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
-        let cards = self.model.cards_state().loaded_or_empty();
+        let LoadState::Loaded(cards) = self.model.cards_state() else {
+            self.set_error("Cards are not loaded yet");
+            return;
+        };
         let eligible_cards: Vec<_> = cards
             .iter()
             .filter(|c| column_ids.contains(&c.column_id))
@@ -1369,7 +1377,10 @@ impl App {
     pub fn toggle_completion_for_card_ids(&mut self, ids: Vec<uuid::Uuid>) {
         use kanban_domain::{CardStatus, CardUpdate, KanbanOperations};
 
-        let all_cards = self.model.cards_state().loaded_or_empty();
+        let LoadState::Loaded(all_cards) = self.model.cards_state() else {
+            self.set_error("Cards are not loaded yet");
+            return;
+        };
 
         let updates: Vec<(uuid::Uuid, CardUpdate)> = ids
             .iter()

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -566,12 +566,15 @@ impl App {
                                             .collect();
 
                                         if let Some(&to_sprint_id) = planning_sprint_ids.get(idx) {
-                                            let sprint_label =
-                                                match self.model.sprint_by_id_state(to_sprint_id) {
-                                                    LoadState::Loaded(s) => self
-                                                        .model
-                                                        .boards_state()
-                                                        .loaded_or_empty()
+                                            let sprint_label = match self
+                                                .model
+                                                .sprint_by_id_state(to_sprint_id)
+                                            {
+                                                LoadState::Loaded(s) => match self
+                                                    .model
+                                                    .boards_state()
+                                                {
+                                                    LoadState::Loaded(boards) => boards
                                                         .iter()
                                                         .find(|b| b.id == board_id)
                                                         .and_then(|b| s.get_name(b))
@@ -579,8 +582,10 @@ impl App {
                                                         .unwrap_or_else(|| {
                                                             format!("Sprint {}", s.sprint_number)
                                                         }),
-                                                    _ => "sprint".to_string(),
-                                                };
+                                                    _ => format!("Sprint {}", s.sprint_number),
+                                                },
+                                                _ => "sprint".to_string(),
+                                            };
 
                                             match self
                                                 .ctx
@@ -626,13 +631,15 @@ impl App {
             self.relationship.card_ids.clone()
         } else {
             let search_lower = self.relationship.search.to_lowercase();
+            let cards = match self.model.cards_state() {
+                LoadState::Loaded(cards) => cards.as_slice(),
+                _ => &[],
+            };
             self.relationship
                 .card_ids
                 .iter()
                 .filter(|card_id| {
-                    self.model
-                        .cards_state()
-                        .loaded_or_empty()
+                    cards
                         .iter()
                         .find(|c| c.id == **card_id)
                         .map(|c| c.title.to_lowercase().contains(&search_lower))
@@ -743,13 +750,15 @@ impl App {
             self.relationship.card_ids.len()
         } else {
             let search_lower = self.relationship.search.to_lowercase();
+            let cards = match self.model.cards_state() {
+                LoadState::Loaded(cards) => cards.as_slice(),
+                _ => &[],
+            };
             self.relationship
                 .card_ids
                 .iter()
                 .filter(|card_id| {
-                    self.model
-                        .cards_state()
-                        .loaded_or_empty()
+                    cards
                         .iter()
                         .find(|c| c.id == **card_id)
                         .map(|c| c.title.to_lowercase().contains(&search_lower))

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -771,7 +771,10 @@ mod tests {
     use crate::test_helpers::{load_with_card_order, setup_reload_resort_fixture};
     use crate::App;
     use crossterm::event::KeyCode;
-    use kanban_domain::{CardPriority, KanbanOperations};
+    use kanban_domain::{
+        CardPriority, CreateCardOptions, EntityIds, Invalidation, KanbanOperations, Snapshot,
+        SprintStatus, SprintUpdate,
+    };
     use std::collections::HashSet;
 
     #[test]
@@ -859,6 +862,120 @@ mod tests {
         assert!(
             !p_parents.contains(&fx.b_id),
             "manage_parents toggle must not attach B as a parent of P when A is the active card"
+        );
+    }
+
+    fn refresh(app: &mut App) {
+        let snap = Snapshot {
+            archived_boards: Vec::new(),
+            boards: app.ctx.data_store().list_boards().unwrap(),
+            columns: app.ctx.data_store().list_all_columns().unwrap(),
+            cards: app.ctx.data_store().list_all_cards().unwrap(),
+            archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+            sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+            graph: app.ctx.data_store().get_graph().unwrap(),
+            prefixes: Vec::new(),
+        };
+        app.load_snapshot(snap);
+    }
+
+    #[test]
+    fn test_carry_over_sprint_cards_label_with_a_not_loaded_boards_tier_falls_back_without_a_banner(
+    ) {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let source = app
+            .ctx
+            .create_sprint(board.id, None, Some("Source Sprint".into()))
+            .unwrap();
+        app.ctx
+            .update_sprint(
+                source.id,
+                SprintUpdate {
+                    status: Some(SprintStatus::Completed),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let target = app
+            .ctx
+            .create_sprint(board.id, None, Some("Target Sprint".into()))
+            .unwrap();
+        refresh(&mut app);
+
+        app.dialog_input.carry_over_source_sprint_id = Some(source.id);
+        app.dialog_input.carry_over_sprint_selection.set(Some(0));
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::boards([
+                uuid::Uuid::new_v4(),
+            ])));
+
+        app.handle_carry_over_sprint_popup(KeyCode::Enter);
+
+        let banner = app
+            .ui_state
+            .banner
+            .as_ref()
+            .expect("carry-over succeeded so a success banner must be set");
+        assert!(
+            !banner.message.to_lowercase().contains("fail"),
+            "must not report failure once the mutation already succeeded, got: {}",
+            banner.message
+        );
+        assert!(
+            banner
+                .message
+                .contains(&format!("Sprint {}", target.sprint_number)),
+            "with the boards tier not loaded, the label must fall back to 'Sprint {{number}}' instead of the board-resolved name, got: {}",
+            banner.message
+        );
+    }
+
+    fn seed_relationship_dialog(app: &mut App) -> (uuid::Uuid, uuid::Uuid) {
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "Todo".into(), None)
+            .unwrap();
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Findable".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        refresh(app);
+        app.relationship.card_ids = vec![card.id];
+        (board.id, card.id)
+    }
+
+    #[test]
+    fn test_handle_relationship_popup_search_with_a_not_loaded_cards_tier_shows_no_matches_without_a_banner(
+    ) {
+        let mut app = App::test_default();
+        let (_board_id, _card_id) = seed_relationship_dialog(&mut app);
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::cards([
+                uuid::Uuid::new_v4(),
+            ])));
+
+        app.relationship.search_active = true;
+        app.handle_manage_parents_popup(KeyCode::Char('f'));
+
+        assert_eq!(
+            app.relationship.selection.get(),
+            None,
+            "a NotLoaded cards tier must filter to zero matches, clearing the selection"
+        );
+        assert!(
+            app.ui_state.banner.is_none(),
+            "the per-keystroke search filter must degrade silently, not spam a banner per character"
         );
     }
 }

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -112,7 +112,8 @@ pub fn setup_reload_resort_fixture(app: &mut App) -> ReloadResortFixture {
     app.selection.active_board_id = app
         .model
         .boards_state()
-        .loaded_or_empty()
+        .loaded()
+        .expect("boards should be loaded by this fixture")
         .first()
         .map(|b| b.id);
 

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -128,3 +128,20 @@ pub fn setup_reload_resort_fixture(app: &mut App) -> ReloadResortFixture {
         c_id: c.id,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::App;
+
+    #[test]
+    #[should_panic(expected = "boards should be loaded by this fixture")]
+    fn test_boards_state_seed_helper_panics_loudly_when_boards_tier_is_not_loaded() {
+        let app = App::test_default();
+
+        let _ = app
+            .model
+            .boards_state()
+            .loaded()
+            .expect("boards should be loaded by this fixture");
+    }
+}

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -132,17 +132,19 @@ pub fn setup_reload_resort_fixture(app: &mut App) -> ReloadResortFixture {
 
 #[cfg(test)]
 mod tests {
+    use super::setup_reload_resort_fixture;
     use crate::App;
 
     #[test]
-    #[should_panic(expected = "boards should be loaded by this fixture")]
-    fn test_boards_state_seed_helper_panics_loudly_when_boards_tier_is_not_loaded() {
-        let app = App::test_default();
+    fn test_setup_reload_resort_fixture_seeds_the_active_board_id() {
+        let mut app = App::test_default();
 
-        let _ = app
-            .model
-            .boards_state()
-            .loaded()
-            .expect("boards should be loaded by this fixture");
+        let fixture = setup_reload_resort_fixture(&mut app);
+
+        assert_eq!(
+            app.selection.active_board_id,
+            Some(fixture.board_id),
+            "the fixture's boards_state().loaded() seed must produce the fixture's own board id"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Migrates the 19 remaining production `loaded_or_empty()` reads on the cards/boards tiers in kanban-tui's handlers/app onto explicit `LoadState` handling.

- Acting handlers (`create_card`, `handle_move_card`, `move_selected_cards`, `toggle_selected_cards_completion`, `start_delete_animation`, `handle_manage_children_from_list`, `CardListAction::MoveColumn`, `handle_manage_parents`, `handle_manage_children`, `toggle_completion_for_card_ids`) decline with a "not loaded yet" banner and leave state unchanged when their cards tier is not loaded.
- Per-frame paths (`handle_animation_tick`'s archive branch, `check_ended_sprints`'s board-name lookup) and read-only per-keystroke search filters (the relationship popup) skip silently, matching the established per-frame decline shape.
- `cursor_archive_anchor` and the carry-over-sprint label lookup keep their existing no-banner, caller-declines/degrades contract, just made explicit.
- `test_helpers.rs`'s shared fixture seed now panics loudly via `.expect()` if boards were never loaded before it runs, instead of silently producing `active_board_id: None`.

`git grep -n 'loaded_or_empty' -- crates/kanban-tui/src` still returns hits, but only inside test fixtures in files outside this card's scope (`board_handlers.rs`, `column_handlers.rs`, `navigation_handlers.rs`, `sprint_handlers.rs`, `query.rs`), none of which were in the card's `files_to_touch` list. All production sites in the six files this card owns are migrated; see the notes below for the drift from the card's literal repo-wide grep claim.

## Notes for review

- The card's step 2 undercounted the per-frame skip tests as singular; there are two per-frame sites (`animation_tick.rs`, `sprint_management.rs`), each got its own test, as flagged in the handoff's corrections.
- One planned red test (`CardListAction::Complete` decline in `detail_view_handlers.rs`) was dropped: the `'c'` key that would dispatch `CardListAction::Complete` is shadowed by an earlier `KeyCode::Char('c')` arm in the same `handle_sprint_detail_key` match that always routes to `toggle_completion_for_card_ids` (multi-select) or `handle_complete_sprint_key` (single-select) instead, so the `CardListAction::Complete` match arm is unreachable dead code pre-existing this change. The production fix at that site is still correct in isolation (byte-equivalent Loaded branch, explicit non-Loaded branch), just not black-box testable via any key path today. Worth a follow-up card to either wire a reachable key to it or delete the arm.
- Several migrated sites (the carry-over-sprint label fallback, the relationship-popup search filters, `cursor_archive_anchor`, `handle_animation_tick`'s archive branch, `check_ended_sprints`'s board lookup) are behavior-preserving refactors: `loaded_or_empty()` on a `NotLoaded` tier already returned an empty slice, which is functionally identical to the new explicit skip branch. Confirmed via mutation-check (reverting each production fix and re-running its test): the acting-handler/banner sites all failed as expected when reverted; these skip-shape sites did not, since old and new code produce the same observable result. This matches the card's own SKIP-vs-DECLINE classification.
- Mutation-check was run per production site (revert fix, confirm test fails or is behavior-neutral, restore) rather than committed as a mutant; not included in the diff.
