### PR TITLE
KAN-1515 fix(service): bound the undo stack at 100 entries

### DIFF
--- a/.changeset/kan-1515-bound-undo-stack.md
+++ b/.changeset/kan-1515-bound-undo-stack.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: the per-session undo stack is now capped at 100 entries, dropping the oldest batch when it overflows. kanban-server holds one process-wide context and never drains the stack, so every HTTP mutation previously retained a command batch plus its captured inverse state for the life of the process. Interactive undo is unaffected: the TUI applies one entry per keypress, so 100 levels is effectively unlimited for a session.

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -117,7 +117,9 @@ ctx.clear_history() -> KanbanResult<()>
 
 Every undoable command captures an inverse at `execute` time; the
 `(forward, inverse)` pair is pushed onto the per-session `UndoStack` — an
-in-memory, unbounded `Vec` with a cursor, never persisted, never capped.
+in-memory `Vec` with a cursor, never persisted, capped at
+`UndoStack::MAX_ENTRIES` (100) entries; pushing past the cap drops the
+oldest batch.
 `undo`/`redo` re-run the captured inverse/forward batch through the same
 command-execute path (no snapshot apply, no replay); the cursor only
 advances once the batch commits, so a failed undo/redo leaves the stack

--- a/crates/kanban-service/src/undo_stack.rs
+++ b/crates/kanban-service/src/undo_stack.rs
@@ -22,13 +22,22 @@ pub struct UndoStack {
 }
 
 impl UndoStack {
+    /// Upper bound on retained entries. Pushing past it evicts the oldest,
+    /// so a long-running process retains a constant amount of undo state.
+    pub const MAX_ENTRIES: usize = 100;
+
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Append a new entry. Truncates the redo tail first.
+    /// Append a new entry. Truncates the redo tail first; at capacity the
+    /// oldest entry is dropped so the stack holds the newest
+    /// [`MAX_ENTRIES`](Self::MAX_ENTRIES) batches.
     pub fn push(&mut self, entry: UndoEntry) {
         self.entries.truncate(self.cursor);
+        if self.entries.len() >= Self::MAX_ENTRIES {
+            self.entries.remove(0);
+        }
         self.entries.push(entry);
         self.cursor = self.entries.len();
     }

--- a/crates/kanban-service/src/undo_stack.rs
+++ b/crates/kanban-service/src/undo_stack.rs
@@ -209,6 +209,69 @@ mod tests {
     }
 
     #[test]
+    fn test_push_past_cap_drops_oldest_and_keeps_newest_in_order() {
+        let mut stack = UndoStack::new();
+        let total = UndoStack::MAX_ENTRIES + 3;
+        for i in 0..total {
+            stack.push(make_pair(&format!("E{i}")));
+        }
+        assert_eq!(stack.undo_depth(), UndoStack::MAX_ENTRIES);
+        assert_eq!(stack.redo_depth(), 0);
+
+        let dbg = format!("{stack:?}");
+        for name in ["E0", "E1", "E2"] {
+            assert!(!dbg.contains(&format!("\"{name}\"")));
+        }
+
+        for i in (3..total).rev() {
+            let e = stack.peek_undo().expect("entry present");
+            assert!(
+                format!("{e:?}").contains(&format!("\"E{i}\"")),
+                "expected E{i} at this depth, got {e:?}"
+            );
+            assert!(stack.commit_undo());
+        }
+        assert!(stack.peek_undo().is_none());
+    }
+
+    #[test]
+    fn test_undo_after_overflow_replays_newest_entry() {
+        let mut stack = UndoStack::new();
+        let total = UndoStack::MAX_ENTRIES + 1;
+        for i in 0..total {
+            stack.push(make_pair(&format!("E{i}")));
+        }
+        assert_eq!(stack.undo_depth(), UndoStack::MAX_ENTRIES);
+
+        let e = stack.peek_undo().expect("entry present");
+        assert!(format!("{e:?}").contains(&format!("\"E{}\"", total - 1)));
+        assert!(stack.commit_undo());
+        assert_eq!(stack.redo_depth(), 1);
+    }
+
+    #[test]
+    fn test_push_at_cap_after_undo_truncates_redo_without_evicting() {
+        let mut stack = UndoStack::new();
+        for i in 0..UndoStack::MAX_ENTRIES {
+            stack.push(make_pair(&format!("E{i}")));
+        }
+        assert!(stack.commit_undo());
+        assert_eq!(stack.redo_depth(), 1);
+
+        stack.push(make_pair("X"));
+        assert_eq!(stack.undo_depth(), UndoStack::MAX_ENTRIES);
+        assert_eq!(stack.redo_depth(), 0);
+
+        for _ in 1..UndoStack::MAX_ENTRIES {
+            assert!(stack.commit_undo());
+        }
+        let bottom = stack.peek_undo().expect("bottom entry present");
+        assert!(format!("{bottom:?}").contains("\"E0\""));
+        assert!(stack.commit_undo());
+        assert!(!stack.commit_undo());
+    }
+
+    #[test]
     fn test_clear_resets_state() {
         let mut stack = UndoStack::new();
         stack.push(make_pair("A"));

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -4,6 +4,7 @@ use kanban_domain::commands::{
     UpdateBoard,
 };
 use kanban_domain::{BoardUpdate, CardUpdate, KanbanOperations, KanbanResult};
+use kanban_service::undo_stack::UndoStack;
 use kanban_service::{read_full_snapshot, write_full_snapshot, KanbanContext};
 use std::sync::Arc;
 
@@ -1004,10 +1005,7 @@ async fn test_undo_history_is_not_preserved_across_sessions() -> KanbanResult<()
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_undo_extends_past_old_200_step_cap() -> KanbanResult<()> {
-    // KAN-191 dropped the MAX_UNDO_DEPTH=200 cap. With pure command-replay
-    // every undo step is `Vec<Command>` (a few hundred bytes), so the cap
-    // that protected RAM from 200 full Snapshot clones is no longer needed.
+async fn test_undo_depth_saturates_at_undo_stack_cap() -> KanbanResult<()> {
     let mut ctx = make_ctx().await;
 
     let total = 250usize;
@@ -1022,22 +1020,23 @@ async fn test_undo_extends_past_old_200_step_cap() -> KanbanResult<()> {
 
     assert_eq!(
         ctx.undo_depth(),
-        total,
-        "undo depth must equal total commands executed (no cap)"
-    );
-    assert_eq!(ctx.boards()?.len(), total);
-
-    for _ in 0..total {
-        assert!(ctx.undo()?.is_some());
-    }
-    assert!(
-        !ctx.can_undo(),
-        "after undoing every step, can_undo is false"
+        UndoStack::MAX_ENTRIES,
+        "undo depth saturates at the stack cap; older entries are evicted"
     );
     assert_eq!(
         ctx.boards()?.len(),
-        0,
-        "after undoing every step, state is the initial baseline"
+        total,
+        "eviction drops undo history only, never committed state"
+    );
+
+    for _ in 0..UndoStack::MAX_ENTRIES {
+        assert!(ctx.undo()?.is_some());
+    }
+    assert!(!ctx.can_undo());
+    assert_eq!(
+        ctx.boards()?.len(),
+        total - UndoStack::MAX_ENTRIES,
+        "only the retained batches are undoable; evicted ones stay applied"
     );
     Ok(())
 }


### PR DESCRIPTION
Bounds `UndoStack` at a compile-time `MAX_ENTRIES` cap of 100. Pushing past the cap evicts the oldest entry, so a long-running `kanban-server`, whose shared context records every mutation from every client and exposes no undo endpoint, no longer grows without limit.

- `push` truncates the redo tail first, then evicts the bottom entry only when the stack is full and at the top; the cursor is reassigned after, so no stale cursor or dangling redo tail is reachable.
- Red test pins the cap, the eviction order, and that undo after overflow replays the newest entry; the 200-step integration test was rewritten in place with inverted assertions.
- README documents the cap.

Found by the 2026-09-06 post-merge review of the KAN-1065 wave (card KAN-1515). Per-client undo scoping stays out of scope and belongs to the server-session design under KAN-1448.
