### PR TITLE
KAN-1528 fix(domain,service): invalidate drops archival-marker tiers

### DIFF
--- a/.changeset/kan-1528-invalidate-drops-archival-markers.md
+++ b/.changeset/kan-1528-invalidate-drops-archival-markers.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+invalidate drops the flat archival-marker tiers on the entities path

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -88,8 +88,8 @@ mod tests {
     use super::*;
     use crate::resolved::Collection;
     use crate::{
-        ArchivedCard, Board, Card, Column, DependencyGraph, EntityIds, NoProjections, Resolved,
-        Snapshot, Sprint,
+        ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, EntityIds,
+        NoProjections, Resolved, Snapshot, Sprint,
     };
 
     fn seeded() -> (Model, Board, Column, Column, Card, Card, Sprint) {
@@ -597,27 +597,90 @@ mod tests {
     }
 
     #[test]
-    fn test_invalidate_does_not_touch_the_snapshot_derived_archived_ids() {
+    fn test_invalidate_card_entities_drops_flat_archived_card_marker_tier() {
         let board = Board::new("B", None::<String>);
-        let card = Card::new(board.id, Uuid::new_v4(), "task", 0);
-        let card_id = card.id;
-        let marker = ArchivedCard::new(card_id, board.id);
+        let live = Card::new(board.id, Uuid::new_v4(), "live", 0);
+        let archived = Card::new(board.id, Uuid::new_v4(), "archived", 0);
 
-        let mut m = Model::default();
-        let changed = m.load_from_snapshot(Snapshot {
-            boards: vec![board],
-            cards: vec![card],
-            archived_cards: vec![marker],
+        let mut m = Model::with_load_states(ModelLoadStates {
+            cards: LoadState::Loaded(vec![live.clone(), archived.clone()]),
+            archived_cards: Some(vec![ArchivedCard::new(archived.id, board.id)]),
             ..Default::default()
         });
-        NoProjections.resync(&m, changed);
-        let before: std::collections::HashSet<_> = m.archived_card_ids().clone();
-        assert!(!before.is_empty());
+        assert!(m.archived_cards_state().is_loaded());
+        assert!(m.archived_card_ids().contains(&archived.id));
 
-        let _ = m.invalidate(Invalidation::Entities(EntityIds::cards([card_id])));
+        let _ = m.invalidate(Invalidation::Entities(EntityIds::cards([live.id])));
 
-        assert_eq!(m.archived_card_ids(), &before);
-        assert!(!m.archived_card_markers().is_empty());
+        assert!(m.archived_cards_state().is_not_loaded());
+        assert!(m.archived_card_ids().is_empty());
+    }
+
+    #[test]
+    fn test_invalidate_board_entities_drops_flat_archived_board_marker_tier() {
+        let live_board = Board::new("B1", None::<String>);
+        let archived_board = Board::new("B2", None::<String>);
+        let card = Card::new(live_board.id, Uuid::new_v4(), "task", 0);
+
+        let mut m = Model::with_load_states(ModelLoadStates {
+            boards: LoadState::Loaded(vec![live_board.clone(), archived_board.clone()]),
+            cards: LoadState::Loaded(vec![card.clone()]),
+            archived_boards: Some(vec![ArchivedBoard::now(archived_board.id)]),
+            archived_cards: Some(vec![ArchivedCard::new(card.id, live_board.id)]),
+            ..Default::default()
+        });
+        assert!(m.archived_boards_state().is_loaded());
+        assert!(m.archived_board_ids().contains(&archived_board.id));
+        assert!(m.archived_cards_state().is_loaded());
+        assert!(m.archived_card_ids().contains(&card.id));
+
+        let _ = m.invalidate(Invalidation::Entities(EntityIds::boards([live_board.id])));
+
+        assert!(m.archived_boards_state().is_not_loaded());
+        assert!(m.archived_board_ids().is_empty());
+        assert!(m.archived_cards_state().is_loaded());
+        assert!(m.archived_card_ids().contains(&card.id));
+    }
+
+    #[test]
+    fn test_invalidate_prefix_bump_drops_the_flat_archived_board_marker_tier() {
+        let live_board = Board::new("B1", None::<String>);
+        let archived_board = Board::new("B2", None::<String>);
+        let card = Card::new(live_board.id, Uuid::new_v4(), "task", 0);
+
+        let mut m = Model::with_load_states(ModelLoadStates {
+            boards: LoadState::Loaded(vec![live_board.clone(), archived_board.clone()]),
+            cards: LoadState::Loaded(vec![card.clone()]),
+            archived_boards: Some(vec![ArchivedBoard::now(archived_board.id)]),
+            archived_cards: Some(vec![ArchivedCard::new(card.id, live_board.id)]),
+            ..Default::default()
+        });
+
+        let _ = m.invalidate(Invalidation::Entities(EntityIds::default().with_prefixes()));
+
+        assert!(m.archived_boards_state().is_not_loaded());
+        assert!(m.archived_board_ids().is_empty());
+    }
+
+    #[test]
+    fn test_invalidate_sprint_entities_leaves_archival_marker_tiers_loaded() {
+        let board = Board::new("B", None::<String>);
+        let card = Card::new(board.id, Uuid::new_v4(), "task", 0);
+        let sprint = Sprint::new(board.id, 1, None, None::<String>);
+
+        let mut m = Model::with_load_states(ModelLoadStates {
+            boards: LoadState::Loaded(vec![board.clone()]),
+            cards: LoadState::Loaded(vec![card.clone()]),
+            sprints: LoadState::Loaded(vec![sprint.clone()]),
+            archived_boards: Some(vec![]),
+            archived_cards: Some(vec![ArchivedCard::new(card.id, board.id)]),
+            ..Default::default()
+        });
+
+        let _ = m.invalidate(Invalidation::Entities(EntityIds::sprints([sprint.id])));
+
+        assert!(m.archived_cards_state().is_loaded());
+        assert!(m.archived_boards_state().is_loaded());
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -22,9 +22,13 @@ impl Model {
     /// clear of that tier here clears the matching index entries too, so
     /// `set_cards_of_column` remains its only writer.
     ///
-    /// The snapshot-derived archival markers are left untouched on the
-    /// `Entities` path: only `load_from_snapshot` recomputes them, and
-    /// blanking them here would reclassify every archived entity as live.
+    /// The flat archival-marker tiers (`archived_cards`/`archived_boards` and
+    /// their id sets) are dropped by the arm of the entity kind they mark: a
+    /// `cards` id drops the card markers, a `boards` id or a `prefixes` bump
+    /// drops the board markers. `EntityIds` cannot name a marker directly, so
+    /// this is conservative in the same way a card id already drops the whole
+    /// `cards_by_column`/`archived_cards_by_board` scoped tiers. Both
+    /// `apply_resolved` and `load_from_snapshot` repopulate the dropped tier.
     pub fn invalidate(&mut self, invalidation: Invalidation) -> ModelChanged {
         let ids = match invalidation {
             Invalidation::All => {
@@ -39,6 +43,9 @@ impl Model {
             self.boards = LoadState::NotLoaded;
             self.boards_by_id.clear();
             self.board_index.clear();
+            self.archived_boards = None;
+            self.archived_boards_error = None;
+            self.archived_board_ids.clear();
         }
         for id in &ids.boards {
             self.columns_by_board.remove(id);
@@ -65,6 +72,9 @@ impl Model {
             self.cards_by_column.clear();
             self.scoped_card_index.clear();
             self.archived_cards_by_board.clear();
+            self.archived_cards = None;
+            self.archived_cards_error = None;
+            self.archived_card_ids.clear();
         }
 
         if !ids.sprints.is_empty() {

--- a/crates/kanban-service/src/invalidation_plan.rs
+++ b/crates/kanban-service/src/invalidation_plan.rs
@@ -94,11 +94,10 @@ fn build_entities_round(ids: &EntityIds, loaded: &dyn LoadedState) -> FetchRound
         columns_by_board: Vec::new(),
         cards_by_column: Vec::new(),
         sprints_by_board: Vec::new(),
-        // `Model::invalidate`'s `Entities` path never blanks either flat
-        // archival tier; only `load_from_snapshot` recomputes them.
-        archived_card_list: false,
+        archived_card_list: !ids.cards.is_empty() && was_read(loaded.archived_card_list()),
         archived_cards_by_board: Vec::new(),
-        archived_board_list: false,
+        archived_board_list: (!ids.boards.is_empty() || ids.prefixes)
+            && was_read(loaded.archived_board_list()),
     }
 }
 

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -451,7 +451,7 @@ fn test_all_repairs_every_read_tier_including_the_archival_markers() {
 }
 
 #[test]
-fn test_an_invalidated_archived_card_list_is_not_requested_because_invalidate_does_not_blank_it() {
+fn test_entities_plan_rerequests_archived_card_list_when_model_had_read_it() {
     let a = Uuid::new_v4();
     let world = StubWorld {
         cards: HashMap::from([(a, FetchStatus::Loaded)]),
@@ -464,12 +464,12 @@ fn test_an_invalidated_archived_card_list_is_not_requested_because_invalidate_do
             .expect("card a was loaded");
 
     assert_eq!(plan.round().cards, vec![a]);
-    assert!(!plan.round().archived_card_list);
+    assert!(plan.round().archived_card_list);
+    assert!(!plan.round().archived_board_list);
 }
 
 #[test]
-fn test_an_invalidated_board_never_repairs_the_archived_board_list_because_invalidate_does_not_blank_it(
-) {
+fn test_entities_plan_rerequests_archived_board_list_when_model_had_read_it() {
     let b = Uuid::new_v4();
     let world = StubWorld {
         board_list: FetchStatus::Loaded,
@@ -482,6 +482,54 @@ fn test_an_invalidated_board_never_repairs_the_archived_board_list_because_inval
             .expect("board_list was loaded");
 
     assert!(plan.round().board_list);
+    assert!(plan.round().archived_board_list);
+    assert!(!plan.round().archived_card_list);
+}
+
+#[test]
+fn test_entities_plan_rerequests_archived_board_list_on_a_prefix_only_invalidation() {
+    let world = StubWorld {
+        board_list: FetchStatus::Loaded,
+        archived_board_list: FetchStatus::Loaded,
+        ..Default::default()
+    };
+
+    let plan = InvalidationPlan::for_invalidation(
+        &Invalidation::Entities(EntityIds::default().with_prefixes()),
+        &world,
+    )
+    .expect("board_list was loaded");
+
+    assert!(plan.round().archived_board_list);
+}
+
+#[test]
+fn test_entities_plan_skips_archived_card_list_when_never_read() {
+    let a = Uuid::new_v4();
+    let world = StubWorld {
+        cards: HashMap::from([(a, FetchStatus::Loaded)]),
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
+            .expect("card a was loaded");
+
+    assert!(!plan.round().archived_card_list);
+}
+
+#[test]
+fn test_entities_plan_skips_archived_board_list_when_never_read() {
+    let b = Uuid::new_v4();
+    let world = StubWorld {
+        board_list: FetchStatus::Loaded,
+        ..Default::default()
+    };
+
+    let plan =
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::boards([b])), &world)
+            .expect("board_list was loaded");
+
     assert!(!plan.round().archived_board_list);
 }
 

--- a/crates/kanban-service/tests/resync_invalidated_backend_parity.rs
+++ b/crates/kanban-service/tests/resync_invalidated_backend_parity.rs
@@ -1,5 +1,5 @@
 use kanban_backend_memory::InMemoryStore;
-use kanban_domain::{FieldUpdate, Invalidation, NoProjections};
+use kanban_domain::{Board, Card, Column, FieldUpdate, Invalidation, NoProjections, Sprint};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_service::{
     requestable, AppConfig, CardUpdate, FetchPlan, FetchRound, KanbanBackend, KanbanContext,
@@ -32,6 +32,8 @@ impl FetchPlan for WarmPlan {
             } else {
                 vec![]
             },
+            archived_card_list: requestable(loaded.archived_card_list()),
+            archived_board_list: requestable(loaded.archived_board_list()),
             ..Default::default()
         }
     }
@@ -44,7 +46,7 @@ impl FetchPlan for NothingPlan {
     }
 }
 
-fn assert_resync_invalidated_returns_the_updated_graph(ctx: &mut KanbanContext) {
+fn seed(ctx: &mut KanbanContext) -> (Board, Column, Card, Sprint) {
     let board = ctx
         .create_board("Board".into(), Some("BRD".into()))
         .unwrap();
@@ -60,6 +62,11 @@ fn assert_resync_invalidated_returns_the_updated_graph(ctx: &mut KanbanContext) 
     let sprint = ctx
         .create_sprint(board.id, Some("SPR".into()), Some("Sprint".into()))
         .unwrap();
+    (board, column, card, sprint)
+}
+
+fn assert_resync_invalidated_returns_the_updated_graph(ctx: &mut KanbanContext) {
+    let (board, column, card, sprint) = seed(ctx);
 
     let mut model = kanban_domain::Model::default();
     ctx.sync(
@@ -132,6 +139,56 @@ fn assert_resync_invalidated_returns_the_updated_graph(ctx: &mut KanbanContext) 
     assert!(model.graph_state().is_loaded());
 }
 
+fn assert_resync_invalidated_classifies_a_restored_card_as_live(ctx: &mut KanbanContext) {
+    let (_board, _column, card, sprint) = seed(ctx);
+
+    let _ = ctx.archive_card_impl(card.id).unwrap();
+
+    let mut model = kanban_domain::Model::default();
+    ctx.sync(
+        &WarmPlan {
+            card_id: card.id,
+            sprint_id: sprint.id,
+        },
+        &mut model,
+        &mut NoProjections,
+    );
+    assert!(model.archived_cards_state().is_loaded());
+    assert!(model.archived_card_ids().contains(&card.id));
+
+    let (_card, inv) = ctx.restore_card_impl(card.id, None).unwrap();
+    assert!(matches!(inv, Invalidation::Entities(_)));
+
+    ctx.resync_invalidated(inv, &NothingPlan, &mut model, &mut NoProjections);
+
+    assert!(!model.archived_card_ids().contains(&card.id));
+    assert!(model.archived_cards_state().is_loaded());
+}
+
+fn assert_resync_invalidated_classifies_an_archived_board_as_archived(ctx: &mut KanbanContext) {
+    let (board, _column, card, sprint) = seed(ctx);
+
+    let mut model = kanban_domain::Model::default();
+    ctx.sync(
+        &WarmPlan {
+            card_id: card.id,
+            sprint_id: sprint.id,
+        },
+        &mut model,
+        &mut NoProjections,
+    );
+    assert!(model.archived_boards_state().is_loaded());
+    assert!(!model.archived_board_ids().contains(&board.id));
+
+    let inv = ctx.archive_board_impl(board.id).unwrap();
+    assert!(matches!(inv, Invalidation::Entities(_)));
+
+    ctx.resync_invalidated(inv, &NothingPlan, &mut model, &mut NoProjections);
+
+    assert!(model.archived_board_ids().contains(&board.id));
+    assert!(model.archived_boards_state().is_loaded());
+}
+
 #[test]
 fn test_resync_invalidated_returns_the_updated_card_on_the_in_memory_backend() {
     let mut ctx =
@@ -170,4 +227,58 @@ async fn test_resync_invalidated_returns_the_updated_card_on_the_sqlite_backend(
     let path = dir.path().join("test.sqlite3");
     let mut ctx = open_sqlite_context(path.to_str().unwrap(), AppConfig::default()).await;
     assert_resync_invalidated_returns_the_updated_graph(&mut ctx);
+}
+
+#[test]
+fn test_resync_invalidated_classifies_restored_card_as_live_on_the_in_memory_backend() {
+    let mut ctx =
+        KanbanContext::open_deferred(Arc::new(InMemoryStore::new()), AppConfig::default());
+    assert_resync_invalidated_classifies_a_restored_card_as_live(&mut ctx);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resync_invalidated_classifies_restored_card_as_live_on_the_json_backend() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.json");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    assert_resync_invalidated_classifies_a_restored_card_as_live(&mut ctx);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resync_invalidated_classifies_restored_card_as_live_on_the_sqlite_backend() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let mut ctx = open_sqlite_context(path.to_str().unwrap(), AppConfig::default()).await;
+    assert_resync_invalidated_classifies_a_restored_card_as_live(&mut ctx);
+}
+
+#[test]
+fn test_resync_invalidated_classifies_archived_board_as_archived_on_the_in_memory_backend() {
+    let mut ctx =
+        KanbanContext::open_deferred(Arc::new(InMemoryStore::new()), AppConfig::default());
+    assert_resync_invalidated_classifies_an_archived_board_as_archived(&mut ctx);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resync_invalidated_classifies_archived_board_as_archived_on_the_json_backend() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.json");
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    assert_resync_invalidated_classifies_an_archived_board_as_archived(&mut ctx);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resync_invalidated_classifies_archived_board_as_archived_on_the_sqlite_backend() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.sqlite3");
+    let mut ctx = open_sqlite_context(path.to_str().unwrap(), AppConfig::default()).await;
+    assert_resync_invalidated_classifies_an_archived_board_as_archived(&mut ctx);
 }


### PR DESCRIPTION
## Summary

- `Model::invalidate`'s `Entities` path now drops the flat archival-marker tiers alongside the other tiers of the entity kind they belong to: a `cards` id drops `archived_cards`/`archived_cards_error`/`archived_card_ids`, and a `boards` id or a `prefixes` bump drops `archived_boards`/`archived_boards_error`/`archived_board_ids`.
- `InvalidationPlan::build_entities_round` re-requests `archived_card_list`/`archived_board_list` under the same `was_read` gate every other tier already uses, so a dropped marker tier the caller had actually read gets repaired in the same round.
- Replaced two false doc/comment blocks that stated the old ("markers are never touched") behavior with the true contract.
- Rewrote the three tests that pinned the old, now-reversed behavior, and added coverage for the prefix-bump path and for sprint/column invalidations leaving the marker tiers untouched.
- Added three cross-backend (in-memory, JSON, SQLite) integration tests proving a restored card is reclassified as live and an archived board is reclassified as archived after `resync_invalidated`.

## Test plan

- [x] `cargo test -p kanban-domain -p kanban-service --all-features`
- [x] `cargo test -p kanban-view -p kanban-tui -p kanban-cli -p kanban-mcp --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] Mutation check: reverted each of the two production fixes individually, confirmed the corresponding red test failed, restored the fix.
