### PR TITLE
KAN-1514 fix(domain): an empty entities invalidation touches no tier

### DIFF
--- a/.changeset/kan-1514-empty-entities-noop.md
+++ b/.changeset/kan-1514-empty-entities-noop.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+an empty entities invalidation no longer resets the whole model

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -190,6 +190,33 @@ mod tests {
         assert!(m.board_archived_cards_state(board.id).is_not_loaded());
     }
 
+    fn assert_every_tier_loaded(
+        m: &Model,
+        board: &Board,
+        col_a: &Column,
+        _col_b: &Column,
+        c1: &Card,
+        _c2: &Card,
+        sprint: &Sprint,
+    ) {
+        assert!(m.boards_state().is_loaded());
+        assert!(m.columns_state().is_loaded());
+        assert!(m.cards_state().is_loaded());
+        assert!(m.sprints_state().is_loaded());
+        assert!(m.graph_state().is_loaded());
+        assert!(m.board_by_id_state(board.id).is_loaded());
+        assert!(m.column_id_status(col_a.id).is_loaded());
+        assert!(m.card_id_status(c1.id).is_loaded());
+        assert!(m.sprint_id_status(sprint.id).is_loaded());
+        assert!(m.column_cards_state(col_a.id).is_loaded());
+        assert!(m.board_columns_state(board.id).is_loaded());
+        assert!(m.board_sprints_state(board.id).is_loaded());
+        assert!(m.board_archived_cards_state(board.id).is_loaded());
+        assert!(!m.scoped_card_index.is_empty());
+        assert!(!m.card_index.is_empty());
+        assert!(!m.board_index.is_empty());
+    }
+
     #[test]
     fn test_a_moved_card_is_not_served_from_a_stale_scope() {
         let board = Board::new("B", None::<String>);
@@ -516,13 +543,13 @@ mod tests {
     }
 
     #[test]
-    fn test_an_empty_entity_ids_clears_every_tier() {
+    fn test_invalidate_empty_entity_ids_leaves_every_tier_loaded() {
         let (mut m, board, col_a, col_b, c1, c2, sprint) = seeded();
         load_every_tier(&mut m, &board, &col_a, &col_b, &c1, &c2, &sprint);
 
         let _ = m.invalidate(Invalidation::Entities(EntityIds::default()));
 
-        assert_every_tier_not_loaded(&m, &board, &col_a, &col_b, &c1, &c2, &sprint);
+        assert_every_tier_loaded(&m, &board, &col_a, &col_b, &c1, &c2, &sprint);
     }
 
     #[test]
@@ -545,6 +572,29 @@ mod tests {
 
         assert!(m.archived_card_markers().is_empty());
         assert!(m.archived_card_ids().is_empty());
+    }
+
+    #[test]
+    fn test_invalidate_empty_entity_ids_keeps_the_snapshot_derived_archived_markers() {
+        let board = Board::new("B", None::<String>);
+        let card = Card::new(board.id, Uuid::new_v4(), "task", 0);
+        let marker = ArchivedCard::new(card.id, board.id);
+
+        let mut m = Model::default();
+        let changed = m.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            cards: vec![card],
+            archived_cards: vec![marker],
+            ..Default::default()
+        });
+        NoProjections.resync(&m, changed);
+        assert!(!m.archived_card_ids().is_empty());
+
+        let _ = m.invalidate(Invalidation::Entities(EntityIds::default()));
+
+        assert!(!m.archived_card_markers().is_empty());
+        assert!(!m.archived_card_ids().is_empty());
+        assert!(m.cards_state().is_loaded());
     }
 
     #[test]
