### PR TITLE
KAN-1521 fix(tui): stop the assign-to-sprint dialogs failing silently on non-loaded tiers

### DIFF
--- a/.changeset/kan-1521-tui-popup-silent-failures.md
+++ b/.changeset/kan-1521-tui-popup-silent-failures.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+fix the assign-to-sprint dialogs no longer close silently on an unloaded card or board, and the active card selection no longer clears on a transient load failure

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -187,7 +187,8 @@ impl App {
 #[cfg(test)]
 mod active_card_helpers {
     use crate::App;
-    use kanban_domain::{CreateCardOptions, KanbanOperations, Snapshot};
+    use kanban_domain::{CreateCardOptions, EntityIds, Invalidation, KanbanError, KanbanOperations, Snapshot};
+    use std::sync::Arc;
 
     fn app_with_card() -> (App, uuid::Uuid) {
         let mut app = App::test_default();
@@ -264,5 +265,43 @@ mod active_card_helpers {
                 app.selection.active_card_id, None,
                 "set_active_card_or_clear must clear the previous active card when the new id is absent — prevents downstream handlers from acting on a stale active card"
             );
+    }
+
+    #[test]
+    fn test_set_active_card_or_clear_with_not_loaded_tier_preserves_selection() {
+        let (mut app, card_id) = app_with_card();
+        app.selection.active_card_id = Some(card_id);
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::cards([
+                uuid::Uuid::new_v4(),
+            ])));
+
+        app.set_active_card_or_clear(card_id);
+
+        assert_eq!(
+            app.selection.active_card_id,
+            Some(card_id),
+            "a transiently NotLoaded card tier must not clear the selection — only a genuinely Missing card may"
+        );
+    }
+
+    #[test]
+    fn test_set_active_card_or_clear_with_failed_tier_preserves_selection() {
+        let (mut app, card_id) = app_with_card();
+        app.selection.active_card_id = Some(card_id);
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        let _ = app
+            .model
+            .mark_failed(EntityIds::cards([uuid::Uuid::new_v4()]), err);
+
+        app.set_active_card_or_clear(card_id);
+
+        assert_eq!(
+            app.selection.active_card_id,
+            Some(card_id),
+            "a failed fetch does not mean the card is gone; only a genuinely Missing card may clear the selection"
+        );
     }
 }

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -1,5 +1,5 @@
 use super::{App, SprintTaskPanel};
