### PR TITLE
KAN-1512 perf(mcp): resolve single-card MCP tools through the indexed lookup

### DIFF
--- a/.changeset/kan-1512-mcp-indexed-card-resolution.md
+++ b/.changeset/kan-1512-mcp-indexed-card-resolution.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+mcp: resolve single-card identifiers through the indexed lookup instead of the full card list

--- a/crates/kanban-mcp/src/helpers/model_read.rs
+++ b/crates/kanban-mcp/src/helpers/model_read.rs
@@ -236,32 +236,6 @@ fn find_card_matches<'a>(
     }
 }
 
-pub(crate) fn resolve_card(model: &Model, raw: &str) -> Result<Uuid, McpError> {
-    if let Ok(uuid) = Uuid::parse_str(raw) {
-        return Ok(uuid);
-    }
-    let cards = require_loaded(model.cards_state().as_ref(), "card list")?;
-    let matches = find_card_matches(cards, raw);
-    match matches.as_slice() {
-        [] => Err(kanban_err_to_mcp(KanbanError::not_found_by_name(
-            "Card",
-            raw,
-            Vec::new(),
-        ))),
-        [c] => Ok(c.id),
-        many => Err(kanban_err_to_mcp(KanbanError::ambiguous(
-            "Card",
-            raw,
-            many.iter()
-                .map(|c| AmbiguousMatch {
-                    label: format!("'{}'", c.title),
-                    id: c.id,
-                })
-                .collect(),
-        ))),
-    }
-}
-
 pub(crate) fn resolve_cards(model: &Model, raws: &[String]) -> Result<Vec<Uuid>, McpError> {
     let mut resolved = Vec::with_capacity(raws.len());
     let mut failures = Vec::new();
@@ -521,32 +495,6 @@ mod tests {
 
         let err = resolve_sprint_global(&Model::default(), "1").unwrap_err();
         assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
-    }
-
-    #[test]
-    fn test_resolve_card_by_identifier_reads_the_card_list() {
-        let mut card = Card::new(Uuid::new_v4(), Uuid::new_v4(), "Title", 0);
-        card.prefix = "KAN".into();
-        card.card_number = 5;
-        let card_id = card.id;
-
-        let mut model = Model::default();
-        let _ = model.apply_resolved(Resolved {
-            cards: Collection {
-                all: LoadState::Loaded(vec![card]),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        assert_eq!(resolve_card(&model, "KAN-5").unwrap(), card_id);
-        assert_eq!(resolve_card(&model, "5").unwrap(), card_id);
-
-        let err = resolve_card(&Model::default(), "KAN-5").unwrap_err();
-        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
-        assert!(err.message.contains("card list"));
-
-        assert!(resolve_card(&model, "KAN-999").is_err());
     }
 
     #[test]

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -1,6 +1,6 @@
 use crate::helpers::model_read::{
-    resolve_board, resolve_card, resolve_column_global, resolve_column_in_board,
-    resolve_sprint_global, resolve_sprint_in_board,
+    resolve_board, resolve_column_global, resolve_column_in_board, resolve_sprint_global,
+    resolve_sprint_in_board,
 };
 use crate::helpers::{
     board_head, card_board, core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write,
@@ -61,10 +61,7 @@ impl ToolScoped for ListCardsRequest {
 
 impl ToolScoped for UpdateCardRequest {
     fn scope(&self) -> ToolScope {
-        ToolScope {
-            cards: vec![Ref::of(&self.card)],
-            ..Default::default()
-        }
+        ToolScope::default()
     }
 }
 
@@ -72,7 +69,6 @@ impl ToolScoped for MoveCardRequest {
     fn scope(&self) -> ToolScope {
         let column_ref = Ref::of(&self.column);
         ToolScope {
-            cards: vec![Ref::of(&self.card)],
             column: Some(column_ref),
             wants_board_columns: matches!(column_ref, Ref::Name),
             ..Default::default()
@@ -82,10 +78,7 @@ impl ToolScoped for MoveCardRequest {
 
 impl ToolScoped for ArchiveCardRequest {
     fn scope(&self) -> ToolScope {
-        ToolScope {
-            cards: vec![Ref::of(&self.card)],
-            ..Default::default()
-        }
+        ToolScope::default()
     }
 }
 
@@ -93,7 +86,6 @@ impl ToolScoped for RestoreCardRequest {
     fn scope(&self) -> ToolScope {
         let column_ref = self.column.as_deref().map(Ref::of);
         ToolScope {
-            cards: vec![Ref::of(&self.card)],
             column: column_ref,
             wants_board_columns: matches!(column_ref, Some(Ref::Name)),
             ..Default::default()
@@ -103,28 +95,19 @@ impl ToolScoped for RestoreCardRequest {
 
 impl ToolScoped for DeleteCardRequest {
     fn scope(&self) -> ToolScope {
-        ToolScope {
-            cards: vec![Ref::of(&self.card)],
-            ..Default::default()
-        }
+        ToolScope::default()
     }
 }
 
 impl ToolScoped for GetCardBranchNameRequest {
     fn scope(&self) -> ToolScope {
-        ToolScope {
-            cards: vec![Ref::of(&self.card)],
-            ..Default::default()
-        }
+        ToolScope::default()
     }
 }
 
 impl ToolScoped for GetCardGitCheckoutRequest {
     fn scope(&self) -> ToolScope {
-        ToolScope {
-            cards: vec![Ref::of(&self.card)],
-            ..Default::default()
-        }
+        ToolScope::default()
     }
 }
 
@@ -276,7 +259,6 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<UpdateCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let scope = req.scope();
         let priority = req.priority.as_deref().map(parse_priority).transpose()?;
         let status = req.status.as_deref().map(parse_status).transpose()?;
         let due_date = if req.clear_due_date == Some(true) {
@@ -305,8 +287,7 @@ impl KanbanMcpServer {
             sprint_id: FieldUpdate::NoChange,
         };
         let card = locked_write(&self.ctx, |ctx| {
-            let model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             ctx.mutate(|c| c.update_card_impl(id, updates))
                 .map(|(card, _inv)| card)
                 .map_err(kanban_err_to_mcp)
@@ -320,12 +301,10 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<MoveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let scope = req.scope();
         let card = locked_write(&self.ctx, |ctx| {
-            let mut model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             let board_id = card_board(ctx, id)?;
-            ctx.sync_into(&req.scope().for_board(board_id), &mut model);
+            let model = ctx.model_for(&req.scope().for_board(board_id));
             let column_id = resolve_column_in_board(&model, &req.column, board_id)?;
             ctx.mutate(|c| c.move_card_impl(id, column_id, req.position))
                 .map(|(card, _inv)| card)
@@ -340,10 +319,8 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<ArchiveCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let scope = req.scope();
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             let (_val, _inv) = ctx
                 .mutate(|c| c.archive_card_impl(id))
                 .map_err(kanban_err_to_mcp)?;
@@ -358,14 +335,12 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<RestoreCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let scope = req.scope();
         let card = locked_write(&self.ctx, |ctx| {
-            let mut model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             let column_id = match req.column.as_deref() {
                 Some(raw) => {
                     let board_id = card_board(ctx, id)?;
-                    ctx.sync_into(&req.scope().for_board(board_id), &mut model);
+                    let model = ctx.model_for(&req.scope().for_board(board_id));
                     Some(resolve_column_in_board(&model, raw, board_id)?)
                 }
                 None => None,
@@ -383,10 +358,8 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<DeleteCardRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let scope = req.scope();
         let id = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             let _inv = ctx
                 .mutate_unit(|c| c.delete_card_impl(id))
                 .map_err(kanban_err_to_mcp)?;
@@ -403,10 +376,8 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetCardBranchNameRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let scope = req.scope();
         let branch_name = locked_read(&self.ctx, |ctx| {
-            let model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             ctx.get_card_branch_name(id).map_err(kanban_err_to_mcp)
         })
         .await?;
@@ -418,10 +389,8 @@ impl KanbanMcpServer {
         &self,
         Parameters(req): Parameters<GetCardGitCheckoutRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let scope = req.scope();
         let command = locked_read(&self.ctx, |ctx| {
-            let model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             ctx.get_card_git_checkout(id).map_err(kanban_err_to_mcp)
         })
         .await?;

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -616,7 +616,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_card_crud_tools_resolve_names_from_the_model_not_the_backend_on_json() {
+    async fn test_card_crud_tools_resolve_a_card_identifier_via_the_index_on_json() {
         let seeded = seeded_server("test.json").await;
         seeded.handle.clear_ops();
 
@@ -637,7 +637,8 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(updated["title"], "Renamed");
-        assert_eq!(seeded.handle.op_count("list_all_cards"), 1);
+        assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
+        assert_eq!(seeded.handle.op_count("list_cards_by_prefix_and_number"), 1);
 
         seeded.handle.clear_ops();
         text_payload(
@@ -664,7 +665,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_card_crud_tools_resolve_names_from_the_model_not_the_backend_on_sqlite() {
+    async fn test_card_crud_tools_resolve_a_card_identifier_via_the_index_on_sqlite() {
         let seeded = seeded_server("test.sqlite").await;
         seeded.handle.clear_ops();
 
@@ -685,7 +686,8 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(updated["title"], "Renamed");
-        assert_eq!(seeded.handle.op_count("list_all_cards"), 1);
+        assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
+        assert_eq!(seeded.handle.op_count("list_cards_by_prefix_and_number"), 1);
 
         seeded.handle.clear_ops();
         text_payload(
@@ -712,11 +714,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_card_crud_tool_with_an_unloadable_collection_errors_instead_of_reporting_not_found_on_json(
+    async fn test_card_crud_tool_with_an_unloadable_card_index_errors_instead_of_reporting_not_found_on_json(
     ) {
         let seeded = seeded_server("test.json").await;
         seeded.handle.clear_ops();
-        seeded.handle.fail("list_all_cards");
+        seeded.handle.fail("list_cards_by_prefix_and_number");
 
         let err = seeded
             .server
@@ -727,17 +729,16 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
-        assert!(err.message.contains("card list"));
         assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_card_crud_tool_with_an_unloadable_collection_errors_instead_of_reporting_not_found_on_sqlite(
+    async fn test_card_crud_tool_with_an_unloadable_card_index_errors_instead_of_reporting_not_found_on_sqlite(
     ) {
         let seeded = seeded_server("test.sqlite").await;
         seeded.handle.clear_ops();
-        seeded.handle.fail("list_all_cards");
+        seeded.handle.fail("list_cards_by_prefix_and_number");
 
         let err = seeded
             .server
@@ -748,7 +749,6 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
-        assert!(err.message.contains("card list"));
         assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
@@ -1134,7 +1134,7 @@ mod tests {
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 
-    async fn assert_card_ref_by_name_errors_on_unloadable_card_list(
+    async fn assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
         seeded: &Seeded,
         label: &str,
         result: Result<CallToolResult, McpError>,
@@ -1144,11 +1144,6 @@ mod tests {
             err.code,
             ErrorCode::INTERNAL_ERROR,
             "{label} did not surface INTERNAL_ERROR"
-        );
-        assert!(
-            err.message.contains("card list"),
-            "{label}: {}",
-            err.message
         );
         assert!(
             err.message.contains("injected fault"),
@@ -1164,12 +1159,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_card_crud_tools_error_on_unloadable_card_list_by_name_on_json() {
+    async fn test_card_crud_tools_error_on_an_unloadable_card_index_by_identifier_on_json() {
         let seeded = seeded_server("test.json").await;
         seeded.handle.clear_ops();
-        seeded.handle.fail("list_all_cards");
+        seeded.handle.fail("list_cards_by_prefix_and_number");
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_update_card",
             seeded
@@ -1188,7 +1183,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_move_card",
             seeded
@@ -1202,7 +1197,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_restore_card",
             seeded
@@ -1215,7 +1210,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_delete_card",
             seeded
@@ -1227,7 +1222,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_get_card_branch_name",
             seeded
@@ -1239,7 +1234,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_get_card_git_checkout",
             seeded
@@ -1253,12 +1248,12 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_card_crud_tools_error_on_unloadable_card_list_by_name_on_sqlite() {
+    async fn test_card_crud_tools_error_on_an_unloadable_card_index_by_identifier_on_sqlite() {
         let seeded = seeded_server("test.sqlite").await;
         seeded.handle.clear_ops();
-        seeded.handle.fail("list_all_cards");
+        seeded.handle.fail("list_cards_by_prefix_and_number");
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_update_card",
             seeded
@@ -1277,7 +1272,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_move_card",
             seeded
@@ -1291,7 +1286,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_restore_card",
             seeded
@@ -1304,7 +1299,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_delete_card",
             seeded
@@ -1316,7 +1311,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_get_card_branch_name",
             seeded
@@ -1328,7 +1323,7 @@ mod tests {
         )
         .await;
 
-        assert_card_ref_by_name_errors_on_unloadable_card_list(
+        assert_card_ref_by_identifier_errors_on_an_unloadable_card_index(
             &seeded,
             "tool_get_card_git_checkout",
             seeded
@@ -1686,5 +1681,214 @@ mod tests {
         assert!(err.message.contains("sprints of the board"));
         assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    async fn assert_ambiguous_bare_number_reports_ambiguity(file_name: &str) {
+        let seeded = seeded_server(file_name).await;
+
+        let second_board = text_payload(
+            &seeded
+                .server
+                .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                    content: CreateBoardRequest {
+                        id: None,
+                        name: "Beta".to_string(),
+                        description: None,
+                        sprint_prefix: None,
+                        card_prefix: Some("BETA".to_string()),
+                        task_sort_field: None,
+                        task_sort_order: None,
+                        sprint_duration_days: None,
+                        task_list_view: None,
+                    },
+                    with_default_columns: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let second_board_id = second_board["id"].as_str().unwrap().to_string();
+
+        let second_column = text_payload(
+            &seeded
+                .server
+                .tool_create_column(Parameters(CreateColumnParams {
+                    board: second_board_id.clone(),
+                    content: kanban_service::api::CreateColumnRequest {
+                        id: None,
+                        name: "TODO".to_string(),
+                        wip_limit: None,
+                        default_status: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let second_column_id = second_column["id"].as_str().unwrap().to_string();
+
+        text_payload(
+            &seeded
+                .server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: second_board_id,
+                    column: second_column_id,
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Other board's card".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+
+        let err = seeded
+            .server
+            .tool_update_card(Parameters(UpdateCardRequest {
+                card: "1".to_string(),
+                title: Some("Should not apply".into()),
+                description: None,
+                priority: None,
+                status: None,
+                due_date: None,
+                clear_due_date: None,
+                points: None,
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("Do the thing"));
+        assert!(err.message.contains("Other board's card"));
+
+        let card = text_payload(
+            &seeded
+                .server
+                .tool_get_card(Parameters(GetCardRequest {
+                    card: seeded.card_id.clone(),
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(card["title"], "Do the thing");
+    }
+
+    #[tokio::test]
+    async fn test_update_card_by_an_ambiguous_bare_number_reports_ambiguity_on_json() {
+        assert_ambiguous_bare_number_reports_ambiguity("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_card_by_an_ambiguous_bare_number_reports_ambiguity_on_sqlite() {
+        assert_ambiguous_bare_number_reports_ambiguity("test.sqlite").await;
+    }
+
+    async fn assert_update_card_on_an_archived_board_still_mutates_it(file_name: &str) {
+        let seeded = seeded_server(file_name).await;
+
+        let second_board = text_payload(
+            &seeded
+                .server
+                .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                    content: CreateBoardRequest {
+                        id: None,
+                        name: "Beta".to_string(),
+                        description: None,
+                        sprint_prefix: None,
+                        card_prefix: Some("BETA".to_string()),
+                        task_sort_field: None,
+                        task_sort_order: None,
+                        sprint_duration_days: None,
+                        task_list_view: None,
+                    },
+                    with_default_columns: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let second_board_id = second_board["id"].as_str().unwrap().to_string();
+
+        let second_column = text_payload(
+            &seeded
+                .server
+                .tool_create_column(Parameters(CreateColumnParams {
+                    board: second_board_id.clone(),
+                    content: kanban_service::api::CreateColumnRequest {
+                        id: None,
+                        name: "TODO".to_string(),
+                        wip_limit: None,
+                        default_status: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let second_column_id = second_column["id"].as_str().unwrap().to_string();
+
+        let second_card = text_payload(
+            &seeded
+                .server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: second_board_id.clone(),
+                    column: second_column_id,
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Card on archived board".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let second_card_identifier = format!(
+            "{}-{}",
+            second_card["prefix"].as_str().unwrap(),
+            second_card["card_number"].as_u64().unwrap()
+        );
+
+        seeded
+            .server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: second_board_id,
+            }))
+            .await
+            .unwrap();
+
+        let updated = text_payload(
+            &seeded
+                .server
+                .tool_update_card(Parameters(UpdateCardRequest {
+                    card: second_card_identifier,
+                    title: Some("Renamed on an archived board".into()),
+                    description: None,
+                    priority: None,
+                    status: None,
+                    due_date: None,
+                    clear_due_date: None,
+                    points: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(updated["title"], "Renamed on an archived board");
+    }
+
+    #[tokio::test]
+    async fn test_update_card_by_identifier_on_an_archived_board_still_mutates_it_on_json() {
+        assert_update_card_on_an_archived_board_still_mutates_it("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_card_by_identifier_on_an_archived_board_still_mutates_it_on_sqlite() {
+        assert_update_card_on_an_archived_board_still_mutates_it("test.sqlite").await;
     }
 }

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -70,7 +70,9 @@ impl KanbanMcpServer {
         let child_raw = req.child.clone();
         let (child_id, parent_id) = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let child_id = ctx.resolve_card_id(&req.child).map_err(kanban_err_to_mcp)?;
-            let parent_id = ctx.resolve_card_id(&req.parent).map_err(kanban_err_to_mcp)?;
+            let parent_id = ctx
+                .resolve_card_id(&req.parent)
+                .map_err(kanban_err_to_mcp)?;
             let _inv = ctx
                 .mutate_unit(|c| c.attach_children_impl(parent_id, vec![child_id]))
                 .map_err(|e| mcp_enrich_add_error(e, &parent_raw, &child_raw))?;
@@ -92,7 +94,9 @@ impl KanbanMcpServer {
         let child_raw = req.child.clone();
         let (child_id, parent_id) = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
             let child_id = ctx.resolve_card_id(&req.child).map_err(kanban_err_to_mcp)?;
-            let parent_id = ctx.resolve_card_id(&req.parent).map_err(kanban_err_to_mcp)?;
+            let parent_id = ctx
+                .resolve_card_id(&req.parent)
+                .map_err(kanban_err_to_mcp)?;
             let _inv = ctx
                 .mutate_unit(|c| c.detach_children_impl(parent_id, vec![child_id]))
                 .map_err(|e| mcp_enrich_remove_error(e, &parent_raw, &child_raw))?;
@@ -348,8 +352,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_set_card_parent_with_an_unloadable_card_index_errors_naming_the_lookup_on_json()
-    {
+    async fn test_set_card_parent_with_an_unloadable_card_index_errors_naming_the_lookup_on_json() {
         let seeded = seeded_server("test.json").await;
         seeded.handle.clear_ops();
         seeded.handle.fail("list_cards_by_prefix_and_number");
@@ -369,8 +372,8 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_set_card_parent_with_an_unloadable_card_index_errors_naming_the_lookup_on_sqlite(
-    ) {
+    async fn test_set_card_parent_with_an_unloadable_card_index_errors_naming_the_lookup_on_sqlite()
+    {
         let seeded = seeded_server("test.sqlite").await;
         seeded.handle.clear_ops();
         seeded.handle.fail("list_cards_by_prefix_and_number");
@@ -463,10 +466,7 @@ mod tests {
 
         assert_eq!(seeded.handle.op_count("get_graph"), 0);
         assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
-        assert_eq!(
-            seeded.handle.op_count("list_cards_by_prefix_and_number"),
-            2
-        );
+        assert_eq!(seeded.handle.op_count("list_cards_by_prefix_and_number"), 2);
 
         let response = text_payload(
             &seeded
@@ -500,10 +500,7 @@ mod tests {
 
         assert_eq!(seeded.handle.op_count("get_graph"), 0);
         assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
-        assert_eq!(
-            seeded.handle.op_count("list_cards_by_prefix_and_number"),
-            2
-        );
+        assert_eq!(seeded.handle.op_count("list_cards_by_prefix_and_number"), 2);
 
         let response = text_payload(
             &seeded
@@ -545,10 +542,7 @@ mod tests {
 
         assert_eq!(seeded.handle.op_count("get_graph"), 0);
         assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
-        assert_eq!(
-            seeded.handle.op_count("list_cards_by_prefix_and_number"),
-            2
-        );
+        assert_eq!(seeded.handle.op_count("list_cards_by_prefix_and_number"), 2);
 
         let response = text_payload(
             &seeded
@@ -589,10 +583,7 @@ mod tests {
 
         assert_eq!(seeded.handle.op_count("get_graph"), 0);
         assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
-        assert_eq!(
-            seeded.handle.op_count("list_cards_by_prefix_and_number"),
-            2
-        );
+        assert_eq!(seeded.handle.op_count("list_cards_by_prefix_and_number"), 2);
 
         let response = text_payload(
             &seeded

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -362,11 +362,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_set_card_parent_with_an_unloadable_card_list_errors_naming_the_collection_on_json(
-    ) {
+    async fn test_set_card_parent_with_an_unloadable_card_index_errors_naming_the_lookup_on_json()
+    {
         let seeded = seeded_server("test.json").await;
         seeded.handle.clear_ops();
-        seeded.handle.fail("list_all_cards");
+        seeded.handle.fail("list_cards_by_prefix_and_number");
 
         let err = seeded
             .server
@@ -378,17 +378,16 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
-        assert!(err.message.contains("card list"));
         assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_set_card_parent_with_an_unloadable_card_list_errors_naming_the_collection_on_sqlite(
+    async fn test_set_card_parent_with_an_unloadable_card_index_errors_naming_the_lookup_on_sqlite(
     ) {
         let seeded = seeded_server("test.sqlite").await;
         seeded.handle.clear_ops();
-        seeded.handle.fail("list_all_cards");
+        seeded.handle.fail("list_cards_by_prefix_and_number");
 
         let err = seeded
             .server
@@ -400,9 +399,280 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
-        assert!(err.message.contains("card list"));
         assert!(err.message.contains("injected fault"));
         assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_remove_card_parent_with_an_unloadable_card_index_errors_naming_the_lookup_on_json(
+    ) {
+        let seeded = seeded_server("test.json").await;
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_cards_by_prefix_and_number");
+
+        let err = seeded
+            .server
+            .tool_remove_card_parent(Parameters(RemoveCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("injected fault"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_remove_card_parent_with_an_unloadable_card_index_errors_naming_the_lookup_on_sqlite(
+    ) {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+        seeded.handle.clear_ops();
+        seeded.handle.fail("list_cards_by_prefix_and_number");
+
+        let err = seeded
+            .server
+            .tool_remove_card_parent(Parameters(RemoveCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("injected fault"));
+        assert!(!err.message.to_lowercase().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_set_card_parent_does_not_fetch_the_graph_or_the_card_list_on_json() {
+        let seeded = seeded_server("test.json").await;
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(seeded.handle.op_count("get_graph"), 0);
+        assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
+        assert_eq!(
+            seeded.handle.op_count("list_cards_by_prefix_and_number"),
+            2
+        );
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_list_card_children(Parameters(ListCardChildrenRequest {
+                    card: seeded.card_a_identifier.clone(),
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let items = response["items"].as_array().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["id"], seeded.card_b_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_set_card_parent_does_not_fetch_the_graph_or_the_card_list_on_sqlite() {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(seeded.handle.op_count("get_graph"), 0);
+        assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
+        assert_eq!(
+            seeded.handle.op_count("list_cards_by_prefix_and_number"),
+            2
+        );
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_list_card_children(Parameters(ListCardChildrenRequest {
+                    card: seeded.card_a_identifier.clone(),
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let items = response["items"].as_array().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["id"], seeded.card_b_id);
+    }
+
+    #[tokio::test]
+    async fn test_remove_card_parent_does_not_fetch_the_graph_or_the_card_list_on_json() {
+        let seeded = seeded_server("test.json").await;
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_remove_card_parent(Parameters(RemoveCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(seeded.handle.op_count("get_graph"), 0);
+        assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
+        assert_eq!(
+            seeded.handle.op_count("list_cards_by_prefix_and_number"),
+            2
+        );
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_list_card_children(Parameters(ListCardChildrenRequest {
+                    card: seeded.card_a_identifier.clone(),
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let items = response["items"].as_array().unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_remove_card_parent_does_not_fetch_the_graph_or_the_card_list_on_sqlite() {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_remove_card_parent(Parameters(RemoveCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(seeded.handle.op_count("get_graph"), 0);
+        assert_eq!(seeded.handle.op_count("list_all_cards"), 0);
+        assert_eq!(
+            seeded.handle.op_count("list_cards_by_prefix_and_number"),
+            2
+        );
+
+        let response = text_payload(
+            &seeded
+                .server
+                .tool_list_card_children(Parameters(ListCardChildrenRequest {
+                    card: seeded.card_a_identifier.clone(),
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let items = response["items"].as_array().unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_card_parents_still_fetches_the_graph_on_json() {
+        let seeded = seeded_server("test.json").await;
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_list_card_parents(Parameters(ListCardParentsRequest {
+                card: seeded.card_b_identifier.clone(),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap();
+
+        assert!(seeded.handle.op_count("get_graph") >= 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_list_card_parents_still_fetches_the_graph_on_sqlite() {
+        let seeded = seeded_server("test.sqlite").await;
+        seeded
+            .server
+            .tool_set_card_parent(Parameters(SetCardParentRequest {
+                parent: seeded.card_a_identifier.clone(),
+                child: seeded.card_b_identifier.clone(),
+            }))
+            .await
+            .unwrap();
+        seeded.handle.clear_ops();
+
+        seeded
+            .server
+            .tool_list_card_parents(Parameters(ListCardParentsRequest {
+                card: seeded.card_b_identifier.clone(),
+                page: None,
+                page_size: None,
+            }))
+            .await
+            .unwrap();
+
+        assert!(seeded.handle.op_count("get_graph") >= 1);
     }
 
     #[tokio::test]
@@ -453,7 +723,7 @@ mod tests {
         assert_eq!(not_found_err.code, ErrorCode::INVALID_PARAMS);
         assert!(not_found_err.message.to_lowercase().contains("not found"));
 
-        seeded.handle.fail("list_all_cards");
+        seeded.handle.fail("list_cards_by_prefix_and_number");
 
         let fault_err = seeded
             .server
@@ -465,7 +735,6 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(fault_err.code, ErrorCode::INTERNAL_ERROR);
-        assert!(fault_err.message.contains("card list"));
         assert!(fault_err.message.contains("injected fault"));
 
         assert_ne!(not_found_err.code, fault_err.code);

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -1,15 +1,15 @@
-use crate::helpers::model_read::{require_loaded, resolve_card};
+use crate::helpers::model_read::require_loaded;
 use crate::helpers::{
-    core_err_to_mcp, locked_read, locked_write, mcp_enrich_add_error, mcp_enrich_remove_error,
-    resolve_summaries, to_call_tool_result, to_call_tool_result_json,
+    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, mcp_enrich_add_error,
+    mcp_enrich_remove_error, resolve_summaries, to_call_tool_result, to_call_tool_result_json,
 };
 use crate::requests::card::{
     ListCardChildrenRequest, ListCardParentsRequest, RemoveCardParentRequest, SetCardParentRequest,
 };
-use crate::scope::{Ref, ToolScope, ToolScoped};
+use crate::scope::{ToolScope, ToolScoped};
 use crate::KanbanMcpServer;
 use kanban_core::{resolve_page_params, PaginatedList};
-use kanban_domain::Model;
+use kanban_domain::{KanbanOperations, Model};
 use rmcp::{
     handler::server::wrapper::Parameters,
     model::{CallToolResult, ErrorData as McpError},
@@ -19,28 +19,19 @@ use uuid::Uuid;
 
 impl ToolScoped for SetCardParentRequest {
     fn scope(&self) -> ToolScope {
-        ToolScope {
-            cards: vec![Ref::of(&self.parent), Ref::of(&self.child)],
-            wants_graph: true,
-            ..Default::default()
-        }
+        ToolScope::default()
     }
 }
 
 impl ToolScoped for RemoveCardParentRequest {
     fn scope(&self) -> ToolScope {
-        ToolScope {
-            cards: vec![Ref::of(&self.parent), Ref::of(&self.child)],
-            wants_graph: true,
-            ..Default::default()
-        }
+        ToolScope::default()
     }
 }
 
 impl ToolScoped for ListCardParentsRequest {
     fn scope(&self) -> ToolScope {
         ToolScope {
-            cards: vec![Ref::of(&self.card)],
             wants_graph: true,
             ..Default::default()
         }
@@ -50,7 +41,6 @@ impl ToolScoped for ListCardParentsRequest {
 impl ToolScoped for ListCardChildrenRequest {
     fn scope(&self) -> ToolScope {
         ToolScope {
-            cards: vec![Ref::of(&self.card)],
             wants_graph: true,
             ..Default::default()
         }
@@ -78,11 +68,9 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let parent_raw = req.parent.clone();
         let child_raw = req.child.clone();
-        let scope = req.scope();
         let (child_id, parent_id) = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let model = ctx.model_for(&scope);
-            let child_id = resolve_card(&model, &req.child)?;
-            let parent_id = resolve_card(&model, &req.parent)?;
+            let child_id = ctx.resolve_card_id(&req.child).map_err(kanban_err_to_mcp)?;
+            let parent_id = ctx.resolve_card_id(&req.parent).map_err(kanban_err_to_mcp)?;
             let _inv = ctx
                 .mutate_unit(|c| c.attach_children_impl(parent_id, vec![child_id]))
                 .map_err(|e| mcp_enrich_add_error(e, &parent_raw, &child_raw))?;
@@ -102,11 +90,9 @@ impl KanbanMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let parent_raw = req.parent.clone();
         let child_raw = req.child.clone();
-        let scope = req.scope();
         let (child_id, parent_id) = locked_write(&self.ctx, |ctx| -> Result<_, McpError> {
-            let model = ctx.model_for(&scope);
-            let child_id = resolve_card(&model, &req.child)?;
-            let parent_id = resolve_card(&model, &req.parent)?;
+            let child_id = ctx.resolve_card_id(&req.child).map_err(kanban_err_to_mcp)?;
+            let parent_id = ctx.resolve_card_id(&req.parent).map_err(kanban_err_to_mcp)?;
             let _inv = ctx
                 .mutate_unit(|c| c.detach_children_impl(parent_id, vec![child_id]))
                 .map_err(|e| mcp_enrich_remove_error(e, &parent_raw, &child_raw))?;
@@ -129,7 +115,7 @@ impl KanbanMcpServer {
         let scope = req.scope();
         let parents = locked_read(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             let ids = list_parents_in_model(&model, id)?;
             Ok(resolve_summaries(ctx, ids))
         })
@@ -150,7 +136,7 @@ impl KanbanMcpServer {
         let scope = req.scope();
         let children = locked_read(&self.ctx, |ctx| -> Result<_, McpError> {
             let model = ctx.model_for(&scope);
-            let id = resolve_card(&model, &req.card)?;
+            let id = ctx.resolve_card_id(&req.card).map_err(kanban_err_to_mcp)?;
             let ids = list_children_in_model(&model, id)?;
             Ok(resolve_summaries(ctx, ids))
         })

--- a/crates/kanban-service/src/test_helpers/fault.rs
+++ b/crates/kanban-service/src/test_helpers/fault.rs
@@ -37,6 +37,8 @@ pub const FAULTABLE_READS: &[&str] = &[
     "get_column",
     "list_all_cards",
     "list_cards_by_column",
+    "list_cards_by_prefix_and_number",
+    "list_cards_by_number",
     "get_card",
     "list_all_sprints",
     "list_sprints_by_board",
@@ -240,10 +242,12 @@ impl DataStore for FaultInjectingBackend {
         prefix: &str,
         card_number: u32,
     ) -> KanbanResult<Vec<Card>> {
+        self.check("list_cards_by_prefix_and_number", vec![])?;
         self.inner
             .list_cards_by_prefix_and_number(prefix, card_number)
     }
     fn list_cards_by_number(&self, card_number: u32) -> KanbanResult<Vec<Card>> {
+        self.check("list_cards_by_number", vec![])?;
         self.inner.list_cards_by_number(card_number)
     }
     fn get_card_by_board_and_number(

--- a/crates/kanban-service/tests/fault_injection.rs
+++ b/crates/kanban-service/tests/fault_injection.rs
@@ -129,9 +129,7 @@ fn test_faulting_an_indexed_card_lookup_returns_an_error() {
     let (backend, _board) = wrapped_in_memory();
 
     backend.fail("list_cards_by_prefix_and_number");
-    assert!(backend
-        .list_cards_by_prefix_and_number("KAN", 5)
-        .is_err());
+    assert!(backend.list_cards_by_prefix_and_number("KAN", 5).is_err());
 
     backend.clear_faults();
 
@@ -163,9 +161,7 @@ async fn test_fault_backend_records_indexed_card_lookups_on_sqlite() {
 
     let backend = FaultInjectingBackend::new(inner);
 
-    let by_prefix = backend
-        .list_cards_by_prefix_and_number("PIN", 7)
-        .unwrap();
+    let by_prefix = backend.list_cards_by_prefix_and_number("PIN", 7).unwrap();
     let by_number = backend.list_cards_by_number(7).unwrap();
 
     assert_eq!(by_prefix.first().map(|c| c.id), Some(card.id));

--- a/crates/kanban-service/tests/fault_injection.rs
+++ b/crates/kanban-service/tests/fault_injection.rs
@@ -125,6 +125,62 @@ async fn test_the_wrapper_delegates_a_backend_overridden_default_method() {
 }
 
 #[test]
+fn test_faulting_an_indexed_card_lookup_returns_an_error() {
+    let (backend, _board) = wrapped_in_memory();
+
+    backend.fail("list_cards_by_prefix_and_number");
+    assert!(backend
+        .list_cards_by_prefix_and_number("KAN", 5)
+        .is_err());
+
+    backend.clear_faults();
+
+    backend.fail("list_cards_by_number");
+    assert!(backend.list_cards_by_number(5).is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fault_backend_records_indexed_card_lookups_on_sqlite() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("indexed.sqlite3");
+    let inner: Arc<dyn KanbanBackend> = Arc::new(
+        SqliteBackend::open(path.to_str().unwrap())
+            .await
+            .expect("open sqlite backend"),
+    );
+
+    let board = Board::new("Pinned", Some("PIN"));
+    let column = Column::new(board.id, "Todo", 0);
+    let mut card = Card::new(board.id, column.id, "Pinned card", 0);
+    card.card_number = 7;
+    card.prefix = "PIN".to_string();
+    inner
+        .upsert_prefix(kanban_domain::Prefix::new("PIN"))
+        .unwrap();
+    inner.upsert_board(board.clone()).unwrap();
+    inner.upsert_column(column).unwrap();
+    inner.upsert_card(card.clone()).unwrap();
+
+    let backend = FaultInjectingBackend::new(inner);
+
+    let by_prefix = backend
+        .list_cards_by_prefix_and_number("PIN", 7)
+        .unwrap();
+    let by_number = backend.list_cards_by_number(7).unwrap();
+
+    assert_eq!(by_prefix.first().map(|c| c.id), Some(card.id));
+    assert_eq!(by_number.first().map(|c| c.id), Some(card.id));
+
+    assert_eq!(backend.op_count("list_cards_by_prefix_and_number"), 1);
+    assert_eq!(backend.op_count("list_cards_by_number"), 1);
+    assert_eq!(
+        backend.op_count("list_all_cards"),
+        0,
+        "the wrapper must answer from the backend's indexed override, not fall back"
+    );
+}
+
+#[test]
 fn test_an_intercepted_read_is_recorded_in_call_order() {
     let (backend, _board) = wrapped_in_memory();
     let card_id = uuid::Uuid::new_v4();


### PR DESCRIPTION
## Summary

Single-card MCP tools (`update`, `move`, `archive`, `restore`, `delete`, `get_card_branch_name`, `get_card_git_checkout`, `set_card_parent`, `remove_card_parent`) resolved their card identifier by fetching the entire live card list into the `Model` and scanning it. That means every single-card mutation or relation edit paid the cost of a full-card-list read, and the two relation mutations also pulled the dependency graph even though they never touch it.

- Swapped all 13 `resolve_card(&model, ..)` call sites in `card_crud.rs` / `card_relations.rs` to `ctx.resolve_card_id(..)`, which resolves through the backend's indexed `list_cards_by_prefix_and_number` / `list_cards_by_number` methods instead of a full scan.
- Dropped the now-unneeded `cards` tier from 11 `ToolScope` impls, and `wants_graph` from the two relation-mutation scopes (`set_card_parent`, `remove_card_parent`); the two relation-list scopes keep `wants_graph` since they read the graph.
- Deleted `resolve_card` from `helpers/model_read.rs` now that nothing calls it.
- Wired `list_cards_by_prefix_and_number` and `list_cards_by_number` through `FaultInjectingBackend::check` and widened `FAULTABLE_READS`, so the win is assertable in tests (previously faulting these methods was a no-op).
- Retargeted every existing test that faulted `list_all_cards` on a path this change removes, and added tests pinning `list_all_cards == 0` / `get_graph == 0` for the affected tools on both JSON and SQLite backends.
- Added guard tests confirming ambiguous bare-number resolution and archived-board card resolution are unaffected, and that the two relation-list tools still fetch the graph.

Archived-card and archived-board resolution semantics are unchanged: the indexed lookups apply the same live-only filter as `list_all_cards` did on every backend, and board archival stays marker-only so a card on an archived board still resolves.

## Test plan

- [x] `cargo test -p kanban-service --features test-helpers`
- [x] `cargo test -p kanban-mcp`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
