### PR TITLE
KAN-1520 fix(tui): stop collapsing a cold graph or cards tier into zero relations

### DIFF
--- a/.changeset/kan-1520-tui-graph-and-search-collapses.md
+++ b/.changeset/kan-1520-tui-graph-and-search-collapses.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+fix TUI relationship views to distinguish a cold graph/cards tier from zero parents, children, or search matches

--- a/crates/kanban-tui/src/app/keybindings.rs
+++ b/crates/kanban-tui/src/app/keybindings.rs
@@ -96,15 +96,8 @@ impl App {
     /// effect on the shared `CardListComponent` dispatch, needs no terminal.
     pub(in crate::app) fn open_sprint_detail_card_for_edit(&mut self, card_id: uuid::Uuid) {
         if self.activate_card(card_id) {
-            let parents = self.get_current_card_parents();
-            let children = self.get_current_card_children();
-            self.relationship
-                .parents_list
-                .update_item_count(parents.len());
-            self.relationship
-                .children_list
-                .update_item_count(children.len());
             self.push_mode(AppMode::CardDetail);
+            self.refresh_relationship_counts();
             self.focus.card_focus = crate::app::CardFocus::Title;
         }
     }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1760,7 +1760,7 @@ mod cards_tier_decline_tests {
     }
 
     #[test]
-    fn test_handle_manage_children_from_list_with_a_not_loaded_cards_tier_declines() {
+    fn test_handle_manage_children_from_list_with_a_cold_cards_tier_repopulates_and_opens() {
         let mut app = App::test_default();
         let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
         refresh(&mut app);
@@ -1773,11 +1773,37 @@ mod cards_tier_decline_tests {
 
         app.handle_manage_children_from_list();
 
-        assert_error_banner(&app, "Cards are not loaded yet");
-        assert_ne!(
+        assert_eq!(
             app.mode,
             crate::app::AppMode::Dialog(crate::app::DialogMode::ManageChildren),
-            "the ManageChildren dialog must not open while the cards tier is not loaded"
+            "opening the dialog first lets the mode-transition populate repair the cards tier, so the handler no longer dead-ends"
         );
+        assert!(
+            app.ui_state.banner.is_none(),
+            "a repaired cards tier must not leave a stale decline banner"
+        );
+    }
+
+    #[test]
+    fn test_handle_manage_children_from_list_with_a_cold_graph_opens_the_dialog() {
+        let mut app = App::test_default();
+        let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
+        refresh(&mut app);
+        app.selection.active_board_id = Some(board_id);
+        app.focus.active = Focus::Cards;
+        select_card_in_active_task_list(&mut app, card_id);
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+
+        app.handle_manage_children_from_list();
+
+        assert_eq!(
+            app.mode,
+            crate::app::AppMode::Dialog(crate::app::DialogMode::ManageChildren),
+            "opening the dialog before the graph read lets the transition populate warm the graph instead of dead-ending on a stale check"
+        );
+        assert!(app.ui_state.banner.is_none());
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -984,7 +984,10 @@ impl App {
             None => return,
         };
 
+        self.open_dialog(DialogMode::ManageChildren);
+
         let Some(graph) = self.model.graph_state().loaded() else {
+            self.pop_mode();
             self.set_error("Relationships are still loading. Try again in a moment.");
             return;
         };
@@ -1001,6 +1004,7 @@ impl App {
                         .map(|c| c.id)
                         .collect(),
                     _ => {
+                        self.pop_mode();
                         self.set_error("Columns are not loaded yet");
                         return;
                     }
@@ -1010,6 +1014,7 @@ impl App {
         let target_is_archived = self.model.archived_card_ids().contains(&card_id);
 
         let LoadState::Loaded(cards) = self.model.cards_state() else {
+            self.pop_mode();
             self.set_error("Cards are not loaded yet");
             return;
         };
@@ -1033,8 +1038,6 @@ impl App {
         self.relationship.selected = current_children;
         self.relationship.selection.set(Some(0));
         self.relationship.search.clear();
-
-        self.open_dialog(DialogMode::ManageChildren);
     }
 }
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -6,7 +6,6 @@ use crate::events::EventHandler;
 use crossterm::event::KeyCode;
 use kanban_core::Editable;
 use kanban_domain::card_lifecycle::sorted_board_columns;
-use kanban_domain::Model;
 use kanban_domain::{
     BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, LoadState, Searcher,
 };
@@ -101,7 +100,15 @@ impl App {
                 match self.focus.card_focus {
                     CardFocus::Parents => {
                         // Navigate within parents list or wrap to next section
-                        let parents = self.get_current_card_parents();
+                        let (Some(parents), Some(children)) = (
+                            self.get_current_card_parents(),
+                            self.get_current_card_children(),
+                        ) else {
+                            self.set_error(
+                                "Relationships are still loading. Try again in a moment.",
+                            );
+                            return should_restart;
+                        };
                         if !parents.is_empty() {
                             let was_at_boundary = self.relationship.parents_list.navigate_down();
                             let viewport = self
@@ -117,7 +124,6 @@ impl App {
                                 self.focus.card_focus = CardFocus::Children;
                                 self.relationship.parents_list.selection.clear();
 
-                                let children = self.get_current_card_children();
                                 self.relationship
                                     .children_list
                                     .update_item_count(children.len());
@@ -132,7 +138,12 @@ impl App {
                     }
                     CardFocus::Children => {
                         // Navigate within children list or wrap to next section
-                        let children = self.get_current_card_children();
+                        let Some(children) = self.get_current_card_children() else {
+                            self.set_error(
+                                "Relationships are still loading. Try again in a moment.",
+                            );
+                            return should_restart;
+                        };
                         if !children.is_empty() {
                             let was_at_boundary = self.relationship.children_list.navigate_down();
                             let viewport = self
@@ -169,7 +180,12 @@ impl App {
                 match self.focus.card_focus {
                     CardFocus::Parents => {
                         // Navigate within parents list or wrap to previous section
-                        let parents = self.get_current_card_parents();
+                        let Some(parents) = self.get_current_card_parents() else {
+                            self.set_error(
+                                "Relationships are still loading. Try again in a moment.",
+                            );
+                            return should_restart;
+                        };
                         if !parents.is_empty() {
                             let was_at_boundary = self.relationship.parents_list.navigate_up();
                             let viewport = self
@@ -192,7 +208,15 @@ impl App {
                     }
                     CardFocus::Children => {
                         // Navigate within children list or wrap to previous section
-                        let children = self.get_current_card_children();
+                        let (Some(children), Some(parents)) = (
+                            self.get_current_card_children(),
+                            self.get_current_card_parents(),
+                        ) else {
+                            self.set_error(
+                                "Relationships are still loading. Try again in a moment.",
+                            );
+                            return should_restart;
+                        };
                         if !children.is_empty() {
                             let was_at_boundary = self.relationship.children_list.navigate_up();
                             let viewport = self
@@ -205,7 +229,6 @@ impl App {
 
                             if was_at_boundary {
                                 // At first child or no selection, wrap to Parents section
-                                let parents = self.get_current_card_parents();
                                 self.focus.card_focus = CardFocus::Parents;
                                 self.relationship.children_list.selection.clear();
                                 self.relationship
@@ -225,7 +248,12 @@ impl App {
                     }
                     CardFocus::Title => {
                         // When at Title, wrap backward to Children and select last child
-                        let children = self.get_current_card_children();
+                        let Some(children) = self.get_current_card_children() else {
+                            self.set_error(
+                                "Relationships are still loading. Try again in a moment.",
+                            );
+                            return should_restart;
+                        };
                         self.focus.card_focus = CardFocus::Children;
                         self.relationship
                             .children_list
@@ -936,31 +964,15 @@ impl App {
                     match action {
                         CardListAction::Select(card_id) => {
                             if self.activate_card(card_id) {
-                                // Initialize list components with item counts
-                                let parents = self.get_current_card_parents();
-                                let children = self.get_current_card_children();
-                                self.relationship
-                                    .parents_list
-                                    .update_item_count(parents.len());
-                                self.relationship
-                                    .children_list
-                                    .update_item_count(children.len());
                                 self.push_mode(AppMode::CardDetail);
+                                self.refresh_relationship_counts();
                                 self.focus.card_focus = CardFocus::Title;
                             }
                         }
                         CardListAction::Edit(card_id) => {
                             if self.activate_card(card_id) {
-                                // Initialize list components with item counts
-                                let parents = self.get_current_card_parents();
-                                let children = self.get_current_card_children();
-                                self.relationship
-                                    .parents_list
-                                    .update_item_count(parents.len());
-                                self.relationship
-                                    .children_list
-                                    .update_item_count(children.len());
                                 self.push_mode(AppMode::CardDetail);
+                                self.refresh_relationship_counts();
                                 self.focus.card_focus = CardFocus::Title;
                             }
                         }
@@ -1258,37 +1270,39 @@ impl App {
         self.open_dialog(DialogMode::ManageChildren);
     }
 
-    pub fn get_current_card_parents(&self) -> Vec<uuid::Uuid> {
+    pub fn get_current_card_parents(&self) -> Option<Vec<uuid::Uuid>> {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 return self
                     .model
                     .graph_state()
                     .loaded()
-                    .unwrap_or_else(|| Model::empty_graph())
-                    .parents(card.id);
+                    .map(|graph| graph.parents(card.id));
             }
         }
-        Vec::new()
+        Some(Vec::new())
     }
 
-    pub fn get_current_card_children(&self) -> Vec<uuid::Uuid> {
+    pub fn get_current_card_children(&self) -> Option<Vec<uuid::Uuid>> {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
                 return self
                     .model
                     .graph_state()
                     .loaded()
-                    .unwrap_or_else(|| Model::empty_graph())
-                    .children(card.id);
+                    .map(|graph| graph.children(card.id));
             }
         }
-        Vec::new()
+        Some(Vec::new())
     }
 
-    fn refresh_relationship_counts(&mut self) {
-        let parents = self.get_current_card_parents();
-        let children = self.get_current_card_children();
+    pub(crate) fn refresh_relationship_counts(&mut self) {
+        let (Some(parents), Some(children)) = (
+            self.get_current_card_parents(),
+            self.get_current_card_children(),
+        ) else {
+            return;
+        };
         self.relationship
             .parents_list
             .update_item_count(parents.len());
@@ -1297,7 +1311,7 @@ impl App {
             .update_item_count(children.len());
     }
 
-    fn related_card_ids(&self, side: RelationSide) -> Vec<uuid::Uuid> {
+    fn related_card_ids(&self, side: RelationSide) -> Option<Vec<uuid::Uuid>> {
         match side {
             RelationSide::Parents => self.get_current_card_parents(),
             RelationSide::Children => self.get_current_card_children(),
@@ -1335,7 +1349,10 @@ impl App {
         let Some(current_card_id) = self.selection.active_card_id else {
             return;
         };
-        let related = self.related_card_ids(side);
+        let Some(related) = self.related_card_ids(side) else {
+            self.set_error("Relationships are still loading. Try again in a moment.");
+            return;
+        };
         let selected_id = self
             .list_selection(side)
             .and_then(|i| related.get(i).copied());

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1918,7 +1918,7 @@ mod tests {
 
         assert_eq!(
             parents,
-            vec![fx.p_id],
+            Some(vec![fx.p_id]),
             "after reload-resort, parents of the active card (A) must be returned by id; resolving by stale index would return parents of the wrong card"
         );
     }
@@ -1933,8 +1933,142 @@ mod tests {
 
         assert_eq!(
             children,
-            vec![fx.d_id],
+            Some(vec![fx.d_id]),
             "after reload-resort, children of the active card (A) must be returned by id; resolving by stale index would return children of the wrong card"
+        );
+    }
+
+    #[test]
+    fn test_get_current_card_parents_with_a_not_loaded_graph_returns_none() {
+        let mut app = App::test_default();
+        let fx = setup_reload_resort_fixture(&mut app);
+
+        assert_eq!(app.get_current_card_parents(), Some(vec![fx.p_id]));
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+
+        assert_eq!(
+            app.get_current_card_parents(),
+            None,
+            "a NotLoaded graph tier must be reported as a tier gap, not as zero parents"
+        );
+    }
+
+    #[test]
+    fn test_get_current_card_children_with_a_not_loaded_graph_returns_none() {
+        let mut app = App::test_default();
+        let fx = setup_reload_resort_fixture(&mut app);
+
+        assert_eq!(app.get_current_card_children(), Some(vec![fx.d_id]));
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+
+        assert_eq!(
+            app.get_current_card_children(),
+            None,
+            "a NotLoaded graph tier must be reported as a tier gap, not as zero children"
+        );
+    }
+
+    #[test]
+    fn test_refresh_relationship_counts_with_a_not_loaded_graph_leaves_the_list_counts_untouched() {
+        let mut app = App::test_default();
+        let _fx = setup_reload_resort_fixture(&mut app);
+
+        app.refresh_relationship_counts();
+        assert_eq!(app.relationship.parents_list.selection.get(), Some(0));
+        assert_eq!(app.relationship.children_list.selection.get(), Some(0));
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+
+        app.refresh_relationship_counts();
+
+        assert_eq!(
+            app.relationship.parents_list.selection.get(),
+            Some(0),
+            "a cold graph tier must not clear an already-populated parents selection"
+        );
+        assert_eq!(
+            app.relationship.children_list.selection.get(),
+            Some(0),
+            "a cold graph tier must not clear an already-populated children selection"
+        );
+    }
+
+    #[test]
+    fn test_navigate_to_selected_parent_with_a_not_loaded_graph_banners_instead_of_silently_doing_nothing(
+    ) {
+        let mut app = App::test_default();
+        let fx = setup_reload_resort_fixture(&mut app);
+        app.focus.card_focus = CardFocus::Parents;
+        app.relationship.parents_list.update_item_count(1);
+        app.relationship.parents_list.selection.set(Some(0));
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+
+        app.navigate_to_selected_parent();
+
+        assert_eq!(
+            app.selection.active_card_id,
+            Some(fx.a_id),
+            "a cold graph tier must not change the active card"
+        );
+        let banner = app
+            .ui_state
+            .banner
+            .as_ref()
+            .expect("a cold graph tier must banner rather than silently do nothing");
+        let message = banner.message.to_lowercase();
+        assert!(
+            message.contains("loading") || message.contains("not loaded"),
+            "banner should explain the graph tier is not loaded, got: {}",
+            banner.message
+        );
+    }
+
+    #[test]
+    fn test_handle_selection_activate_into_card_detail_with_a_cold_graph_counts_the_children() {
+        use crate::app::Focus;
+
+        let mut app = App::test_default();
+        let fx = setup_reload_resort_fixture(&mut app);
+        app.selection.active_card_id = None;
+        app.mode = AppMode::Normal;
+        app.focus.active = Focus::Cards;
+        app.prepare_frame();
+        {
+            let list = app
+                .view
+                .strategy
+                .get_active_task_list_mut()
+                .expect("active task list");
+            let idx = list
+                .cards
+                .iter()
+                .position(|&id| id == fx.a_id)
+                .expect("card A present in active task list");
+            list.set_selected_index(Some(idx));
+        }
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+
+        app.handle_selection_activate();
+
+        assert_eq!(app.mode, AppMode::CardDetail);
+        assert_eq!(
+            app.relationship.children_list.selection.get(),
+            Some(0),
+            "the mode-transition populate must warm the graph before the counts are snapshotted"
         );
     }
 

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -485,16 +485,8 @@ impl App {
                 if let Some(selected_card) = self.get_selected_card_in_context() {
                     let card_id = selected_card.id;
                     self.set_active_card_or_clear(card_id);
-                    // Initialize list components with item counts
-                    let parents = self.get_current_card_parents();
-                    let children = self.get_current_card_children();
-                    self.relationship
-                        .parents_list
-                        .update_item_count(parents.len());
-                    self.relationship
-                        .children_list
-                        .update_item_count(children.len());
                     self.push_mode(AppMode::CardDetail);
+                    self.refresh_relationship_counts();
                 }
             }
         }

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -998,10 +998,10 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_relationship_popup_search_with_a_not_loaded_cards_tier_shows_no_matches_without_a_banner(
-    ) {
+    fn test_relationship_search_with_not_loaded_cards_tier_banners_and_preserves_list() {
         let mut app = App::test_default();
         let (_board_id, _card_id) = seed_relationship_dialog(&mut app);
+        app.relationship.selection.set(Some(0));
 
         let _ = app
             .model
@@ -1014,12 +1014,23 @@ mod tests {
 
         assert_eq!(
             app.relationship.selection.get(),
-            None,
-            "a NotLoaded cards tier must filter to zero matches, clearing the selection"
+            Some(0),
+            "a NotLoaded cards tier must not clear a staged selection"
         );
+        assert_eq!(
+            app.relationship.card_ids.len(),
+            1,
+            "a NotLoaded cards tier must not empty the candidate list"
+        );
+        let banner = app
+            .ui_state
+            .banner
+            .as_ref()
+            .expect("a NotLoaded cards tier must banner rather than silently show no matches");
         assert!(
-            app.ui_state.banner.is_none(),
-            "the per-keystroke search filter must degrade silently, not spam a banner per character"
+            banner.message.to_lowercase().contains("not loaded"),
+            "banner should explain the cards tier is not loaded, got: {}",
+            banner.message
         );
     }
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -636,16 +636,15 @@ impl App {
         }
     }
 
-    fn handle_relationship_popup(&mut self, key_code: KeyCode, is_parent_mode: bool) {
-        // Filter cards by search
-        let filtered_cards: Vec<_> = if self.relationship.search.is_empty() {
-            self.relationship.card_ids.clone()
-        } else {
-            let search_lower = self.relationship.search.to_lowercase();
-            let cards = match self.model.cards_state() {
-                LoadState::Loaded(cards) => cards.as_slice(),
-                _ => &[],
-            };
+    fn filtered_relationship_card_ids(&self) -> Option<Vec<uuid::Uuid>> {
+        if self.relationship.search.is_empty() {
+            return Some(self.relationship.card_ids.clone());
+        }
+        let LoadState::Loaded(cards) = self.model.cards_state() else {
+            return None;
+        };
+        let search_lower = self.relationship.search.to_lowercase();
+        Some(
             self.relationship
                 .card_ids
                 .iter()
@@ -657,11 +656,11 @@ impl App {
                         .unwrap_or(false)
                 })
                 .copied()
-                .collect()
-        };
+                .collect(),
+        )
+    }
 
-        let list_len = filtered_cards.len();
-
+    fn handle_relationship_popup(&mut self, key_code: KeyCode, is_parent_mode: bool) {
         // Handle search mode separately
         if self.relationship.search_active {
             match key_code {
@@ -701,12 +700,20 @@ impl App {
                 self.relationship.search_active = true;
             }
             KeyCode::Char('j') | KeyCode::Down => {
-                self.relationship.selection.next(list_len);
+                let Some(filtered_cards) = self.filtered_relationship_card_ids() else {
+                    self.set_error("Cards are not loaded yet");
+                    return;
+                };
+                self.relationship.selection.next(filtered_cards.len());
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.relationship.selection.prev();
             }
             KeyCode::Char(' ') | KeyCode::Enter => {
+                let Some(filtered_cards) = self.filtered_relationship_card_ids() else {
+                    self.set_error("Cards are not loaded yet");
+                    return;
+                };
                 // Toggle relationship
                 if let Some(idx) = self.relationship.selection.get() {
                     if let Some(selected_card_id) = filtered_cards.get(idx).copied() {
@@ -757,31 +764,14 @@ impl App {
     }
 
     fn update_relationship_selection_after_search(&mut self) {
-        let filtered_count = if self.relationship.search.is_empty() {
-            self.relationship.card_ids.len()
-        } else {
-            let search_lower = self.relationship.search.to_lowercase();
-            let cards = match self.model.cards_state() {
-                LoadState::Loaded(cards) => cards.as_slice(),
-                _ => &[],
-            };
-            self.relationship
-                .card_ids
-                .iter()
-                .filter(|card_id| {
-                    cards
-                        .iter()
-                        .find(|c| c.id == **card_id)
-                        .map(|c| c.title.to_lowercase().contains(&search_lower))
-                        .unwrap_or(false)
-                })
-                .count()
+        let Some(filtered) = self.filtered_relationship_card_ids() else {
+            self.set_error("Cards are not loaded yet");
+            return;
         };
-
-        if filtered_count > 0 {
-            self.relationship.selection.set(Some(0));
-        } else {
+        if filtered.is_empty() {
             self.relationship.selection.clear();
+        } else {
+            self.relationship.selection.set(Some(0));
         }
     }
 }

--- a/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
@@ -624,12 +624,11 @@ fn test_restore_card_without_reload_remaps_to_first_column_when_the_original_is_
 }
 
 // ---------------------------------------------------------------------
-// handle_manage_children_from_list: decline on a NotLoaded board-scoped
-// columns tier
+// handle_manage_children_from_list: a NotLoaded board-scoped columns tier
 // ---------------------------------------------------------------------
 
 #[test]
-fn test_handle_manage_children_from_list_declines_on_a_not_loaded_column_tier() {
+fn test_handle_manage_children_from_list_with_a_cold_column_tier_repopulates_and_opens() {
     let mut app = App::test_default();
     let (board_id, first_col, _second_col) = seed_board_with_two_columns(&mut app);
     let card = app
@@ -657,15 +656,14 @@ fn test_handle_manage_children_from_list_declines_on_a_not_loaded_column_tier() 
 
     app.handle_manage_children_from_list();
 
-    let banner = app
-        .ui_state
-        .banner
-        .as_ref()
-        .expect("declining a NotLoaded board-scoped columns tier must set an error banner");
-    assert!(banner.message.to_lowercase().contains("column"));
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageChildren),
+        "opening the dialog first lets the mode-transition populate repair the columns tier, so the handler no longer dead-ends"
+    );
     assert!(
-        app.relationship.card_ids.is_empty(),
-        "the manage-children list must not be populated while the columns tier is declined"
+        app.ui_state.banner.is_none(),
+        "a repaired columns tier must not leave a stale decline banner"
     );
 }
 

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -290,7 +290,7 @@ fn test_manage_children_refuses_to_open_when_the_graph_is_not_loaded() {
 }
 
 #[test]
-fn test_manage_children_from_list_refuses_to_open_when_the_graph_is_not_loaded() {
+fn test_manage_children_from_list_repopulates_and_opens_when_the_graph_is_not_loaded() {
     let mut app = App::test_default();
     let (board_id, column_id) = create_board_and_column(&mut app, "Board");
     let subject = create_card(&mut app, board_id, column_id, "Subject");
@@ -311,10 +311,12 @@ fn test_manage_children_from_list_refuses_to_open_when_the_graph_is_not_loaded()
 
     app.handle_manage_children_from_list();
 
-    let banner = app.ui_state.banner.expect("expected an error banner");
-    let message = banner.message.to_lowercase();
-    assert!(message.contains("relationship") || message.contains("loading"));
-    assert_ne!(app.mode, AppMode::Dialog(DialogMode::ManageChildren));
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ManageChildren),
+        "opening the dialog first lets the mode-transition populate repair the graph, so the handler no longer dead-ends"
+    );
+    assert!(app.ui_state.banner.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `get_current_card_parents`/`get_current_card_children` now return `Option<Vec<Uuid>>`. `None` means the graph tier is NotLoaded/Missing/Failed, distinct from a resolved card with genuinely zero parents/children. All 19 production call sites across `detail_view_handlers.rs`, `card_handlers.rs`'s sibling `refresh_relationship_counts`, `keybindings.rs`, and `navigation_handlers.rs` now decline with a banner on a tier gap instead of silently treating it as zero.
- `refresh_relationship_counts` leaves the relationship list counts untouched on a tier gap rather than zeroing them, since zeroing clears the list selections via `ListComponent::update_item_count`. The four CardDetail-entry sites (sprint-view select/edit, `open_sprint_detail_card_for_edit`, `handle_selection_activate`) now call it after `push_mode(AppMode::CardDetail)` instead of before, so the mode-transition populate has already warmed the graph.
- The relationship popup's search filtering is unified behind a new `filtered_relationship_card_ids` helper, which declines with a banner on a NotLoaded cards tier instead of silently filtering to an empty candidate list and clearing the selection. Esc and `/` stay unguarded so the dialog can still be closed on a cold cards tier.
- `handle_manage_children_from_list` now opens the ManageChildren dialog before its graph/columns/cards tier reads and pops it on any decline, so the mode-transition populate can repair a cold tier instead of the handler dead-ending on a stale pre-check.

## Test changes

- Rewrote three tests whose fixtures now hit the post-populate repaired path instead of a decline, since the reordered dialog-open makes the old decline unreachable from an in-memory-backed `App::test_default`:
  - `test_handle_manage_children_from_list_with_a_not_loaded_cards_tier_declines` -> `test_handle_manage_children_from_list_with_a_cold_cards_tier_repopulates_and_opens` (`card_handlers.rs`)
  - `test_handle_manage_children_from_list_declines_on_a_not_loaded_column_tier` -> `test_handle_manage_children_from_list_with_a_cold_column_tier_repopulates_and_opens` (`card_handlers_collapsing_accessor_tests.rs`)
  - `test_manage_children_from_list_refuses_to_open_when_the_graph_is_not_loaded` -> `test_manage_children_from_list_repopulates_and_opens_when_the_graph_is_not_loaded` (`relationship_resolution_tests.rs`)
- Added new red coverage for the accessor signature change, the search banner behavior, the count-preservation behavior, `navigate_to_selected_parent`'s banner-on-decline, `handle_selection_activate`'s post-populate count, and a cold-graph pin for `handle_manage_children_from_list`.

The post-populate decline branches inside `handle_manage_children_from_list` (Columns/Cards "not loaded yet" after the pop) are unreachable from `src/` unit tests with the in-memory backend used by `App::test_default`, since the mode-transition populate always succeeds against it. They are retained as defensive code for backends whose populate can fail (e.g. a remote backend); no test currently drives a failing populate through this handler.

## Test plan

- [x] `cargo test -p kanban-tui` green
- [x] `cargo test --all-features --workspace` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation-checked the accessor `None`-on-tier-gap behavior, the popup search banner, and the `handle_manage_children_from_list` reorder (the last one fails to compile under the old ordering, confirming the borrow-checker forces the fix)

