### PR TITLE
KAN-1523 fix(mcp): exclude archived-board descendants from global name resolvers

### DIFF
--- a/.changeset/kan-1523-mcp-archived-descendant-filter.md
+++ b/.changeset/kan-1523-mcp-archived-descendant-filter.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+MCP name resolvers ignore archived-board columns, sprints, and cards

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -393,6 +393,10 @@ mod tests {
                 all: LoadState::Loaded(vec![column]),
                 ..Default::default()
             },
+            archived_boards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
             ..Default::default()
         });
 
@@ -413,9 +417,33 @@ mod tests {
                 ]),
                 ..Default::default()
             },
+            archived_boards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
             ..Default::default()
         });
         assert!(resolve_column_global(&dup_model, "TODO").is_err());
+    }
+
+    #[test]
+    fn test_resolve_column_global_requires_the_archived_marker_tier() {
+        let board_id = Uuid::new_v4();
+        let column = Column::new(board_id, "TODO", 0);
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            columns: Collection {
+                all: LoadState::Loaded(vec![column]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let err = resolve_column_global(&model, "TODO").unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("archived board markers"));
+        assert!(!err.message.contains("not found"));
     }
 
     #[test]
@@ -464,6 +492,10 @@ mod tests {
                 all: LoadState::Loaded(vec![sprint]),
                 ..Default::default()
             },
+            archived_boards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
             ..Default::default()
         });
 
