### PR TITLE
KAN-1476 refactor(server): route every mutation through one AppState seam that owns the Invalidation

### DIFF
--- a/.changeset/kan-1476-server-mutation-seam.md
+++ b/.changeset/kan-1476-server-mutation-seam.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+server: route every mutation site through a single `mutate`/`mutate_unit` seam in `state.rs` that owns the `Invalidation` a mutation produces, instead of calling `KanbanOperations` trait methods or raw inherent `*_impl` methods directly from the routes and handlers.

--- a/crates/kanban-server/src/handlers/boards.rs
+++ b/crates/kanban-server/src/handlers/boards.rs
@@ -18,8 +18,7 @@ pub fn create_board(
     req: CreateBoardRequest,
 ) -> Result<BoardResponse, ApiError> {
     let (id, spec) = req.into_new_board();
-    let (board, _inv) = ctx
-        .create_board_from_spec(id, spec)
+    let board = crate::state::mutate(ctx, |c| c.create_board_from_spec(id, spec))
         .map_err(|e| ApiError::from(&e))?;
     Ok(BoardResponse::from(&board))
 }
@@ -33,8 +32,7 @@ pub fn create_or_replace_board(
     req: ReplaceBoardRequest,
 ) -> Result<(BoardResponse, bool), ApiError> {
     let spec = req.into_new_board();
-    let (outcome, _inv) = ctx
-        .create_or_replace_board(id, spec)
+    let outcome = crate::state::mutate(ctx, |c| c.create_or_replace_board(id, spec))
         .map_err(|e| ApiError::from(&e))?;
     Ok((BoardResponse::from(&outcome.board), outcome.created))
 }

--- a/crates/kanban-server/src/handlers/cards.rs
+++ b/crates/kanban-server/src/handlers/cards.rs
@@ -29,8 +29,7 @@ pub fn create_card(
         .map_err(|e| ApiError::from(&e))?;
     let id = maybe_id.unwrap_or_else(Uuid::new_v4);
     require_card_in_column_if_present(ctx, id, column_id)?;
-    let (outcome, _invalidation) = ctx
-        .create_or_replace_card(id, spec)
+    let outcome = crate::state::mutate(ctx, |c| c.create_or_replace_card(id, spec))
         .map_err(|e| ApiError::from(&e))?;
     Ok((CardResponse::from(&outcome.card), outcome.created))
 }
@@ -54,8 +53,7 @@ pub fn create_or_replace_card(
     let (_body_id, spec) = req
         .into_new_card(column_id)
         .map_err(|e| ApiError::from(&e))?;
-    let (outcome, _invalidation) = ctx
-        .create_or_replace_card(id, spec)
+    let outcome = crate::state::mutate(ctx, |c| c.create_or_replace_card(id, spec))
         .map_err(|e| ApiError::from(&e))?;
     Ok((CardResponse::from(&outcome.card), outcome.created))
 }

--- a/crates/kanban-server/src/handlers/columns.rs
+++ b/crates/kanban-server/src/handlers/columns.rs
@@ -28,8 +28,7 @@ pub fn create_column(
         .map_err(|e| ApiError::from(&e))?;
     let id = maybe_id.unwrap_or_else(Uuid::new_v4);
     require_column_in_board_if_present(ctx, id, board_id)?;
-    let (outcome, _invalidation) = ctx
-        .create_or_replace_column(id, spec, None)
+    let outcome = crate::state::mutate(ctx, |c| c.create_or_replace_column(id, spec, None))
         .map_err(|e| ApiError::from(&e))?;
     Ok((ColumnResponse::from(&outcome.column), outcome.created))
 }
@@ -52,9 +51,10 @@ pub fn create_or_replace_column(
     let (spec, position) = req
         .into_new_column(board_id)
         .map_err(|e| ApiError::from(&e))?;
-    let (outcome, _invalidation) = ctx
-        .create_or_replace_column(id, spec, Some(position))
-        .map_err(|e| ApiError::from(&e))?;
+    let outcome = crate::state::mutate(ctx, |c| {
+        c.create_or_replace_column(id, spec, Some(position))
+    })
+    .map_err(|e| ApiError::from(&e))?;
     Ok((ColumnResponse::from(&outcome.column), outcome.created))
 }
 

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -31,9 +31,10 @@ pub fn create_sprint(
     // already exists is a conflict (`AlreadyExists` -> 409), not a silent
     // replace. `create_sprint_from_spec` mints the id when absent and rejects a
     // collision before any side effect.
-    let (sprint, _invalidation) = ctx
-        .create_sprint_from_spec(board_id, req.id, req.name, req.prefix, false)
-        .map_err(|e| ApiError::from(&e))?;
+    let sprint = crate::state::mutate(ctx, |c| {
+        c.create_sprint_from_spec(board_id, req.id, req.name, req.prefix, false)
+    })
+    .map_err(|e| ApiError::from(&e))?;
     project(ctx, sprint, true)
 }
 
