### PR TITLE
KAN-1475 feat(mcp): route mcp mutations through McpContext::mutate/mutate_unit

### DIFF
--- a/.changeset/kan-1475-mcp-mutation-seam.md
+++ b/.changeset/kan-1475-mcp-mutation-seam.md
@@ -2,4 +2,4 @@
 bump: minor
 ---
 
-mcp: every mutating tool handler now goes through a new `McpContext::mutate` / `mutate_unit` seam that absorbs the `Invalidation` a service `*_impl` call produces and hands the tool only its result, replacing the `mutating_op!` macro (deleted). `McpContext::create_board_from_spec` now returns `KanbanResult<(Board, Invalidation)>` instead of `KanbanResult<Board>`, mirroring the KAN-1499 precedent on the other `create_*_from_spec` forwarders.
+mcp: every mutating tool handler now goes through a new `McpContext::mutate` / `mutate_unit` seam that hands the tool the `(value, Invalidation)` pair a service `*_impl` call produces, replacing the `mutating_op!` macro (deleted). `McpContext::create_board_from_spec`, `create_column_from_spec`, `create_card_from_spec`, and `create_sprint_from_spec` are removed; tool handlers now call the equivalent `KanbanContext` method directly through `mutate`.

--- a/.changeset/kan-1475-mcp-mutation-seam.md
+++ b/.changeset/kan-1475-mcp-mutation-seam.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+mcp: every mutating tool handler now goes through a new `McpContext::mutate` / `mutate_unit` seam that absorbs the `Invalidation` a service `*_impl` call produces and hands the tool only its result, replacing the `mutating_op!` macro (deleted). `McpContext::create_board_from_spec` now returns `KanbanResult<(Board, Invalidation)>` instead of `KanbanResult<Board>`, mirroring the KAN-1499 precedent on the other `create_*_from_spec` forwarders.

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -525,6 +525,74 @@ mod tests {
         StoreManager::new(registry, backends)
     }
 
