### PR TITLE
KAN-1519 fix(tui): read one sprint tier per feature so handlers and renderers agree

### DIFF
--- a/.changeset/kan-1519-tui-sprint-tier-mismatch.md
+++ b/.changeset/kan-1519-tui-sprint-tier-mismatch.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+fix the sprint task panel so a filter cursor and rendered list can no longer come from different tiers

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -1,6 +1,27 @@
 use super::{App, AppMode};
+use kanban_domain::{LoadState, Sprint};
 
 impl App {
+    /// One sprint tier per board-scoped feature: the scoped tier when it has
+    /// resolved, otherwise the flat tier filtered to `board_id`. A scoped
+    /// `Loaded` (including an empty one) is authoritative and never falls
+    /// back; only `NotLoaded` triggers the fallback.
+    pub(crate) fn board_sprints_view(&self, board_id: uuid::Uuid) -> LoadState<Vec<Sprint>> {
+        match self.model.board_sprints_state(board_id) {
+            LoadState::Loaded(sprints) => LoadState::Loaded(sprints.to_vec()),
+            LoadState::NotLoaded => match self.model.sprints_state() {
+                LoadState::Loaded(all) => LoadState::Loaded(
+                    all.iter()
+                        .filter(|s| s.board_id == board_id)
+                        .cloned()
+                        .collect(),
+                ),
+                _ => LoadState::NotLoaded,
+            },
+            other => other.map(|_| Vec::new()),
+        }
+    }
+
     pub fn get_current_priority_selection_index(&self) -> usize {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
@@ -22,11 +43,9 @@ impl App {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 if let Some(card_sprint_id) = card.sprint_id {
-                    if let Some(board) = self.active_board() {
-                        if let kanban_domain::LoadState::Loaded(sprints) =
-                            self.model.sprints_state()
-                        {
-                            let entries = build_entries(sprints, board.id, chrono::Utc::now());
+                    if let Some(board_id) = self.active_board().map(|board| board.id) {
+                        if let LoadState::Loaded(sprints) = self.board_sprints_view(board_id) {
+                            let entries = build_entries(&sprints, board_id, chrono::Utc::now());
                             for (idx, entry) in entries.iter().enumerate() {
                                 if sprint_id_of(entry) == Some(card_sprint_id) {
                                     return idx;

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -125,3 +125,138 @@ mod active_card_index_regression {
         );
     }
 }
+
+#[cfg(test)]
+mod board_sprints_view_tests {
+    use crate::App;
+    use kanban_domain::resolved::Collection;
+    use kanban_domain::{Board, Column, DependencyGraph, LoadState, Resolved, Sprint};
+    use std::collections::HashMap;
+
+    fn base_resolved(board: &Board) -> Resolved {
+        Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board.clone()]),
+                ..Default::default()
+            },
+            cards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            columns: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            graph: LoadState::Loaded(DependencyGraph::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_board_sprints_view_prefers_the_scoped_tier_and_falls_back_to_the_flat_one() {
+        let board = Board::new("B", None::<String>);
+        let other_board = Board::new("Other", None::<String>);
+        let s_on_board = Sprint::new(board.id, 1, None, None::<String>);
+        let s_other_board = Sprint::new(other_board.id, 1, None, None::<String>);
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.sprints = Collection {
+            all: LoadState::Loaded(vec![s_on_board.clone(), s_other_board.clone()]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        match app.board_sprints_view(board.id) {
+            LoadState::Loaded(sprints) => {
+                assert_eq!(sprints, vec![s_on_board.clone()]);
+            }
+            other => panic!("expected fallback to the flat tier, got {other:?}"),
+        }
+
+        let app = App::test_default();
+        assert!(app.board_sprints_view(board.id).is_not_loaded());
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.sprints = Collection {
+            by_parent: HashMap::from([(
+                board.id,
+                LoadState::Failed(std::sync::Arc::new(
+                    kanban_domain::KanbanError::unsupported("boom"),
+                )),
+            )]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        assert!(app.board_sprints_view(board.id).is_failed());
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.sprints = Collection {
+            all: LoadState::Loaded(vec![s_on_board.clone()]),
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(Vec::new()))]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        match app.board_sprints_view(board.id) {
+            LoadState::Loaded(sprints) => assert!(sprints.is_empty()),
+            other => panic!("expected Loaded(empty), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_sprint_selection_index_matches_scoped_tier_entries() {
+        use kanban_view::sprint_assign_list::{build_entries, sprint_id_of};
+
+        let board = Board::new("B", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
+        let mut s_a = Sprint::new(board.id, 2, None, None::<String>);
+        let mut s_b = Sprint::new(board.id, 1, None, None::<String>);
+        s_a.status = kanban_domain::SprintStatus::Planning;
+        s_b.status = kanban_domain::SprintStatus::Planning;
+
+        let mut app = App::test_default();
+        let mut card = kanban_domain::Card::new(board.id, column.id, "Task", 0);
+        card.sprint_id = Some(s_b.id);
+
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            all: LoadState::Loaded(vec![column]),
+            ..Default::default()
+        };
+        resolved.cards = Collection {
+            all: LoadState::Loaded(vec![card.clone()]),
+            ..Default::default()
+        };
+        resolved.sprints = Collection {
+            all: LoadState::Loaded(vec![s_a.clone(), s_b.clone()]),
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![s_b.clone()]))]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        app.selection.active_board_id = Some(board.id);
+        app.selection.active_card_id = Some(card.id);
+
+        let sprints = app.model.sprints_state();
+        let flat_entries = if let LoadState::Loaded(sprints) = sprints {
+            build_entries(sprints, board.id, chrono::Utc::now())
+        } else {
+            panic!("expected flat tier loaded")
+        };
+        let flat_idx = flat_entries
+            .iter()
+            .position(|e| sprint_id_of(e) == Some(s_b.id))
+            .unwrap();
+        assert_eq!(
+            flat_idx, 3,
+            "sanity: the flat tier lists s_a before s_b, so s_b sits later there"
+        );
+
+        let idx = app.get_current_sprint_selection_index();
+
+        assert_eq!(
+            idx, 2,
+            "must index into the scoped tier's entries ([None, Header, s_b]), not the flat tier's"
+        );
+    }
+}

--- a/crates/kanban-tui/src/components/card_list_item.rs
+++ b/crates/kanban-tui/src/components/card_list_item.rs
@@ -10,6 +10,7 @@ pub struct CardListItemConfig<'a> {
     pub card: &'a Card,
     pub board: &'a Board,
     pub sprints: &'a [Sprint],
+    pub sprints_loaded: bool,
     pub is_selected: bool,
     pub is_focused: bool,
     pub is_multi_selected: bool,
@@ -49,12 +50,11 @@ pub fn render_card_list_item(config: CardListItemConfig) -> Line<'static> {
 
     let suffix_text = if config.show_sprint_name {
         if let Some(sprint_id) = config.card.sprint_id {
-            config
-                .sprints
-                .iter()
-                .find(|s| s.id == sprint_id)
-                .map(|s| format!(" ({})", s.formatted_name(config.board, None)))
-                .unwrap_or_default()
+            match config.sprints.iter().find(|s| s.id == sprint_id) {
+                Some(s) => format!(" ({})", s.formatted_name(config.board, None)),
+                None if !config.sprints_loaded => " (\u{2026})".to_string(),
+                None => String::new(),
+            }
         } else {
             String::new()
         }

--- a/crates/kanban-tui/src/components/filter_popup.rs
+++ b/crates/kanban-tui/src/components/filter_popup.rs
@@ -85,7 +85,8 @@ fn render_filter_sprints_section(
     )));
 
     if let Some(board) = app.active_board() {
-        match app.model.board_sprints_state(board.id) {
+        let board_sprints_view = app.board_sprints_view(board.id);
+        match &board_sprints_view {
             LoadState::Loaded(board_sprints) => {
                 if board_sprints.is_empty() {
                     sprint_lines.push(Line::from(Span::styled(
@@ -114,7 +115,10 @@ fn render_filter_sprints_section(
                     }
                 }
             }
-            other => sprint_lines.extend(load_state_body("Sprints", &other)),
+            _ => sprint_lines.extend(load_state_body(
+                "Sprints",
+                &board_sprints_view.as_ref().map(Vec::as_slice),
+            )),
         }
     }
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2581,4 +2581,136 @@ mod tests {
             "status must be unchanged when the handler declines"
         );
     }
+
+    fn seed_board_with_scoped_and_flat_sprints(
+        app: &mut App,
+        build_scoped: impl FnOnce(uuid::Uuid) -> Vec<kanban_domain::Sprint>,
+        build_flat_all: impl FnOnce(uuid::Uuid) -> LoadState<Vec<kanban_domain::Sprint>>,
+    ) -> uuid::Uuid {
+        use kanban_domain::resolved::Collection;
+        use kanban_domain::{Column, DependencyGraph, Resolved};
+
+        let board = kanban_domain::Board::new("Board", None::<String>);
+        let board_id = board.id;
+        let column = Column::new(board_id, "Todo", 0);
+        let scoped = build_scoped(board_id);
+        let flat_all = build_flat_all(board_id);
+
+        let resolved = Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board]),
+                ..Default::default()
+            },
+            columns: Collection {
+                all: LoadState::Loaded(vec![column]),
+                ..Default::default()
+            },
+            cards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            sprints: Collection {
+                all: flat_all,
+                by_parent: [(board_id, LoadState::Loaded(scoped))].into(),
+                ..Default::default()
+            },
+            graph: LoadState::Loaded(DependencyGraph::default()),
+            ..Default::default()
+        };
+        let changed = app.model.apply_resolved(resolved);
+        app.controller.resync(&app.model, changed);
+        app.selection.active_board_id = Some(board_id);
+        app.prepare_frame();
+        board_id
+    }
+
+    #[test]
+    fn test_board_detail_sprint_nav_uses_scoped_tier_rows() {
+        let mut app = App::test_default();
+        let board_id = seed_board_with_scoped_and_flat_sprints(
+            &mut app,
+            |board_id| {
+                vec![
+                    kanban_domain::Sprint::new(board_id, 1, None, None::<String>),
+                    kanban_domain::Sprint::new(board_id, 2, None, None::<String>),
+                ]
+            },
+            |_| LoadState::NotLoaded,
+        );
+
+        app.selection.active_board_id = Some(board_id);
+        app.focus.board_focus = BoardFocus::Sprints;
+        app.selection.sprint.set(Some(0));
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('j'));
+
+        assert_eq!(app.selection.sprint.get(), Some(1));
+        assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
+        assert_no_banner(&app);
+    }
+
+    #[test]
+    fn test_board_detail_sprint_enter_opens_the_sprint_the_scoped_tier_shows() {
+        let mut app = App::test_default();
+        let s2_id = std::cell::Cell::new(uuid::Uuid::nil());
+        let board_id = seed_board_with_scoped_and_flat_sprints(
+            &mut app,
+            |board_id| {
+                let s1 = kanban_domain::Sprint::new(board_id, 1, None, None::<String>);
+                let s2 = kanban_domain::Sprint::new(board_id, 2, None, None::<String>);
+                s2_id.set(s2.id);
+                vec![s1, s2]
+            },
+            |board_id| {
+                LoadState::Loaded(vec![kanban_domain::Sprint::new(
+                    board_id,
+                    99,
+                    None,
+                    None::<String>,
+                )])
+            },
+        );
+        let s2_id = s2_id.get();
+
+        app.selection.active_board_id = Some(board_id);
+        app.focus.board_focus = BoardFocus::Sprints;
+        app.selection.sprint.set(Some(1));
+
+        app.handle_board_detail_navigation_key(KeyCode::Enter);
+
+        assert_eq!(app.selection.active_sprint_id, Some(s2_id));
+        assert_eq!(app.mode, AppMode::SprintDetail);
+        assert_no_banner(&app);
+    }
+
+    #[test]
+    fn test_column_focus_exit_upwards_lands_on_the_last_scoped_sprint_row() {
+        let mut app = App::test_default();
+        let board_id = seed_board_with_scoped_and_flat_sprints(
+            &mut app,
+            |board_id| {
+                vec![
+                    kanban_domain::Sprint::new(board_id, 1, None, None::<String>),
+                    kanban_domain::Sprint::new(board_id, 2, None, None::<String>),
+                ]
+            },
+            |board_id| {
+                LoadState::Loaded(vec![
+                    kanban_domain::Sprint::new(board_id, 1, None, None::<String>),
+                    kanban_domain::Sprint::new(board_id, 2, None, None::<String>),
+                    kanban_domain::Sprint::new(board_id, 3, None, None::<String>),
+                ])
+            },
+        );
+
+        app.selection.active_board_id = Some(board_id);
+        app.focus.board_focus = BoardFocus::Columns;
+        app.dialog_input.column_list.update_item_count(1);
+        app.dialog_input.column_list.set_selected_index(Some(0));
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('k'));
+
+        assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
+        assert_eq!(app.selection.sprint.get(), Some(1));
+    }
 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -467,10 +467,9 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => match self.focus.board_focus {
                 BoardFocus::Sprints => {
                     if let Some(board_id) = self.active_board().map(|board| board.id) {
-                        match self.model.sprints_state() {
+                        match self.board_sprints_view(board_id) {
                             LoadState::Loaded(sprints) => {
-                                let sprint_count =
-                                    sprints.iter().filter(|s| s.board_id == board_id).count();
+                                let sprint_count = sprints.len();
                                 let current_idx = self.selection.sprint.get().unwrap_or(0);
                                 if sprint_count == 0 || current_idx >= sprint_count - 1 {
                                     if self.model.columns_state().is_loaded() {
@@ -551,24 +550,17 @@ impl App {
                             .update_item_count(column_count);
                         let was_at_top = self.dialog_input.column_list.navigate_up();
                         if was_at_top {
-                            let sprints_ready =
-                                board_id.is_none() || self.model.sprints_state().is_loaded();
-                            if !sprints_ready {
-                                self.set_error("Sprints are not loaded yet");
-                            } else {
-                                let sprint_count = board_id
-                                    .and_then(|id| match self.model.sprints_state() {
-                                        LoadState::Loaded(sprints) => Some(
-                                            sprints.iter().filter(|s| s.board_id == id).count(),
-                                        ),
-                                        _ => None,
-                                    })
-                                    .unwrap_or(0);
-                                if sprint_count == 0 {
-                                    self.focus.board_focus = BoardFocus::Settings;
-                                } else {
+                            let sprint_rows = match board_id.map(|id| self.board_sprints_view(id)) {
+                                None => Some(0usize),
+                                Some(LoadState::Loaded(sprints)) => Some(sprints.len()),
+                                Some(_) => None,
+                            };
+                            match sprint_rows {
+                                None => self.set_error("Sprints are not loaded yet"),
+                                Some(0) => self.focus.board_focus = BoardFocus::Settings,
+                                Some(n) => {
                                     self.focus.board_focus = BoardFocus::Sprints;
-                                    self.selection.sprint.set(Some(sprint_count - 1));
+                                    self.selection.sprint.set(Some(n - 1));
                                 }
                             }
                         }
@@ -594,13 +586,9 @@ impl App {
                     if let Some(sprint_idx) = self.selection.sprint.get() {
                         let board_ctx = self.board_in_context().map(|b| b.id);
                         if let Some(board_id) = board_ctx {
-                            match self.model.sprints_state() {
+                            match self.board_sprints_view(board_id) {
                                 LoadState::Loaded(sprints) => {
-                                    let sprint_id = sprints
-                                        .iter()
-                                        .filter(|s| s.board_id == board_id)
-                                        .nth(sprint_idx)
-                                        .map(|s| s.id);
+                                    let sprint_id = sprints.get(sprint_idx).map(|s| s.id);
                                     if let Some(sprint_id) = sprint_id {
                                         self.selection.active_sprint_id = Some(sprint_id);
                                         self.selection.active_board_id = Some(board_id);

--- a/crates/kanban-tui/src/handlers/filter_handlers.rs
+++ b/crates/kanban-tui/src/handlers/filter_handlers.rs
@@ -24,6 +24,17 @@ impl App {
     pub fn handle_filter_options_popup(&mut self, key_code: KeyCode) {
         use crossterm::event::KeyCode;
 
+        if self.filter.dialog_state.is_none() {
+            return;
+        }
+
+        let board_id = self
+            .selection
+            .active_board_id
+            .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
+            .map(|board| board.id);
+        let board_sprints = board_id.map(|id| self.board_sprints_view(id));
+
         if let Some(ref mut dialog_state) = self.filter.dialog_state {
             match key_code {
                 KeyCode::Esc => {
@@ -31,31 +42,20 @@ impl App {
                     self.pop_mode();
                 }
                 KeyCode::Char('j') | KeyCode::Down => match dialog_state.current_section {
-                    FilterDialogSection::Sprints => {
-                        if let Some(board_id) = self.selection.active_board_id.and_then(|id| {
-                            self.model
-                                .board_by_id_state(id)
-                                .loaded()
-                                .copied()
-                                .map(|b| b.id)
-                        }) {
-                            match self.model.sprints_state() {
-                                LoadState::Loaded(sprints) => {
-                                    let sprint_count =
-                                        sprints.iter().filter(|s| s.board_id == board_id).count();
-                                    let total_items = 1 + sprint_count;
-                                    if dialog_state.item_selection < total_items.saturating_sub(1) {
-                                        dialog_state.item_selection += 1;
-                                    } else {
-                                        dialog_state.next_section();
-                                    }
-                                }
-                                _ => {
-                                    self.set_error("Sprints are not loaded yet".to_string());
-                                }
+                    FilterDialogSection::Sprints => match &board_sprints {
+                        Some(LoadState::Loaded(sprints)) => {
+                            let total_items = 1 + sprints.len();
+                            if dialog_state.item_selection < total_items.saturating_sub(1) {
+                                dialog_state.item_selection += 1;
+                            } else {
+                                dialog_state.next_section();
                             }
                         }
-                    }
+                        Some(_) => {
+                            self.set_error("Sprints are not loaded yet".to_string());
+                        }
+                        None => {}
+                    },
                     _ => {
                         dialog_state.next_section();
                     }
@@ -78,42 +78,35 @@ impl App {
                                 dialog_state.filters.show_unassigned_sprints
                             );
                             self.apply_filters();
-                        } else if let Some(board) = self
-                            .selection
-                            .active_board_id
-                            .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
-                        {
-                            match self.model.sprints_state() {
-                                LoadState::Loaded(sprints) => {
-                                    let board_sprints: Vec<_> =
-                                        sprints.iter().filter(|s| s.board_id == board.id).collect();
+                        } else {
+                            match &board_sprints {
+                                Some(LoadState::Loaded(sprints)) => {
                                     let sprint_idx = dialog_state.item_selection - 1;
-                                    if let Some(sprint) = board_sprints.get(sprint_idx) {
+                                    if let Some(sprint) = sprints.get(sprint_idx) {
+                                        let sprint_id = sprint.id;
                                         if dialog_state
                                             .filters
                                             .selected_sprint_ids
-                                            .contains(&sprint.id)
+                                            .contains(&sprint_id)
                                         {
                                             dialog_state
                                                 .filters
                                                 .selected_sprint_ids
-                                                .remove(&sprint.id);
+                                                .remove(&sprint_id);
                                         } else {
                                             dialog_state
                                                 .filters
                                                 .selected_sprint_ids
-                                                .insert(sprint.id);
+                                                .insert(sprint_id);
                                         }
-                                        tracing::info!(
-                                            "Toggled sprint: {}",
-                                            sprint.formatted_name(board, None)
-                                        );
+                                        tracing::info!("Toggled sprint: {sprint_id}");
                                         self.apply_filters();
                                     }
                                 }
-                                _ => {
+                                Some(_) => {
                                     self.set_error("Sprints are not loaded yet".to_string());
                                 }
+                                None => {}
                             }
                         }
                     }

--- a/crates/kanban-tui/src/render_strategy.rs
+++ b/crates/kanban-tui/src/render_strategy.rs
@@ -148,11 +148,9 @@ impl RenderStrategy for SinglePanelRenderer {
 
                             // Render all cards with column headers interspersed
                             let mut columns_shown = std::collections::HashSet::new();
-                            let empty_sprints: &[kanban_domain::Sprint] = &[];
-                            let sprints = match app.model.board_sprints_state(board.id) {
-                                LoadState::Loaded(sprints) => sprints,
-                                _ => empty_sprints,
-                            };
+                            let board_sprints_view = app.board_sprints_view(board.id);
+                            let sprints = board_sprints_view.loaded_or_empty();
+                            let sprints_loaded = board_sprints_view.is_loaded();
 
                             for card_idx in &render_info.visible_card_indices {
                                 // Find which column this card belongs to
@@ -192,6 +190,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                             card,
                                             board,
                                             sprints,
+                                            sprints_loaded,
                                             is_selected,
                                             is_focused: app.focus.active
                                                 == crate::app::Focus::Cards,
@@ -272,11 +271,9 @@ impl RenderStrategy for SinglePanelRenderer {
                             "Task",
                         ));
 
-                        let empty_sprints: &[kanban_domain::Sprint] = &[];
-                        let sprints = match app.model.board_sprints_state(board.id) {
-                            LoadState::Loaded(sprints) => sprints,
-                            _ => empty_sprints,
-                        };
+                        let board_sprints_view = app.board_sprints_view(board.id);
+                        let sprints = board_sprints_view.loaded_or_empty();
+                        let sprints_loaded = board_sprints_view.is_loaded();
 
                         for card_idx in &render_info.visible_card_indices {
                             if let Some(card_id) = task_list.cards.get(*card_idx) {
@@ -292,6 +289,7 @@ impl RenderStrategy for SinglePanelRenderer {
                                         card,
                                         board,
                                         sprints,
+                                        sprints_loaded,
                                         is_selected: task_list.get_selected_index()
                                             == Some(*card_idx),
                                         is_focused: app.focus.active == crate::app::Focus::Cards,
@@ -382,11 +380,9 @@ impl RenderStrategy for MultiPanelRenderer {
                     .split(area);
 
                 let active_task_list = app.view.strategy.get_active_task_list();
-                let empty_sprints: &[kanban_domain::Sprint] = &[];
-                let sprints = match app.model.board_sprints_state(board.id) {
-                    LoadState::Loaded(sprints) => sprints,
-                    _ => empty_sprints,
-                };
+                let board_sprints_view = app.board_sprints_view(board.id);
+                let sprints = board_sprints_view.loaded_or_empty();
+                let sprints_loaded = board_sprints_view.is_loaded();
 
                 for (col_idx, task_list) in task_lists.iter().enumerate() {
                     let mut lines = vec![];
@@ -443,6 +439,7 @@ impl RenderStrategy for MultiPanelRenderer {
                                         card,
                                         board,
                                         sprints,
+                                        sprints_loaded,
                                         is_selected,
                                         is_focused: app.focus.active == crate::app::Focus::Cards
                                             && is_focused_column,

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -154,7 +154,8 @@ fn render_board_sprints_list(
 
     let mut sprint_lines = vec![];
 
-    match app.model.board_sprints_state(board.id) {
+    let board_sprints_view = app.board_sprints_view(board.id);
+    match &board_sprints_view {
         LoadState::Loaded(board_sprints) => {
             if board_sprints.is_empty() {
                 sprint_lines.push(Line::from(Span::styled(
@@ -219,7 +220,10 @@ fn render_board_sprints_list(
                 }
             }
         }
-        other => sprint_lines.extend(load_state_body("Sprints", &other)),
+        _ => sprint_lines.extend(load_state_body(
+            "Sprints",
+            &board_sprints_view.as_ref().map(Vec::as_slice),
+        )),
     }
 
     let selected_idx = app.selection.sprint.get().unwrap_or(0);

--- a/crates/kanban-tui/src/ui/sprint_detail.rs
+++ b/crates/kanban-tui/src/ui/sprint_detail.rs
@@ -243,11 +243,9 @@ pub(super) fn render_sprint_task_panel_with_selection(
             "Task",
         ));
 
-        let empty_sprints: &[Sprint] = &[];
-        let sprints = match app.model.board_sprints_state(board.id) {
-            LoadState::Loaded(sprints) => sprints,
-            _ => empty_sprints,
-        };
+        let board_sprints_view = app.board_sprints_view(board.id);
+        let sprints = board_sprints_view.loaded_or_empty();
+        let sprints_loaded = board_sprints_view.is_loaded();
 
         for card_idx in &render_info.visible_card_indices {
             if let Some(card_id) = task_list.cards.get(*card_idx) {
@@ -262,6 +260,7 @@ pub(super) fn render_sprint_task_panel_with_selection(
                         card,
                         board,
                         sprints,
+                        sprints_loaded,
                         is_selected,
                         is_focused,
                         is_multi_selected: false,

--- a/crates/kanban-tui/tests/sprint_tier_coherence_tests.rs
+++ b/crates/kanban-tui/tests/sprint_tier_coherence_tests.rs
@@ -17,8 +17,8 @@ fn seed_board_with_divergent_sprint_tiers(
     let mut app = App::test_default();
     let board = Board::new("TestBoard", None::<String>);
     let scoped = build_scoped(board.id);
-    let mut all_sprints = scoped.clone();
-    all_sprints.extend(build_flat_extra(board.id));
+    let mut all_sprints = build_flat_extra(board.id);
+    all_sprints.extend(scoped.clone());
 
     let resolved = Resolved {
         boards: Collection {

--- a/crates/kanban-tui/tests/sprint_tier_coherence_tests.rs
+++ b/crates/kanban-tui/tests/sprint_tier_coherence_tests.rs
@@ -1,0 +1,225 @@
+mod helpers;
+
+use kanban_domain::resolved::Collection;
+use kanban_domain::{
+    Board, Card, Column, DependencyGraph, DerivedProjections, LoadState, Resolved, Sprint,
+};
+use kanban_tui::app::Focus;
+use kanban_tui::render_strategy::{RenderStrategy, SinglePanelRenderer};
+use kanban_tui::App;
+use kanban_view::view_strategy::ViewRefreshContext;
+use std::collections::HashMap;
+
+fn seed_board_with_divergent_sprint_tiers(
+    build_scoped: impl FnOnce(uuid::Uuid) -> Vec<Sprint>,
+    build_flat_extra: impl FnOnce(uuid::Uuid) -> Vec<Sprint>,
+) -> (App, Board) {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let scoped = build_scoped(board.id);
+    let mut all_sprints = scoped.clone();
+    all_sprints.extend(build_flat_extra(board.id));
+
+    let resolved = Resolved {
+        boards: Collection {
+            all: LoadState::Loaded(vec![board.clone()]),
+            ..Default::default()
+        },
+        cards: Collection {
+            all: LoadState::Loaded(vec![]),
+            ..Default::default()
+        },
+        columns: Collection {
+            all: LoadState::Loaded(vec![]),
+            ..Default::default()
+        },
+        sprints: Collection {
+            all: LoadState::Loaded(all_sprints),
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(scoped))]),
+            ..Default::default()
+        },
+        graph: LoadState::Loaded(DependencyGraph::default()),
+        ..Default::default()
+    };
+    let changed = app.model.apply_resolved(resolved);
+    app.controller.resync(&app.model, changed);
+    app.selection.active_board_id = Some(board.id);
+    (app, board)
+}
+
+fn open_filter_dialog(app: &mut App) {
+    app.focus.active = Focus::Cards;
+    app.handle_open_filter_dialog();
+}
+
+#[test]
+fn test_filter_dialog_sprint_toggle_targets_rendered_sprint() {
+    let s_a_id = std::cell::Cell::new(uuid::Uuid::nil());
+    let s_b_id = std::cell::Cell::new(uuid::Uuid::nil());
+    let (mut app, _board) = seed_board_with_divergent_sprint_tiers(
+        |board_id| {
+            let s_b = Sprint::new(board_id, 2, None, None::<String>);
+            s_b_id.set(s_b.id);
+            vec![s_b]
+        },
+        |board_id| {
+            let s_a = Sprint::new(board_id, 1, None, None::<String>);
+            s_a_id.set(s_a.id);
+            vec![s_a]
+        },
+    );
+    let s_a_id = s_a_id.get();
+    let s_b_id = s_b_id.get();
+
+    open_filter_dialog(&mut app);
+    let dialog_state = app
+        .filter
+        .dialog_state
+        .as_mut()
+        .expect("filter dialog must be open");
+    dialog_state.item_selection = 1;
+
+    app.handle_filter_options_popup(crossterm::event::KeyCode::Char(' '));
+
+    assert!(app.filter.active_sprint_filters.contains(&s_b_id));
+    assert!(!app.filter.active_sprint_filters.contains(&s_a_id));
+}
+
+#[test]
+fn test_filter_dialog_sprint_nav_counts_the_rendered_rows() {
+    let (mut app, _board) = seed_board_with_divergent_sprint_tiers(
+        |board_id| vec![Sprint::new(board_id, 2, None, None::<String>)],
+        |board_id| vec![Sprint::new(board_id, 1, None, None::<String>)],
+    );
+
+    open_filter_dialog(&mut app);
+    {
+        let dialog_state = app
+            .filter
+            .dialog_state
+            .as_mut()
+            .expect("filter dialog must be open");
+        dialog_state.item_selection = 1;
+    }
+
+    app.handle_filter_options_popup(crossterm::event::KeyCode::Char('j'));
+
+    let dialog_state = app
+        .filter
+        .dialog_state
+        .as_ref()
+        .expect("filter dialog stays open on next-section advance");
+    assert_ne!(
+        dialog_state.current_section,
+        kanban_view::filters::FilterDialogSection::Sprints
+    );
+    assert_eq!(dialog_state.item_selection, 0);
+}
+
+#[test]
+fn test_task_row_sprint_suffix_not_loaded_renders_marker_not_blank() {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let column = Column::new(board.id, "Backlog", 0);
+    let mut card = Card::new(board.id, column.id, "Task", 0);
+    card.sprint_id = Some(uuid::Uuid::new_v4());
+
+    let resolved = Resolved {
+        boards: Collection {
+            all: LoadState::Loaded(vec![board.clone()]),
+            ..Default::default()
+        },
+        cards: Collection {
+            all: LoadState::Loaded(vec![card.clone()]),
+            ..Default::default()
+        },
+        columns: Collection {
+            all: LoadState::Loaded(vec![column.clone()]),
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column.clone()]))]),
+            ..Default::default()
+        },
+        graph: LoadState::Loaded(DependencyGraph::default()),
+        ..Default::default()
+    };
+    let changed = app.model.apply_resolved(resolved);
+    app.controller.resync(&app.model, changed);
+    app.selection.active_board_id = Some(board.id);
+    app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.view.strategy.refresh_task_lists(&ViewRefreshContext {
+        board: &board,
+        all_cards: &[card],
+        all_columns: &[column],
+        all_sprints: &[],
+        active_sprint_filters: Default::default(),
+        hide_assigned_cards: false,
+        search_query: None,
+    });
+
+    let rendered = helpers::render_widget_to_string(80, 20, |f| {
+        SinglePanelRenderer::grouped().render(&app, f, f.area());
+    });
+
+    assert!(
+        rendered.contains("(\u{2026})"),
+        "expected the not-loaded sprint marker in:\n{rendered}"
+    );
+}
+
+#[test]
+fn test_task_row_sprint_suffix_loaded_renders_the_sprint_name() {
+    let mut app = App::test_default();
+    let board = Board::new("TestBoard", None::<String>);
+    let column = Column::new(board.id, "Backlog", 0);
+    let mut sprint = Sprint::new(board.id, 1, None, None::<String>);
+    sprint.prefix = Some("SPR".to_string());
+    let mut card = Card::new(board.id, column.id, "Task", 0);
+    card.sprint_id = Some(sprint.id);
+
+    let resolved = Resolved {
+        boards: Collection {
+            all: LoadState::Loaded(vec![board.clone()]),
+            ..Default::default()
+        },
+        cards: Collection {
+            all: LoadState::Loaded(vec![card.clone()]),
+            ..Default::default()
+        },
+        columns: Collection {
+            all: LoadState::Loaded(vec![column.clone()]),
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column.clone()]))]),
+            ..Default::default()
+        },
+        sprints: Collection {
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![sprint.clone()]))]),
+            ..Default::default()
+        },
+        graph: LoadState::Loaded(DependencyGraph::default()),
+        ..Default::default()
+    };
+    let changed = app.model.apply_resolved(resolved);
+    app.controller.resync(&app.model, changed);
+    app.selection.active_board_id = Some(board.id);
+    app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
+    app.view.strategy.refresh_task_lists(&ViewRefreshContext {
+        board: &board,
+        all_cards: &[card],
+        all_columns: &[column],
+        all_sprints: std::slice::from_ref(&sprint),
+        active_sprint_filters: Default::default(),
+        hide_assigned_cards: false,
+        search_query: None,
+    });
+
+    let rendered = helpers::render_widget_to_string(80, 20, |f| {
+        SinglePanelRenderer::grouped().render(&app, f, f.area());
+    });
+
+    assert!(
+        !rendered.contains("(\u{2026})"),
+        "must not show the not-loaded marker once the scoped tier resolves:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(&sprint.formatted_name(&board, None)),
+        "expected the loaded sprint's name in:\n{rendered}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `App::board_sprints_view(board_id) -> LoadState<Vec<Sprint>>`: the board-scoped sprint tier when it has resolved, falling back to the flat tier filtered by board only when the scoped tier is `NotLoaded`. A scoped `Loaded` (including an empty one) is authoritative and never falls back.

Routes every board-scoped sprint read through it:

- `detail_view_handlers.rs`: the Sprints-panel `j`/`k` navigation arms and the Enter-to-open-sprint arm (the `k` arm fix was not in the original card; it shared the same defect).
- `filter_handlers.rs`: the filter dialog's Sprints section navigation and space-toggle (the tier read is hoisted above the `dialog_state` borrow so it still borrow-checks).
- `app/query.rs`: `get_current_sprint_selection_index`.
- `ui/board_detail.rs` and `components/filter_popup.rs`: the two renderers, adapted to the accessor's owned `Vec` via `.as_ref().map(Vec::as_slice)` for the `load_state_body` marker.
- `render_strategy.rs` (three task-row sites) and `ui/sprint_detail.rs` (compile-forced by the new `CardListItemConfig` field, behavior there unchanged since `show_sprint_name` is false).

Before this, a navigation index (built from the scoped tier) and a rendered row (drawn from the flat tier, or vice versa) could come from different tiers, so a keypress could move the cursor to a row the panel never draws, or open a different sprint than the one highlighted.

Also adds a `sprints_loaded: bool` field to `CardListItemConfig`. A task row whose card has a sprint but whose sprint tier has not resolved now renders a `(…)` suffix instead of a blank indistinguishable from "no sprint".

## Out of scope, reported (not fixed here)

- `j`/`Enter` in the Sprints panel resolve the board differently (`active_board()` vs `board_in_context()`); when only a board-list highlight exists (no board opened), `j` silently no-ops while Enter and the renderer work. Belongs with the column-focus work.
- `SprintAssignDialog::options_count` collapses a non-Loaded scoped tier to `1`, independently of this fix.
- `ui/board_detail.rs`'s "Active Sprint Card Prefix" settings line reads the scoped tier directly and silently omits itself when not Loaded; cosmetic only.

## Surviving `sprints_state()` reads in touched files

- `detail_view_handlers.rs::handle_assign_sprint_shortcut` and `open_assign_sprint_dialog_for`, the assign-to-sprint picker, out of this card's scope.
- Two pre-existing tests in `app/query.rs`'s `active_card_index_regression` module, unaffected (seeded via a real snapshot load where both tiers always agree).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] Mutation check: reverted the accessor to always return `NotLoaded`, confirmed the new tests fail, restored the fix.
