### PR TITLE
KAN-1517 fix(cli,service): route CLI mutations through the invalidation seam

### DIFF
--- a/.changeset/kan-1517-cli-mutation-seam.md
+++ b/.changeset/kan-1517-cli-mutation-seam.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+route CLI mutations and the detailed batch invalidations through the shared seam

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -2,8 +2,8 @@ use kanban_core::AppConfig;
 use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
-    CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, FieldUpdate,
-    GraphOperations, Invalidation, KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
+    CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
+    Invalidation, KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;
@@ -100,12 +100,7 @@ impl CliContext {
         op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
     ) -> KanbanResult<T> {
         let (value, invalidation) = op(&mut self.inner)?;
-        self.inner.sync_invalidated(
-            invalidation,
-            &self.scope,
-            &mut self.model,
-            &mut kanban_domain::NoProjections,
-        );
+        self.apply_invalidation(invalidation);
         Ok(value)
     }
 
@@ -116,13 +111,17 @@ impl CliContext {
         op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
     ) -> KanbanResult<()> {
         let invalidation = op(&mut self.inner)?;
+        self.apply_invalidation(invalidation);
+        Ok(())
+    }
+
+    fn apply_invalidation(&mut self, invalidation: Invalidation) {
         self.inner.sync_invalidated(
             invalidation,
             &self.scope,
             &mut self.model,
             &mut kanban_domain::NoProjections,
         );
-        Ok(())
     }
 
     pub async fn save(&self) -> KanbanResult<()> {
@@ -162,24 +161,25 @@ impl CliContext {
         &mut self,
         commands: Vec<kanban_domain::commands::Command>,
     ) -> KanbanResult<()> {
-        self.inner.execute(commands).map(|_| ())
+        self.mutate_unit(|c| c.execute(commands))
     }
 
     pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {
-        self.inner.archive_cards_detailed(ids)
+        let (result, invalidation) = self.inner.archive_cards_detailed(ids);
+        self.apply_invalidation(invalidation);
+        result
     }
 
     pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BatchOperationResult {
-        self.inner.move_cards_detailed(ids, column_id)
+        let (result, invalidation) = self.inner.move_cards_detailed(ids, column_id);
+        self.apply_invalidation(invalidation);
+        result
     }
 
     /// Create a column carrying a `default_status`. An explicit `position`
-    /// routes through the same `KanbanOperations::create_column` trait method
-    /// `column create --position` already uses (not widened — it still takes
-    /// no `default_status` parameter), followed by an `update_column` call
-    /// that sets `default_status` on the freshly created column. A `None`
-    /// position keeps the existing server-assigned append path via
-    /// `create_column_from_spec`, which does carry `default_status` on the
+    /// dispatches a single `CreateColumn` command carrying `default_status`
+    /// directly. A `None` position keeps the server-assigned append path via
+    /// `create_column_from_spec`, which also carries `default_status` on the
     /// create spec itself.
     pub fn create_column_with_default_status(
         &mut self,
@@ -188,37 +188,40 @@ impl CliContext {
         position: Option<i32>,
         default_status: Option<CardStatus>,
     ) -> KanbanResult<Column> {
-        let column = match position {
+        use kanban_domain::commands::{ColumnCommand, Command, CreateColumn};
+
+        match position {
             Some(position) => {
-                let column = self.inner.create_column(board_id, name, Some(position))?;
-                match default_status {
-                    Some(_) => self.inner.update_column(
-                        column.id,
-                        ColumnUpdate {
-                            name: None,
-                            position: None,
-                            wip_limit: FieldUpdate::NoChange,
-                            default_status: Some(default_status),
-                        },
-                    )?,
-                    None => column,
-                }
-            }
-            None => {
-                self.inner
-                    .create_column_from_spec(
-                        None,
-                        NewColumn {
+                let id = Uuid::new_v4();
+                self.mutate(|c| {
+                    let invalidation =
+                        c.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
+                            id,
                             board_id,
                             name,
-                            wip_limit: None,
+                            position,
                             default_status,
-                        },
-                    )?
-                    .0
+                        }))])?;
+                    let column = KanbanOperations::get_column(c, id)?.ok_or_else(|| {
+                        kanban_domain::KanbanError::Internal(
+                            "Column creation succeeded but column not found".into(),
+                        )
+                    })?;
+                    Ok((column, invalidation))
+                })
             }
