### PR TITLE
KAN-1509 fix(tui): populate the view scope on every mode and dialog transition

### DIFF
--- a/.changeset/kan-1509-populate-on-transition.md
+++ b/.changeset/kan-1509-populate-on-transition.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: fix stale-tier dialogs by populating the ViewScope on every mode and dialog transition

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -69,7 +69,7 @@ impl App {
                 .help_list
                 .update_item_count(context.bindings.len());
             self.ui_state.help_list.set_scroll_offset(0);
-            self.mode = AppMode::Help(Box::new(previous_mode));
+            self.set_mode(AppMode::Help(Box::new(previous_mode)));
             return false;
         }
 
@@ -651,11 +651,11 @@ impl App {
                     let context = provider.get_context();
 
                     if let Some(binding) = context.bindings.get(index) {
-                        if let AppMode::Help(previous_mode) = &self.mode {
-                            self.mode = (**previous_mode).clone();
-                        } else {
-                            self.mode = AppMode::Normal;
-                        }
+                        let restored = match &self.mode {
+                            AppMode::Help(previous_mode) => (**previous_mode).clone(),
+                            _ => AppMode::Normal,
+                        };
+                        self.set_mode(restored);
                         self.ui_state.help_list.reset();
 
                         should_restart =
@@ -665,11 +665,11 @@ impl App {
             }
             KeyCode::Esc | KeyCode::Char('?') => {
                 self.ui_state.help_pending_action = None;
-                if let AppMode::Help(previous_mode) = &self.mode {
-                    self.mode = (**previous_mode).clone();
-                } else {
-                    self.mode = AppMode::Normal;
-                }
+                let restored = match &self.mode {
+                    AppMode::Help(previous_mode) => (**previous_mode).clone(),
+                    _ => AppMode::Normal,
+                };
+                self.set_mode(restored);
                 self.ui_state.help_list.reset();
             }
             _ => {

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -207,17 +207,18 @@ impl App {
                                 }
 
                                 // Check if help menu pending action should execute
-                                if let Some((start_time, action)) = &self.ui_state.help_pending_action {
+                                if let Some((start_time, action)) = self.ui_state.help_pending_action {
                                     if start_time.elapsed().as_millis() >= 100 {
                                         self.needs_redraw = true;
-                                        if let AppMode::Help(previous_mode) = &self.mode {
-                                            self.mode = (**previous_mode).clone();
-                                        } else {
-                                            self.mode = AppMode::Normal;
-                                        }
+                                        let restored = match &self.mode {
+                                            AppMode::Help(previous_mode) => {
+                                                (**previous_mode).clone()
+                                            }
+                                            _ => AppMode::Normal,
+                                        };
+                                        self.set_mode(restored);
                                         self.ui_state.help_list.reset();
 
-                                        let action = *action;
                                         self.ui_state.help_pending_action = None;
                                         let should_restart =
                                             self.dispatch_help_action(action, &mut terminal, &events);

--- a/crates/kanban-tui/src/app/mode_stack.rs
+++ b/crates/kanban-tui/src/app/mode_stack.rs
@@ -37,13 +37,25 @@ impl App {
         self.quit();
     }
 
+    pub fn set_mode(&mut self, new_mode: AppMode) {
+        self.mode = new_mode;
+        self.populate_for_current_mode();
+    }
+
     pub fn push_mode(&mut self, new_mode: AppMode) {
         self.mode_stack.push(self.mode.clone());
         self.mode = new_mode;
+        self.populate_for_current_mode();
     }
 
     pub fn pop_mode(&mut self) {
         self.mode = self.mode_stack.pop().unwrap_or(AppMode::Normal);
+        self.populate_for_current_mode();
+    }
+
+    fn populate_for_current_mode(&mut self) {
+        let scope = self.view_scope();
+        self.populate(scope);
     }
 
     pub fn is_dialog_mode(&self) -> bool {

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -127,11 +127,25 @@ impl App {
             _ => {}
         }
 
-        match &self.mode {
+        let mut current = &self.mode;
+        while let AppMode::Help(inner) = current {
+            current = inner.as_ref();
+        }
+
+        match current {
             AppMode::Dialog(DialogMode::ManageParents | DialogMode::ManageChildren) => {
                 scope.graph = true;
             }
-            AppMode::Dialog(DialogMode::CarryOverSprint) => {
+            AppMode::Dialog(
+                DialogMode::CarryOverSprint
+                | DialogMode::AssignCardToSprint
+                | DialogMode::AssignMultipleCardsToSprint
+                | DialogMode::CreateCard
+                | DialogMode::CreateSprint
+                | DialogMode::FilterOptions
+                | DialogMode::SetSprintPrefix
+                | DialogMode::DeleteBoardConfirm,
+            ) => {
                 scope.board_sprints = true;
             }
             _ => {}

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -134,14 +134,15 @@ impl App {
     pub fn handle_delete_board_key(&mut self) {
         if self.focus.active == Focus::Boards {
             if let Some(board_id) = self.board_list.get_selected_board_id() {
+                self.open_dialog(DialogMode::DeleteBoardConfirm);
                 // Snapshot the counts once, here, rather than re-scanning the
                 // model on every frame the modal is open.
                 let Some(counts) = self.board_delete_counts(board_id) else {
+                    self.pop_mode();
                     self.set_error("Board contents are not loaded yet".to_string());
                     return;
                 };
                 self.dialog_input.board_delete_counts = Some(counts);
-                self.open_dialog(DialogMode::DeleteBoardConfirm);
             }
         }
     }
@@ -299,9 +300,10 @@ impl App {
     /// `handle_toggle_archived_cards_view`). Only meaningful when the Boards panel
     /// is the context; a no-op from unrelated modes.
     pub fn handle_toggle_archived_boards_view(&mut self) {
-        match self.mode {
+        let mode = self.mode.clone();
+        match mode {
             AppMode::Normal if self.focus.active == Focus::Boards => {
-                self.mode = AppMode::ArchivedBoardsView;
+                self.set_mode(AppMode::ArchivedBoardsView);
                 // Toggling the displayed set returns to the projects list; any
                 // board that was open is no longer active.
                 self.selection.active_board_id = None;
@@ -316,7 +318,7 @@ impl App {
                 self.needs_redraw = true;
             }
             AppMode::ArchivedBoardsView => {
-                self.mode = AppMode::Normal;
+                self.set_mode(AppMode::Normal);
                 self.selection.active_board_id = None;
                 self.prepare_frame();
                 self.needs_redraw = true;

--- a/crates/kanban-tui/tests/cold_start_reload_tests.rs
+++ b/crates/kanban-tui/tests/cold_start_reload_tests.rs
@@ -2,6 +2,8 @@ mod helpers;
 
 use helpers::{create_test_json_file, CountingBackend};
 use kanban_domain::{Column, Snapshot, Sprint};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::app::Focus;
 use kanban_tui::App;
 
 #[tokio::test]
@@ -83,4 +85,49 @@ async fn test_cold_start_after_a_sprint_log_migration_loads_the_migrated_state()
         migrated_log_present,
         "cold start must serve the migrated sprint log, not the stale pre-migration probe snapshot"
     );
+}
+
+#[tokio::test]
+async fn test_delete_board_key_after_cold_start_opens_delete_confirm() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("delete_after_cold_start.json");
+    let path_str = path.to_str().unwrap().to_string();
+
+    let store = kanban_persistence_json::JsonFileStore::new(&path_str);
+    let board = kanban_domain::Board::new("Board".to_string(), None::<String>);
+    let column = Column::new(board.id, "Todo".to_string(), 0);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+    let card = kanban_domain::Card::new(board.id, column.id, "Card".to_string(), 0);
+
+    let snapshot = Snapshot {
+        archived_boards: Vec::new(),
+        boards: vec![board.clone()],
+        columns: vec![column.clone()],
+        cards: vec![card.clone()],
+        archived_cards: vec![],
+        sprints: vec![sprint.clone()],
+        graph: Default::default(),
+        prefixes: Vec::new(),
+    };
+
+    use kanban_persistence::{PersistenceMetadata, PersistenceStore, StoreSnapshot};
+    let store_snapshot = StoreSnapshot {
+        data: serde_json::to_vec(&snapshot).unwrap(),
+        metadata: PersistenceMetadata::new(store.instance_id()),
+    };
+    store.save(store_snapshot).await.unwrap();
+
+    let (mut app, _rx) = App::new(Some(path_str)).await.unwrap();
+    app.load_initial_state().await;
+
+    assert!(
+        !app.model.board_sprints_state(board.id).is_loaded(),
+        "precondition: cold start must not have absorbed the sprints tier"
+    );
+
+    app.focus.active = Focus::Boards;
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.handle_delete_board_key();
+
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeleteBoardConfirm));
 }

--- a/crates/kanban-tui/tests/column_and_board_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/column_and_board_handlers_collapsing_accessor_tests.rs
@@ -4,7 +4,10 @@
 //! "board has zero columns/sprints" instead of declining. These tests pin
 //! the decline behaviour.
 
+mod helpers;
+
 use crossterm::event::KeyCode;
+use helpers::CountingBackend;
 use kanban_domain::{EntityIds, Invalidation, KanbanOperations};
 use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::app::{BoardFocus, Focus};
@@ -291,6 +294,8 @@ fn test_handle_delete_board_key_declines_when_board_delete_counts_is_not_loaded(
     app.board_list.inner_mut().set_selected_index(Some(0));
 
     invalidate_columns_tier(&mut app);
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_columns_by_board");
+    app.ctx.replace_backend(failing);
 
     app.handle_delete_board_key();
 

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -58,8 +58,16 @@ fn test_navigation_performs_no_store_reads() {
     app.reload_model();
     app.prepare_frame();
 
+    navigate(&mut app);
+
     let ops = wrap_backend_with_ops(&mut app);
 
+    navigate(&mut app);
+
+    assert_ops(&ops, &[]);
+}
+
+fn navigate(app: &mut App) {
     app.focus.active = Focus::Boards;
     app.handle_selection_activate();
     app.handle_navigation_down();
@@ -83,8 +91,6 @@ fn test_navigation_performs_no_store_reads() {
     app.handle_card_selection_toggle();
     app.handle_clear_card_selection();
     app.handle_select_all_cards_in_view();
-
-    assert_ops(&ops, &[]);
 }
 
 #[test]

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -124,6 +124,7 @@ impl DataStore for CountingBackend {
     }
     fn list_columns_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
         self.record("list_columns_by_board", vec![board_id]);
+        self.fault("list_columns_by_board")?;
         self.inner.list_columns_by_board(board_id)
     }
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {

--- a/crates/kanban-tui/tests/keybinding_store_io_tests.rs
+++ b/crates/kanban-tui/tests/keybinding_store_io_tests.rs
@@ -110,6 +110,17 @@ fn seeded_app() -> App {
     app.reload_model();
     app.prepare_frame();
     app.selection.active_board_id = Some(board.id);
+    // `reload_model` clears the per-column card tier without refilling it, so
+    // warm it here before the counting backend is installed per-action below.
+    app.populate(kanban_tui::app::ViewScope {
+        board_list: true,
+        board: Some(board.id),
+        board_columns: true,
+        board_cards: true,
+        board_sprints: true,
+        graph: true,
+        ..Default::default()
+    });
     app
 }
 

--- a/crates/kanban-tui/tests/load_state_render_tests.rs
+++ b/crates/kanban-tui/tests/load_state_render_tests.rs
@@ -220,7 +220,7 @@ fn test_a_not_loaded_sprint_tier_does_not_render_no_sprints_available() {
     use kanban_domain::CardFilters;
     use kanban_view::filters::FilterDialogState;
     let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
-    app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
+    app.mode = AppMode::Dialog(DialogMode::FilterOptions);
     app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::components::render_filter_options_popup(&app, frame);
@@ -234,7 +234,7 @@ fn test_a_loaded_but_empty_sprint_tier_still_renders_no_sprints_available() {
     use kanban_domain::CardFilters;
     use kanban_view::filters::FilterDialogState;
     let (mut app, _board) = app_with_board_and_sprint_state(LoadState::Loaded(vec![]));
-    app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
+    app.mode = AppMode::Dialog(DialogMode::FilterOptions);
     app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::components::render_filter_options_popup(&app, frame);
@@ -253,7 +253,7 @@ fn test_render_filter_sprints_section_always_draws_its_panel() {
         LoadState::Loaded(vec![]),
     ] {
         let (mut app, _board) = app_with_board_and_sprint_state(state);
-        app.push_mode(AppMode::Dialog(DialogMode::FilterOptions));
+        app.mode = AppMode::Dialog(DialogMode::FilterOptions);
         app.filter.dialog_state = Some(FilterDialogState::new(CardFilters::default()));
         let output = helpers::render_widget_to_string(120, 40, |frame| {
             kanban_tui::components::render_filter_options_popup(&app, frame);
@@ -269,7 +269,7 @@ fn test_render_filter_sprints_section_always_draws_its_panel() {
 fn test_sprint_detail_with_an_unloaded_sprint_renders_an_unavailable_panel() {
     let mut app = App::test_default();
     app.selection.active_sprint_id = Some(uuid::Uuid::new_v4());
-    app.push_mode(AppMode::SprintDetail);
+    app.mode = AppMode::SprintDetail;
     let output = helpers::render_widget_to_string(120, 30, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -281,7 +281,7 @@ fn test_sprint_detail_with_an_unloaded_sprint_renders_an_unavailable_panel() {
 fn test_sprint_detail_with_no_sprint_selected_still_draws_nothing() {
     let mut app = App::test_default();
     app.selection.active_sprint_id = None;
-    app.push_mode(AppMode::SprintDetail);
+    app.mode = AppMode::SprintDetail;
     let output = helpers::render_widget_to_string(120, 30, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -295,7 +295,7 @@ fn test_sprint_detail_with_no_sprint_selected_still_draws_nothing() {
 #[test]
 fn test_card_detail_with_an_unloaded_sprint_tier_does_not_render_no_sprint() {
     let (mut app, _board, _card) = app_with_card_and_sprint_state(LoadState::NotLoaded);
-    app.push_mode(AppMode::CardDetail);
+    app.mode = AppMode::CardDetail;
     let output = helpers::render_widget_to_string(120, 30, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -305,7 +305,7 @@ fn test_card_detail_with_an_unloaded_sprint_tier_does_not_render_no_sprint() {
 #[test]
 fn test_card_detail_with_a_loaded_sprint_tier_renders_metadata_normally() {
     let (mut app, _board, _card) = app_with_card_and_sprint_state(LoadState::Loaded(vec![]));
-    app.push_mode(AppMode::CardDetail);
+    app.mode = AppMode::CardDetail;
     let output = helpers::render_widget_to_string(120, 30, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -316,7 +316,7 @@ fn test_card_detail_with_a_loaded_sprint_tier_renders_metadata_normally() {
 #[test]
 fn test_board_detail_columns_section_distinguishes_not_loaded_from_empty() {
     let (mut app, _board) = app_with_board_and_column_state(LoadState::NotLoaded);
-    app.push_mode(AppMode::BoardDetail);
+    app.mode = AppMode::BoardDetail;
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -327,7 +327,7 @@ fn test_board_detail_columns_section_distinguishes_not_loaded_from_empty() {
 #[test]
 fn test_board_detail_columns_section_still_renders_no_columns_message_when_loaded_empty() {
     let (mut app, _board) = app_with_board_and_column_state(LoadState::Loaded(vec![]));
-    app.push_mode(AppMode::BoardDetail);
+    app.mode = AppMode::BoardDetail;
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -337,7 +337,7 @@ fn test_board_detail_columns_section_still_renders_no_columns_message_when_loade
 #[test]
 fn test_the_create_card_dialog_sprint_field_distinguishes_not_loaded_from_empty() {
     let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
-    app.push_mode(AppMode::Dialog(DialogMode::CreateCard));
+    app.mode = AppMode::Dialog(DialogMode::CreateCard);
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -348,7 +348,7 @@ fn test_the_create_card_dialog_sprint_field_distinguishes_not_loaded_from_empty(
 #[test]
 fn test_the_sprint_picker_distinguishes_not_loaded_from_empty() {
     let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
-    app.push_mode(AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint));
+    app.mode = AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint);
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -365,7 +365,7 @@ fn test_carry_over_sprint_dialog_distinguishes_not_loaded_from_empty() {
     let dialog = CarryOverSprintDialog { card_count: 0 };
     assert_eq!(dialog.options_count(&app), 0);
 
-    app.push_mode(AppMode::Dialog(DialogMode::CarryOverSprint));
+    app.mode = AppMode::Dialog(DialogMode::CarryOverSprint);
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -381,7 +381,7 @@ fn test_carry_over_sprint_dialog_still_renders_when_loaded_empty() {
     let dialog = CarryOverSprintDialog { card_count: 0 };
     assert_eq!(dialog.options_count(&app), 0);
 
-    app.push_mode(AppMode::Dialog(DialogMode::CarryOverSprint));
+    app.mode = AppMode::Dialog(DialogMode::CarryOverSprint);
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -398,7 +398,7 @@ fn test_sprint_assign_dialog_distinguishes_not_loaded_from_empty() {
     let dialog = SprintAssignDialog;
     assert_eq!(dialog.options_count(&app), 1);
 
-    app.push_mode(AppMode::Dialog(DialogMode::AssignCardToSprint));
+    app.mode = AppMode::Dialog(DialogMode::AssignCardToSprint);
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -409,7 +409,7 @@ fn test_sprint_assign_dialog_distinguishes_not_loaded_from_empty() {
 #[test]
 fn test_board_detail_sprints_section_distinguishes_not_loaded_from_empty() {
     let (mut app, _board) = app_with_board_and_sprint_state(LoadState::NotLoaded);
-    app.push_mode(AppMode::BoardDetail);
+    app.mode = AppMode::BoardDetail;
     let output = helpers::render_widget_to_string(120, 40, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -457,7 +457,7 @@ fn test_multi_panel_column_name_lookup_renders_failed_distinctly() {
 #[test]
 fn test_a_not_loaded_graph_tier_does_not_render_no_parents_or_no_children() {
     let (mut app, _board, _card) = app_with_card_and_graph_state(LoadState::NotLoaded);
-    app.push_mode(AppMode::CardDetail);
+    app.mode = AppMode::CardDetail;
     let output = helpers::render_widget_to_string(120, 30, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -472,7 +472,7 @@ fn test_a_failed_graph_tier_renders_the_error_inline_in_the_relationship_panel()
     let (mut app, _board, _card) = app_with_card_and_graph_state(LoadState::Failed(Arc::new(
         KanbanError::unsupported("boom"),
     )));
-    app.push_mode(AppMode::CardDetail);
+    app.mode = AppMode::CardDetail;
     let output = helpers::render_widget_to_string(120, 30, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });
@@ -485,7 +485,7 @@ fn test_a_failed_graph_tier_renders_the_error_inline_in_the_relationship_panel()
 fn test_a_loaded_but_genuinely_empty_graph_still_renders_no_parents_and_no_children() {
     let (mut app, _board, _card) =
         app_with_card_and_graph_state(LoadState::Loaded(DependencyGraph::default()));
-    app.push_mode(AppMode::CardDetail);
+    app.mode = AppMode::CardDetail;
     let output = helpers::render_widget_to_string(120, 30, |frame| {
         kanban_tui::ui::render(&mut app, frame);
     });

--- a/crates/kanban-tui/tests/mode_transition_populate_tests.rs
+++ b/crates/kanban-tui/tests/mode_transition_populate_tests.rs
@@ -1,0 +1,120 @@
+use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+use std::fs;
+use std::path::Path;
+use uuid::Uuid;
+
+fn seed_board_column_sprint_card(app: &mut App) -> (Uuid, Uuid, Uuid, Uuid) {
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    (board.id, column.id, sprint.id, card.id)
+}
+
+#[test]
+fn test_push_mode_card_detail_populates_the_graph_tier() {
+    let mut app = App::test_default();
+    let (board_id, _column_id, _sprint_id, card_id) = seed_board_column_sprint_card(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.selection.active_card_id = Some(card_id);
+
+    assert!(!app.model.graph_state().is_loaded());
+
+    app.push_mode(AppMode::CardDetail);
+
+    assert!(app.model.graph_state().is_loaded());
+}
+
+#[test]
+fn test_open_filter_options_dialog_populates_the_board_sprints_tier() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.selection.active_board_id = Some(board_id);
+
+    assert!(!app.model.board_sprints_state(board_id).is_loaded());
+
+    app.open_dialog(DialogMode::FilterOptions);
+
+    assert_eq!(
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .map(|s| s.len()),
+        Some(1)
+    );
+}
+
+#[test]
+fn test_pop_mode_repopulates_the_scope_of_the_mode_it_returns_to() {
+    let mut app = App::test_default();
+    let (board_id, column_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.selection.active_board_id = Some(board_id);
+    app.mode_stack.push(AppMode::Normal);
+    app.mode = AppMode::Settings;
+
+    assert!(!app.model.board_columns_state(board_id).is_loaded());
+    assert!(!app.model.column_cards_state(column_id).is_loaded());
+
+    app.pop_mode();
+
+    assert_eq!(app.mode, AppMode::Normal);
+    assert!(app.model.board_columns_state(board_id).is_loaded());
+    assert!(app.model.column_cards_state(column_id).is_loaded());
+}
+
+#[test]
+fn test_no_direct_mode_assignment_outside_the_mode_stack_seam() {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    collect_offenders(&src_dir, &mut offenders);
+
+    assert!(
+        offenders.is_empty(),
+        "found direct `self.mode = ...` assignments outside the mode_stack seam: {offenders:?}"
+    );
+}
+
+fn collect_offenders(dir: &Path, offenders: &mut Vec<String>) {
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            collect_offenders(&path, offenders);
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        if path.ends_with("app/mode_stack.rs") {
+            continue;
+        }
+        let contents = fs::read_to_string(&path).unwrap();
+        for (idx, line) in contents.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with("self.mode") {
+                continue;
+            }
+            let rest = trimmed["self.mode".len()..].trim_start();
+            let Some(after_eq) = rest.strip_prefix('=') else {
+                continue;
+            };
+            if after_eq.starts_with('=') {
+                continue;
+            }
+            offenders.push(format!("{}:{}", path.display(), idx + 1));
+        }
+    }
+}

--- a/crates/kanban-tui/tests/view_scope_tests.rs
+++ b/crates/kanban-tui/tests/view_scope_tests.rs
@@ -178,3 +178,45 @@ fn test_search_mode_needs_no_scope_beyond_the_board_it_filters() {
         }
     );
 }
+
+#[test]
+fn test_every_dialog_that_renders_sprints_scopes_the_board_sprints_tier() {
+    let variants = [
+        DialogMode::CarryOverSprint,
+        DialogMode::AssignCardToSprint,
+        DialogMode::AssignMultipleCardsToSprint,
+        DialogMode::CreateCard,
+        DialogMode::CreateSprint,
+        DialogMode::FilterOptions,
+        DialogMode::SetSprintPrefix,
+        DialogMode::DeleteBoardConfirm,
+    ];
+
+    for variant in variants {
+        let mut app = App::test_default();
+        let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+        app.reload_model();
+        app.selection.active_board_id = Some(board_id);
+        app.mode = AppMode::Dialog(variant.clone());
+
+        let scope = app.view_scope();
+
+        assert!(
+            scope.board_sprints,
+            "expected board_sprints to be scoped for {variant:?}"
+        );
+    }
+}
+
+#[test]
+fn test_help_over_a_sprint_dialog_still_scopes_the_board_sprints_tier() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::Help(Box::new(AppMode::Dialog(DialogMode::FilterOptions)));
+
+    let scope = app.view_scope();
+
+    assert!(scope.board_sprints);
+}


### PR DESCRIPTION
## Summary

- Adds a single populate choke point on the TUI mode/dialog transition seam: `set_mode`/`push_mode`/`pop_mode` in `mode_stack.rs` all populate the current `view_scope()` after updating `self.mode`.
- Routes every direct `self.mode = ...` assignment outside `mode_stack.rs` through `set_mode`, restructuring the sites that held a live borrow across the assignment (the `?` help-toggle and its two unwind sites, and the archived-boards-view toggle) so the mutable call compiles.
- Widens the dialog to `ViewScope` mapping so every sprint-rendering dialog (`CarryOverSprint`, `AssignCardToSprint`, `AssignMultipleCardsToSprint`, `CreateCard`, `CreateSprint`, `FilterOptions`, `SetSprintPrefix`, `DeleteBoardConfirm`) requests `board_sprints`, and unwraps `AppMode::Help` before matching so a help-wrapped dialog still gets the right scope.
- Reorders `handle_delete_board_key` to open the `DeleteBoardConfirm` dialog before reading the delete counts, so the dialog's own transition populate can satisfy an unabsorbed `board_sprints` tier (e.g. right after startup) before the counts are read. The handler still declines and pops back out if the tiers remain unloaded.

Net effect: `App::view_scope()` stops being dead code after startup, and the decline-on-`NotLoaded` discipline becomes user-retriable. Pressing `d` on a board straight after launch now reaches the delete confirmation instead of declining.

## Pre-existing test fixtures adjusted

Populate-on-transition makes `push_mode`/`open_dialog` fetch the current scope, so tests that transitioned modes purely as fixture setup on an unloaded model now warm tiers they used to leave `NotLoaded`:

- `load_state_render_tests.rs`: 18 `push_mode` calls converted to direct `app.mode` assignments. These tests hand-build the model to assert the renderer distinguishes `NotLoaded` from loaded-but-empty; a direct mode write is behaviourally identical here (base mode stays `Normal`) and no longer heals the tier being pinned.
- `keybinding_store_io_tests.rs`: `seeded_app()` now explicitly warms the per-column card tier, since `reload_model` clears `cards_by_column` without refilling it. Without this, the first transition-driven populate after installing the counting backend recorded a genuine (and now expected) read.
- `frame_reload_tests.rs`: `test_navigation_performs_no_store_reads` now runs its navigation sequence once uncounted to warm every tier a transition touches, then again with the counting backend installed, preserving the "no read amplification on repeat navigation" invariant.
- `column_and_board_handlers_collapsing_accessor_tests.rs` / `helpers.rs`: `test_handle_delete_board_key_declines_when_board_delete_counts_is_not_loaded` now needs a genuinely unrecoverable read failure (a `wrap_failing` backend on `list_columns_by_board`, added to `CountingBackend`) rather than a bare invalidation, since the reordered handler now repopulates an invalidated columns tier on dialog open.

## Test plan

- [x] All six new red tests demonstrated failing before implementation, then green after.
- [x] `cargo test -p kanban-tui` green
- [x] `cargo test --all-features --workspace` green
- [x] `git grep -nE 'self\.mode\s*=[^=]' crates/kanban-tui/src` matches only `app/mode_stack.rs`
- [x] `git grep -n '\.populate(' crates/kanban-tui/src` matches only the two startup calls plus the new seam call
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: reverting `push_mode`'s populate call fails the new tests as expected

## Known residual gaps (reported, not fixed here, out of scope)

- `handle_delete_board_key` still declines when a board is open and focus is switched back to Boards without clearing `active_board_id` (`view_scope()` follows the active board, not the highlighted one in that case).
- The confirm dialog under-reports archived cards on a cold start (`archived_card_markers()` is snapshot-fed and never requested by `ViewScope::next_round`); pre-existing, just newly reachable now that the dialog opens on a cold start.