-use kanban_domain::{partition_sprint_cards, sort_card_ids, Card, SortField, SortOrder};
+use kanban_domain::{partition_sprint_cards, sort_card_ids, Card, LoadState, SortField, SortOrder};
 
 impl App {
     pub fn get_selected_card_in_context(&self) -> Option<Card> {
@@ -69,18 +69,17 @@ impl App {
         }
     }
 
-    /// Sets `active_card_id` to `id` if the card resolves in the model,
-    /// otherwise clears it. Use at sites where `id` was obtained from a
-    /// surface that may still reference an archived card (the file-watcher
-    /// reload race), so downstream code that gates on
-    /// `active_card_id.is_some()` does not act on a stale previous card.
+    /// Sets `active_card_id` to `id` when the card is loaded, clears it when
+    /// the card is genuinely `Missing` (the archived-card / file-watcher
+    /// reload race this exists for), and otherwise leaves the current
+    /// selection untouched: a `NotLoaded` or `Failed` tier means the card's
+    /// existence is unknown, not that it is gone.
     pub(crate) fn set_active_card_or_clear(&mut self, id: uuid::Uuid) {
-        self.selection.active_card_id = self
-            .model
-            .card_by_id_state(id)
-            .loaded()
-            .copied()
-            .map(|c| c.id);
+        match self.model.card_by_id_state(id) {
+            LoadState::Loaded(card) => self.selection.active_card_id = Some(card.id),
+            LoadState::Missing => self.selection.active_card_id = None,
+            LoadState::NotLoaded | LoadState::Failed(_) => {}
+        }
     }
 
     pub fn populate_sprint_task_lists(&mut self, sprint_id: uuid::Uuid) {
@@ -187,7 +186,9 @@ impl App {
 #[cfg(test)]
 mod active_card_helpers {
     use crate::App;
-    use kanban_domain::{CreateCardOptions, EntityIds, Invalidation, KanbanError, KanbanOperations, Snapshot};
+    use kanban_domain::{
+        CreateCardOptions, EntityIds, Invalidation, KanbanError, KanbanOperations, Snapshot,
+    };
     use std::sync::Arc;
 
     fn app_with_card() -> (App, uuid::Uuid) {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -777,7 +777,8 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helpers::{load_with_card_order, setup_reload_resort_fixture};
+    use crate::app::{AppMode, DialogMode};
+    use crate::test_helpers::{load_with_card_order, setup_reload_resort_fixture, ReloadResortFixture};
     use crate::App;
     use crossterm::event::KeyCode;
     use kanban_domain::{
@@ -785,6 +786,27 @@ mod tests {
         SprintStatus, SprintUpdate,
     };
     use std::collections::HashSet;
+
+    fn assign_dialog_fixture(app: &mut App) -> (ReloadResortFixture, uuid::Uuid) {
+        let fx = setup_reload_resort_fixture(app);
+        let sprint = app.ctx.create_sprint(fx.board_id, None, None).unwrap();
+        load_with_card_order(app, &[fx.a_id, fx.p_id, fx.b_id, fx.c_id, fx.d_id]);
+
+        let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+        let board = app
+            .model
+            .boards_state()
+            .loaded_or_empty()
+            .iter()
+            .find(|b| b.id == fx.board_id)
+            .cloned()
+            .expect("board exists");
+        app.dialog_input
+            .assign_sprint_picker
+            .reset_for_card_assignment(Some(sprint.id), &sprints, &board, chrono::Utc::now());
+
+        (fx, sprint.id)
+    }
 
     #[test]
     fn test_handle_set_card_priority_popup_after_reload_resort_updates_originally_selected_card_priority(
@@ -985,6 +1007,130 @@ mod tests {
         assert!(
             app.ui_state.banner.is_none(),
             "the per-keystroke search filter must degrade silently, not spam a banner per character"
+        );
+    }
+
+    #[test]
+    fn test_assign_sprint_enter_with_not_loaded_board_tier_keeps_dialog_open_and_banners() {
+        let mut app = App::test_default();
+        let (fx, sprint_id) = assign_dialog_fixture(&mut app);
+        app.mode = AppMode::Dialog(DialogMode::AssignCardToSprint);
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::boards([
+                uuid::Uuid::new_v4(),
+            ])));
+
+        app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
+
+        assert_eq!(
+            app.mode,
+            AppMode::Dialog(DialogMode::AssignCardToSprint),
+            "a not-loaded board tier must keep the dialog open"
+        );
+        assert_eq!(
+            app.dialog_input.assign_sprint_picker.selected_sprint_id(),
+            Some(sprint_id),
+            "the staged sprint pick must survive"
+        );
+        assert_eq!(
+            app.dialog_input.assign_sprint_picker.bound_board_id(),
+            Some(fx.board_id),
+            "the picker must not be cleared"
+        );
+        let banner = app
+            .ui_state
+            .banner
+            .as_ref()
+            .expect("a not-loaded board tier must banner instead of failing silently");
+        assert!(
+            banner.message.to_lowercase().contains("not loaded"),
+            "banner should explain the tier is not loaded, got: {}",
+            banner.message
+        );
+        let cards = app.ctx.data_store().list_all_cards().unwrap();
+        let a_card = cards.iter().find(|c| c.id == fx.a_id).expect("A exists");
+        assert_eq!(
+            a_card.sprint_id, None,
+            "declining on an unloaded tier must not mutate the store"
+        );
+    }
+
+    #[test]
+    fn test_assign_sprint_enter_with_not_loaded_card_tier_banners_instead_of_dead_modal() {
+        let mut app = App::test_default();
+        let (_fx, sprint_id) = assign_dialog_fixture(&mut app);
+        app.mode = AppMode::Dialog(DialogMode::AssignCardToSprint);
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::cards([
+                uuid::Uuid::new_v4(),
+            ])));
+
+        app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
+
+        let banner = app
+            .ui_state
+            .banner
+            .as_ref()
+            .expect("a not-loaded card tier must banner instead of leaving a dead modal");
+        assert!(
+            banner.message.to_lowercase().contains("not loaded"),
+            "banner should explain the tier is not loaded, got: {}",
+            banner.message
+        );
+        assert_eq!(
+            app.mode,
+            AppMode::Dialog(DialogMode::AssignCardToSprint),
+            "pin: the dialog must still be open (not a new close-on-miss path)"
+        );
+        assert_eq!(
+            app.dialog_input.assign_sprint_picker.selected_sprint_id(),
+            Some(sprint_id),
+            "pin: the staged sprint pick must survive"
+        );
+    }
+
+    #[test]
+    fn test_assign_multiple_enter_with_not_loaded_board_tier_keeps_dialog_and_selection() {
+        let mut app = App::test_default();
+        let (fx, sprint_id) = assign_dialog_fixture(&mut app);
+        app.multi_select.selected_cards = HashSet::from_iter([fx.a_id, fx.b_id]);
+        app.multi_select.selection_mode_active = true;
+        app.mode = AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint);
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::boards([
+                uuid::Uuid::new_v4(),
+            ])));
+
+        app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Enter);
+
+        assert_eq!(
+            app.mode,
+            AppMode::Dialog(DialogMode::AssignMultipleCardsToSprint),
+            "a not-loaded board tier must keep the dialog open"
+        );
+        assert_eq!(
+            app.multi_select.selected_cards,
+            HashSet::from_iter([fx.a_id, fx.b_id]),
+            "the multi-selection must survive"
+        );
+        assert!(
+            app.multi_select.selection_mode_active,
+            "selection mode must stay active"
+        );
+        assert_eq!(
+            app.dialog_input.assign_sprint_picker.selected_sprint_id(),
+            Some(sprint_id),
+            "the staged sprint pick must survive"
+        );
+        assert!(
+            app.ui_state.banner.is_some(),
+            "a not-loaded board tier must banner instead of failing silently"
         );
     }
 }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -356,24 +356,27 @@ impl App {
                         return;
                     }
                 };