-        };
-        Ok(column)
+            None => self.mutate(|c| {
+                c.create_column_from_spec(
+                    None,
+                    NewColumn {
+                        board_id,
+                        name,
+                        wip_limit: None,
+                        default_status,
+                    },
+                )
+            }),
+        }
     }
 
     pub fn assign_cards_to_sprint_detailed(
@@ -226,7 +229,9 @@ impl CliContext {
         ids: Vec<Uuid>,
         sprint_id: Uuid,
     ) -> BatchOperationResult {
-        self.inner.assign_cards_to_sprint_detailed(ids, sprint_id)
+        let (result, invalidation) = self.inner.assign_cards_to_sprint_detailed(ids, sprint_id);
+        self.apply_invalidation(invalidation);
+        result
     }
 }
 
@@ -676,20 +681,24 @@ mod tests {
         let mut ctx = seam_context();
         ctx.mutate(|c| c.create_board_impl("First".to_string(), None))?;
 
-        ctx.set_scope(CommandScope::from_command(&Commands::Board(CliBoardCommand {
-            action: BoardAction::Get {
-                board: "First".to_string(),
+        ctx.set_scope(CommandScope::from_command(&Commands::Board(
+            CliBoardCommand {
+                action: BoardAction::Get {
+                    board: "First".to_string(),
+                },
             },
-        })));
+        )));
         ctx.sync();
         assert_eq!(ctx.model().boards_state().loaded().unwrap().len(), 1);
 
-        ctx.execute_commands(vec![Command::Board(DomainBoardCommand::Create(CreateBoard {
-            id: Uuid::new_v4(),
-            name: "Second".to_string(),
-            card_prefix: None,
-            position: 1,
-        }))])?;
+        ctx.execute_commands(vec![Command::Board(DomainBoardCommand::Create(
+            CreateBoard {
+                id: Uuid::new_v4(),
+                name: "Second".to_string(),
+                card_prefix: None,
+                position: 1,
+            },
+        ))])?;
 
         assert_eq!(ctx.model().boards_state().loaded().unwrap().len(), 2);
 

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -775,4 +775,48 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_all_invalid_detailed_batch_leaves_the_loaded_tier_loaded() -> KanbanResult<()> {
+        use crate::cli::{Commands, RelationAction, RelationCommand, SortDir, SortKey};
+        use crate::scope::CommandScope;
+
+        let mut ctx = seam_context();
+        let board = ctx.mutate(|c| c.create_board_impl("Board".to_string(), None))?;
+        let column = ctx.mutate(|c| c.create_column_impl(board.id, "Col".to_string(), None))?;
+        let parent = ctx.mutate(|c| {
+            c.create_card_impl(
+                board.id,
+                column.id,
+                "Parent".to_string(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+        })?;
+        let child = ctx.mutate(|c| {
+            c.create_card_impl(
+                board.id,
+                column.id,
+                "Child".to_string(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+        })?;
+        ctx.mutate_unit(|c| c.attach_children_impl(parent.id, vec![child.id]))?;
+
+        ctx.set_scope(CommandScope::from_command(&Commands::Relation(
+            RelationCommand {
+                action: RelationAction::Children {
+                    card: parent.id.to_string(),
+                    sort: SortKey::CardNumber,
+                    order: SortDir::Asc,
+                },
+            },
+        )));
+        ctx.sync();
+
+        let result = ctx.archive_cards_detailed(vec![Uuid::new_v4()]);
+        assert!(result.succeeded.is_empty());
+        assert_eq!(ctx.list_children_of(parent.id)?, vec![child.id]);
+
+        Ok(())
+    }
 }

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -666,4 +666,104 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_execute_commands_applies_the_returned_invalidation() -> KanbanResult<()> {
+        use crate::cli::{BoardAction, BoardCommand as CliBoardCommand, Commands};
+        use crate::scope::CommandScope;
+        use kanban_domain::commands::{BoardCommand as DomainBoardCommand, Command, CreateBoard};
+
+        let mut ctx = seam_context();
+        ctx.mutate(|c| c.create_board_impl("First".to_string(), None))?;
+
+        ctx.set_scope(CommandScope::from_command(&Commands::Board(CliBoardCommand {
+            action: BoardAction::Get {
+                board: "First".to_string(),
+            },
+        })));
+        ctx.sync();
+        assert_eq!(ctx.model().boards_state().loaded().unwrap().len(), 1);
+
+        ctx.execute_commands(vec![Command::Board(DomainBoardCommand::Create(CreateBoard {
+            id: Uuid::new_v4(),
+            name: "Second".to_string(),
+            card_prefix: None,
+            position: 1,
+        }))])?;
+
+        assert_eq!(ctx.model().boards_state().loaded().unwrap().len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_archive_cards_detailed_applies_the_returned_invalidation() -> KanbanResult<()> {
+        use crate::cli::{Commands, RelationAction, RelationCommand, SortDir, SortKey};
+        use crate::scope::CommandScope;
+
+        let mut ctx = seam_context();
+        let board = ctx.mutate(|c| c.create_board_impl("Board".to_string(), None))?;
+        let column = ctx.mutate(|c| c.create_column_impl(board.id, "Col".to_string(), None))?;
+        let parent = ctx.mutate(|c| {
+            c.create_card_impl(
+                board.id,
+                column.id,
+                "Parent".to_string(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+        })?;
+        let child = ctx.mutate(|c| {
+            c.create_card_impl(
+                board.id,
+                column.id,
+                "Child".to_string(),
+                kanban_domain::CreateCardOptions::default(),
+            )
+        })?;
+        ctx.mutate_unit(|c| c.attach_children_impl(parent.id, vec![child.id]))?;
+
+        ctx.set_scope(CommandScope::from_command(&Commands::Relation(
+            RelationCommand {
+                action: RelationAction::Children {
+                    card: parent.id.to_string(),
+                    sort: SortKey::CardNumber,
+                    order: SortDir::Asc,
+                },
+            },
+        )));
+        ctx.sync();
+        assert_eq!(ctx.list_children_of(parent.id)?, vec![child.id]);
+
+        let result = ctx.archive_cards_detailed(vec![child.id]);
+        assert_eq!(result.succeeded, vec![child.id]);
+        assert!(ctx.list_children_of(parent.id)?.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_column_with_default_status_and_position_creates_one_undo_entry(
+    ) -> KanbanResult<()> {
+        let mut ctx = seam_context();
+        let board = ctx.mutate(|c| c.create_board_impl("Board".to_string(), None))?;
+
+        let before = ctx.inner.undo_depth();
+        let column = ctx.create_column_with_default_status(
+            board.id,
+            "Mid".to_string(),
+            Some(1),
+            Some(CardStatus::InProgress),
+        )?;
+        assert_eq!(ctx.inner.undo_depth() - before, 1);
+        assert_eq!(column.position, 1);
+        assert_eq!(column.default_status, Some(CardStatus::InProgress));
+        assert_eq!(
+            KanbanOperations::get_column(&ctx, column.id)?
+                .unwrap()
+                .default_status,
+            Some(CardStatus::InProgress)
+        );
+
+        Ok(())
+    }
 }

--- a/crates/kanban-service/src/context/cards_batch_detailed.rs
+++ b/crates/kanban-service/src/context/cards_batch_detailed.rs
@@ -1,24 +1,30 @@
 use super::{BatchOperationFailure, BatchOperationResult, KanbanContext};
 use kanban_domain::commands::{CardCommand, Command};
-use kanban_domain::KanbanError;
+use kanban_domain::{EntityIds, Invalidation, KanbanError};
 use uuid::Uuid;
 
 impl KanbanContext {
-    pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {
+    pub fn archive_cards_detailed(
+        &mut self,
+        ids: Vec<Uuid>,
+    ) -> (BatchOperationResult, Invalidation) {
         use kanban_domain::commands::ArchiveCards;
         let all_cards = match self.list_live_cards_impl() {
             Ok(c) => c,
             Err(e) => {
-                return BatchOperationResult {
-                    succeeded: vec![],
-                    failed: ids
-                        .into_iter()
-                        .map(|id| BatchOperationFailure {
-                            id,
-                            error: e.to_string(),
-                        })
-                        .collect(),
-                };
+                return (
+                    BatchOperationResult {
+                        succeeded: vec![],
+                        failed: ids
+                            .into_iter()
+                            .map(|id| BatchOperationFailure {
+                                id,
+                                error: e.to_string(),
+                            })
+                            .collect(),
+                    },
+                    Invalidation::Entities(EntityIds::default()),
+                );
             }
         };
         let card_ids: std::collections::HashSet<Uuid> = all_cards.iter().map(|c| c.id).collect();
@@ -35,16 +41,19 @@ impl KanbanContext {
             }
         }
         if to_archive.is_empty() {
-            return BatchOperationResult {
-                succeeded: vec![],
-                failed,
-            };
+            return (
+                BatchOperationResult {
+                    succeeded: vec![],
+                    failed,
+                },
+                Invalidation::Entities(EntityIds::default()),
+            );
         }
         let succeeded = to_archive.clone();
         match self.execute(vec![Command::Card(CardCommand::Archive(ArchiveCards {
             ids: to_archive,
         }))]) {
-            Ok(_) => BatchOperationResult { succeeded, failed },
+            Ok(invalidation) => (BatchOperationResult { succeeded, failed }, invalidation),
             Err(e) => {
                 let err = e.to_string();
                 let mut all_failed = failed;
@@ -52,15 +61,22 @@ impl KanbanContext {
                     id,
                     error: err.clone(),
                 }));
-                BatchOperationResult {
-                    succeeded: vec![],
-                    failed: all_failed,
-                }
+                (
+                    BatchOperationResult {
+                        succeeded: vec![],
+                        failed: all_failed,
+                    },
+                    Invalidation::Entities(EntityIds::default()),
+                )
             }
         }
     }
 
-    pub fn move_cards_detailed(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> BatchOperationResult {
+    pub fn move_cards_detailed(
+        &mut self,
+        ids: Vec<Uuid>,
+        column_id: Uuid,
+    ) -> (BatchOperationResult, Invalidation) {
         // Dedup at the input boundary so the per-id classification loop both
         // (a) reports each invalid id once in `failed` and (b) reports each
         // valid id once in `succeeded`, matching the one `MoveCard` per
@@ -83,10 +99,13 @@ impl KanbanContext {
             }
         }
         if to_move.is_empty() {
-            return BatchOperationResult {
-                succeeded: vec![],
-                failed,
-            };
+            return (
+                BatchOperationResult {
+                    succeeded: vec![],
+                    failed,
+                },
+                Invalidation::Entities(EntityIds::default()),
+            );
         }
         let succeeded = to_move.clone();
 
@@ -100,10 +119,13 @@ impl KanbanContext {
                         id,
                         error: err.clone(),
                     }));
-                    return BatchOperationResult {
-                        succeeded: vec![],
-                        failed: all_failed,
-                    };
+                    return (
+                        BatchOperationResult {
+                            succeeded: vec![],
+                            failed: all_failed,
+                        },
+                        Invalidation::Entities(EntityIds::default()),
+                    );
                 }
             };
 
@@ -116,15 +138,18 @@ impl KanbanContext {
                     id,
                     error: err.clone(),
                 }));
-                return BatchOperationResult {
-                    succeeded: vec![],
-                    failed: all_failed,
-                };
+                return (
+                    BatchOperationResult {
+                        succeeded: vec![],
+                        failed: all_failed,
+                    },
+                    Invalidation::Entities(EntityIds::default()),
+                );
             }
         };
 
         match self.execute(batch) {
-            Ok(_) => BatchOperationResult { succeeded, failed },
+            Ok(invalidation) => (BatchOperationResult { succeeded, failed }, invalidation),
             Err(e) => {
                 let err = e.to_string();
                 let mut all_failed = failed;
@@ -132,10 +157,13 @@ impl KanbanContext {
                     id,
                     error: err.clone(),
                 }));
-                BatchOperationResult {
-                    succeeded: vec![],
-                    failed: all_failed,
-                }
+                (
+                    BatchOperationResult {
+                        succeeded: vec![],
+                        failed: all_failed,
+                    },
+                    Invalidation::Entities(EntityIds::default()),
+                )
             }
         }
     }
