### PR TITLE
KAN-1522 fix(tui): scope-first column and board-delete-count reads

### DIFF
--- a/.changeset/kan-1522-tui-column-and-confirm-reads.md
+++ b/.changeset/kan-1522-tui-column-and-confirm-reads.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+fix column and delete-count reads that silently ignored a loaded board-scoped tier

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -1,7 +1,29 @@
 use super::{App, AppMode};
-use kanban_domain::{LoadState, Sprint};
+use kanban_domain::{Column, LoadState, Sprint};
 
 impl App {
+    /// One column tier per board-scoped feature: the scoped tier when it has
+    /// resolved, otherwise the flat tier filtered to `board_id`. A scoped
+    /// `Loaded` (including an empty one) is authoritative and never falls
+    /// back; only `NotLoaded` triggers the fallback. Unfiltered — callers
+    /// that need the position-ordered, search-narrowed view use
+    /// `visible_board_columns` instead.
+    pub(crate) fn board_columns_view(&self, board_id: uuid::Uuid) -> LoadState<Vec<Column>> {
+        match self.model.board_columns_state(board_id) {
+            LoadState::Loaded(columns) => LoadState::Loaded(columns.to_vec()),
+            LoadState::NotLoaded => match self.model.columns_state() {
+                LoadState::Loaded(all) => LoadState::Loaded(
+                    all.iter()
+                        .filter(|c| c.board_id == board_id)
+                        .cloned()
+                        .collect(),
+                ),
+                _ => LoadState::NotLoaded,
+            },
+            other => other.map(|_| Vec::new()),
+        }
+    }
+
     /// One sprint tier per board-scoped feature: the scoped tier when it has
     /// resolved, otherwise the flat tier filtered to `board_id`. A scoped
     /// `Loaded` (including an empty one) is authoritative and never falls

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -146,6 +146,84 @@ mod active_card_index_regression {
 }
 
 #[cfg(test)]
+mod board_columns_view_tests {
+    use crate::App;
+    use kanban_domain::resolved::Collection;
+    use kanban_domain::{Board, Column, DependencyGraph, LoadState, Resolved};
+    use std::collections::HashMap;
+
+    fn base_resolved(board: &Board) -> Resolved {
+        Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board.clone()]),
+                ..Default::default()
+            },
+            cards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            graph: LoadState::Loaded(DependencyGraph::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_board_columns_view_prefers_the_scoped_tier_and_falls_back_to_the_flat_one() {
+        let board = Board::new("B", None::<String>);
+        let other_board = Board::new("Other", None::<String>);
+        let col_a = Column::new(board.id, "A", 0);
+        let col_b = Column::new(board.id, "B", 1);
+        let col_other = Column::new(other_board.id, "Other", 0);
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            by_parent: HashMap::from([(
+                board.id,
+                LoadState::Loaded(vec![col_a.clone(), col_b.clone()]),
+            )]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        match app.board_columns_view(board.id) {
+            LoadState::Loaded(columns) => {
+                assert_eq!(columns, vec![col_a.clone(), col_b.clone()]);
+            }
+            other => panic!("expected the scoped tier, got {other:?}"),
+        }
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            all: LoadState::Loaded(vec![col_a.clone(), col_other.clone()]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        match app.board_columns_view(board.id) {
+            LoadState::Loaded(columns) => assert_eq!(columns, vec![col_a.clone()]),
+            other => panic!("expected fallback to the flat tier, got {other:?}"),
+        }
+
+        let app = App::test_default();
+        assert!(app.board_columns_view(board.id).is_not_loaded());
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            by_parent: HashMap::from([(
+                board.id,
+                LoadState::Failed(std::sync::Arc::new(
+                    kanban_domain::KanbanError::unsupported("boom"),
+                )),
+            )]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        assert!(app.board_columns_view(board.id).is_failed());
+    }
+}
+
+#[cfg(test)]
 mod board_sprints_view_tests {
     use crate::App;
     use kanban_domain::resolved::Collection;

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -135,6 +135,9 @@ impl App {
         if self.focus.active == Focus::Boards {
             if let Some(board_id) = self.board_list.get_selected_board_id() {
                 self.open_dialog(DialogMode::DeleteBoardConfirm);
+                if !self.model.archived_card_markers_absorbed() {
+                    self.reload_model();
+                }
                 // Snapshot the counts once, here, rather than re-scanning the
                 // model on every frame the modal is open.
                 let Some(counts) = self.board_delete_counts(board_id) else {
@@ -175,6 +178,9 @@ impl App {
         let Some(board_id) = self.selected_archived_board_id() else {
             return;
         };
+        if !self.model.archived_card_markers_absorbed() {
+            self.reload_model();
+        }
         let Some(counts) = self.board_delete_counts(board_id) else {
             self.set_error("Board contents are not loaded yet".to_string());
             return;
@@ -270,18 +276,17 @@ impl App {
         let col_ids: std::collections::HashSet<uuid::Uuid> =
             scoped_columns.iter().map(|c| c.id).collect();
         let columns = col_ids.len();
-        let cards = self
-            .controller
-            .live_cards()
-            .loaded()
-            .copied()
-            .unwrap_or(&[])
+        let LoadState::Loaded(cards_all) = self.controller.live_cards() else {
+            return None;
+        };
+        let cards = cards_all
             .iter()
             .filter(|c| col_ids.contains(&c.column_id))
             .count();
-        let archived = self
-            .model
-            .archived_card_markers()
+        let LoadState::Loaded(markers) = self.model.archived_cards_state() else {
+            return None;
+        };
+        let archived = markers
             .iter()
             .filter(|a| a.context.board_id == board_id)
             .count();

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -603,7 +603,7 @@ mod tests {
     use crate::App;
     use crossterm::event::KeyCode;
     use kanban_domain::{
-        BoardUpdate, CreateCardOptions, KanbanOperations, SortOrder, TaskListView,
+        BoardUpdate, CreateCardOptions, KanbanOperations, LoadState, SortOrder, TaskListView,
     };
 
     /// Pull the store snapshot into `app.model` and resync `app.board_list` so
@@ -893,6 +893,105 @@ mod tests {
             ])));
 
         assert_eq!(app.board_delete_counts(board_id), None);
+    }
+
+    fn base_resolved(board: &kanban_domain::Board) -> kanban_domain::Resolved {
+        use kanban_domain::resolved::Collection;
+        kanban_domain::Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board.clone()]),
+                ..Default::default()
+            },
+            graph: LoadState::Loaded(kanban_domain::DependencyGraph::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_board_delete_counts_declines_when_the_live_cards_tier_is_not_loaded() {
+        use kanban_domain::resolved::Collection;
+        use kanban_domain::{Board, Column, DerivedProjections, Sprint};
+        use std::collections::HashMap;
+
+        let board = Board::new("Roadmap", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column]))]),
+            ..Default::default()
+        };
+        resolved.sprints = Collection {
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(Vec::<Sprint>::new()))]),
+            ..Default::default()
+        };
+        resolved.archived_cards = Collection {
+            all: LoadState::Loaded(Vec::new()),
+            ..Default::default()
+        };
+        let changed = app.model.apply_resolved(resolved);
+        app.controller.resync(&app.model, changed);
+
+        assert!(
+            app.model.cards_state().is_not_loaded(),
+            "cards must stay NotLoaded for this fixture to isolate the live-cards gate"
+        );
+        assert_eq!(app.board_delete_counts(board.id), None);
+    }
+
+    #[test]
+    fn test_board_delete_counts_declines_when_the_archived_marker_tier_is_not_absorbed() {
+        use kanban_domain::resolved::Collection;
+        use kanban_domain::{Board, Column, DerivedProjections, Sprint};
+        use std::collections::HashMap;
+
+        let board = Board::new("Roadmap", None::<String>);
+        let column = Column::new(board.id, "Todo", 0);
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column]))]),
+            ..Default::default()
+        };
+        resolved.sprints = Collection {
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(Vec::<Sprint>::new()))]),
+            ..Default::default()
+        };
+        resolved.cards = Collection {
+            all: LoadState::Loaded(Vec::new()),
+            ..Default::default()
+        };
+        let changed = app.model.apply_resolved(resolved);
+        app.controller.resync(&app.model, changed);
+
+        assert!(
+            !app.model.archived_card_markers_absorbed(),
+            "the archived marker tier must not be absorbed by this fixture"
+        );
+        assert_eq!(app.board_delete_counts(board.id), None);
+
+        let resolved_archived = kanban_domain::Resolved {
+            archived_cards: Collection {
+                all: LoadState::Loaded(Vec::new()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let changed = app.model.apply_resolved(resolved_archived);
+        app.controller.resync(&app.model, changed);
+
+        assert_eq!(
+            app.board_delete_counts(board.id),
+            Some(BoardDeleteCounts {
+                columns: 1,
+                cards: 0,
+                archived: 0,
+                sprints: 0,
+            }),
+            "a Loaded-but-empty archived marker tier must not decline"
+        );
     }
 
     #[test]

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1618,6 +1618,55 @@ mod cards_tier_decline_tests {
         );
     }
 
+    fn invalidate_columns_tier(app: &mut App) {
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::columns([
+                uuid::Uuid::new_v4(),
+            ])));
+    }
+
+    fn resupply_scoped_columns_only(app: &mut App, board_id: uuid::Uuid) {
+        let columns = app
+            .ctx
+            .data_store()
+            .list_all_columns()
+            .unwrap()
+            .into_iter()
+            .filter(|c| c.board_id == board_id)
+            .collect();
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            columns: kanban_domain::resolved::Collection {
+                by_parent: [(board_id, kanban_domain::LoadState::Loaded(columns))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        NoProjections.resync(&app.model, changed);
+    }
+
+    #[test]
+    fn test_create_card_creates_when_only_the_scoped_column_tier_is_loaded() {
+        let mut app = App::test_default();
+        let (board_id, _column_id, _card_id) = seed_board_column_card(&mut app);
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+
+        invalidate_columns_tier(&mut app);
+        resupply_scoped_columns_only(&mut app, board_id);
+
+        app.input.set("New card".to_string());
+        app.create_card();
+        app.input.clear();
+
+        assert!(app.ui_state.banner.is_none());
+        let cards = app.ctx.data_store().list_all_cards().unwrap();
+        assert!(
+            cards.iter().any(|c| c.title == "New card"),
+            "the card must be created from the scoped-only column tier"
+        );
+    }
+
     #[test]
     fn test_handle_move_card_with_a_not_loaded_cards_tier_declines() {
         let mut app = App::test_default();

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -394,10 +394,12 @@ impl App {
                 .map(|b| b.id);
 
             if let Some(bid) = board_info {
-                if !self.model.board_columns_state(bid).is_loaded()
-                    && !self.model.columns_state().is_loaded()
-                {
+                if !self.board_columns_view(bid).is_loaded() {
                     self.set_error("Columns are not loaded yet");
+                    return;
+                }
+                if !self.model.cards_state().is_loaded() {
+                    self.set_error("Cards are not loaded yet");
                     return;
                 }
                 let existing_column = self.create_card_target_column(bid);
@@ -411,7 +413,7 @@ impl App {
                         };
                         let position =
                             kanban_domain::card_lifecycle::next_position_in_column(cards, col.id);
-                        let LoadState::Loaded(columns) = self.model.columns_state() else {
+                        let LoadState::Loaded(columns) = self.board_columns_view(bid) else {
                             self.set_error("Columns are not loaded yet");
                             return;
                         };
@@ -422,7 +424,7 @@ impl App {
                             .copied()
                             .map(|board| {
                                 kanban_domain::card_lifecycle::should_auto_complete_new_card(
-                                    col.id, board, columns,
+                                    col.id, board, &columns,
                                 )
                             })
                             .unwrap_or(false);
@@ -598,7 +600,7 @@ impl App {
             if self.is_kanban_view() {
                 let num_cols = self
                     .active_board()
-                    .map(|b| self.visible_board_columns(b.id).len())
+                    .map(|b| self.visible_board_columns(b.id).loaded_or_empty().len())
                     .unwrap_or(0);
                 self.dialog_input.column_list.update_item_count(num_cols);
                 if let Some(current_col_idx) = self.dialog_input.column_list.get_selected_index() {

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -30,7 +30,11 @@ impl App {
             {
                 if let Some(board) = self.active_board() {
                     let board_id = board.id;
-                    let board_columns = self.visible_board_columns(board_id);
+                    let LoadState::Loaded(board_columns) = self.visible_board_columns(board_id)
+                    else {
+                        self.set_error("Columns are not loaded yet".to_string());
+                        return;
+                    };
 
                     if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
                         if let Some(column) = board_columns.get(column_idx) {
@@ -49,8 +53,12 @@ impl App {
         {
             if let Some(board) = self.active_board() {
                 let board_id = board.id;
+                let LoadState::Loaded(board_columns) = self.visible_board_columns(board_id) else {
+                    self.set_error("Columns are not loaded yet".to_string());
+                    return;
+                };
                 if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
-                    if let Some(column) = self.visible_board_columns(board_id).get(column_idx) {
+                    if let Some(column) = board_columns.get(column_idx) {
                         let idx = kanban_view::selection_dialog::popup_index_of_default_status(
                             column.default_status,
                         );
@@ -295,21 +303,19 @@ impl App {
 
     pub fn rename_column(&mut self) {
         {
-            // Collect column ID before mutable borrow
-            let column_info = {
-                if let Some(board) = self.active_board() {
-                    let board_id = board.id;
-                    if let Some(column_idx) = self.dialog_input.column_list.get_selected_index() {
-                        self.visible_board_columns(board_id)
-                            .get(column_idx)
-                            .map(|col| col.id)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
+            let board_id = match self.active_board() {
+                Some(board) => board.id,
+                None => return,
             };
+            let column_idx = match self.dialog_input.column_list.get_selected_index() {
+                Some(idx) => idx,
+                None => return,
+            };
+            let LoadState::Loaded(board_columns) = self.visible_board_columns(board_id) else {
+                self.set_error("Columns are not loaded yet".to_string());
+                return;
+            };
+            let column_info = board_columns.get(column_idx).map(|col| col.id);
 
             if let Some(column_id) = column_info {
                 let new_name = self.input.as_str().trim().to_string();
@@ -361,11 +367,13 @@ impl App {
                             return;
                         }
 
-                        // Resolved against the filtered list the confirm
-                        // dialog was opened from, not `all_columns`, so a
-                        // narrowed search doesn't delete the wrong column.
-                        let column_to_delete = self
-                            .visible_board_columns(board_id)
+                        let LoadState::Loaded(visible_columns) =
+                            self.visible_board_columns(board_id)
+                        else {
+                            self.set_error("Columns are not loaded yet".to_string());
+                            return;
+                        };
+                        let column_to_delete = visible_columns
                             .get(column_idx)
                             .map(|col| (col.id, col.name.clone()));
                         let first_column_id = all_columns.first().map(|(id, _)| *id);

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -29,31 +29,31 @@ impl App {
     /// per `FieldSearcher`'s empty-query contract). This is the single
     /// source of truth for both rendering (`ui::board_detail`) and index
     /// resolution in the column handlers, so a filtered list and an
-    /// unfiltered handler can never disagree on what index N means.
-    pub(crate) fn visible_board_columns(&self, board_id: uuid::Uuid) -> Vec<Column> {
-        let columns: &[Column] = match self.model.columns_state() {
-            LoadState::Loaded(columns) => columns,
-            _ => &[],
-        };
-        let ordered = sorted_board_columns(board_id, columns);
-        let query = self.filter.column_search.active_query().unwrap_or("");
-        let searcher = FieldSearcher::new(query, |c: &&Column| c.name.as_str());
-        kanban_view::list_query::search_and_sort(
-            ordered,
-            |c| searcher.matches(c),
-            |a, b| a.position.cmp(&b.position),
-        )
-        .into_iter()
-        .cloned()
-        .collect()
+    /// unfiltered handler can never disagree on what index N means. Prefers
+    /// the board-scoped column tier and falls back to the flat one, per
+    /// `board_columns_view`.
+    pub(crate) fn visible_board_columns(&self, board_id: uuid::Uuid) -> LoadState<Vec<Column>> {
+        self.board_columns_view(board_id).map(|columns| {
+            let ordered = sorted_board_columns(board_id, &columns);
+            let query = self.filter.column_search.active_query().unwrap_or("");
+            let searcher = FieldSearcher::new(query, |c: &&Column| c.name.as_str());
+            kanban_view::list_query::search_and_sort(
+                ordered,
+                |c| searcher.matches(c),
+                |a, b| a.position.cmp(&b.position),
+            )
+            .into_iter()
+            .cloned()
+            .collect()
+        })
     }
 
     fn column_count_for_board(&self, board_id: uuid::Uuid) -> usize {
-        self.visible_board_columns(board_id).len()
+        self.visible_board_columns(board_id).loaded_or_empty().len()
     }
 
     fn enter_column_focus_at_top(&mut self, board_id: uuid::Uuid) {
-        if !self.model.columns_state().is_loaded() {
+        if !self.visible_board_columns(board_id).is_loaded() {
             self.set_error("Columns are not loaded yet");
             return;
         }
@@ -472,7 +472,7 @@ impl App {
                                 let sprint_count = sprints.len();
                                 let current_idx = self.selection.sprint.get().unwrap_or(0);
                                 if sprint_count == 0 || current_idx >= sprint_count - 1 {
-                                    if self.model.columns_state().is_loaded() {
+                                    if self.visible_board_columns(board_id).is_loaded() {
                                         self.focus.board_focus = BoardFocus::Columns;
                                         self.enter_column_focus_at_top(board_id);
                                     } else {
@@ -488,7 +488,7 @@ impl App {
                 }
                 BoardFocus::Columns => {
                     if let Some(board_id) = self.active_board().map(|board| board.id) {
-                        if self.model.columns_state().is_loaded() {
+                        if self.visible_board_columns(board_id).is_loaded() {
                             let column_count = self.column_count_for_board(board_id);
                             self.dialog_input
                                 .column_list
@@ -537,8 +537,10 @@ impl App {
                 }
                 BoardFocus::Columns => {
                     let board_id = self.board_list.get_selected_board_id();
-                    let columns_ready =
-                        board_id.is_none() || self.model.columns_state().is_loaded();
+                    let columns_ready = match board_id {
+                        None => true,
+                        Some(id) => self.visible_board_columns(id).is_loaded(),
+                    };
                     if !columns_ready {
                         self.set_error("Columns are not loaded yet");
                     } else {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2163,7 +2163,10 @@ mod tests {
             app.filter.column_search.input.insert_char(c);
         }
 
-        let visible = app.visible_board_columns(board_id);
+        let visible = app
+            .visible_board_columns(board_id)
+            .loaded_or_empty()
+            .to_vec();
 
         assert_eq!(
             visible.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
@@ -2186,7 +2189,10 @@ mod tests {
         );
         app.filter.column_search.activate();
 
-        let visible = app.visible_board_columns(board_id);
+        let visible = app
+            .visible_board_columns(board_id)
+            .loaded_or_empty()
+            .to_vec();
 
         assert_eq!(
             visible.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
@@ -2202,7 +2208,10 @@ mod tests {
         app.filter.column_search.activate();
         app.filter.column_search.input.insert_char('a');
 
-        let visible = app.visible_board_columns(board_id);
+        let visible = app
+            .visible_board_columns(board_id)
+            .loaded_or_empty()
+            .to_vec();
 
         assert_eq!(
             visible.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
@@ -2700,5 +2709,89 @@ mod tests {
 
         assert_eq!(app.focus.board_focus, BoardFocus::Sprints);
         assert_eq!(app.selection.sprint.get(), Some(1));
+    }
+}
+
+#[cfg(test)]
+mod visible_board_columns_tests {
+    use crate::App;
+    use kanban_domain::resolved::Collection;
+    use kanban_domain::{Board, Column, DependencyGraph, LoadState, Resolved};
+    use std::collections::HashMap;
+
+    fn base_resolved(board: &Board) -> Resolved {
+        Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board.clone()]),
+                ..Default::default()
+            },
+            cards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            graph: LoadState::Loaded(DependencyGraph::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_visible_board_columns_prefers_the_scoped_tier_and_falls_back_to_the_flat_one() {
+        let board = Board::new("B", None::<String>);
+        let other_board = Board::new("Other", None::<String>);
+        let col_a = Column::new(board.id, "A", 1);
+        let col_b = Column::new(board.id, "B", 0);
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            by_parent: HashMap::from([(
+                board.id,
+                LoadState::Loaded(vec![col_a.clone(), col_b.clone()]),
+            )]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        match app.visible_board_columns(board.id) {
+            LoadState::Loaded(columns) => {
+                assert_eq!(
+                    columns.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+                    vec!["B", "A"],
+                    "position order wins, sourced from the scoped tier"
+                );
+            }
+            other => panic!("expected the scoped tier, got {other:?}"),
+        }
+
+        let col_other = Column::new(other_board.id, "Other", 0);
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            all: LoadState::Loaded(vec![col_a.clone(), col_other.clone()]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        match app.visible_board_columns(board.id) {
+            LoadState::Loaded(columns) => {
+                assert_eq!(columns, vec![col_a.clone()]);
+            }
+            other => panic!("expected fallback to the flat tier, got {other:?}"),
+        }
+
+        let app = App::test_default();
+        assert!(app.visible_board_columns(board.id).is_not_loaded());
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
+            by_parent: HashMap::from([(
+                board.id,
+                LoadState::Failed(std::sync::Arc::new(
+                    kanban_domain::KanbanError::unsupported("boom"),
+                )),
+            )]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        assert!(app.visible_board_columns(board.id).is_failed());
     }
 }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -111,29 +111,35 @@ impl App {
                             if let Some(column_idx) =
                                 self.dialog_input.column_list.get_selected_index()
                             {
-                                if let Some(column) =
-                                    self.visible_board_columns(board_id).get(column_idx)
-                                {
-                                    let column_id = column.id;
-                                    let cmd =
-                                        Command::Column(ColumnCommand::Update(UpdateColumn {
-                                            column_id,
-                                            updates: ColumnUpdate {
-                                                default_status: Some(status),
-                                                ..Default::default()
-                                            },
-                                        }));
-                                    if let Err(e) = self.execute_command(cmd) {
-                                        tracing::error!(
-                                            "Failed to update column default status: {}",
-                                            e
-                                        );
-                                        self.set_error(format!(
-                                            "Failed to update column default status: {}",
-                                            e
-                                        ));
+                                match self.visible_board_columns(board_id) {
+                                    LoadState::Loaded(columns) => {
+                                        if let Some(column) = columns.get(column_idx) {
+                                            let column_id = column.id;
+                                            let cmd = Command::Column(ColumnCommand::Update(
+                                                UpdateColumn {
+                                                    column_id,
+                                                    updates: ColumnUpdate {
+                                                        default_status: Some(status),
+                                                        ..Default::default()
+                                                    },
+                                                },
+                                            ));
+                                            if let Err(e) = self.execute_command(cmd) {
+                                                tracing::error!(
+                                                    "Failed to update column default status: {}",
+                                                    e
+                                                );
+                                                self.set_error(format!(
+                                                    "Failed to update column default status: {}",
+                                                    e
+                                                ));
+                                            }
+                                            self.reload_model();
+                                        }
                                     }
-                                    self.reload_model();
+                                    _ => {
+                                        self.set_error("Columns are not loaded yet".to_string());
+                                    }
                                 }
                             }
                         }

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -257,7 +257,10 @@ fn render_board_columns_list(
     match app.model.board_columns_state(board.id) {
         LoadState::Loaded(columns) => {
             let total_columns = sorted_board_columns(board.id, columns).len();
-            let board_columns = app.visible_board_columns(board.id);
+            let board_columns = app
+                .visible_board_columns(board.id)
+                .loaded_or_empty()
+                .to_vec();
 
             if board_columns.is_empty() {
                 column_lines.push(Line::from(Span::styled(

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -39,9 +39,12 @@ pub(super) fn render_projects_panel(app: &App, frame: &mut Frame, area: Rect) {
     // `displayed_boards()`), rather than flipping to the live set under the modal.
     let archived_view = matches!(app.get_base_mode(), AppMode::ArchivedBoardsView);
     let boards_state = app.displayed_boards();
-    let boards: &[Board] = boards_state.loaded().map(Vec::as_slice).unwrap_or(&[]);
+    let boards_slice = boards_state.as_ref().map(Vec::as_slice);
+    let boards: &[Board] = boards_slice.loaded().copied().unwrap_or(&[]);
 
-    if boards.is_empty() {
+    if let Some(marker) = crate::ui::load_state_body("Projects", &boards_slice) {
+        lines.push(marker);
+    } else if boards.is_empty() {
         let empty = if archived_view {
             "No archived projects."
         } else {

--- a/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
+++ b/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
@@ -77,3 +77,62 @@ fn test_board_delete_confirmation_card_count_excludes_archived_cards() {
         output
     );
 }
+
+#[test]
+fn test_the_delete_board_confirmation_reports_the_archived_count_after_a_lazy_populate() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let _live = app
+        .ctx
+        .create_card(board.id, col.id, "Live".to_string(), Default::default())
+        .unwrap();
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+
+    app.populate(kanban_tui::app::ViewScope {
+        board_list: true,
+        board: Some(board.id),
+        board_columns: true,
+        board_cards: true,
+        board_sprints: true,
+        ..Default::default()
+    });
+    app.prepare_frame();
+
+    assert!(
+        !app.model.archived_card_markers_absorbed(),
+        "a lazy populate must not absorb the archived marker tier"
+    );
+
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Boards;
+
+    app.handle_delete_board_key();
+
+    assert!(
+        app.ui_state.banner.is_none(),
+        "the delete-board confirmation must open after absorbing the archived tier, got banner:\n{:?}",
+        app.ui_state.banner
+    );
+
+    let output = render_to_string(&mut app, 100, 30);
+
+    assert!(
+        output.contains("1 archived task(s)"),
+        "the archived task count must reflect the one archived card, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("1 task(s)"),
+        "the live task count must be reported, got:\n{}",
+        output
+    );
+}

--- a/crates/kanban-tui/tests/column_and_board_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/column_and_board_handlers_collapsing_accessor_tests.rs
@@ -442,3 +442,90 @@ fn test_all_nine_migrated_sites_still_produce_identical_results_on_a_fully_loade
 
     assert!(app.ui_state.banner.is_none());
 }
+
+fn resupply_scoped_columns_only(app: &mut App, board_id: Uuid) {
+    use kanban_domain::resolved::Collection;
+    use kanban_domain::{LoadState, Resolved};
+
+    let columns = app
+        .ctx
+        .data_store()
+        .list_all_columns()
+        .unwrap()
+        .into_iter()
+        .filter(|c| c.board_id == board_id)
+        .collect();
+    let _ = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_parent: [(board_id, LoadState::Loaded(columns))].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
+#[test]
+fn test_delete_column_deletes_when_only_the_scoped_column_tier_is_loaded() {
+    let mut app = App::test_default();
+    let (board_id, first, second) = seed_board_with_two_columns(&mut app);
+    sync_model_from_store(&mut app);
+    invalidate_columns_tier(&mut app);
+    resupply_scoped_columns_only(&mut app, board_id);
+
+    app.selection.active_board_id = Some(board_id);
+    app.focus.board_focus = BoardFocus::Columns;
+    app.dialog_input.column_list.update_item_count(2);
+    app.dialog_input.column_list.set_selected_index(Some(0));
+
+    app.delete_column();
+
+    assert!(app.ui_state.banner.is_none());
+    assert!(app.ctx.data_store().get_column(first).unwrap().is_none());
+    assert!(app.ctx.data_store().get_column(second).unwrap().is_some());
+}
+
+#[test]
+fn test_rename_column_renames_when_only_the_scoped_column_tier_is_loaded() {
+    let mut app = App::test_default();
+    let (board_id, first, _second) = seed_board_with_two_columns(&mut app);
+    sync_model_from_store(&mut app);
+    invalidate_columns_tier(&mut app);
+    resupply_scoped_columns_only(&mut app, board_id);
+
+    app.selection.active_board_id = Some(board_id);
+    app.focus.board_focus = BoardFocus::Columns;
+    app.dialog_input.column_list.update_item_count(2);
+    app.dialog_input.column_list.set_selected_index(Some(0));
+
+    app.input.set("Renamed".to_string());
+    app.rename_column();
+
+    assert!(app.ui_state.banner.is_none());
+    let renamed = app.ctx.data_store().get_column(first).unwrap().unwrap();
+    assert_eq!(renamed.name, "Renamed");
+}
+
+#[test]
+fn test_rename_column_declines_when_no_column_tier_is_loaded() {
+    let mut app = App::test_default();
+    let (board_id, first, _second) = seed_board_with_two_columns(&mut app);
+    sync_model_from_store(&mut app);
+    invalidate_columns_tier(&mut app);
+
+    app.selection.active_board_id = Some(board_id);
+    app.focus.board_focus = BoardFocus::Columns;
+    app.dialog_input.column_list.update_item_count(2);
+    app.dialog_input.column_list.set_selected_index(Some(0));
+
+    app.input.set("Renamed".to_string());
+    app.rename_column();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded columns tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("column"));
+    let unchanged = app.ctx.data_store().get_column(first).unwrap().unwrap();
+    assert_eq!(unchanged.name, "Todo");
+}

--- a/crates/kanban-tui/tests/load_state_render_tests.rs
+++ b/crates/kanban-tui/tests/load_state_render_tests.rs
@@ -492,3 +492,66 @@ fn test_a_loaded_but_genuinely_empty_graph_still_renders_no_parents_and_no_child
     assert!(output.contains("No parents"));
     assert!(output.contains("No children"));
 }
+
+fn app_with_boards_state(state: LoadState<Vec<Board>>) -> App {
+    let mut app = App::test_default();
+    let changed = app.model.apply_resolved(Resolved {
+        boards: Collection {
+            all: state,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    app.controller.resync(&app.model, changed);
+    app
+}
+
+#[test]
+fn test_the_projects_panel_renders_the_not_loaded_marker_instead_of_the_empty_hint() {
+    let mut app = App::test_default();
+    let output = helpers::render_widget_to_string(400, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(
+        !output.contains("No projects yet"),
+        "a NotLoaded boards tier must not render the empty hint, got:\n{output}"
+    );
+    assert!(
+        output.contains("Projects not loaded yet"),
+        "a NotLoaded boards tier must render the load-state marker, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_the_projects_panel_renders_the_failed_marker_instead_of_the_empty_hint() {
+    let mut app = app_with_boards_state(LoadState::Failed(Arc::new(KanbanError::unsupported(
+        "boom",
+    ))));
+    let output = helpers::render_widget_to_string(400, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(
+        !output.contains("No projects yet"),
+        "a Failed boards tier must not render the empty hint, got:\n{output}"
+    );
+    assert!(
+        output.contains("Projects failed to load"),
+        "a Failed boards tier must render the load-state marker, got:\n{output}"
+    );
+    assert!(
+        output.contains("boom"),
+        "the marker must include the error detail, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_the_projects_panel_still_renders_the_empty_hint_on_a_loaded_empty_boards_tier() {
+    let mut app = app_with_boards_state(LoadState::Loaded(Vec::new()));
+    let output = helpers::render_widget_to_string(400, 30, |frame| {
+        kanban_tui::ui::render(&mut app, frame);
+    });
+    assert!(
+        output.contains("No projects yet. Press 'n' to create one!"),
+        "a Loaded-but-empty boards tier is a genuine empty state, got:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary

- `visible_board_columns` now returns `LoadState<Vec<Column>>`: it prefers the board-scoped column tier (including a loaded-empty one) and falls back to the flat tier only when the scoped tier is `NotLoaded`, mirroring the `board_sprints_view` pattern from KAN-1519.
- Added `board_columns_view`, the unfiltered scoped-first-then-flat column accessor `visible_board_columns` builds on. `create_card`'s auto-complete derivation reads this unfiltered view instead of the search-narrowed one, since an active column search would otherwise flip whether a new card is auto-completed.
- Every production caller of `visible_board_columns` now handles the non-loaded case explicitly instead of resolving against an empty list: `delete_column`, `rename_column`, `handle_rename_column_key`, `handle_set_column_default_status_key`, and the `SetColumnDefaultStatus` confirm popup all set a "Columns are not loaded yet" banner and decline.
- `create_card`'s guard now names exactly the tiers its body consumes (scoped-first columns, flat cards), instead of an either-tier check that could pass while the body's flat-only requires still aborted.
- `board_delete_counts` declines (`None`) unless the scoped columns, the scoped sprints, the live-cards partition, and the whole-store archived-marker tier are all loaded, instead of silently collapsing an unloaded live-cards or archived-marker tier to zero. Both delete-board key handlers now force an archived-marker absorption (`reload_model()`) before counting, since a lazy TUI startup never absorbs that tier on its own.
- The projects panel renders the shared load-state marker ("Projects not loaded yet" / "Projects failed to load: ...") for a non-loaded boards tier, instead of showing the "No projects yet" empty-state hint for a state that was never actually queried.

## Surviving `unwrap_or(&[])` / `=> &[]` in the touched files

- `column_handlers.rs:388` (`cards_to_move` in `delete_column`): collapses the live-cards partition, a different tier from the columns tier this change scopes; the surrounding columns guard already declines before this line runs.
- `card_handlers.rs:783` (`select_card_after_deletion`'s `live_cards` read): unrelated card-selection bookkeeping after a command has already executed successfully; not part of this leaf.
- `popup_handlers.rs:647,766` (relationship search popup): filters the flat cards tier for the parent/child management dialog, unrelated to the column tier.
- `ui/board_detail.rs:166,268` (`all_cards` for per-column card counts): live-cards tier, not the columns tier; line 166 is explicitly out of scope for this card.
- `ui/main_view.rs:43` (`boards_slice` extraction): only reached after the new load-state marker branch has already handled every non-loaded case, so the collapse never actually fires for a non-loaded tier.

## Test plan

- [x] `cargo test -p kanban-tui` (all new and pre-existing tests green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features --workspace`
- [x] Mutation-checked the central assertions (archived-tier gate, live-cards gate, scoped-first fallback, absorption call, projects-panel marker) by reverting each fix in turn and confirming the corresponding test fails, then restoring.