-                let card_id = match self
+                let card_id = self
                     .model
                     .card_by_id_state(active_card_id)
                     .loaded()
                     .copied()
-                {
-                    Some(card) => card.id,
-                    None => return,
+                    .map(|c| c.id);
+                let Some(card_id) = card_id else {
+                    self.set_error("Card is not loaded yet".to_string());
+                    return;
                 };
                 let active_board_id = self
                     .selection
                     .active_board_id
                     .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                     .map(|b| b.id);
+                let Some(active_board_id) = active_board_id else {
+                    self.set_error("Board is not loaded yet".to_string());
+                    return;
+                };
                 let picker = &self.dialog_input.assign_sprint_picker;
-                let board_matches = active_board_id
-                    .map(|bid| picker.bound_board_id() == Some(bid))
-                    .unwrap_or(false);
+                let board_matches = picker.bound_board_id() == Some(active_board_id);
                 let cmd = if !board_matches {
                     None
                 } else if let Some(sprint_id) = picker.selected_sprint_id() {
@@ -442,10 +445,12 @@ impl App {
                     .active_board_id
                     .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                     .map(|b| b.id);
+                let Some(active_board_id) = active_board_id else {
+                    self.set_error("Board is not loaded yet".to_string());
+                    return;
+                };
                 let picker = &self.dialog_input.assign_sprint_picker;
-                let board_matches = active_board_id
-                    .map(|bid| picker.bound_board_id() == Some(bid))
-                    .unwrap_or(false);
+                let board_matches = picker.bound_board_id() == Some(active_board_id);
                 let cmds: Vec<kanban_domain::commands::Command> = if !board_matches {
                     Vec::new()
                 } else if let Some(sprint_id) = picker.selected_sprint_id() {
@@ -778,7 +783,9 @@ impl App {
 #[cfg(test)]
 mod tests {
     use crate::app::{AppMode, DialogMode};
-    use crate::test_helpers::{load_with_card_order, setup_reload_resort_fixture, ReloadResortFixture};
+    use crate::test_helpers::{
+        load_with_card_order, setup_reload_resort_fixture, ReloadResortFixture,
+    };
     use crate::App;
     use crossterm::event::KeyCode;
     use kanban_domain::{


### PR DESCRIPTION
## Summary

- `handle_assign_card_to_sprint_popup` and `handle_assign_multiple_cards_to_sprint_popup` no longer bare-return or silently close on Enter when the active card's or board's model tier is not `Loaded`. Both now set an error banner and keep the dialog, the staged sprint pick, and (for the multi popup) the multi-selection intact.
- `set_active_card_or_clear` is now a three-way match over `LoadState`: it clears `active_card_id` only on `LoadState::Missing`. A transiently `NotLoaded` or `Failed` card tier no longer wipes the user's active card selection.
- A genuine board mismatch (both tiers loaded, but the picker is bound to a different board) still closes the dialog and discards the assignment, unchanged.

## Test plan

- [x] `cargo test -p kanban-tui` green, including 5 new tests and all previously pinned regression tests
- [x] Mutation check: reverted the `set_active_card_or_clear` fix, confirmed both new tests fail, restored the fix
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --all-features --workspace` green