@@ -510,6 +542,10 @@ mod tests {
         let _ = model.apply_resolved(Resolved {
             cards: Collection {
                 all: LoadState::Loaded(vec![card]),
+                ..Default::default()
+            },
+            archived_boards: Collection {
+                all: LoadState::Loaded(vec![]),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -5,6 +5,7 @@ use kanban_domain::{
     BatchResolutionFailure, Card, KanbanError, LoadState, Model, ParsedIdentifier, Prefix,
 };
 use rmcp::model::ErrorData as McpError;
+use std::collections::HashSet;
 use uuid::Uuid;
 
 pub(crate) fn require_loaded<T>(state: LoadState<T>, what: &str) -> Result<T, McpError> {
@@ -78,17 +79,30 @@ pub(crate) fn resolve_column_in_board(
     }
 }
 
+fn require_archived_board_ids(model: &Model) -> Result<&HashSet<Uuid>, McpError> {
+    require_loaded(model.archived_boards_state(), "archived board markers")?;
+    Ok(model.archived_board_ids())
+}
+
 pub(crate) fn resolve_column_global(model: &Model, raw: &str) -> Result<Uuid, McpError> {
     if let Ok(uuid) = Uuid::parse_str(raw) {
         return Ok(uuid);
     }
     let columns = require_loaded(model.columns_state().as_ref(), "column list")?;
-    let matches = find_columns_by_name(raw, columns);
+    let archived = require_archived_board_ids(model)?;
+    let matches = find_columns_by_name(raw, columns)
+        .into_iter()
+        .filter(|c| !archived.contains(&c.board_id))
+        .collect::<Vec<_>>();
     match matches.as_slice() {
         [] => Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
             "Column",
             raw,
-            columns.iter().map(|c| c.name.clone()).collect(),
+            columns
+                .iter()
+                .filter(|c| !archived.contains(&c.board_id))
+                .map(|c| c.name.clone())
+                .collect(),
         ))),
         [c] => Ok(c.id),
         many => {
@@ -160,11 +174,16 @@ pub(crate) fn resolve_sprint_global(model: &Model, raw: &str) -> Result<Uuid, Mc
     }
     let all_sprints = require_loaded(model.sprints_state().as_ref(), "sprint list")?;
     let boards = require_loaded(model.boards_state().as_ref(), "board list")?;
-    let matches = find_sprints_by_query_global(raw, all_sprints, boards);
+    let archived = require_archived_board_ids(model)?;
+    let matches = find_sprints_by_query_global(raw, all_sprints, boards)
+        .into_iter()
+        .filter(|s| !archived.contains(&s.board_id))
+        .collect::<Vec<_>>();
     match matches.as_slice() {
         [] => {
             let available = all_sprints
                 .iter()
+                .filter(|s| !archived.contains(&s.board_id))
                 .map(|s| {
                     let label = boards
                         .iter()
@@ -247,21 +266,25 @@ pub(crate) fn resolve_card(model: &Model, raw: &str) -> Result<Uuid, McpError> {
 pub(crate) fn resolve_cards(model: &Model, raws: &[String]) -> Result<Vec<Uuid>, McpError> {
     let mut resolved = Vec::with_capacity(raws.len());
     let mut failures = Vec::new();
-    let mut cards: Option<&Vec<Card>> = None;
+    let mut loaded: Option<(&Vec<Card>, &HashSet<Uuid>)> = None;
     for raw in raws {
         if let Ok(uuid) = Uuid::parse_str(raw) {
             resolved.push(uuid);
             continue;
         }
-        let cards = match cards {
-            Some(cards) => cards,
+        let (cards, archived) = match loaded {
+            Some(pair) => pair,
             None => {
-                let loaded = require_loaded(model.cards_state().as_ref(), "card list")?;
-                cards = Some(loaded);
-                loaded
+                let cards = require_loaded(model.cards_state().as_ref(), "card list")?;
+                let archived = require_archived_board_ids(model)?;
+                loaded = Some((cards, archived));
+                (cards, archived)
             }
         };
-        let matches = find_card_matches(cards, raw);
+        let matches = find_card_matches(cards, raw)
+            .into_iter()
+            .filter(|c| !archived.contains(&c.board_id))
+            .collect::<Vec<_>>();
         match matches.as_slice() {
             [] => failures.push(BatchResolutionFailure {
                 raw_input: raw.clone(),

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -46,19 +46,19 @@ pub(crate) trait ToolScoped {
 
 impl FetchPlan for ToolScope {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        let global_column = matches!(self.column, Some(Ref::Name)) && !self.wants_board_columns;
+        let global_sprint = matches!(self.sprint, Some(Ref::Name)) && !self.wants_board_sprints;
+        let named_cards = self.cards.iter().any(|r| matches!(r, Ref::Name));
         let wants_board_list = matches!(self.board, Some(Ref::Name))
             || (self.resolved_board.is_some() && self.wants_board_sprints)
             || matches!(self.sprint, Some(Ref::Name));
         FetchRound {
             board_list: wants_board_list && requestable(loaded.board_list()),
-            column_list: matches!(self.column, Some(Ref::Name))
-                && !self.wants_board_columns
-                && requestable(loaded.column_list()),
-            card_list: self.cards.iter().any(|r| matches!(r, Ref::Name))
-                && requestable(loaded.card_list()),
-            sprint_list: matches!(self.sprint, Some(Ref::Name))
-                && !self.wants_board_sprints
-                && requestable(loaded.sprint_list()),
+            column_list: global_column && requestable(loaded.column_list()),
+            card_list: named_cards && requestable(loaded.card_list()),
+            sprint_list: global_sprint && requestable(loaded.sprint_list()),
+            archived_board_list: (global_column || global_sprint || named_cards)
+                && requestable(loaded.archived_board_list()),
             graph: self.wants_graph && requestable(loaded.graph()),
             columns_by_board: self
                 .resolved_board
@@ -347,19 +347,31 @@ mod tests {
             column: Some(Ref::Name),
             ..Default::default()
         };
-        assert!(column_scope.next_round(&Model::default()).archived_board_list);
+        assert!(
+            column_scope
+                .next_round(&Model::default())
+                .archived_board_list
+        );
 
         let sprint_scope = ToolScope {
             sprint: Some(Ref::Name),
             ..Default::default()
         };
-        assert!(sprint_scope.next_round(&Model::default()).archived_board_list);
+        assert!(
+            sprint_scope
+                .next_round(&Model::default())
+                .archived_board_list
+        );
 
         let cards_scope = ToolScope {
             cards: vec![Ref::Name],
             ..Default::default()
         };
-        assert!(cards_scope.next_round(&Model::default()).archived_board_list);
+        assert!(
+            cards_scope
+                .next_round(&Model::default())
+                .archived_board_list
+        );
     }
 
     #[test]
@@ -372,7 +384,11 @@ mod tests {
             ..Default::default()
         }
         .for_board(board_id);
-        assert!(!column_in_board.next_round(&Model::default()).archived_board_list);
+        assert!(
+            !column_in_board
+                .next_round(&Model::default())
+                .archived_board_list
+        );
 
         let sprint_in_board = ToolScope {
             sprint: Some(Ref::Name),
@@ -380,19 +396,31 @@ mod tests {
             ..Default::default()
         }
         .for_board(board_id);
-        assert!(!sprint_in_board.next_round(&Model::default()).archived_board_list);
+        assert!(
+            !sprint_in_board
+                .next_round(&Model::default())
+                .archived_board_list
+        );
 
         let cards_by_id = ToolScope {
             cards: vec![Ref::Id],
             ..Default::default()
         };
-        assert!(!cards_by_id.next_round(&Model::default()).archived_board_list);
+        assert!(
+            !cards_by_id
+                .next_round(&Model::default())
+                .archived_board_list
+        );
 
         let board_by_id = ToolScope {
             board: Some(Ref::Id),
             ..Default::default()
         };
-        assert!(!board_by_id.next_round(&Model::default()).archived_board_list);
+        assert!(
+            !board_by_id
+                .next_round(&Model::default())
+                .archived_board_list
+        );
     }
 
     /// Mirrors crates/kanban-cli/src/scope.rs:86-95: a `Some(Ref::Name)`

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -293,6 +293,10 @@ mod tests {
                 all: LoadState::Loaded(vec![]),
                 ..Default::default()
             },
+            archived_boards: kanban_domain::resolved::Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
             graph: LoadState::Loaded(Default::default()),
             ..Default::default()
         });
@@ -335,6 +339,60 @@ mod tests {
         let round = scope.next_round(&Model::default());
         assert!(round.board_list);
         assert!(round.sprint_list);
+    }
+
+    #[test]
+    fn test_a_global_named_reference_requests_the_archived_board_markers() {
+        let column_scope = ToolScope {
+            column: Some(Ref::Name),
+            ..Default::default()
+        };
+        assert!(column_scope.next_round(&Model::default()).archived_board_list);
+
+        let sprint_scope = ToolScope {
+            sprint: Some(Ref::Name),
+            ..Default::default()
+        };
+        assert!(sprint_scope.next_round(&Model::default()).archived_board_list);
+
+        let cards_scope = ToolScope {
+            cards: vec![Ref::Name],
+            ..Default::default()
+        };
+        assert!(cards_scope.next_round(&Model::default()).archived_board_list);
+    }
+
+    #[test]
+    fn test_a_board_scoped_reference_requests_no_archived_marker_tier() {
+        let board_id = Uuid::new_v4();
+
+        let column_in_board = ToolScope {
+            column: Some(Ref::Name),
+            wants_board_columns: true,
+            ..Default::default()
+        }
+        .for_board(board_id);
+        assert!(!column_in_board.next_round(&Model::default()).archived_board_list);
+
+        let sprint_in_board = ToolScope {
+            sprint: Some(Ref::Name),
+            wants_board_sprints: true,
+            ..Default::default()
+        }
+        .for_board(board_id);
+        assert!(!sprint_in_board.next_round(&Model::default()).archived_board_list);
+
+        let cards_by_id = ToolScope {
+            cards: vec![Ref::Id],
+            ..Default::default()
+        };
+        assert!(!cards_by_id.next_round(&Model::default()).archived_board_list);
+
+        let board_by_id = ToolScope {
+            board: Some(Ref::Id),
+            ..Default::default()
+        };
+        assert!(!board_by_id.next_round(&Model::default()).archived_board_list);
     }
 
     /// Mirrors crates/kanban-cli/src/scope.rs:86-95: a `Some(Ref::Name)`

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -423,6 +423,119 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_archive_cards_by_identifier_only_on_archived_board_reports_not_found_on_json() {
+        test_archive_cards_by_identifier_only_on_archived_board_reports_not_found("test.json")
+            .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_archive_cards_by_identifier_only_on_archived_board_reports_not_found_on_sqlite() {
+        test_archive_cards_by_identifier_only_on_archived_board_reports_not_found("test.sqlite")
+            .await;
+    }
+
+    async fn test_archive_cards_by_identifier_only_on_archived_board_reports_not_found(
+        file_name: &str,
+    ) {
+        let seeded = seeded_server(file_name).await;
+
+        let beta = text_payload(
+            &seeded
+                .server
+                .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                    content: CreateBoardRequest {
+                        id: None,
+                        name: "Beta".to_string(),
+                        description: None,
+                        sprint_prefix: None,
+                        card_prefix: None,
+                        task_sort_field: None,
+                        task_sort_order: None,
+                        sprint_duration_days: None,
+                        task_list_view: None,
+                    },
+                    with_default_columns: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let beta_id = beta["id"].as_str().unwrap().to_string();
+
+        let beta_column = text_payload(
+            &seeded
+                .server
+                .tool_create_column(Parameters(CreateColumnParams {
+                    board: beta_id.clone(),
+                    content: kanban_service::api::CreateColumnRequest {
+                        id: None,
+                        name: "TODO".to_string(),
+                        wip_limit: None,
+                        default_status: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let beta_column_id = beta_column["id"].as_str().unwrap().to_string();
+
+        let beta_card = text_payload(
+            &seeded
+                .server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: beta_id.clone(),
+                    column: beta_column_id,
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Only on Beta".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let beta_card_id = beta_card["id"].as_str().unwrap().to_string();
+        let beta_card_identifier = format!(
+            "{}-{}",
+            beta_card["prefix"].as_str().unwrap(),
+            beta_card["card_number"].as_u64().unwrap()
+        );
+
+        seeded
+            .server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: "Beta".into(),
+            }))
+            .await
+            .unwrap();
+
+        let err = seeded
+            .server
+            .tool_archive_cards(Parameters(ArchiveCardsRequest {
+                cards: vec![beta_card_identifier.clone()],
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains(&beta_card_identifier));
+
+        let still_live = text_payload(
+            &seeded
+                .server
+                .tool_get_card(Parameters(crate::requests::card::GetCardRequest {
+                    card: beta_card_id,
+                }))
+                .await
+                .unwrap(),
+        );
+        assert!(still_live["archived_at"].is_null());
+    }
+
+    #[tokio::test]
     async fn test_move_cards_with_an_unloadable_column_collection_errors_naming_the_collection_on_json(
     ) {
         let seeded = seeded_server("test.json").await;

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -549,6 +549,153 @@ mod tests {
         assert_eq!(reads_before_write, vec!["list_boards"]);
     }
 
+    async fn create_board(server: &KanbanMcpServer, name: &str) -> serde_json::Value {
+        text_payload(
+            &server
+                .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                    content: CreateBoardRequest {
+                        id: None,
+                        name: name.to_string(),
+                        description: None,
+                        sprint_prefix: None,
+                        card_prefix: None,
+                        task_sort_field: None,
+                        task_sort_order: None,
+                        sprint_duration_days: None,
+                        task_list_view: None,
+                    },
+                    with_default_columns: None,
+                }))
+                .await
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_get_column_by_name_ignores_archived_board_duplicates_on_json() {
+        test_get_column_by_name_ignores_archived_board_duplicates("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_column_by_name_ignores_archived_board_duplicates_on_sqlite() {
+        test_get_column_by_name_ignores_archived_board_duplicates("test.sqlite").await;
+    }
+
+    async fn test_get_column_by_name_ignores_archived_board_duplicates(file_name: &str) {
+        let (server, _dir, _handle) = seeded_server(file_name).await;
+
+        let alpha_todo = text_payload(
+            &server
+                .tool_get_column(Parameters(GetColumnRequest {
+                    column: "TODO".into(),
+                }))
+                .await
+                .unwrap(),
+        );
+        let alpha_todo_id = alpha_todo["id"].as_str().unwrap().to_string();
+
+        create_board(&server, "Beta").await;
+        server
+            .tool_create_column(Parameters(CreateColumnParams {
+                board: "Beta".into(),
+                content: kanban_service::api::CreateColumnRequest {
+                    id: None,
+                    name: "TODO".into(),
+                    wip_limit: None,
+                    default_status: None,
+                },
+            }))
+            .await
+            .unwrap();
+        server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: "Beta".into(),
+            }))
+            .await
+            .unwrap();
+
+        let result = text_payload(
+            &server
+                .tool_get_column(Parameters(GetColumnRequest {
+                    column: "TODO".into(),
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(result["id"], alpha_todo_id);
+    }
+
+    #[tokio::test]
+    async fn test_get_column_named_only_on_archived_board_returns_not_found_on_json() {
+        test_get_column_named_only_on_archived_board_returns_not_found("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_column_named_only_on_archived_board_returns_not_found_on_sqlite() {
+        test_get_column_named_only_on_archived_board_returns_not_found("test.sqlite").await;
+    }
+
+    async fn test_get_column_named_only_on_archived_board_returns_not_found(file_name: &str) {
+        let (server, _dir, _handle) = seeded_server(file_name).await;
+
+        create_board(&server, "Beta").await;
+        let icebox = text_payload(
+            &server
+                .tool_create_column(Parameters(CreateColumnParams {
+                    board: "Beta".into(),
+                    content: kanban_service::api::CreateColumnRequest {
+                        id: None,
+                        name: "Icebox".into(),
+                        wip_limit: None,
+                        default_status: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let icebox_id = icebox["id"].as_str().unwrap().to_string();
+
+        server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: "Beta".into(),
+            }))
+            .await
+            .unwrap();
+
+        let get_err = server
+            .tool_get_column(Parameters(GetColumnRequest {
+                column: "Icebox".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(get_err.code, ErrorCode::INVALID_PARAMS);
+        assert!(get_err.message.to_lowercase().contains("not found"));
+
+        let update_err = server
+            .tool_update_column(Parameters(UpdateColumnRequest {
+                column: "Icebox".into(),
+                name: Some("Hijacked".into()),
+                position: None,
+                wip_limit: None,
+                clear_wip_limit: None,
+                default_status: None,
+                clear_default_status: None,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(update_err.code, ErrorCode::INVALID_PARAMS);
+
+        let still_live = text_payload(
+            &server
+                .tool_get_column(Parameters(GetColumnRequest {
+                    column: icebox_id,
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(still_live["name"], "Icebox");
+    }
+
     #[tokio::test]
     async fn test_get_column_result_json_is_unchanged() {
         let (server, _dir, _handle) = seeded_server("test.json").await;

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -687,9 +687,7 @@ mod tests {
 
         let still_live = text_payload(
             &server
-                .tool_get_column(Parameters(GetColumnRequest {
-                    column: icebox_id,
-                }))
+                .tool_get_column(Parameters(GetColumnRequest { column: icebox_id }))
                 .await
                 .unwrap(),
         );

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -733,6 +733,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_sprint_by_number_ignores_archived_board_sprints_on_json() {
+        test_get_sprint_by_number_ignores_archived_board_sprints("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_sprint_by_number_ignores_archived_board_sprints_on_sqlite() {
+        test_get_sprint_by_number_ignores_archived_board_sprints("test.sqlite").await;
+    }
+
+    async fn test_get_sprint_by_number_ignores_archived_board_sprints(file_name: &str) {
+        let seeded = seeded_server(file_name).await;
+
+        seeded
+            .server
+            .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                content: CreateBoardRequest {
+                    id: None,
+                    name: "Beta".to_string(),
+                    description: None,
+                    sprint_prefix: Some("ZED".into()),
+                    card_prefix: None,
+                    task_sort_field: None,
+                    task_sort_order: None,
+                    sprint_duration_days: None,
+                    task_list_view: None,
+                },
+                with_default_columns: None,
+            }))
+            .await
+            .unwrap();
+
+        let beta_sprint = text_payload(
+            &seeded
+                .server
+                .tool_create_sprint(Parameters(CreateSprintParams {
+                    board: "Beta".into(),
+                    content: kanban_service::api::CreateSprintRequest {
+                        id: None,
+                        name: Some("Collides".into()),
+                        prefix: None,
+                        card_prefix: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(beta_sprint["sprint_number"], 1);
+
+        seeded
+            .server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: "Beta".into(),
+            }))
+            .await
+            .unwrap();
+
+        let result = text_payload(
+            &seeded
+                .server
+                .tool_get_sprint(Parameters(GetSprintRequest {
+                    sprint: "1".into(),
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(result["name"], "From");
+    }
+
+    #[tokio::test]
     async fn test_get_sprint_result_json_is_unchanged() {
         let seeded = seeded_server("test.json").await;
 

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -792,9 +792,7 @@ mod tests {
         let result = text_payload(
             &seeded
                 .server
-                .tool_get_sprint(Parameters(GetSprintRequest {
-                    sprint: "1".into(),
-                }))
+                .tool_get_sprint(Parameters(GetSprintRequest { sprint: "1".into() }))
                 .await
                 .unwrap(),
         );


### PR DESCRIPTION
## Summary

The MCP server's three global name resolvers (`resolve_column_global`, `resolve_sprint_global`, `resolve_cards`) matched by name across every board in the raw flat tier, live and archived alike. This meant:

- A name that existed on both a live board and an archived board resolved ambiguously instead of picking the live one.
- A name that existed only on an archived board still resolved, and could be read or mutated through MCP tools, even though the board is supposed to be frozen.

This restores the pre-wave live-scoped semantics that the CLI already has (`archived_board_id_set` in `kanban-service/src/context/cards.rs`).

## Changes

- `ToolScope::next_round` now requests the archived-board marker tier (`FetchRound::archived_board_list`) whenever a scope will resolve a global name reference (a bare column name, a bare sprint name, or a named card identifier).
- `resolve_column_global`, `resolve_sprint_global`, and `resolve_cards` in `crates/kanban-mcp/src/helpers/model_read.rs` now filter their name matches to exclude any candidate whose `board_id` is in `Model::archived_board_ids()`, gated behind a `require_loaded` check so an unfetched archived tier fails loud (INTERNAL_ERROR) instead of silently matching everything.
- The archived-board gate runs after each resolver's existing collection checks, so the existing fault-injection tests still report the primary collection's name in their error messages.
- Pure-UUID batches (`resolve_cards`) still touch neither the card list nor the archived-board tier, matching existing behavior.

## Tests

- `scope.rs`: pins that a global name reference requests the archived-board tier, and a guard that board-scoped references do not.
- `helpers/model_read.rs`: pins that `resolve_column_global` requires the archived marker tier before resolving (fails loud if unfetched).
- `tools/column.rs`, `tools/sprint.rs`, `tools/card_batch.rs`: end-to-end tests on both the JSON and SQLite backends proving a live/archived name collision resolves to the live entity, and a name that exists only on an archived board is NotFound and cannot be mutated.

All new tests were confirmed failing against the base tip before the fix, and a mutation check (reverting the archived-board filter in `resolve_column_global`) reproduces the failures.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`

All green.
