### PR TITLE
KAN-1526 fix(service): wrap transfer_state_to's write in the target's transaction

### DIFF
--- a/.changeset/kan-1526-transfer-transactional.md
+++ b/.changeset/kan-1526-transfer-transactional.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+service: `KanbanContext::transfer_state_to` now takes the target as `&dyn KanbanBackend` instead of `&dyn DataStore` and runs the whole snapshot write inside `target.with_transaction(..)`, so a mid-write referential-integrity failure rolls the target back to unchanged instead of leaving it half-populated. tui: `TuiContext::transfer_state_to` takes the same new parameter type; its one caller in `App::adopt_storage_file` now passes the backend directly.

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -1,4 +1,5 @@
 use super::KanbanContext;
+use crate::backend::KanbanBackend;
 use kanban_core::{ClientId, KANBAN_VERSION};
 use kanban_domain::commands::{Command, SprintCommand};
 use kanban_domain::export::{AllBoardsExport, BoardImporter};
@@ -360,11 +361,20 @@ impl KanbanContext {
     }
 
     /// Copies this context's whole workspace onto `target`, upserting into
-    /// whatever is already there rather than clearing it first. No FK repair
-    /// runs; a dangling reference in the source lands dangling on `target` too.
-    pub fn transfer_state_to(&self, target: &dyn DataStore) -> KanbanResult<()> {
+    /// whatever is already there rather than clearing it first, all inside
+    /// `target`'s own transaction so the copy is all-or-nothing. No FK repair
+    /// runs: on a target that enforces referential integrity (SQLite's
+    /// foreign keys on `cards.sprint_id` and card prefixes, or the JSON
+    /// backend's card-prefix check) a dangling reference in the source fails
+    /// the whole transfer and leaves `target` unchanged; on a target that
+    /// enforces nothing the dangling reference lands as-is. Only the
+    /// `Snapshot` is copied; the source's `CommandBatch` history is not.
+    pub fn transfer_state_to(&self, target: &dyn KanbanBackend) -> KanbanResult<()> {
         let snapshot = crate::store_adapter::read_full_snapshot(self.backend.as_data_store())?;
-        crate::store_adapter::write_full_snapshot(target, snapshot)
+        let store = target.as_data_store();
+        target.with_transaction(Box::new(move || {
+            crate::store_adapter::write_full_snapshot(store, snapshot)
+        }))
     }
 
     pub fn import_board_impl(&mut self, data: &str) -> KanbanResult<(Board, Invalidation)> {

--- a/crates/kanban-service/tests/transfer_pairs.rs
+++ b/crates/kanban-service/tests/transfer_pairs.rs
@@ -358,7 +358,7 @@ async fn test_transfer_state_to_is_lossless_for_every_backend_pair() {
             let dst_ctx = open_ctx(&dst_factory, &dst_path).await;
 
             src_ctx
-                .transfer_state_to(dst_ctx.data_store())
+                .transfer_state_to(&*dst_ctx.backend())
                 .unwrap_or_else(|e| {
                     panic!("transfer {src_name} -> {dst_name} failed: {e}");
                 });
@@ -591,7 +591,7 @@ async fn test_transfer_state_to_into_a_populated_target_is_an_upsert_not_a_wipe(
         let fixture = seed_rich(src_ctx.data_store()).unwrap();
 
         src_ctx
-            .transfer_state_to(dst_ctx.data_store())
+            .transfer_state_to(&*dst_ctx.backend())
             .unwrap_or_else(|e| panic!("transfer into populated {dst_name} failed: {e}"));
         dst_ctx.save().await.unwrap();
 
@@ -642,7 +642,7 @@ async fn test_transfer_state_to_leaves_the_source_untouched() {
         let dst_ctx = open_ctx(&dst_factory, &dst_path).await;
 
         src_ctx
-            .transfer_state_to(dst_ctx.data_store())
+            .transfer_state_to(&*dst_ctx.backend())
             .unwrap_or_else(|e| panic!("transfer from {src_name} failed: {e}"));
 
         assert_transfer_matches(&fixture, src_ctx.data_store());
@@ -786,6 +786,27 @@ impl DataStore for UnsupportedArchivedBoards {
     }
 }
 
+impl CommandStore for UnsupportedArchivedBoards {
+    fn append_batch(&self, batch: &CommandBatch) -> KanbanResult<u64> {
+        self.0.append_batch(batch)
+    }
+    fn batch_count(&self) -> KanbanResult<u64> {
+        self.0.batch_count()
+    }
+    fn load_batches(&self, from: u64, to: u64) -> KanbanResult<Vec<CommandBatch>> {
+        self.0.load_batches(from, to)
+    }
+}
+
+impl KanbanBackend for UnsupportedArchivedBoards {
+    fn as_data_store(&self) -> &dyn DataStore {
+        self
+    }
+    fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
+        self.0.with_transaction(f)
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_transfer_state_to_a_backend_that_cannot_accept_it_fails_loud() {
     let dir = TempDir::new().unwrap();
@@ -837,7 +858,7 @@ async fn test_transfer_with_dangling_sprint_id_onto_sqlite_fails_atomically_then
     let dst_ctx = open_ctx(&dst_factory, &dst_path).await;
 
     assert!(
-        src_ctx.transfer_state_to(dst_ctx.data_store()).is_err(),
+        src_ctx.transfer_state_to(&*dst_ctx.backend()).is_err(),
         "transfer with a dangling sprint_id onto an FK-enforcing target must fail"
     );
 
@@ -863,7 +884,7 @@ async fn test_transfer_with_dangling_sprint_id_onto_sqlite_fails_atomically_then
     src_ctx.data_store().upsert_card(card.clone()).unwrap();
 
     src_ctx
-        .transfer_state_to(dst_ctx.data_store())
+        .transfer_state_to(&*dst_ctx.backend())
         .expect("transfer must succeed once the dangling sprint_id is repaired");
     dst_ctx.save().await.unwrap();
 

--- a/crates/kanban-service/tests/transfer_pairs.rs
+++ b/crates/kanban-service/tests/transfer_pairs.rs
@@ -807,3 +807,80 @@ async fn test_transfer_state_to_a_backend_that_cannot_accept_it_fails_loud() {
         "expected the archived-board default (Unsupported {{ operation: \"insert_archived_board\" }}) to surface, got {err}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transfer_with_dangling_sprint_id_onto_sqlite_fails_atomically_then_repaired_source_succeeds(
+) {
+    let dir = TempDir::new().unwrap();
+
+    let src_path = dir.path().join("src.store");
+    let src_ctx = open_ctx(&in_memory_backend_factory(), &src_path).await;
+    let src_store = src_ctx.data_store();
+
+    src_store
+        .upsert_prefix(Prefix {
+            name: "tst".into(),
+            card_counter: 1,
+            sprint_counter: 0,
+        })
+        .unwrap();
+    let board = Board::new("Src", Some("tst"));
+    src_store.upsert_board(board.clone()).unwrap();
+    let column = Column::new(board.id, "Todo", 0);
+    src_store.upsert_column(column.clone()).unwrap();
+    let mut card = Card::new(board.id, column.id, "Orphan", 0);
+    card.sprint_id = Some(Uuid::new_v4());
+    src_store.upsert_card(card.clone()).unwrap();
+
+    let dst_path = dir.path().join("dst.store");
+    let dst_factory = sqlite_backend_factory();
+    let dst_ctx = open_ctx(&dst_factory, &dst_path).await;
+
+    assert!(
+        src_ctx.transfer_state_to(dst_ctx.data_store()).is_err(),
+        "transfer with a dangling sprint_id onto an FK-enforcing target must fail"
+    );
+
+    let dst_store = dst_ctx.data_store();
+    assert!(
+        dst_store.list_prefixes().unwrap().is_empty(),
+        "a failed transfer must roll the target back atomically: prefixes leaked onto the target"
+    );
+    assert!(
+        dst_store.list_boards().unwrap().is_empty(),
+        "a failed transfer must roll the target back atomically: boards leaked onto the target"
+    );
+    assert!(
+        dst_store.list_all_columns().unwrap().is_empty(),
+        "a failed transfer must roll the target back atomically: columns leaked onto the target"
+    );
+    assert!(
+        dst_store.list_all_cards().unwrap().is_empty(),
+        "a failed transfer must roll the target back atomically: cards leaked onto the target"
+    );
+
+    card.sprint_id = None;
+    src_ctx.data_store().upsert_card(card.clone()).unwrap();
+
+    src_ctx
+        .transfer_state_to(dst_ctx.data_store())
+        .expect("transfer must succeed once the dangling sprint_id is repaired");
+    dst_ctx.save().await.unwrap();
+
+    let reopened = open_ctx(&dst_factory, &dst_path).await;
+    let reopened_store = reopened.data_store();
+    assert!(
+        reopened_store.get_prefix("tst").unwrap().is_some(),
+        "prefix must survive the retried transfer"
+    );
+    let boards = reopened_store.list_boards().unwrap();
+    assert_eq!(boards.len(), 1);
+    assert_eq!(boards[0].id, board.id);
+    let columns = reopened_store.list_all_columns().unwrap();
+    assert_eq!(columns.len(), 1);
+    assert_eq!(columns[0].id, column.id);
+    let cards = reopened_store.list_all_cards().unwrap();
+    assert_eq!(cards.len(), 1);
+    assert_eq!(cards[0].id, card.id);
+    assert_eq!(cards[0].sprint_id, None);
+}

--- a/crates/kanban-tui/src/app/lifecycle.rs
+++ b/crates/kanban-tui/src/app/lifecycle.rs
@@ -281,7 +281,7 @@ impl App {
 
         match backend_result {
             Ok(backend) => {
-                if let Err(e) = self.ctx.transfer_state_to(backend.as_data_store()) {
+                if let Err(e) = self.ctx.transfer_state_to(&*backend) {
                     self.set_error(format!("Could not seed \"{}\": {}", filename, e));
                     return false;
                 }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -98,7 +98,7 @@ impl TuiContext {
         self.inner.snapshot()
     }
 
-    pub fn transfer_state_to(&self, target: &dyn kanban_domain::DataStore) -> KanbanResult<()> {
+    pub fn transfer_state_to(&self, target: &dyn KanbanBackend) -> KanbanResult<()> {
         self.inner.transfer_state_to(target)
     }
 


### PR DESCRIPTION
## What

`KanbanContext::transfer_state_to` now takes the target as `&dyn KanbanBackend` and runs the whole `write_full_snapshot` call inside `target.with_transaction(..)`. Before this change, each entity upsert during a transfer committed on its own, so a mid-write failure (for example a dangling `sprint_id` hitting SQLite's foreign key) left the target with a partially written workspace: prefixes, boards and columns already durably written, cards missing. Now a failing transfer rolls the target all the way back to its prior state, and a retry after repairing the source succeeds cleanly.

Also rewrote the method's doc comment, which previously promised that "a dangling reference in the source lands dangling on `target` too" - that is only true for a target that does not enforce referential integrity. On SQLite (foreign keys on `cards.sprint_id` and card prefixes) and on the JSON backend (its own card-prefix check), a dangling reference now fails the whole transfer atomically instead of landing half-applied.

## Changes

- `crates/kanban-service/src/context/sprints.rs`: `transfer_state_to` signature changed to `&dyn KanbanBackend`, write wrapped in `target.with_transaction(..)`, doc comment rewritten to describe the atomic, all-or-nothing behavior and name both SQLite's foreign keys and the JSON backend's prefix check as the enforcing cases.
- `crates/kanban-tui/src/tui_context.rs` and `crates/kanban-tui/src/app/lifecycle.rs`: mechanical call-site updates for the new signature.
- `crates/kanban-service/tests/transfer_pairs.rs`: new test `test_transfer_with_dangling_sprint_id_onto_sqlite_fails_atomically_then_repaired_source_succeeds` pinning the rollback behavior on SQLite, plus mechanical call-site updates and a delegating `CommandStore`/`KanbanBackend` impl for the `UnsupportedArchivedBoards` test double.
- Changeset added.

## Testing

- `cargo test -p kanban-service --features test-helpers --test transfer_pairs` - 6/6 green
- `cargo test --all-features --workspace` - green
- `cargo clippy --all-targets --all-features -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean
- Mutation check: reverted the transaction wrap locally, confirmed the new test fails on the same assertion it was designed to pin, then restored the fix.
