### PR TITLE
KAN-1525 fix(mcp): request the board list for column-referencing scopes so ambiguity labels show real board names

### DIFF
--- a/.changeset/kan-1525-mcp-ambiguity-labels.md
+++ b/.changeset/kan-1525-mcp-ambiguity-labels.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+mcp: named column lookups now resolve ambiguity against real board names instead of (unknown)

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -51,7 +51,8 @@ impl FetchPlan for ToolScope {
         let named_cards = self.cards.iter().any(|r| matches!(r, Ref::Name));
         let wants_board_list = matches!(self.board, Some(Ref::Name))
             || (self.resolved_board.is_some() && self.wants_board_sprints)
-            || matches!(self.sprint, Some(Ref::Name));
+            || matches!(self.sprint, Some(Ref::Name))
+            || global_column;
         FetchRound {
             board_list: wants_board_list && requestable(loaded.board_list()),
             column_list: global_column && requestable(loaded.column_list()),

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -342,6 +342,35 @@ mod tests {
     }
 
     #[test]
+    fn test_a_named_global_column_reference_also_requests_the_board_list() {
+        let scope = ToolScope {
+            column: Some(Ref::Name),
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&Model::default());
+        assert!(round.board_list);
+        assert!(round.column_list);
+    }
+
+    #[test]
+    fn test_a_board_scoped_column_reference_requests_no_board_list() {
+        let scoped = ToolScope {
+            column: Some(Ref::Name),
+            wants_board_columns: true,
+            ..Default::default()
+        }
+        .for_board(Uuid::new_v4());
+        assert!(!scoped.next_round(&Model::default()).board_list);
+
+        let by_id = ToolScope {
+            column: Some(Ref::Id),
+            ..Default::default()
+        };
+        assert!(by_id.next_round(&Model::default()).is_empty());
+    }
+
+    #[test]
     fn test_a_global_named_reference_requests_the_archived_board_markers() {
         let column_scope = ToolScope {
             column: Some(Ref::Name),

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -268,7 +268,7 @@ mod tests {
         };
         let round = named_get.scope().next_round(&Model::default());
         assert!(round.column_list);
-        assert!(!round.board_list);
+        assert!(round.board_list);
         assert!(round.columns_by_board.is_empty());
         assert!(!named_get.scope().wants_board_columns);
 
@@ -288,7 +288,7 @@ mod tests {
         };
         let round = named_update.scope().next_round(&Model::default());
         assert!(round.column_list);
-        assert!(!round.board_list);
+        assert!(round.board_list);
         assert!(!named_update.scope().wants_board_columns);
 
         let named_delete = DeleteColumnRequest {
@@ -296,6 +296,7 @@ mod tests {
         };
         let round = named_delete.scope().next_round(&Model::default());
         assert!(round.column_list);
+        assert!(round.board_list);
         assert!(!named_delete.scope().wants_board_columns);
 
         let named_reorder = ReorderColumnRequest {
@@ -304,6 +305,7 @@ mod tests {
         };
         let round = named_reorder.scope().next_round(&Model::default());
         assert!(round.column_list);
+        assert!(round.board_list);
         assert!(!named_reorder.scope().wants_board_columns);
     }
 
@@ -491,7 +493,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_column_by_name_reads_the_column_list_exactly_once_on_json() {
+    async fn test_get_column_by_name_reads_the_column_list_and_the_board_list_exactly_once_on_json()
+    {
         let (server, _dir, handle) = seeded_server("test.json").await;
         handle.clear_ops();
 
@@ -503,11 +506,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(handle.op_count("list_all_columns"), 1);
-        assert_eq!(handle.op_count("list_boards"), 0);
+        assert_eq!(handle.op_count("list_boards"), 1);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_get_column_by_name_reads_the_column_list_exactly_once_on_sqlite() {
+    async fn test_get_column_by_name_reads_the_column_list_and_the_board_list_exactly_once_on_sqlite(
+    ) {
         let (server, _dir, handle) = seeded_server("test.sqlite").await;
         handle.clear_ops();
 
@@ -519,7 +523,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(handle.op_count("list_all_columns"), 1);
-        assert_eq!(handle.op_count("list_boards"), 0);
+        assert_eq!(handle.op_count("list_boards"), 1);
     }
 
     #[tokio::test]
@@ -692,6 +696,47 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(still_live["name"], "Icebox");
+    }
+
+    #[tokio::test]
+    async fn test_column_ambiguity_error_names_the_real_boards_on_json() {
+        test_column_ambiguity_error_names_the_real_boards("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_column_ambiguity_error_names_the_real_boards_on_sqlite() {
+        test_column_ambiguity_error_names_the_real_boards("test.sqlite").await;
+    }
+
+    async fn test_column_ambiguity_error_names_the_real_boards(file_name: &str) {
+        let (server, _dir, _handle) = seeded_server(file_name).await;
+
+        create_board(&server, "Beta").await;
+        server
+            .tool_create_column(Parameters(CreateColumnParams {
+                board: "Beta".into(),
+                content: kanban_service::api::CreateColumnRequest {
+                    id: None,
+                    name: "TODO".into(),
+                    wip_limit: None,
+                    default_status: None,
+                },
+            }))
+            .await
+            .unwrap();
+
+        let err = server
+            .tool_get_column(Parameters(GetColumnRequest {
+                column: "TODO".into(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("is ambiguous"));
+        assert!(err.message.contains("on board 'Alpha'"));
+        assert!(err.message.contains("on board 'Beta'"));
+        assert!(!err.message.contains("(unknown)"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `ToolScope::next_round` now requests the `board_list` tier whenever a global named-column reference is in play (`|| global_column`), mirroring the existing rule for global named sprints.
- This makes `resolve_column_global`'s ambiguity error name the real board for each candidate instead of falling back to `(unknown)`, since `boards_state()` is now loaded by the time the ambiguous branch runs.
- Four existing tool-level assertions in `crates/kanban-mcp/src/tools/column.rs` encoded the old fetch plan (no board list for a named column reference) and are updated to match the new behaviour: two scope-mapping assertions flip from `!round.board_list` to `round.board_list`, and two op-count regression tests move from `list_boards == 0` to `list_boards == 1` (renamed to reflect that the board list is now read too).

## Tests

- `test_a_named_global_column_reference_also_requests_the_board_list` (new, `scope.rs`)
- `test_a_board_scoped_column_reference_requests_no_board_list` (new guard, `scope.rs`)
- `test_column_ambiguity_error_names_the_real_boards_on_json` / `_on_sqlite` (new, `tools/column.rs`): seeds two live boards each with a column named "TODO", asserts the ambiguity error names both boards and never falls back to `(unknown)`

## Cost

Every named-column tool call now issues one extra `list_boards` read per call (relevant on the HTTP backend), the same cost already paid by named sprint references.

## Test plan

- [x] `cargo test -p kanban-mcp` green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features --workspace` green