@@ -144,48 +172,57 @@ impl KanbanContext {
         &mut self,
         ids: Vec<Uuid>,
         sprint_id: Uuid,
-    ) -> BatchOperationResult {
+    ) -> (BatchOperationResult, Invalidation) {
         use kanban_domain::commands::AssignCardsToSprint;
         let all_sprints = match self.list_live_sprints_impl() {
             Ok(s) => s,
             Err(e) => {
-                return BatchOperationResult {
+                return (
+                    BatchOperationResult {
+                        succeeded: vec![],
+                        failed: ids
+                            .into_iter()
+                            .map(|id| BatchOperationFailure {
+                                id,
+                                error: e.to_string(),
+                            })
+                            .collect(),
+                    },
+                    Invalidation::Entities(EntityIds::default()),
+                );
+            }
+        };
+        if !all_sprints.iter().any(|s| s.id == sprint_id) {
+            return (
+                BatchOperationResult {
                     succeeded: vec![],
                     failed: ids
                         .into_iter()
                         .map(|id| BatchOperationFailure {
                             id,
-                            error: e.to_string(),
+                            error: KanbanError::not_found("Sprint", sprint_id).to_string(),
                         })
                         .collect(),
-                };
-            }
-        };
-        if !all_sprints.iter().any(|s| s.id == sprint_id) {
-            return BatchOperationResult {
-                succeeded: vec![],
-                failed: ids
-                    .into_iter()
-                    .map(|id| BatchOperationFailure {
-                        id,
-                        error: KanbanError::not_found("Sprint", sprint_id).to_string(),
-                    })
-                    .collect(),
-            };
+                },
+                Invalidation::Entities(EntityIds::default()),
+            );
         }
         let all_cards = match self.list_live_cards_impl() {
             Ok(c) => c,
             Err(e) => {
-                return BatchOperationResult {
-                    succeeded: vec![],
-                    failed: ids
-                        .into_iter()
-                        .map(|id| BatchOperationFailure {
-                            id,
-                            error: e.to_string(),
-                        })
-                        .collect(),
-                };
+                return (
+                    BatchOperationResult {
+                        succeeded: vec![],
+                        failed: ids
+                            .into_iter()
+                            .map(|id| BatchOperationFailure {
+                                id,
+                                error: e.to_string(),
+                            })
+                            .collect(),
+                    },
+                    Invalidation::Entities(EntityIds::default()),
+                );
             }
         };
         let card_ids: std::collections::HashSet<Uuid> = all_cards.iter().map(|c| c.id).collect();
