### PR TITLE
KAN-1529 fix(view): report the archived partitions as the join of the collection and marker states

### DIFF
--- a/.changeset/kan-1529-partition-honest-archival-loadstate.md
+++ b/.changeset/kan-1529-partition-honest-archival-loadstate.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+controller archived partitions report the join of the collection and marker load states

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -511,9 +511,9 @@ mod tests {
                 ..Default::default()
             },
             archived_cards: Collection {
-                all: LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
-                    "boom",
-                ))),
+                all: LoadState::Failed(std::sync::Arc::new(
+                    kanban_domain::KanbanError::unsupported("boom"),
+                )),
                 ..Default::default()
             },
             ..Default::default()
@@ -535,9 +535,9 @@ mod tests {
                 ..Default::default()
             },
             archived_boards: Collection {
-                all: LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
-                    "boom",
-                ))),
+                all: LoadState::Failed(std::sync::Arc::new(
+                    kanban_domain::KanbanError::unsupported("boom"),
+                )),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -410,6 +410,14 @@ mod tests {
                 all: LoadState::Loaded(Vec::new()),
                 ..Default::default()
             },
+            archived_cards: Collection {
+                all: LoadState::Loaded(Vec::new()),
+                ..Default::default()
+            },
+            archived_boards: Collection {
+                all: LoadState::Loaded(Vec::new()),
+                ..Default::default()
+            },
             ..Default::default()
         });
         let mut controller = Controller::default();
@@ -419,6 +427,126 @@ mod tests {
         assert!(matches!(controller.displayed_cards(true), LoadState::Loaded(v) if v.is_empty()));
         assert!(matches!(controller.displayed_boards(false), LoadState::Loaded(v) if v.is_empty()));
         assert!(matches!(controller.displayed_boards(true), LoadState::Loaded(v) if v.is_empty()));
+    }
+
+    #[test]
+    fn test_card_partitions_report_not_loaded_when_markers_not_loaded_and_cards_loaded() {
+        let board = seed_board("B", 0);
+        let column = Column::new(board.id, "Col", 0);
+        let card = Card::new(board.id, column.id, "card", 0);
+        let card_id = card.id;
+        let mut model = Model::default();
+        let changed = model.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![card.clone()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model, changed);
+
+        assert!(!controller.displayed_cards(true).is_loaded());
+        assert!(controller.displayed_cards(true).is_not_loaded());
+        assert!(controller.displayed_cards(false).is_loaded());
+        let live_ids: Vec<Uuid> = controller
+            .displayed_cards(false)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(live_ids, vec![card_id]);
+
+        let changed = model.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            columns: vec![column],
+            cards: vec![card],
+            archived_cards: Vec::new(),
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+        controller.resync(&model, changed);
+        assert!(controller.displayed_cards(true).is_loaded());
+    }
+
+    #[test]
+    fn test_board_partitions_report_not_loaded_when_markers_not_loaded_and_boards_loaded() {
+        let board = seed_board("B", 0);
+        let board_id = board.id;
+        let mut model = Model::default();
+        let changed = model.apply_resolved(Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model, changed);
+
+        assert!(controller.displayed_boards(true).is_not_loaded());
+        assert!(controller.displayed_boards(false).is_loaded());
+        let live_ids: Vec<Uuid> = controller
+            .displayed_boards(false)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|b| b.id)
+            .collect();
+        assert_eq!(live_ids, vec![board_id]);
+    }
+
+    #[test]
+    fn test_card_partitions_report_failed_when_marker_tier_failed() {
+        let board = seed_board("B", 0);
+        let column = Column::new(board.id, "Col", 0);
+        let card = Card::new(board.id, column.id, "card", 0);
+        let mut model = Model::default();
+        let changed = model.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![card]),
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                all: LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
+                    "boom",
+                ))),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model, changed);
+
+        assert!(controller.displayed_cards(true).is_failed());
+        assert!(controller.displayed_cards(false).is_loaded());
+    }
+
+    #[test]
+    fn test_board_partitions_report_failed_when_marker_tier_failed() {
+        let board = seed_board("B", 0);
+        let mut model = Model::default();
+        let changed = model.apply_resolved(Resolved {
+            boards: Collection {
+                all: LoadState::Loaded(vec![board]),
+                ..Default::default()
+            },
+            archived_boards: Collection {
+                all: LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
+                    "boom",
+                ))),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model, changed);
+
+        assert!(controller.displayed_boards(true).is_failed());
+        assert!(controller.displayed_boards(false).is_loaded());
     }
 
     #[test]

