### PR TITLE
KAN-1516 fix(backend-http): return an empty list for archived cards of a missing board

### DIFF
--- a/.changeset/kan-1516-http-archived-missing-board.md
+++ b/.changeset/kan-1516-http-archived-missing-board.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+HttpBackend returns an empty list for archived cards of a missing board, matching every local backend

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -200,6 +200,11 @@ impl DataStore for HttpBackend {
 
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
         self.block_on(async {
+            let board: Option<BoardResponse> =
+                self.get_json(&format!("/v1/boards/{board_id}")).await?;
+            let Some(_) = board else {
+                return Ok(Vec::new());
+            };
             let resp: Vec<ArchivedCardResponse> = self
                 .get_json_list(&format!("/v1/boards/{board_id}/archived-cards"))
                 .await?;

--- a/crates/kanban-backend-http/tests/archived_cards.rs
+++ b/crates/kanban-backend-http/tests/archived_cards.rs
@@ -89,6 +89,27 @@ async fn test_list_archived_cards_by_board_excludes_other_boards() {
     server.shutdown().await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_archived_cards_by_missing_board_returns_empty() {
+    let server = TestServer::start_with(|ctx| {
+        seed_archived_card(ctx);
+    })
+    .await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let result: Result<Vec<ArchivedCard>, String> = blocking(move || {
+        backend
+            .list_archived_cards_by_board(Uuid::new_v4())
+            .map_err(|e| e.to_string())
+    })
+    .await;
+
+    let markers = result.expect("unknown board must resolve to an empty list, not an error");
+    assert!(markers.is_empty());
+
+    server.shutdown().await;
+}
+
 struct ArchivedCardsByBoardPlan {
     board_id: Uuid,
 }

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -90,10 +90,7 @@ pub async fn test_list_archived_cards_by_missing_board_returns_empty(factory: &B
         .unwrap();
     ctx.archive_card(card.id).unwrap();
 
-    assert_eq!(
-        ctx.list_archived_cards_by_board(board.id).unwrap().len(),
-        1
-    );
+    assert_eq!(ctx.list_archived_cards_by_board(board.id).unwrap().len(), 1);
     assert!(
         ctx.list_archived_cards_by_board(Uuid::new_v4())
             .unwrap()

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -71,6 +71,37 @@ pub async fn test_archive_card_roundtrip(factory: &BackendFactory) {
     assert_card_eq(&live, &pre_archive);
 }
 
+pub async fn test_list_archived_cards_by_missing_board_returns_empty(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let card = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(card.id).unwrap();
+
+    assert_eq!(
+        ctx.list_archived_cards_by_board(board.id).unwrap().len(),
+        1
+    );
+    assert!(
+        ctx.list_archived_cards_by_board(Uuid::new_v4())
+            .unwrap()
+            .is_empty(),
+        "an unknown board must resolve to an empty archived-card list, not an error"
+    );
+}
+
 pub async fn test_archive_card_with_sprint_logs_roundtrip(factory: &BackendFactory) {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.store");

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -340,6 +340,10 @@ macro_rules! context_contract_tests {
         async fn test_list_boards_liveonly_does_not_fetch_archived_markers() {
             $crate::test_helpers::contract::archive::test_list_boards_liveonly_does_not_fetch_archived_markers(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_archived_cards_by_missing_board_returns_empty() {
+            $crate::test_helpers::contract::archive::test_list_archived_cards_by_missing_board_returns_empty(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- `HttpBackend::list_archived_cards_by_board` now pre-checks the board with `GET /v1/boards/{id}` before requesting its archived cards, matching the idiom already used by `list_columns_by_board` and `list_sprints_by_board`.
- Before this fix, a missing board 404'd and the call returned `Err`, while every local backend (in-memory, JSON, SQLite) returns `Ok(vec![])`.
- Adds a red integration test against a live seeded `TestServer` pinning the new HTTP behaviour.
- Adds a cross-backend parity contract test (`test_list_archived_cards_by_missing_board_returns_empty`) that runs on in-memory, JSON, and SQLite via the shared contract macro, so the HTTP adapter is held to a spec every backend already meets.

## Test plan

- [x] `cargo test -p kanban-backend-http` (all 4 tests in `archived_cards.rs`, including the new one, plus `decline_rulings.rs` and `remote_reads.rs`)
- [x] `cargo test -p kanban-service --features test-helpers --test archival_contract` (3 generated instances of the new parity test: in_memory, json, sqlite)
- [x] `cargo test -p kanban-persistence-json --test contract` (tier2 instance of the same parity test)
- [x] `cargo test --workspace --all-features` (full suite green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: reverted the fix, confirmed the HTTP red test fails with the expected `NotFound`-shaped error, restored the fix