@@ -202,10 +239,13 @@ impl KanbanContext {
             }
         }
         if to_assign.is_empty() {
-            return BatchOperationResult {
-                succeeded: vec![],
-                failed,
-            };
+            return (
+                BatchOperationResult {
+                    succeeded: vec![],
+                    failed,
+                },
+                Invalidation::Entities(EntityIds::default()),
+            );
         }
         let succeeded = to_assign.clone();
         match self.execute(vec![Command::Card(CardCommand::AssignToSprint(
@@ -214,7 +254,7 @@ impl KanbanContext {
                 sprint_id,
             },
         ))]) {
-            Ok(_) => BatchOperationResult { succeeded, failed },
+            Ok(invalidation) => (BatchOperationResult { succeeded, failed }, invalidation),
             Err(e) => {
                 let err = e.to_string();
                 let mut all_failed = failed;
@@ -222,10 +262,13 @@ impl KanbanContext {
                     id,
                     error: err.clone(),
                 }));
-                BatchOperationResult {
-                    succeeded: vec![],
-                    failed: all_failed,
-                }
+                (
+                    BatchOperationResult {
+                        succeeded: vec![],
+                        failed: all_failed,
+                    },
+                    Invalidation::Entities(EntityIds::default()),
+                )
             }
         }
     }