+    async fn test_context() -> (McpContext, tempfile::TempDir) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.json");
+        let store_manager = test_store_manager();
+        let ctx = McpContext::new(
+            &store_manager,
+            &path.to_string_lossy(),
+            AppConfig::default(),
+        )
+        .await
+        .unwrap();
+        (ctx, dir)
+    }
+
+    #[tokio::test]
+    async fn test_mutate_returns_the_operations_value() {
+        let (mut ctx, _dir) = test_context().await;
+
+        let value = ctx
+            .mutate(|_c| Ok::<_, kanban_domain::KanbanError>((42, Invalidation::All)))
+            .unwrap();
+
+        assert_eq!(value, 42);
+    }
+
+    #[tokio::test]
+    async fn test_mutate_propagates_the_error_and_invalidates_nothing() {
+        let (mut ctx, _dir) = test_context().await;
+        let missing_id = Uuid::new_v4();
+
+        let result = ctx.mutate(|c| c.update_board_impl(missing_id, BoardUpdate::default()));
+
+        assert!(result.is_err());
+        assert!(ctx.list_boards().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mutate_runs_the_operation_exactly_once() {
+        let (mut ctx, _dir) = test_context().await;
+        let calls = std::cell::Cell::new(0);
+
+        let value = ctx
+            .mutate(|_c| {
+                calls.set(calls.get() + 1);
+                Ok::<_, kanban_domain::KanbanError>((calls.get(), Invalidation::All))
+            })
+            .unwrap();
+
+        assert_eq!(value, 1);
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mutate_unit_returns_unit_and_propagates_the_invalidation_free_error() {
+        let (mut ctx, _dir) = test_context().await;
+        let board = ctx
+            .create_board("Kanban".into(), Some("KAN".into()))
+            .unwrap();
+
+        let ok = ctx.mutate_unit(|c| c.delete_board_impl(board.id));
+        assert!(ok.is_ok());
+        assert!(ctx.list_boards().unwrap().is_empty());
+
+        let missing_id = Uuid::new_v4();
+        let err = ctx.mutate_unit(|c| c.delete_board_impl(missing_id));
+        assert!(err.is_err());
+    }
+
     #[tokio::test]
     async fn test_model_for_builds_a_model_and_does_not_retain_it() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -104,8 +104,8 @@ impl McpContext {
         &mut self,
         id: Option<Uuid>,
         spec: kanban_domain::NewBoard,
-    ) -> KanbanResult<Board> {
-        Ok(self.inner.create_board_from_spec(id, spec)?.0)
+    ) -> KanbanResult<(Board, Invalidation)> {
+        self.inner.create_board_from_spec(id, spec)
     }
 
     /// Create a column from a full spec + optional client id, funneling through
@@ -214,6 +214,30 @@ impl McpContext {
     ) {
         self.inner
             .sync_invalidated(inv, plan, model, &mut kanban_domain::NoProjections);
+    }
+
+    /// Run a mutation that reports its result alongside the `Invalidation` it
+    /// produced, and hand the caller only the result. Every tool handler goes
+    /// through this instead of matching the `(value, Invalidation)` pair
+    /// itself, so the two never drift apart at a call site.
+    pub(crate) fn mutate<T>(
+        &mut self,
+        op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
+    ) -> KanbanResult<T> {
+        let (value, inv) = op(&mut self.inner)?;
+        let _ = inv;
+        Ok(value)
+    }
+
+    /// Same as [`Self::mutate`] for operations that report only the
+    /// `Invalidation`, with no separate result value.
+    pub(crate) fn mutate_unit(
+        &mut self,
+        op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
+    ) -> KanbanResult<()> {
+        let inv = op(&mut self.inner)?;
+        let _ = inv;
+        Ok(())
     }
 }
 

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -97,60 +97,6 @@ impl McpContext {
         Ok((field, order))
     }
 
-    /// Create a board from a full spec + optional client id, funneling through
-    /// the Board factory (`create_board_from_spec`). The MCP create tool calls
-    /// this after splitting the shared `CreateBoardRequest` via `into_new_board`.
-    pub fn create_board_from_spec(
-        &mut self,
-        id: Option<Uuid>,
-        spec: kanban_domain::NewBoard,
-    ) -> KanbanResult<(Board, Invalidation)> {
-        self.inner.create_board_from_spec(id, spec)
-    }
-
-    /// Create a column from a full spec + optional client id, funneling through
-    /// the Column factory (`create_column_from_spec`). The MCP create tool calls
-    /// this after resolving the `board` name→id and splitting the shared
-    /// `CreateColumnRequest` via `into_new_column`.
-    pub fn create_column_from_spec(
-        &mut self,
-        id: Option<Uuid>,
-        spec: kanban_domain::NewColumn,
-    ) -> KanbanResult<kanban_domain::Column> {
-        Ok(self.inner.create_column_from_spec(id, spec)?.0)
-    }
-
-    /// Create a card from a full spec + optional client id, funneling through the
-    /// Card factory (`create_card_from_spec`). The MCP create tool calls this
-    /// after resolving the `board`/`column`/`sprint` name-or-id references and
-    /// splitting the shared `CreateCardRequest` via `into_new_card(column_id)`.
-    pub fn create_card_from_spec(
-        &mut self,
-        id: Option<Uuid>,
-        spec: kanban_domain::NewCard,
-    ) -> KanbanResult<Card> {
-        Ok(self.inner.create_card_from_spec(id, spec)?.0)
-    }
-
-    /// Create a sprint from its create content + optional client id, funneling
-    /// through the Sprint factory (`create_sprint_from_spec`). The MCP create
-    /// tool calls this after resolving the `board` name→id and splitting the
-    /// shared `CreateSprintRequest` into its `id`/`name`/`prefix`. MCP passes
-    /// `auto_consume_name = false` (no consume of pooled names; that is a
-    /// TUI-only behaviour).
-    pub fn create_sprint_from_spec(
-        &mut self,
-        board_id: Uuid,
-        id: Option<Uuid>,
-        name: Option<String>,
-        prefix: Option<String>,
-    ) -> KanbanResult<Sprint> {
-        Ok(self
-            .inner
-            .create_sprint_from_spec(board_id, id, name, prefix, false)?
-            .0)
-    }
-
     pub fn clear_history(&mut self) -> KanbanResult<()> {
         self.inner.clear_history()
     }
@@ -216,17 +162,16 @@ impl McpContext {
             .sync_invalidated(inv, plan, model, &mut kanban_domain::NoProjections);
     }
 
-    /// Run a mutation that reports its result alongside the `Invalidation` it
-    /// produced, and hand the caller only the result. Every tool handler goes
-    /// through this instead of matching the `(value, Invalidation)` pair
-    /// itself, so the two never drift apart at a call site.
+    /// The crate's only door onto a mutating `KanbanContext` method. Hands the
+    /// `(value, Invalidation)` pair straight back to the caller, who must state
+    /// what happens to the `Invalidation`: pass it to `sync_invalidated` against
+    /// a call-scoped `Model` when the tool re-reads, or bind it `_` when the
+    /// response is built entirely from `value`.
     pub(crate) fn mutate<T>(
         &mut self,
         op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
-    ) -> KanbanResult<T> {
-        let (value, inv) = op(&mut self.inner)?;
-        let _ = inv;
-        Ok(value)
+    ) -> KanbanResult<(T, Invalidation)> {
+        op(&mut self.inner)
     }
 
     /// Same as [`Self::mutate`] for operations that report only the
@@ -234,10 +179,8 @@ impl McpContext {
     pub(crate) fn mutate_unit(
         &mut self,
         op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
-    ) -> KanbanResult<()> {
-        let inv = op(&mut self.inner)?;
-        let _ = inv;
-        Ok(())
+    ) -> KanbanResult<Invalidation> {
+        op(&mut self.inner)
     }
 }
 
@@ -564,25 +507,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mutate_returns_the_operations_value() {
+    async fn test_mutate_returns_the_operations_value_and_invalidation() {
         let (mut ctx, _dir) = test_context().await;
 
-        let value = ctx
+        let (value, inv) = ctx
             .mutate(|_c| Ok::<_, kanban_domain::KanbanError>((42, Invalidation::All)))
             .unwrap();
 
         assert_eq!(value, 42);
+        assert_eq!(inv, Invalidation::All);
     }
 
     #[tokio::test]
-    async fn test_mutate_propagates_the_error_and_invalidates_nothing() {
+    async fn test_mutate_propagates_the_error_and_leaves_the_board_unchanged() {
         let (mut ctx, _dir) = test_context().await;
+        let board = ctx
+            .create_board("Kanban".into(), Some("KAN".into()))
+            .unwrap();
         let missing_id = Uuid::new_v4();
 
         let result = ctx.mutate(|c| c.update_board_impl(missing_id, BoardUpdate::default()));
 
         assert!(result.is_err());
-        assert!(ctx.list_boards().unwrap().is_empty());
+        let boards = ctx.list_boards().unwrap();
+        assert_eq!(boards.len(), 1);
+        assert_eq!(boards[0], board);
     }
 
     #[tokio::test]
@@ -590,7 +539,7 @@ mod tests {
         let (mut ctx, _dir) = test_context().await;
         let calls = std::cell::Cell::new(0);
 
-        let value = ctx
+        let (value, _inv) = ctx
             .mutate(|_c| {
                 calls.set(calls.get() + 1);
                 Ok::<_, kanban_domain::KanbanError>((calls.get(), Invalidation::All))
@@ -602,14 +551,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mutate_unit_returns_unit_and_propagates_the_invalidation_free_error() {
+    async fn test_mutate_unit_returns_the_invalidation_and_propagates_the_error() {
         let (mut ctx, _dir) = test_context().await;
         let board = ctx
             .create_board("Kanban".into(), Some("KAN".into()))
             .unwrap();
 
-        let ok = ctx.mutate_unit(|c| c.delete_board_impl(board.id));
-        assert!(ok.is_ok());
+        let inv = ctx.mutate_unit(|c| c.delete_board_impl(board.id));
+        assert!(inv.is_ok());
         assert!(ctx.list_boards().unwrap().is_empty());
 
         let missing_id = Uuid::new_v4();

--- a/crates/kanban-mcp/src/helpers/macros.rs
+++ b/crates/kanban-mcp/src/helpers/macros.rs
@@ -68,32 +68,3 @@ where
     guard.save().await.map_err(kanban_err_to_mcp)?;
     Ok(result)
 }
-
-/// Lock the context, reload from disk, execute a mutating operation, then save.
-///
-/// # Reload semantics and undo limitations
-///
-/// Every invocation begins with `guard.reload()`, which fully discards the
-/// in-memory cache and resets undo history to the current on-disk state.
-/// Consequently, within-session undo history from earlier API calls is always
-/// wiped before each mutation: `tool_undo` can only undo the operation
-/// recorded during the **current** tool call, not operations from prior calls.
-///
-/// **Future work**: a `reload_if_changed()` method that compares file metadata
-/// (mtime / instance_id) and skips the full reload when no external write has
-/// occurred would allow undo history to persist across calls in the same
-/// session. Track as `KanbanBackend::reload_if_changed()`.
-macro_rules! mutating_op {
-    ($ctx:expr, $method:ident $(, $arg:expr)*) => {{
-        async {
-            let mut guard = $ctx.lock().await;
-            guard.reload().await.map_err($crate::helpers::kanban_err_to_mcp)?;
-            let result = guard.$method($($arg),*).map_err($crate::helpers::kanban_err_to_mcp)?;
-            guard.save().await.map_err($crate::helpers::kanban_err_to_mcp)?;
-            Ok::<_, rmcp::model::ErrorData>(result)
-        }
-        .await
-    }};
-}
-
-pub(crate) use mutating_op;

--- a/crates/kanban-mcp/src/helpers/mod.rs
+++ b/crates/kanban-mcp/src/helpers/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod serialization;
 pub(crate) use error_mapping::{
     core_err_to_mcp, kanban_err_to_mcp, mcp_enrich_add_error, mcp_enrich_remove_error,
 };
-pub(crate) use macros::{locked_read, locked_write, mutating_op};
+pub(crate) use macros::{locked_read, locked_write};
 pub(crate) use parsers::{
     parse_archived_selector, parse_board_sort_field, parse_datetime, parse_priority,
     parse_sort_field, parse_sort_order, parse_status,

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -74,21 +74,24 @@ impl KanbanMcpServer {
         let (id, spec) = req.content.into_new_board();
         let seed_columns = req.with_default_columns.unwrap_or(false);
         let board = locked_write(&self.ctx, |ctx| {
-            let (board, _) = ctx
-                .create_board_from_spec(id, spec)
+            let (board, _inv) = ctx
+                .mutate(|c| c.create_board_from_spec(id, spec))
                 .map_err(kanban_err_to_mcp)?;
             if seed_columns {
                 for (name, default_status) in kanban_domain::DEFAULT_TEMPLATE_COLUMNS {
-                    ctx.create_column_from_spec(
-                        None,
-                        kanban_domain::NewColumn {
-                            board_id: board.id,
-                            name: name.to_string(),
-                            wip_limit: None,
-                            default_status,
-                        },
-                    )
-                    .map_err(kanban_err_to_mcp)?;
+                    let (_column, _inv) = ctx
+                        .mutate(|c| {
+                            c.create_column_from_spec(
+                                None,
+                                kanban_domain::NewColumn {
+                                    board_id: board.id,
+                                    name: name.to_string(),
+                                    wip_limit: None,
+                                    default_status,
+                                },
+                            )
+                        })
+                        .map_err(kanban_err_to_mcp)?;
                 }
             }
             Ok::<_, McpError>(board)
@@ -214,6 +217,7 @@ impl KanbanMcpServer {
                 ..Default::default()
             };
             ctx.mutate(|c| c.update_board_impl(id, updates))
+                .map(|(board, _inv)| board)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -256,7 +260,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_board(&model, &req.board)?;
-            ctx.mutate_unit(|c| c.delete_board_impl(id))
+            let _inv = ctx
+                .mutate_unit(|c| c.delete_board_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
@@ -273,7 +278,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_board(&model, &req.board)?;
-            ctx.mutate_unit(|c| c.archive_board_impl(id))
+            let _inv = ctx
+                .mutate_unit(|c| c.archive_board_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
@@ -291,7 +297,8 @@ impl KanbanMcpServer {
             // the live list, and scoping to archived-only guarantees a same-named
             // live board is never hit (KAN-894 data-loss guard).
             let id = resolve_archived_board(ctx, &req.board)?;
-            ctx.mutate_unit(|c| c.restore_board_impl(id))
+            let _inv = ctx
+                .mutate_unit(|c| c.restore_board_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             ctx.get_board(id).map_err(kanban_err_to_mcp)
         })
@@ -310,7 +317,8 @@ impl KanbanMcpServer {
         // `get_board` is unfiltered. Resolve from either view.
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let id = resolve_archived_board(ctx, &req.board)?;
-            ctx.mutate_unit(|c| c.delete_board_impl(id))
+            let _inv = ctx
+                .mutate_unit(|c| c.delete_board_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -74,7 +74,7 @@ impl KanbanMcpServer {
         let (id, spec) = req.content.into_new_board();
         let seed_columns = req.with_default_columns.unwrap_or(false);
         let board = locked_write(&self.ctx, |ctx| {
-            let board = ctx
+            let (board, _) = ctx
                 .create_board_from_spec(id, spec)
                 .map_err(kanban_err_to_mcp)?;
             if seed_columns {
@@ -213,7 +213,8 @@ impl KanbanMcpServer {
                 task_sort_order,
                 ..Default::default()
             };
-            ctx.update_board(id, updates).map_err(kanban_err_to_mcp)
+            ctx.mutate(|c| c.update_board_impl(id, updates))
+                .map_err(kanban_err_to_mcp)
         })
         .await?;
         to_call_tool_result(&BoardResponse::from(&board))
@@ -255,7 +256,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_board(&model, &req.board)?;
-            ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
+            ctx.mutate_unit(|c| c.delete_board_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
         .await?;
@@ -271,7 +273,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_board(&model, &req.board)?;
-            ctx.archive_board(id).map_err(kanban_err_to_mcp)?;
+            ctx.mutate_unit(|c| c.archive_board_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
         .await?;
@@ -288,7 +291,8 @@ impl KanbanMcpServer {
             // the live list, and scoping to archived-only guarantees a same-named
             // live board is never hit (KAN-894 data-loss guard).
             let id = resolve_archived_board(ctx, &req.board)?;
-            ctx.restore_board(id).map_err(kanban_err_to_mcp)?;
+            ctx.mutate_unit(|c| c.restore_board_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             ctx.get_board(id).map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -306,7 +310,8 @@ impl KanbanMcpServer {
         // `get_board` is unfiltered. Resolve from either view.
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let id = resolve_archived_board(ctx, &req.board)?;
-            ctx.delete_board(id).map_err(kanban_err_to_mcp)?;
+            ctx.mutate_unit(|c| c.delete_board_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -73,7 +73,7 @@ impl KanbanMcpServer {
             let board_id = card_board(ctx, card_id)?;
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let sprint_id = resolve_sprint_in_board(&model, &req.sprint, board_id)?;
-            ctx.assign_card_to_sprint(card_id, sprint_id)
+            ctx.mutate(|c| c.assign_card_to_sprint_impl(card_id, sprint_id))
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -87,7 +87,7 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let card = locked_write(&self.ctx, |ctx| {
             let card_id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
-            ctx.unassign_card_from_sprint(card_id)
+            ctx.mutate(|c| c.unassign_card_from_sprint_impl(card_id))
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -107,7 +107,8 @@ impl KanbanMcpServer {
         let count = locked_write(&self.ctx, |ctx| {
             let model = ctx.model_for(&scope);
             let ids = resolve_cards(&model, &req.cards)?;
-            ctx.archive_cards(ids).map_err(kanban_err_to_mcp)
+            ctx.mutate(|c| c.archive_cards_impl(ids))
+                .map_err(kanban_err_to_mcp)
         })
         .await?;
         to_call_tool_result_json(serde_json::json!({"archived_count": count}))
@@ -127,7 +128,8 @@ impl KanbanMcpServer {
             let board_id = ctx.require_same_board(&ids).map_err(kanban_err_to_mcp)?;
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let column_id = resolve_column_in_board(&model, &req.column, board_id)?;
-            ctx.move_cards(ids, column_id).map_err(kanban_err_to_mcp)
+            ctx.mutate(|c| c.move_cards_impl(ids, column_id))
+                .map_err(kanban_err_to_mcp)
         })
         .await?;
         to_call_tool_result_json(serde_json::json!({"moved_count": count}))
@@ -147,7 +149,7 @@ impl KanbanMcpServer {
             let board_id = ctx.require_same_board(&ids).map_err(kanban_err_to_mcp)?;
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let sprint_id = resolve_sprint_in_board(&model, &req.sprint, board_id)?;
-            ctx.assign_cards_to_sprint(ids, sprint_id)
+            ctx.mutate(|c| c.assign_cards_to_sprint_impl(ids, sprint_id))
                 .map_err(kanban_err_to_mcp)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -74,6 +74,7 @@ impl KanbanMcpServer {
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let sprint_id = resolve_sprint_in_board(&model, &req.sprint, board_id)?;
             ctx.mutate(|c| c.assign_card_to_sprint_impl(card_id, sprint_id))
+                .map(|(card, _inv)| card)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -88,6 +89,7 @@ impl KanbanMcpServer {
         let card = locked_write(&self.ctx, |ctx| {
             let card_id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             ctx.mutate(|c| c.unassign_card_from_sprint_impl(card_id))
+                .map(|(card, _inv)| card)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -108,6 +110,7 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let ids = resolve_cards(&model, &req.cards)?;
             ctx.mutate(|c| c.archive_cards_impl(ids))
+                .map(|(count, _inv)| count)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -129,6 +132,7 @@ impl KanbanMcpServer {
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let column_id = resolve_column_in_board(&model, &req.column, board_id)?;
             ctx.mutate(|c| c.move_cards_impl(ids, column_id))
+                .map(|(count, _inv)| count)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -150,6 +154,7 @@ impl KanbanMcpServer {
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let sprint_id = resolve_sprint_in_board(&model, &req.sprint, board_id)?;
             ctx.mutate(|c| c.assign_cards_to_sprint_impl(ids, sprint_id))
+                .map(|(count, _inv)| count)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -302,7 +302,8 @@ impl KanbanMcpServer {
         let card = locked_write(&self.ctx, |ctx| {
             let model = ctx.model_for(&scope);
             let id = resolve_card(&model, &req.card)?;
-            ctx.update_card(id, updates).map_err(kanban_err_to_mcp)
+            ctx.mutate(|c| c.update_card_impl(id, updates))
+                .map_err(kanban_err_to_mcp)
         })
         .await?;
         to_call_tool_result(&CardResponse::from(&card))
@@ -320,7 +321,7 @@ impl KanbanMcpServer {
             let board_id = card_board(ctx, id)?;
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let column_id = resolve_column_in_board(&model, &req.column, board_id)?;
-            ctx.move_card(id, column_id, req.position)
+            ctx.mutate(|c| c.move_card_impl(id, column_id, req.position))
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -336,7 +337,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_card(&model, &req.card)?;
-            ctx.archive_card(id).map_err(kanban_err_to_mcp)?;
+            ctx.mutate(|c| c.archive_card_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
         .await?;
@@ -360,7 +362,8 @@ impl KanbanMcpServer {
                 }
                 None => None,
             };
-            ctx.restore_card(id, column_id).map_err(kanban_err_to_mcp)
+            ctx.mutate(|c| c.restore_card_impl(id, column_id))
+                .map_err(kanban_err_to_mcp)
         })
         .await?;
         to_call_tool_result(&CardResponse::from(&card))
@@ -375,7 +378,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_card(&model, &req.card)?;
-            ctx.delete_card(id).map_err(kanban_err_to_mcp)?;
+            ctx.mutate_unit(|c| c.delete_card_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -154,7 +154,8 @@ impl KanbanMcpServer {
                 .content
                 .into_new_card(column_id)
                 .map_err(kanban_err_to_mcp)?;
-            ctx.create_card_from_spec(id, spec)
+            ctx.mutate(|c| c.create_card_from_spec(id, spec))
+                .map(|(card, _inv)| card)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -303,6 +304,7 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let id = resolve_card(&model, &req.card)?;
             ctx.mutate(|c| c.update_card_impl(id, updates))
+                .map(|(card, _inv)| card)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -322,6 +324,7 @@ impl KanbanMcpServer {
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let column_id = resolve_column_in_board(&model, &req.column, board_id)?;
             ctx.mutate(|c| c.move_card_impl(id, column_id, req.position))
+                .map(|(card, _inv)| card)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -337,7 +340,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_card(&model, &req.card)?;
-            ctx.mutate(|c| c.archive_card_impl(id))
+            let (_val, _inv) = ctx
+                .mutate(|c| c.archive_card_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
@@ -363,6 +367,7 @@ impl KanbanMcpServer {
                 None => None,
             };
             ctx.mutate(|c| c.restore_card_impl(id, column_id))
+                .map(|(card, _inv)| card)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -378,7 +383,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_card(&model, &req.card)?;
-            ctx.mutate_unit(|c| c.delete_card_impl(id))
+            let _inv = ctx
+                .mutate_unit(|c| c.delete_card_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -83,7 +83,8 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let child_id = resolve_card(&model, &req.child)?;
             let parent_id = resolve_card(&model, &req.parent)?;
-            ctx.mutate_unit(|c| c.attach_children_impl(parent_id, vec![child_id]))
+            let _inv = ctx
+                .mutate_unit(|c| c.attach_children_impl(parent_id, vec![child_id]))
                 .map_err(|e| mcp_enrich_add_error(e, &parent_raw, &child_raw))?;
             Ok((child_id, parent_id))
         })
@@ -106,7 +107,8 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let child_id = resolve_card(&model, &req.child)?;
             let parent_id = resolve_card(&model, &req.parent)?;
-            ctx.mutate_unit(|c| c.detach_children_impl(parent_id, vec![child_id]))
+            let _inv = ctx
+                .mutate_unit(|c| c.detach_children_impl(parent_id, vec![child_id]))
                 .map_err(|e| mcp_enrich_remove_error(e, &parent_raw, &child_raw))?;
             Ok((child_id, parent_id))
         })

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -9,7 +9,7 @@ use crate::requests::card::{
 use crate::scope::{Ref, ToolScope, ToolScoped};
 use crate::KanbanMcpServer;
 use kanban_core::{resolve_page_params, PaginatedList};
-use kanban_domain::{GraphOperations, Model};
+use kanban_domain::Model;
 use rmcp::{
     handler::server::wrapper::Parameters,
     model::{CallToolResult, ErrorData as McpError},
@@ -83,7 +83,7 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let child_id = resolve_card(&model, &req.child)?;
             let parent_id = resolve_card(&model, &req.parent)?;
-            ctx.attach_child(parent_id, child_id)
+            ctx.mutate_unit(|c| c.attach_children_impl(parent_id, vec![child_id]))
                 .map_err(|e| mcp_enrich_add_error(e, &parent_raw, &child_raw))?;
             Ok((child_id, parent_id))
         })
@@ -106,7 +106,7 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let child_id = resolve_card(&model, &req.child)?;
             let parent_id = resolve_card(&model, &req.parent)?;
-            ctx.detach_child(parent_id, child_id)
+            ctx.mutate_unit(|c| c.detach_children_impl(parent_id, vec![child_id]))
                 .map_err(|e| mcp_enrich_remove_error(e, &parent_raw, &child_raw))?;
             Ok((child_id, parent_id))
         })

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -162,7 +162,8 @@ impl KanbanMcpServer {
         let column = locked_write(&self.ctx, |ctx| {
             let model = ctx.model_for(&scope);
             let id = resolve_column_global(&model, &req.column)?;
-            ctx.update_column(id, updates).map_err(kanban_err_to_mcp)
+            ctx.mutate(|c| c.update_column_impl(id, updates))
+                .map_err(kanban_err_to_mcp)
         })
         .await?;
         to_call_tool_result(&ColumnResponse::from(&column))
@@ -177,7 +178,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_column_global(&model, &req.column)?;
-            ctx.delete_column(id).map_err(kanban_err_to_mcp)?;
+            ctx.mutate_unit(|c| c.delete_column_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
         .await?;
@@ -193,7 +195,7 @@ impl KanbanMcpServer {
         let column = locked_write(&self.ctx, |ctx| {
             let model = ctx.model_for(&scope);
             let id = resolve_column_global(&model, &req.column)?;
-            ctx.reorder_column(id, req.position)
+            ctx.mutate(|c| c.reorder_column_impl(id, req.position))
                 .map_err(kanban_err_to_mcp)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -91,7 +91,8 @@ impl KanbanMcpServer {
                 .content
                 .into_new_column(board_id)
                 .map_err(kanban_err_to_mcp)?;
-            ctx.create_column_from_spec(id, spec)
+            ctx.mutate(|c| c.create_column_from_spec(id, spec))
+                .map(|(column, _inv)| column)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -163,6 +164,7 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let id = resolve_column_global(&model, &req.column)?;
             ctx.mutate(|c| c.update_column_impl(id, updates))
+                .map(|(column, _inv)| column)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -178,7 +180,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_column_global(&model, &req.column)?;
-            ctx.mutate_unit(|c| c.delete_column_impl(id))
+            let _inv = ctx
+                .mutate_unit(|c| c.delete_column_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
@@ -196,6 +199,7 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let id = resolve_column_global(&model, &req.column)?;
             ctx.mutate(|c| c.reorder_column_impl(id, req.position))
+                .map(|(column, _inv)| column)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -214,7 +214,9 @@ impl KanbanMcpServer {
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            let sprint = ctx.update_sprint(id, updates).map_err(kanban_err_to_mcp)?;
+            let sprint = ctx
+                .mutate(|c| c.update_sprint_impl(id, updates))
+                .map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
         })
         .await?;
@@ -231,7 +233,7 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
             let sprint = ctx
-                .activate_sprint(id, req.duration_days)
+                .mutate(|c| c.activate_sprint_impl(id, req.duration_days))
                 .map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
         })
@@ -248,7 +250,9 @@ impl KanbanMcpServer {
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            let sprint = ctx.complete_sprint(id).map_err(kanban_err_to_mcp)?;
+            let sprint = ctx
+                .mutate(|c| c.complete_sprint_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
         })
         .await?;
@@ -264,7 +268,9 @@ impl KanbanMcpServer {
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            let sprint = ctx.cancel_sprint(id).map_err(kanban_err_to_mcp)?;
+            let sprint = ctx
+                .mutate(|c| c.cancel_sprint_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
         })
         .await?;
@@ -280,7 +286,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            ctx.delete_sprint(id).map_err(kanban_err_to_mcp)?;
+            ctx.mutate_unit(|c| c.delete_sprint_impl(id))
+                .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
         .await?;
@@ -312,7 +319,7 @@ impl KanbanMcpServer {
             .for_board(from_sprint.board_id);
             ctx.sync_into(&to_scope, &mut model);
             let to_id = resolve_sprint_in_board(&model, &req.to_sprint, from_sprint.board_id)?;
-            ctx.carry_over_sprint_cards(from_id, to_id)
+            ctx.mutate(|c| c.carry_over_sprint_cards_impl(from_id, to_id))
                 .map_err(kanban_err_to_mcp)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -117,8 +117,16 @@ impl KanbanMcpServer {
             let model = ctx.model_for(&scope);
             let board_id = resolve_board(&model, &req.board)?;
             let content = req.content;
-            let sprint = ctx
-                .create_sprint_from_spec(board_id, content.id, content.name, content.prefix)
+            let (sprint, _inv) = ctx
+                .mutate(|c| {
+                    c.create_sprint_from_spec(
+                        board_id,
+                        content.id,
+                        content.name,
+                        content.prefix,
+                        false,
+                    )
+                })
                 .map_err(kanban_err_to_mcp)?;
             let name = resolve_sprint_name(ctx, &sprint).map_err(kanban_err_to_mcp)?;
             Ok(SprintResponse::new(&sprint, name))
@@ -214,7 +222,7 @@ impl KanbanMcpServer {
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            let sprint = ctx
+            let (sprint, _inv) = ctx
                 .mutate(|c| c.update_sprint_impl(id, updates))
                 .map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
@@ -232,7 +240,7 @@ impl KanbanMcpServer {
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            let sprint = ctx
+            let (sprint, _inv) = ctx
                 .mutate(|c| c.activate_sprint_impl(id, req.duration_days))
                 .map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
@@ -250,7 +258,7 @@ impl KanbanMcpServer {
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            let sprint = ctx
+            let (sprint, _inv) = ctx
                 .mutate(|c| c.complete_sprint_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
@@ -268,7 +276,7 @@ impl KanbanMcpServer {
         let response = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            let sprint = ctx
+            let (sprint, _inv) = ctx
                 .mutate(|c| c.cancel_sprint_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             project_sprint(ctx, sprint)
@@ -286,7 +294,8 @@ impl KanbanMcpServer {
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
             let id = resolve_sprint_global(&model, &req.sprint)?;
-            ctx.mutate_unit(|c| c.delete_sprint_impl(id))
+            let _inv = ctx
+                .mutate_unit(|c| c.delete_sprint_impl(id))
                 .map_err(kanban_err_to_mcp)?;
             Ok(id)
         })
@@ -320,6 +329,7 @@ impl KanbanMcpServer {
             ctx.sync_into(&to_scope, &mut model);
             let to_id = resolve_sprint_in_board(&model, &req.to_sprint, from_sprint.board_id)?;
             ctx.mutate(|c| c.carry_over_sprint_cards_impl(from_id, to_id))
+                .map(|(count, _inv)| count)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/transfer.rs
+++ b/crates/kanban-mcp/src/tools/transfer.rs
@@ -1,5 +1,5 @@
 use crate::helpers::model_read::resolve_board;
-use crate::helpers::{kanban_err_to_mcp, locked_read, mutating_op, to_call_tool_result};
+use crate::helpers::{kanban_err_to_mcp, locked_read, locked_write, to_call_tool_result};
 use crate::requests::transfer::{ExportBoardRequest, ImportBoardRequest};
 use crate::scope::{Ref, ToolScope, ToolScoped};
 use crate::KanbanMcpServer;
@@ -46,7 +46,11 @@ impl KanbanMcpServer {
         Parameters(req): Parameters<ImportBoardRequest>,
     ) -> Result<CallToolResult, McpError> {
         let data = req.data;
-        let board = mutating_op!(self.ctx, import_board, &data)?;
+        let board = locked_write(&self.ctx, |ctx| {
+            ctx.mutate(|c| c.import_board_impl(&data))
+                .map_err(kanban_err_to_mcp)
+        })
+        .await?;
         to_call_tool_result(&BoardResponse::from(&board))
     }
 

--- a/crates/kanban-mcp/src/tools/transfer.rs
+++ b/crates/kanban-mcp/src/tools/transfer.rs
@@ -48,6 +48,7 @@ impl KanbanMcpServer {
         let data = req.data;
         let board = locked_write(&self.ctx, |ctx| {
             ctx.mutate(|c| c.import_board_impl(&data))
+                .map(|(board, _inv)| board)
                 .map_err(kanban_err_to_mcp)
         })
         .await?;

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -805,8 +805,9 @@ use kanban_mcp::{
     ArchiveBoardRequest, AssignCardToSprintRequest, CarryOverSprintCardsRequest, CreateBoardParams,
     CreateBoardRequest, CreateCardParams, CreateColumnParams, CreateSprintParams,
     DeleteArchivedBoardRequest, GetBoardRequest, GetCardRequest, GetColumnRequest,
-    GetSprintRequest, KanbanMcpServer, ListBoardsRequest, ListColumnsRequest, ListSprintsRequest,
-    MoveCardRequest, MoveCardsRequest, RestoreBoardRequest, UpdateColumnRequest,
+    GetSprintRequest, ImportBoardRequest, KanbanMcpServer, ListBoardsRequest, ListColumnsRequest,
+    ListSprintsRequest, MoveCardRequest, MoveCardsRequest, RestoreBoardRequest,
+    UpdateColumnRequest,
 };
 use rmcp::handler::server::wrapper::Parameters;
 use serde_json::Value;
@@ -3484,5 +3485,55 @@ async fn test_update_card_status_done_lands_in_configured_column_via_mcp() {
         text_payload(&result)["status"],
         "done",
         "moving into the configured completion column must not reset the status"
+    );
+}
+
+#[tokio::test]
+async fn test_import_board_tool_still_reloads_before_and_saves_after() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.json");
+    let path_str = path.to_string_lossy().to_string();
+    let store_manager = default_store_manager();
+    let server = KanbanMcpServer::new(&store_manager, &path_str, AppConfig::default())
+        .await
+        .unwrap();
+
+    server
+        .tool_create_board(Parameters(board_req("A", None)))
+        .await
+        .unwrap();
+
+    let mut writer = open_context(&path_str, AppConfig::default()).await.unwrap();
+    writer.create_board("B".into(), None).unwrap();
+    writer.save().await.unwrap();
+
+    let other_dir = TempDir::new().unwrap();
+    let other_path = other_dir.path().join("other.json");
+    let mut other = open_context(&other_path.to_string_lossy(), AppConfig::default())
+        .await
+        .unwrap();
+    let board_c = other.create_board("C".into(), None).unwrap();
+    let import_data = other.export_board(Some(board_c.id)).unwrap();
+
+    server
+        .tool_import_board(Parameters(ImportBoardRequest { data: import_data }))
+        .await
+        .unwrap();
+
+    let fresh = open_context(&path_str, AppConfig::default()).await.unwrap();
+    let names: Vec<String> = fresh
+        .list_boards()
+        .unwrap()
+        .into_iter()
+        .map(|b| b.name)
+        .collect();
+    assert!(names.contains(&"A".to_string()));
+    assert!(
+        names.contains(&"B".to_string()),
+        "tool_import_board must reload from disk before importing, or an externally written board is lost"
+    );
+    assert!(
+        names.contains(&"C".to_string()),
+        "tool_import_board must save after importing, or the imported board never reaches disk"
     );
 }


### PR DESCRIPTION
## Summary

- Added `pub(crate) McpContext::mutate` / `mutate_unit`, the crate's only door onto a mutating `KanbanContext` method. Both now return the `(value, Invalidation)` pair (or bare `Invalidation` for `mutate_unit`) straight back to the caller instead of dropping it with a `let _ = inv;`. `McpContext` retains no `Model` between calls, so a body that silently swallowed the `Invalidation` could never apply it later; every call site now states explicitly what happens to it.
- Rewrote every mutation call site across `board.rs`, `card_crud.rs`, `card_batch.rs`, `column.rs`, `sprint.rs`, `card_relations.rs`, and `transfer.rs` to go through the seam, calling the corresponding `*_impl` method on `KanbanContext` directly. This includes `tool_create_board` and its default-columns seeding loop, and the `tool_create_column` / `tool_create_card` / `tool_create_sprint` handlers, which previously called `McpContext` forwarders that absorbed the `Invalidation` inside the forwarder body.
- Deleted `McpContext::create_board_from_spec`, `create_column_from_spec`, `create_card_from_spec`, and `create_sprint_from_spec` now that their only callers go through `mutate` directly against `KanbanContext`'s own methods of the same name.
- Deleted the now-redundant `mutating_op!` macro and its re-export from `helpers/macros.rs` / `helpers/mod.rs`.
- Updated the four `McpContext::mutate` / `mutate_unit` unit tests for the new return shape, plus the existing integration test proving `tool_import_board` still reloads before and saves after the rewrite.

## Fixes from the previous review round

- `tool_create_board` was calling the `create_board_from_spec` forwarder directly (not through `mutate`) and discarding its `Invalidation` with a bare `_`; the dot-form census was non-empty at that site. It now goes through `ctx.mutate`, and the forwarder is gone.
- `mutate` / `mutate_unit` previously discarded the `Invalidation` inside the seam itself with `let _ = inv;`. Since `McpContext` holds no `Model` to apply it against, no future one-line edit could ever make that plan work; the seam now hands the pair back so each call site decides.
- `create_column_from_spec`, `create_card_from_spec`, and `create_sprint_from_spec` still absorbed their `Invalidation` inside `McpContext` forwarders. All three are deleted; their tool sites call the equivalent `KanbanContext` method directly through `mutate`.

## Notes on scope

- `card_relations.rs`'s two graph call sites use `mutate_unit(|c| c.attach_children_impl(parent, vec![child]))` / `detach_children_impl`, since those `*_impl` methods already return a bare `Invalidation`.
- `McpError` is `rmcp::model::ErrorData` (re-exported as `McpError` throughout `tools/`).
- Bump: `minor`. `mutate` / `mutate_unit` are `pub(crate)`, but removing the four `pub` `create_*_from_spec` forwarders on `McpContext` is a breaking change to `kanban-mcp`'s public surface.
- `git grep -n 'mutating_op' -- crates/` returns nothing. The dot-form census (`.mutate(`/`.mutate_unit(`) across `crates/kanban-mcp/src/tools` is 32. `git grep -n 'Invalidation' -- crates/kanban-mcp/src/tools` returns nothing.

## Test plan

- `cargo test -p kanban-mcp --all-features`: all lib, integration, server-builder, and doc tests green.
- `cargo clippy --all-targets --all-features -p kanban-mcp -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Mutation-tested the central assertion: temporarily made `mutate` overwrite the real `Invalidation` with a hardcoded stand-in; `test_mutate_returns_the_operations_value_and_invalidation` failed as expected, then reverted.