@@ -790,16 +840,6 @@ mod tests {
         assert!(m.columns_state().is_loaded());
         assert!(m.cards_state().is_loaded());
         assert!(m.sprints_state().is_loaded());
-    }
-
-    #[test]
-    fn test_invalidate_entities_with_no_ids_clears_everything() {
-        let (mut m, board, col_a, col_b, c1, c2, sprint) = seeded();
-        load_every_tier(&mut m, &board, &col_a, &col_b, &c1, &c2, &sprint);
-
-        let _ = m.invalidate(Invalidation::Entities(EntityIds::default()));
-
-        assert_every_tier_not_loaded(&m, &board, &col_a, &col_b, &c1, &c2, &sprint);
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -3,8 +3,10 @@ use crate::Invalidation;
 
 impl Model {
     /// Drops every tier that could hold a stale view of the entities named by
-    /// `invalidation`. `Invalidation::All` and an `Entities` with an empty
-    /// `EntityIds` both reset the whole `Model`.
+    /// `invalidation`. `Invalidation::All` resets the whole `Model`; an
+    /// `Entities` with an empty `EntityIds` names nothing and touches
+    /// nothing, matching `InvalidationPlan::for_invalidation` returning
+    /// `None` for the same value.
     ///
     /// `EntityIds` names child ids, not the parent key a scoped tier is keyed
     /// on, so a `cards`, `columns` or `sprints` id drops the WHOLE affected
@@ -29,10 +31,7 @@ impl Model {
                 *self = Self::default();
                 return ModelChanged::new();
             }
-            Invalidation::Entities(ids) if ids.is_empty() => {
-                *self = Self::default();
-                return ModelChanged::new();
-            }
+            Invalidation::Entities(ids) if ids.is_empty() => return ModelChanged::new(),
             Invalidation::Entities(ids) => ids,
         };
 

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-use kanban_domain::{Column, EntityIds};
+use kanban_domain::resolved::Collection;
+use kanban_domain::{
+    Board, Card, Column, DependencyGraph, DerivedProjections, EntityIds, LoadState, Model,
+    NoProjections, Resolved, Sprint,
+};
 use uuid::Uuid;
 
 use super::*;
@@ -366,6 +370,51 @@ fn test_an_empty_entities_invalidation_yields_no_plan() {
         InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::default()), &world);
 
     assert!(plan.is_none());
+}
+
+#[test]
+fn test_empty_entities_invalidation_plans_nothing_and_wipes_nothing() {
+    let board = Board::new("B", None::<String>);
+    let column = Column::new(board.id, "A", 0);
+    let card = Card::new(board.id, column.id, "task", 0);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+
+    let mut model = Model::default();
+    let changed = model.apply_resolved(Resolved {
+        boards: Collection {
+            all: LoadState::Loaded(vec![board.clone()]),
+            ..Default::default()
+        },
+        columns: Collection {
+            all: LoadState::Loaded(vec![column.clone()]),
+            by_id: [(column.id, LoadState::Loaded(column.clone()))].into(),
+            ..Default::default()
+        },
+        cards: Collection {
+            all: LoadState::Loaded(vec![card.clone()]),
+            ..Default::default()
+        },
+        sprints: Collection {
+            all: LoadState::Loaded(vec![sprint.clone()]),
+            ..Default::default()
+        },
+        graph: LoadState::Loaded(DependencyGraph::default()),
+        ..Default::default()
+    });
+    NoProjections.resync(&model, changed);
+
+    let inv = Invalidation::Entities(EntityIds::default());
+    let plan_is_none = InvalidationPlan::for_invalidation(&inv, &model).is_none();
+    assert!(plan_is_none);
+
+    let _ = model.invalidate(inv);
+
+    assert_eq!(LoadedState::board_list(&model), FetchStatus::Loaded);
+    assert_eq!(LoadedState::column_list(&model), FetchStatus::Loaded);
+    assert_eq!(LoadedState::card_list(&model), FetchStatus::Loaded);
+    assert_eq!(LoadedState::sprint_list(&model), FetchStatus::Loaded);
+    assert_eq!(LoadedState::graph(&model), FetchStatus::Loaded);
+    assert_eq!(LoadedState::column(&model, column.id), FetchStatus::Loaded);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`Model::invalidate(Invalidation::Entities(EntityIds::default()))` used to reset
the whole `Model`, disagreeing with `InvalidationPlan::for_invalidation`, which
already returns `None` for the same value. This makes the domain half agree:
an empty `EntityIds` names nothing and now touches nothing.

- `crates/kanban-domain/src/model/invalidate.rs`: the empty-`Entities` arm now
  returns `ModelChanged::new()` directly instead of resetting the model, and
  the doc comment is corrected to describe the new behaviour.
- Replaced a byte-for-byte duplicate pair of tests
  (`test_an_empty_entity_ids_clears_every_tier` /
  `test_invalidate_entities_with_no_ids_clears_everything`) that pinned the
  old reset behaviour with two new tests asserting every tier stays loaded
  and the snapshot-derived archived markers survive.
- Added a `kanban-service` parity test that drives one real `Model` through
  both `InvalidationPlan::for_invalidation` and `Model::invalidate` for the
  same empty `Entities` value, asserting neither the plan nor the model does
  anything.
- `Invalidation::All` keeps its full-reset behaviour and coverage unchanged.

## Test plan

- [x] `cargo test -p kanban-domain` and `cargo test -p kanban-service --all-features`
- [x] `cargo test --all-features --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Mutation check: reverted the fix, confirmed all three new tests fail, restored it