--- a/crates/kanban-service/tests/move_cards.rs
+++ b/crates/kanban-service/tests/move_cards.rs
@@ -159,7 +159,7 @@ macro_rules! move_cards_tests {
                 backend.upsert_column(col_to).unwrap();
                 backend.upsert_card(card).unwrap();
 
-                let result = ctx.move_cards_detailed(vec![valid_id, invalid_id], col_to_id);
+                let (result, _) = ctx.move_cards_detailed(vec![valid_id, invalid_id], col_to_id);
 
                 assert_eq!(result.succeeded, vec![valid_id]);
                 assert_eq!(result.failed.len(), 1);
@@ -378,7 +378,7 @@ macro_rules! move_cards_tests {
                     .create_card(board.id, src_col.id, "A".into(), Default::default())
                     .unwrap();
 
-                let result =
+                let (result, _) =
                     ctx.move_cards_detailed(vec![card_a.id, card_a.id, card_a.id], dst_col.id);
 
                 assert_eq!(result.succeeded, vec![card_a.id]);
@@ -400,7 +400,7 @@ macro_rules! move_cards_tests {
                 let dst_col = ctx.create_column(board.id, "Dst".into(), None).unwrap();
                 let bogus = uuid::Uuid::new_v4();
 
-                let result = ctx.move_cards_detailed(vec![bogus, bogus, bogus], dst_col.id);
+                let (result, _) = ctx.move_cards_detailed(vec![bogus, bogus, bogus], dst_col.id);
 
                 assert!(result.succeeded.is_empty());
                 assert_eq!(result.failed.len(), 1);

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -3,7 +3,9 @@ use kanban_domain::commands::{
     BoardCommand, CardCommand, Command, CompactColumnPositions, CreateBoard, ImportEntities,
     UpdateBoard,
 };
-use kanban_domain::{BoardUpdate, CardUpdate, EntityIds, Invalidation, KanbanOperations, KanbanResult};
+use kanban_domain::{
+    BoardUpdate, CardUpdate, EntityIds, Invalidation, KanbanOperations, KanbanResult,
+};
 use kanban_service::undo_stack::UndoStack;
 use kanban_service::{read_full_snapshot, write_full_snapshot, KanbanContext};
 use std::sync::Arc;
@@ -613,7 +615,7 @@ async fn test_archive_cards_detailed_all_valid_creates_single_undo_entry() -> Ka
     ctx.clear_history()?;
     ctx.mark_clean();
 
-    let result = ctx.archive_cards_detailed(vec![c1.id, c2.id]);
+    let (result, _) = ctx.archive_cards_detailed(vec![c1.id, c2.id]);
     assert_eq!(result.succeeded.len(), 2);
     assert!(result.failed.is_empty());
     assert!(ctx.is_dirty());
@@ -633,7 +635,7 @@ async fn test_archive_cards_detailed_all_valid_creates_single_undo_entry() -> Ka
 async fn test_archive_cards_detailed_all_fail_does_not_set_dirty() {
     let mut ctx = make_ctx().await;
     ctx.mark_clean();
-    let result = ctx.archive_cards_detailed(vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()]);
+    let (result, _) = ctx.archive_cards_detailed(vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()]);
     assert!(result.succeeded.is_empty());
     assert_eq!(result.failed.len(), 2);
     assert!(
@@ -655,7 +657,7 @@ async fn test_detailed_archive_partial_success_is_undoable() -> KanbanResult<()>
     ctx.clear_history()?;
     ctx.mark_clean();
 
-    let result = ctx.archive_cards_detailed(vec![card.id, uuid::Uuid::new_v4()]);
+    let (result, _) = ctx.archive_cards_detailed(vec![card.id, uuid::Uuid::new_v4()]);
     assert_eq!(result.succeeded.len(), 1);
     assert_eq!(result.failed.len(), 1);
     assert!(ctx.is_dirty());
@@ -678,7 +680,7 @@ async fn test_move_cards_detailed_all_valid_creates_single_undo_entry() -> Kanba
     ctx.clear_history()?;
     ctx.mark_clean();
 
-    let result = ctx.move_cards_detailed(vec![c1.id, c2.id], col_b.id);
+    let (result, _) = ctx.move_cards_detailed(vec![c1.id, c2.id], col_b.id);
     assert_eq!(result.succeeded.len(), 2);
     assert!(result.failed.is_empty());
     assert!(ctx.is_dirty());
@@ -697,7 +699,7 @@ async fn test_move_cards_detailed_all_valid_creates_single_undo_entry() -> Kanba
 async fn test_move_cards_detailed_all_fail_does_not_set_dirty() {
     let mut ctx = make_ctx().await;
     ctx.mark_clean();
-    let result = ctx.move_cards_detailed(
+    let (result, _) = ctx.move_cards_detailed(
         vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()],
         uuid::Uuid::new_v4(),
     );
@@ -723,7 +725,7 @@ async fn test_move_cards_detailed_partial_success_is_undoable() -> KanbanResult<
     ctx.clear_history()?;
     ctx.mark_clean();
 
-    let result = ctx.move_cards_detailed(vec![card.id, uuid::Uuid::new_v4()], col_b.id);
+    let (result, _) = ctx.move_cards_detailed(vec![card.id, uuid::Uuid::new_v4()], col_b.id);
     assert_eq!(result.succeeded.len(), 1);
     assert_eq!(result.failed.len(), 1);
     assert!(ctx.is_dirty());
@@ -746,7 +748,7 @@ async fn test_assign_cards_to_sprint_detailed_all_valid_creates_single_undo_entr
     ctx.clear_history()?;
     ctx.mark_clean();
 
-    let result = ctx.assign_cards_to_sprint_detailed(vec![c1.id, c2.id], sprint.id);
+    let (result, _) = ctx.assign_cards_to_sprint_detailed(vec![c1.id, c2.id], sprint.id);
     assert_eq!(result.succeeded.len(), 2);
     assert!(result.failed.is_empty());
     assert!(ctx.is_dirty());
@@ -767,7 +769,7 @@ async fn test_assign_cards_to_sprint_detailed_all_valid_creates_single_undo_entr
 async fn test_assign_cards_to_sprint_detailed_all_fail_does_not_set_dirty() {
     let mut ctx = make_ctx().await;
     ctx.mark_clean();
-    let result = ctx.assign_cards_to_sprint_detailed(
+    let (result, _) = ctx.assign_cards_to_sprint_detailed(
         vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()],
         uuid::Uuid::new_v4(),
     );
@@ -793,7 +795,7 @@ async fn test_assign_cards_to_sprint_detailed_partial_success_is_undoable() -> K
     ctx.clear_history()?;
     ctx.mark_clean();
 
-    let result =
+    let (result, _) =
         ctx.assign_cards_to_sprint_detailed(vec![card.id, uuid::Uuid::new_v4()], sprint.id);
     assert_eq!(result.succeeded.len(), 1);
     assert_eq!(result.failed.len(), 1);

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -3,7 +3,7 @@ use kanban_domain::commands::{
     BoardCommand, CardCommand, Command, CompactColumnPositions, CreateBoard, ImportEntities,
     UpdateBoard,
 };
-use kanban_domain::{BoardUpdate, CardUpdate, KanbanOperations, KanbanResult};
+use kanban_domain::{BoardUpdate, CardUpdate, EntityIds, Invalidation, KanbanOperations, KanbanResult};
 use kanban_service::undo_stack::UndoStack;
 use kanban_service::{read_full_snapshot, write_full_snapshot, KanbanContext};
 use std::sync::Arc;
@@ -802,6 +802,71 @@ async fn test_assign_cards_to_sprint_detailed_partial_success_is_undoable() -> K
 
     assert!(ctx.undo()?.is_some());
     assert_eq!(ctx.get_card(card.id)?.unwrap().sprint_id, None);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_move_cards_detailed_returns_entity_invalidation_naming_the_moved_cards(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col_a = ctx.create_column(board.id, "A".into(), None)?;
+    let col_b = ctx.create_column(board.id, "B".into(), None)?;
+    let c1 = ctx.create_card(board.id, col_a.id, "Card 1".into(), Default::default())?;
+    let c2 = ctx.create_card(board.id, col_a.id, "Card 2".into(), Default::default())?;
+    ctx.clear_history()?;
+    ctx.mark_clean();
+
+    let (result, invalidation) = ctx.move_cards_detailed(vec![c1.id, c2.id], col_b.id);
+    assert_eq!(result.succeeded.len(), 2);
+    match invalidation {
+        Invalidation::Entities(ids) => {
+            assert_eq!(ids.cards, std::collections::HashSet::from([c1.id, c2.id]));
+        }
+        other => panic!("expected Invalidation::Entities, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_cards_detailed_on_success_returns_all_because_restore_is_unenumerable(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let c1 = ctx.create_card(board.id, col.id, "Card 1".into(), Default::default())?;
+    let c2 = ctx.create_card(board.id, col.id, "Card 2".into(), Default::default())?;
+    ctx.clear_history()?;
+    ctx.mark_clean();
+
+    let (result, invalidation) = ctx.archive_cards_detailed(vec![c1.id, c2.id]);
+    assert_eq!(result.succeeded.len(), 2);
+    assert_eq!(invalidation, Invalidation::All);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_cards_detailed_all_invalid_returns_empty_invalidation() {
+    let mut ctx = make_ctx().await;
+    let (result, invalidation) =
+        ctx.archive_cards_detailed(vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()]);
+    assert!(result.succeeded.is_empty());
+    assert_eq!(result.failed.len(), 2);
+    assert_eq!(invalidation, Invalidation::Entities(EntityIds::default()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_assign_cards_to_sprint_detailed_missing_sprint_returns_empty_invalidation(
+) -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "C".into(), None)?;
+    let c1 = ctx.create_card(board.id, col.id, "Card 1".into(), Default::default())?;
+
+    let (result, invalidation) =
+        ctx.assign_cards_to_sprint_detailed(vec![c1.id], uuid::Uuid::new_v4());
+    assert_eq!(result.failed.len(), 1);
+    assert_eq!(invalidation, Invalidation::Entities(EntityIds::default()));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `archive_cards_detailed`, `move_cards_detailed`, and `assign_cards_to_sprint_detailed` in `kanban-service` now return `(BatchOperationResult, Invalidation)` instead of a bare `BatchOperationResult`, so the invalidation their success path derives from `execute()` is recoverable by callers instead of being discarded.
- `kanban-cli`'s `CliContext::execute_commands` now routes through `mutate_unit` instead of calling `self.inner.execute(...)` directly and dropping the result.
- `CliContext::create_column_with_default_status` collapses its two-command create-then-update path (`create_column` followed by `update_column`) into a single `CreateColumn` command that already carries `default_status`, read back via `KanbanOperations::get_column`. An explicit `--position` create now produces one undo entry instead of two.
- The three `_detailed` wrappers on `CliContext` now apply the `Invalidation` their inner `KanbanContext` methods return instead of discarding it.
- Extracted `CliContext::apply_invalidation` as the single call site all mutation paths (`mutate`, `mutate_unit`, and the three wrappers) use to hand an `Invalidation` to `sync_invalidated`, so the seam contract documented on `CliContext` is now true for every mutation path in `kanban-cli`.

## Notes

- A successful `archive_cards_detailed` returns `Invalidation::All`, not an enumerable `Entities` set, because the invalidation is derived from the captured inverse batch and `RestoreCard::touched_entities()` returns `None`. Pinned by `test_archive_cards_detailed_on_success_returns_all_because_restore_is_unenumerable`.
- `assign_cards_to_sprint_detailed` similarly returns `All` when every input card is already on the target sprint, since the inverse batch comes back empty in that case.
- `crates/kanban-service/README.md` still lists these three methods by their old single-return-value shape; left untouched since it documents purpose rather than exact signatures, but worth a follow-up pass.
- `impl KanbanOperations for CliContext` and `impl GraphOperations for CliContext` still forward mutators to `self.inner` directly, as required by the trait definitions. Verified none of those forwarded methods have a non-test caller inside `kanban-cli`.

## Test plan

- [x] `cargo test -p kanban-cli --lib` (32 passed, including the 4 new/updated seam tests)
- [x] `cargo test -p kanban-service --all-features` (all green, including the 6 new/updated invalidation tests)
- [x] `cargo test -p kanban-cli --all-features` (integration + sqlite parity + migrate suites green; `test_column_create_with_position_and_default_status_honours_both` unaffected)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] Mutation check: broke the archive-success invalidation arm, confirmed the two Entities-vs-All tests failed, reverted