--- a/crates/kanban-view/src/controller/partitions.rs
+++ b/crates/kanban-view/src/controller/partitions.rs
@@ -1,10 +1,22 @@
 use super::Controller;
 use kanban_domain::{filter_and_sort_boards, Board, BoardListFilter, Card, LoadState, Model};
 
+/// The join of a flat collection's state and its archival-marker tier's
+/// state, payload blanked: `Failed` wins, then `Missing`, then `NotLoaded`.
+/// `Loaded` only when both sides are.
+fn joined<T, A, B>(flat: LoadState<A>, markers: LoadState<B>) -> LoadState<Vec<T>> {
+    match (flat, markers) {
+        (LoadState::Failed(e), _) | (_, LoadState::Failed(e)) => LoadState::Failed(e),
+        (LoadState::Missing, _) | (_, LoadState::Missing) => LoadState::Missing,
+        (LoadState::NotLoaded, _) | (_, LoadState::NotLoaded) => LoadState::NotLoaded,
+        (LoadState::Loaded(_), LoadState::Loaded(_)) => LoadState::Loaded(Vec::new()),
+    }
+}
+
 impl Controller {
     pub(super) fn rebuild_card_partitions(&mut self, model: &Model) {
-        match model.cards_state().as_ref() {
-            LoadState::Loaded(cards) => {
+        match (model.cards_state().as_ref(), model.archived_cards_state()) {
+            (LoadState::Loaded(cards), LoadState::Loaded(_)) => {
                 let (archived_cards, live_cards): (Vec<Card>, Vec<Card>) = cards
                     .iter()
                     .cloned()
@@ -12,16 +24,20 @@ impl Controller {
                 self.displayed_cards_live = LoadState::Loaded(live_cards);
                 self.displayed_cards_archived = LoadState::Loaded(archived_cards);
             }
-            other => {
-                self.displayed_cards_live = other.as_ref().map(|_| Vec::new());
-                self.displayed_cards_archived = other.map(|_| Vec::new());
+            (LoadState::Loaded(cards), markers) => {
+                self.displayed_cards_live = LoadState::Loaded(cards.clone());
+                self.displayed_cards_archived = markers.map(|_| Vec::new());
+            }
+            (flat, markers) => {
+                self.displayed_cards_live = flat.clone().map(|_| Vec::new());
+                self.displayed_cards_archived = joined(flat, markers);
             }
         }
     }
 
     pub(super) fn rebuild_board_partitions(&mut self, model: &Model) {
-        match model.boards_state().as_ref() {
-            LoadState::Loaded(boards) => {
+        match (model.boards_state().as_ref(), model.archived_boards_state()) {
+            (LoadState::Loaded(boards), LoadState::Loaded(_)) => {
                 let (archived_boards, live_boards): (Vec<Board>, Vec<Board>) = boards
                     .iter()
                     .cloned()
@@ -29,9 +45,13 @@ impl Controller {
                 self.displayed_boards_live = LoadState::Loaded(live_boards);
                 self.displayed_boards_archived = LoadState::Loaded(archived_boards);
             }
-            other => {
-                self.displayed_boards_live = other.as_ref().map(|_| Vec::new());
-                self.displayed_boards_archived = other.map(|_| Vec::new());
+            (LoadState::Loaded(boards), markers) => {
+                self.displayed_boards_live = LoadState::Loaded(boards.clone());
+                self.displayed_boards_archived = markers.map(|_| Vec::new());
+            }
+            (flat, markers) => {
+                self.displayed_boards_live = flat.clone().map(|_| Vec::new());
+                self.displayed_boards_archived = joined(flat, markers);
             }
         }
         self.sort_partitions();


### PR DESCRIPTION
## Summary

- `Controller::rebuild_card_partitions` / `rebuild_board_partitions` in `kanban-view` now derive the archived partition's `LoadState` as the join of the flat collection state and the archival-marker tier state (`Failed` wins, then `Missing`, then `NotLoaded`, `Loaded` only when both sides are).
- A never-fetched or failed marker tier can no longer masquerade as `Loaded(empty)` with every archived entity misclassified as live.
- The live partition's semantics are unchanged: it still mirrors the flat collection alone.
- Change is confined to `crates/kanban-view/src/controller/partitions.rs` plus tests in `crates/kanban-view/src/controller/mod.rs`.

## Test plan

- [x] `cargo test -p kanban-view` green, including four new tests pinning the join semantics for cards and boards (`NotLoaded` and `Failed` marker-tier cases)
- [x] `cargo test -p kanban-tui` green (no collateral regressions in the lazy-load path)
- [x] `cargo test --all-features --workspace` green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Mutation check: reverted the fix locally, confirmed the new tests fail, restored the fix
