### PR TITLE
KAN-1524 fix(mcp): resolve sprint-in-board on an archived board

### DIFF
--- a/.changeset/kan-1524-mcp-sprint-in-board-archived.md
+++ b/.changeset/kan-1524-mcp-sprint-in-board-archived.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+mcp resolves sprint-in-board by name/number when the board is archived

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -629,11 +629,12 @@ mod tests {
             crate::helpers::model_read::resolve_column_in_board(&model, "TODO", board_id).unwrap(),
             column.id
         );
+        let board = crate::helpers::board_head(&ctx, &model, board_id).unwrap();
         assert_eq!(
             crate::helpers::model_read::resolve_sprint_in_board(
                 &model,
                 &sprint.sprint_number.to_string(),
-                board_id
+                &board
             )
             .unwrap(),
             sprint.id

--- a/crates/kanban-mcp/src/helpers/mod.rs
+++ b/crates/kanban-mcp/src/helpers/mod.rs
@@ -13,5 +13,5 @@ pub(crate) use parsers::{
     parse_archived_selector, parse_board_sort_field, parse_datetime, parse_priority,
     parse_sort_field, parse_sort_order, parse_status,
 };
-pub(crate) use resolvers::{card_board, project_sprint, resolve_summaries};
+pub(crate) use resolvers::{board_head, card_board, project_sprint, resolve_summaries};
 pub(crate) use serialization::{to_call_tool_result, to_call_tool_result_json};

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -2,7 +2,7 @@ use crate::helpers::error_mapping::kanban_err_to_mcp;
 use kanban_domain::{
     find_boards_by_name, find_columns_by_name, find_sprints_by_query_global,
     find_sprints_by_query_on_board, parse_identifier, AmbiguousMatch, BatchResolutionCause,
-    BatchResolutionFailure, Card, KanbanError, LoadState, Model, ParsedIdentifier, Prefix,
+    BatchResolutionFailure, Board, Card, KanbanError, LoadState, Model, ParsedIdentifier, Prefix,
 };
 use rmcp::model::ErrorData as McpError;
 use std::collections::HashSet;
@@ -130,13 +130,12 @@ pub(crate) fn resolve_column_global(model: &Model, raw: &str) -> Result<Uuid, Mc
 pub(crate) fn resolve_sprint_in_board(
     model: &Model,
     raw: &str,
-    board_id: Uuid,
+    board: &Board,
 ) -> Result<Uuid, McpError> {
     if let Ok(uuid) = Uuid::parse_str(raw) {
         return Ok(uuid);
     }
-    let sprints = require_loaded(model.board_sprints_state(board_id), "sprints of the board")?;
-    let board = require_loaded(model.board_by_id_state(board_id), "board")?;
+    let sprints = require_loaded(model.board_sprints_state(board.id), "sprints of the board")?;
     let matches = find_sprints_by_query_on_board(raw, sprints, board);
     match matches.as_slice() {
         [] => {
@@ -470,7 +469,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_sprint_in_board_reads_the_scoped_tier_and_the_board() {
+    fn test_resolve_sprint_in_board_reads_the_scoped_tier_with_the_supplied_head() {
         let board = Board::new("Kanban", None::<String>);
         let board_id = board.id;
         let sprint = Sprint::new(board_id, 1, None, None::<String>);
@@ -478,10 +477,6 @@ mod tests {
 
         let mut model = Model::default();
         let _ = model.apply_resolved(Resolved {
-            boards: Collection {
-                all: LoadState::Loaded(vec![board]),
-                ..Default::default()
-            },
             sprints: Collection {
                 by_parent: [(board_id, LoadState::Loaded(vec![sprint]))].into(),
                 ..Default::default()
@@ -490,11 +485,11 @@ mod tests {
         });
 
         assert_eq!(
-            resolve_sprint_in_board(&model, "1", board_id).unwrap(),
+            resolve_sprint_in_board(&model, "1", &board).unwrap(),
             sprint_id
         );
 
-        let err = resolve_sprint_in_board(&Model::default(), "1", board_id).unwrap_err();
+        let err = resolve_sprint_in_board(&Model::default(), "1", &board).unwrap_err();
         assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
         assert!(!err.message.contains("not found"));
     }

--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -1,6 +1,6 @@
 use crate::context::McpContext;
 use crate::helpers::error_mapping::kanban_err_to_mcp;
-use kanban_domain::{CardSummary, KanbanOperations, Sprint};
+use kanban_domain::{Board, CardSummary, KanbanError, KanbanOperations, LoadState, Model, Sprint};
 use kanban_service::api::SprintResponse;
 use kanban_service::resolve_sprint_name;
 use rmcp::model::ErrorData as McpError;
@@ -45,6 +45,22 @@ pub(crate) fn card_board(ctx: &McpContext, card_id: Uuid) -> Result<Uuid, McpErr
             McpError::invalid_params(format!("Column not found: {}", card.column_id), None)
         })?;
     Ok(column.board_id)
+}
+
+/// The board head for `board_id`: the model's loaded head when the call's
+/// fetch plan supplied one, otherwise the unfiltered `get_board` point read,
+/// which resolves an archived board as well as a live one.
+pub(crate) fn board_head(
+    ctx: &McpContext,
+    model: &Model,
+    board_id: Uuid,
+) -> Result<Board, McpError> {
+    if let LoadState::Loaded(board) = model.board_by_id_state(board_id) {
+        return Ok(board.clone());
+    }
+    ctx.get_board(board_id)
+        .map_err(kanban_err_to_mcp)?
+        .ok_or_else(|| kanban_err_to_mcp(KanbanError::not_found("Board", board_id)))
 }
 
 /// Project a domain `Sprint` into its v1 `SprintResponse`, resolving the wire

--- a/crates/kanban-mcp/src/helpers/resolvers.rs
+++ b/crates/kanban-mcp/src/helpers/resolvers.rs
@@ -131,4 +131,59 @@ mod tests {
         );
         assert_eq!(summaries[0].id, card.id);
     }
+
+    #[tokio::test]
+    async fn test_board_head_on_nonexistent_board_returns_not_found() {
+        use kanban_core::AppConfig;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.json");
+        let store_manager = test_store_manager();
+        let ctx = McpContext::new(
+            &store_manager,
+            &path.to_string_lossy(),
+            AppConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        let err = board_head(&ctx, &Model::default(), Uuid::new_v4()).unwrap_err();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(!err.message.to_lowercase().contains("board is unavailable"));
+    }
+
+    #[tokio::test]
+    async fn test_board_head_falls_back_to_the_point_read_for_an_archived_board() {
+        use kanban_core::AppConfig;
+        use kanban_domain::{resolved::Collection, Resolved};
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.json");
+        let store_manager = test_store_manager();
+        let mut ctx = McpContext::new(
+            &store_manager,
+            &path.to_string_lossy(),
+            AppConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        let board = ctx
+            .create_board("Kanban".into(), Some("KAN".into()))
+            .unwrap();
+        ctx.archive_board(board.id).unwrap();
+
+        let head = board_head(&ctx, &Model::default(), board.id).unwrap();
+        assert_eq!(head.id, board.id);
+        assert_eq!(head.name, "Kanban");
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board.clone()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let head_from_model = board_head(&ctx, &model, board.id).unwrap();
+        assert_eq!(head_from_model.id, board.id);
+    }
 }

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -1,6 +1,7 @@
 use crate::helpers::model_read::{resolve_cards, resolve_column_in_board, resolve_sprint_in_board};
 use crate::helpers::{
-    card_board, kanban_err_to_mcp, locked_write, to_call_tool_result, to_call_tool_result_json,
+    board_head, card_board, kanban_err_to_mcp, locked_write, to_call_tool_result,
+    to_call_tool_result_json,
 };
 use crate::requests::card::{
     ArchiveCardsRequest, AssignCardToSprintRequest, AssignCardsToSprintRequest, MoveCardsRequest,
@@ -72,7 +73,8 @@ impl KanbanMcpServer {
             let card_id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             let board_id = card_board(ctx, card_id)?;
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
-            let sprint_id = resolve_sprint_in_board(&model, &req.sprint, board_id)?;
+            let board = board_head(ctx, &model, board_id)?;
+            let sprint_id = resolve_sprint_in_board(&model, &req.sprint, &board)?;
             ctx.mutate(|c| c.assign_card_to_sprint_impl(card_id, sprint_id))
                 .map(|(card, _inv)| card)
                 .map_err(kanban_err_to_mcp)
@@ -152,7 +154,8 @@ impl KanbanMcpServer {
             let ids = resolve_cards(&model, &req.cards)?;
             let board_id = ctx.require_same_board(&ids).map_err(kanban_err_to_mcp)?;
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
-            let sprint_id = resolve_sprint_in_board(&model, &req.sprint, board_id)?;
+            let board = board_head(ctx, &model, board_id)?;
+            let sprint_id = resolve_sprint_in_board(&model, &req.sprint, &board)?;
             ctx.mutate(|c| c.assign_cards_to_sprint_impl(ids, sprint_id))
                 .map(|(count, _inv)| count)
                 .map_err(kanban_err_to_mcp)

--- a/crates/kanban-mcp/src/tools/card_batch.rs
+++ b/crates/kanban-mcp/src/tools/card_batch.rs
@@ -536,6 +536,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_assign_card_to_sprint_on_archived_board_resolves_by_name_on_json() {
+        test_assign_card_to_sprint_on_archived_board_resolves_by_name("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_assign_card_to_sprint_on_archived_board_resolves_by_name_on_sqlite() {
+        test_assign_card_to_sprint_on_archived_board_resolves_by_name("test.sqlite").await;
+    }
+
+    async fn test_assign_card_to_sprint_on_archived_board_resolves_by_name(file_name: &str) {
+        let seeded = seeded_server(file_name).await;
+
+        seeded
+            .server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: "Alpha".into(),
+            }))
+            .await
+            .unwrap();
+
+        let card = text_payload(
+            &seeded
+                .server
+                .tool_assign_card_to_sprint(Parameters(AssignCardToSprintRequest {
+                    card: seeded.card_id.clone(),
+                    sprint: "Sprint 1".to_string(),
+                }))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(
+            card["sprint_id"].as_str().unwrap(),
+            seeded.sprint_id.as_str()
+        );
+    }
+
+    #[tokio::test]
     async fn test_move_cards_with_an_unloadable_column_collection_errors_naming_the_collection_on_json(
     ) {
         let seeded = seeded_server("test.json").await;

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -993,9 +993,7 @@ mod tests {
         test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves("test.sqlite").await;
     }
 
-    async fn test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves(
-        file_name: &str,
-    ) {
+    async fn test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves(file_name: &str) {
         let seeded = seeded_server(file_name).await;
 
         let in_sprint = text_payload(

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -980,6 +980,102 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves_on_json() {
+        test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves_on_sqlite() {
+        test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves("test.sqlite").await;
+    }
+
+    async fn test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves(
+        file_name: &str,
+    ) {
+        let seeded = seeded_server(file_name).await;
+
+        let in_sprint = text_payload(
+            &seeded
+                .server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: seeded.board_id.clone(),
+                    column: seeded.column_id.clone(),
+                    sprint: Some(seeded.sprint_id.clone()),
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "In the sprint".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let in_sprint_id = in_sprint["id"].as_str().unwrap().to_string();
+
+        seeded
+            .server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: seeded.board_id.clone(),
+            }))
+            .await
+            .unwrap();
+
+        let result = text_payload(
+            &seeded
+                .server
+                .tool_list_cards(Parameters(ListCardsRequest {
+                    board: Some(seeded.board_id.clone()),
+                    column: None,
+                    sprint: Some(seeded.sprint_identifier.clone()),
+                    status: None,
+                    archived: None,
+                    sort: None,
+                    order: None,
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let ids: Vec<&str> = result["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|item| item["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec![in_sprint_id.as_str()]);
+
+        let result_by_number = text_payload(
+            &seeded
+                .server
+                .tool_list_cards(Parameters(ListCardsRequest {
+                    board: Some(seeded.board_id.clone()),
+                    column: None,
+                    sprint: Some("1".to_string()),
+                    status: None,
+                    archived: None,
+                    sort: None,
+                    order: None,
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let ids_by_number: Vec<&str> = result_by_number["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|item| item["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids_by_number, vec![in_sprint_id.as_str()]);
+    }
+
+    #[tokio::test]
     async fn test_list_cards_by_global_sprint_name_with_an_unloadable_sprint_list_errors_on_json() {
         let seeded = seeded_server("test.json").await;
         seeded.handle.clear_ops();

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -3,7 +3,7 @@ use crate::helpers::model_read::{
     resolve_sprint_global, resolve_sprint_in_board,
 };
 use crate::helpers::{
-    card_board, core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write,
+    board_head, card_board, core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write,
     parse_archived_selector, parse_datetime, parse_priority, parse_sort_field, parse_sort_order,
     parse_status, to_call_tool_result, to_call_tool_result_json,
 };
@@ -148,7 +148,8 @@ impl KanbanMcpServer {
             ctx.sync_into(&req.scope().for_board(board_id), &mut model);
             let column_id = resolve_column_in_board(&model, &req.column, board_id)?;
             if let Some(raw) = req.sprint.as_deref() {
-                req.content.sprint_id = Some(resolve_sprint_in_board(&model, raw, board_id)?);
+                let board = board_head(ctx, &model, board_id)?;
+                req.content.sprint_id = Some(resolve_sprint_in_board(&model, raw, &board)?);
             }
             let (id, spec) = req
                 .content
@@ -199,7 +200,10 @@ impl KanbanMcpServer {
             };
             let sprint_id = match &req.sprint {
                 Some(raw) => Some(match board_id {
-                    Some(bid) => resolve_sprint_in_board(&model, raw, bid)?,
+                    Some(bid) => {
+                        let board = board_head(ctx, &model, bid)?;
+                        resolve_sprint_in_board(&model, raw, &board)?
+                    }
                     None => resolve_sprint_global(&model, raw)?,
                 }),
                 None => None,

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -1,7 +1,7 @@
 use crate::helpers::model_read::{resolve_board, resolve_sprint_global, resolve_sprint_in_board};
 use crate::helpers::{
-    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, parse_datetime, project_sprint,
-    to_call_tool_result, to_call_tool_result_json,
+    board_head, core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, parse_datetime,
+    project_sprint, to_call_tool_result, to_call_tool_result_json,
 };
 use crate::requests::sprint::{
     ActivateSprintRequest, CancelSprintRequest, CarryOverSprintCardsRequest, CompleteSprintRequest,
@@ -327,7 +327,8 @@ impl KanbanMcpServer {
             }
             .for_board(from_sprint.board_id);
             ctx.sync_into(&to_scope, &mut model);
-            let to_id = resolve_sprint_in_board(&model, &req.to_sprint, from_sprint.board_id)?;
+            let board = board_head(ctx, &model, from_sprint.board_id)?;
+            let to_id = resolve_sprint_in_board(&model, &req.to_sprint, &board)?;
             ctx.mutate(|c| c.carry_over_sprint_cards_impl(from_id, to_id))
                 .map(|(count, _inv)| count)
                 .map_err(kanban_err_to_mcp)


### PR DESCRIPTION
Fixes sprint-in-board resolution in kanban-mcp, which errored with `-32603 internal error: board is unavailable` whenever the target board was archived. The MCP fetch path fills the boards tier from `store.list_boards()`, which is live-only, so `resolve_sprint_in_board` could never see an archived board's head.

## Changes

- Add `board_head(ctx, model, board_id)` in `crates/kanban-mcp/src/helpers/resolvers.rs`: returns the model's loaded head when the fetch plan supplied one, otherwise falls back to the unfiltered `get_board` point read, which resolves both live and archived boards. A nonexistent board id now yields a proper `NotFound` instead of the internal error.
- Re-signature `resolve_sprint_in_board` to take `&Board` directly instead of a `board_id` plus an internal `board_by_id_state` lookup.
- Update the five call sites (`tool_assign_card_to_sprint`, `tool_assign_cards_to_sprint`, `tool_create_card`, `tool_list_cards`, `tool_carry_over_sprint_cards`) plus one in-crate test call to resolve the board head first and pass it through.

## Tests

- `test_list_cards_on_archived_board_by_uuid_with_named_sprint_resolves` (json + sqlite): sprint resolves by both name and number on an archived board.
- `test_assign_card_to_sprint_on_archived_board_resolves_by_name` (json + sqlite): assigning a card to a sprint by name still works after its board is archived.
- `test_board_head_on_nonexistent_board_returns_not_found` and `test_board_head_falls_back_to_the_point_read_for_an_archived_board`: unit coverage of the new helper's model-hit, point-read, and not-found paths.

`tool_restore_board` / `tool_delete_archived_board` are untouched; they still route through `resolve_archived_board`. `scope.rs` is untouched.