@@ -65,9 +66,10 @@ pub fn create_or_replace_sprint(
         prefix,
         card_prefix: _,
     } = req;
-    let (outcome, _invalidation) = ctx
-        .create_or_replace_sprint(board_id, id, name, prefix, false)
-        .map_err(|e| ApiError::from(&e))?;
+    let outcome = crate::state::mutate(ctx, |c| {
+        c.create_or_replace_sprint(board_id, id, name, prefix, false)
+    })
+    .map_err(|e| ApiError::from(&e))?;
     project(ctx, outcome.sprint, outcome.created)
 }
 

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -93,8 +93,7 @@ async fn patch_board(
 ) -> Result<Json<BoardResponse>, AppError> {
     let board = {
         let mut ctx = state.ctx.lock().await;
-        let board = ctx
-            .update_board(id, req.into())
+        let board = crate::state::mutate(&mut ctx, |c| c.update_board_impl(id, req.into()))
             .map_err(|e| AppError::from(&e))?;
         state
             .persist_and_broadcast(&ctx, EntityType::Board, id, ChangeKind::Updated)
@@ -111,7 +110,8 @@ async fn delete_board(
 ) -> Result<StatusCode, AppError> {
     {
         let mut ctx = state.ctx.lock().await;
-        ctx.delete_board(id).map_err(|e| AppError::from(&e))?;
+        crate::state::mutate_unit(&mut ctx, |c| c.delete_board_impl(id))
+            .map_err(|e| AppError::from(&e))?;
         state
             .persist_and_broadcast(&ctx, EntityType::Board, id, ChangeKind::Deleted)
             .await

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -106,11 +106,11 @@ fn do_update_card(
     id: Uuid,
     updates: CardUpdate,
 ) -> Result<Card, AppError> {
-    ctx.update_card(id, updates).map_err(|e| AppError::from(&e))
+    crate::state::mutate(ctx, |c| c.update_card_impl(id, updates)).map_err(|e| AppError::from(&e))
 }
 
 fn do_delete_card(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
-    ctx.delete_card(id).map_err(|e| AppError::from(&e))
+    crate::state::mutate_unit(ctx, |c| c.delete_card_impl(id)).map_err(|e| AppError::from(&e))
 }
 
 /// Fetch a card and 404 unless it belongs to `board_id` — the same

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -57,12 +57,11 @@ fn do_update_column(
     id: Uuid,
     updates: ColumnUpdate,
 ) -> Result<Column, AppError> {
-    ctx.update_column(id, updates)
-        .map_err(|e| AppError::from(&e))
+    crate::state::mutate(ctx, |c| c.update_column_impl(id, updates)).map_err(|e| AppError::from(&e))
 }
 
 fn do_delete_column(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
-    ctx.delete_column(id).map_err(|e| AppError::from(&e))
+    crate::state::mutate_unit(ctx, |c| c.delete_column_impl(id)).map_err(|e| AppError::from(&e))
 }
 
 /// Fetch a column and 404 unless it belongs to `board_id` — the same
@@ -172,8 +171,7 @@ async fn reorder_column_route(
     let col = {
         let mut ctx = state.ctx.lock().await;
         require_column_in_board(&ctx, board_id, id)?;
-        let col = ctx
-            .reorder_column(id, position)
+        let col = crate::state::mutate(&mut ctx, |c| c.reorder_column_impl(id, position))
             .map_err(|e| AppError::from(&e))?;
         state
             .persist_and_broadcast(&ctx, EntityType::Column, id, ChangeKind::Updated)

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -65,12 +65,11 @@ fn do_update_sprint(
     id: Uuid,
     updates: SprintUpdate,
 ) -> Result<Sprint, AppError> {
-    ctx.update_sprint(id, updates)
-        .map_err(|e| AppError::from(&e))
+    crate::state::mutate(ctx, |c| c.update_sprint_impl(id, updates)).map_err(|e| AppError::from(&e))
 }
 
 fn do_delete_sprint(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
-    ctx.delete_sprint(id).map_err(|e| AppError::from(&e))
+    crate::state::mutate_unit(ctx, |c| c.delete_sprint_impl(id)).map_err(|e| AppError::from(&e))
 }
 
 fn require_sprint_in_board(

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -1,9 +1,31 @@
 use kanban_core::ClientId;
+use kanban_domain::Invalidation;
 use kanban_service::api::{ChangeEventFrame, ChangeKind, EntityType};
 use kanban_service::{KanbanContext, KanbanResult};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use uuid::Uuid;
+
+/// Run a mutation against `ctx`, returning its value and discarding the
+/// `Invalidation` it produced.
+pub(crate) fn mutate<T>(
+    ctx: &mut KanbanContext,
+    op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
+) -> KanbanResult<T> {
+    let (value, invalidation) = op(ctx)?;
+    let _ = invalidation;
+    Ok(value)
+}
+
+/// Like [`mutate`], for operations that return only an `Invalidation`.
+pub(crate) fn mutate_unit(
+    ctx: &mut KanbanContext,
+    op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
+) -> KanbanResult<()> {
+    let invalidation = op(ctx)?;
+    let _ = invalidation;
+    Ok(())
+}
 
 /// Shared state for every axum handler.
 ///

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -81,3 +81,65 @@ impl AppState {
         Ok(())
     }
 }
+
+#[cfg(all(test, feature = "test-helpers"))]
+mod tests {
+    use super::*;
+    use kanban_backend_memory::InMemoryStore;
+    use kanban_service::{AppConfig, KanbanBackend, KanbanOperations};
+    use std::cell::Cell;
+
+    async fn seeded_ctx() -> (KanbanContext, Uuid) {
+        let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
+        let mut ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        let board = ctx.create_board("Board1".into(), None).unwrap();
+        (ctx, board.id)
+    }
+
+    #[tokio::test]
+    async fn test_mutate_returns_the_operations_value() {
+        let (mut ctx, board_id) = seeded_ctx().await;
+
+        let updated = mutate(&mut ctx, |c| {
+            c.update_board_impl(
+                board_id,
+                kanban_domain::BoardUpdate {
+                    name: Some("Renamed".into()),
+                    ..Default::default()
+                },
+            )
+        })
+        .unwrap();
+
+        assert_eq!(updated.name, "Renamed");
+    }
+
+    #[tokio::test]
+    async fn test_mutate_propagates_the_error_and_invalidates_nothing() {
+        let (mut ctx, _board_id) = seeded_ctx().await;
+        let absent_id = Uuid::new_v4();
+
+        let result = mutate(&mut ctx, |c| {
+            c.update_board_impl(absent_id, kanban_domain::BoardUpdate::default())
+        });
+
+        assert!(result.is_err());
+        assert_eq!(ctx.list_boards().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mutate_runs_the_operation_exactly_once() {
+        let (mut ctx, board_id) = seeded_ctx().await;
+        let calls = Cell::new(0u32);
+
+        mutate(&mut ctx, |c| {
+            calls.set(calls.get() + 1);
+            c.update_board_impl(board_id, kanban_domain::BoardUpdate::default())
+        })
+        .unwrap();
+
+        assert_eq!(calls.get(), 1);
+    }
+}

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -178,6 +178,29 @@ async fn test_patch_board_unknown_id_returns_404() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_patch_board_unknown_id_returns_404_and_broadcasts_nothing() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let random_id = Uuid::new_v4();
+    let mut events = state.event_tx.subscribe();
+
+    let response = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{random_id}"),
+        Some(&json!({"name": "Attempted Patch"})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), events.recv())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_delete_board_returns_204_and_removes_board() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));


### PR DESCRIPTION
## Summary

- Adds `pub(crate) fn mutate` / `mutate_unit` in `crates/kanban-server/src/state.rs`, the single place a mutation's `Invalidation` is handled. Both run the closure, discard the `Invalidation`, and propagate the closure's error (and side-effects) unchanged.
- Routes all 17 mutation call sites across `routes/{boards,cards,columns,sprints}.rs` and `handlers/{boards,cards,columns,sprints}.rs` through `mutate`/`mutate_unit` instead of calling `KanbanOperations` trait methods or the raw inherent `*_impl`/spec methods directly. This unblocks KAN-1448, whose mutation edge needs an `Invalidation` value that today nothing in `kanban-server` produces.
- Adds a regression test (`test_patch_board_unknown_id_returns_404_and_broadcasts_nothing`) proving a failed mutation still 404s and broadcasts no `ChangeEventFrame`.
- No public API surface changed; `mutate`/`mutate_unit` are `pub(crate)`.

## Test plan

- [x] `cargo test -p kanban-server --all-features` (unit tests in `state.rs` + full HTTP integration suite, including a SQLite-backed cascade-delete test that exercises the new `mutate_unit(delete_board_impl)` path)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (workspace)
- [x] `cargo fmt --all -- --check`
- [x] Corrected census (`ctx\.(update_column|delete_column|reorder_column|update_card|delete_card|update_sprint|delete_sprint|update_board|delete_board|create_or_replace_(board|card|column|sprint)|create_sprint_from_spec|create_board_from_spec)\(`) returns 0 hits: every direct-on-`ctx` mutation call site is now behind `mutate`/`mutate_unit`.
- [x] `git grep -c 'state::mutate('` + `git grep -c 'state::mutate_unit('` sum to 17, matching the 17 corrected call sites.
- [x] `persist_and_broadcast` census unchanged: 23 calls, 4/6/7/6 across the same 4 route files.
- [x] `watch.rs` untouched (`git diff origin/develop --stat -- crates/kanban-server/src/watch.rs` is empty).
