### PR TITLE
KAN-1365 refactor(tui): refetch only what a card, board or column mutation invalidated

### DIFF
--- a/.changeset/kan-1365-tui-card-board-column-refetch.md
+++ b/.changeset/kan-1365-tui-card-board-column-refetch.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+tui: refetch only what a card, board or column mutation invalidated instead of reloading the whole model

--- a/crates/kanban-tui/src/app/command_execution.rs
+++ b/crates/kanban-tui/src/app/command_execution.rs
@@ -1,5 +1,5 @@
 use super::App;
-use kanban_domain::KanbanResult;
+use kanban_domain::{Invalidation, KanbanResult};
 
 impl App {
     /// Execute a single command and queue a flush.
@@ -7,7 +7,7 @@ impl App {
     pub fn execute_command(
         &mut self,
         command: kanban_domain::commands::Command,
-    ) -> KanbanResult<()> {
+    ) -> KanbanResult<Invalidation> {
         self.execute_commands_batch(vec![command])
     }
 
@@ -15,9 +15,8 @@ impl App {
     pub fn execute_commands_batch(
         &mut self,
         commands: Vec<kanban_domain::commands::Command>,
-    ) -> KanbanResult<()> {
-        self.ctx.execute_commands_batch(commands)?;
-        Ok(())
+    ) -> KanbanResult<Invalidation> {
+        self.ctx.execute_commands_batch(commands)
     }
 
     /// Like `execute_commands_batch`, but the batch is built inside the
@@ -28,7 +27,7 @@ impl App {
         build: impl FnOnce(
             &dyn kanban_domain::DataStore,
         ) -> KanbanResult<Vec<kanban_domain::commands::Command>>,
-    ) -> KanbanResult<()> {
+    ) -> KanbanResult<Invalidation> {
         self.execute_with_extra(kanban_domain::EntityIds::default(), build)
     }
 
@@ -41,8 +40,7 @@ impl App {
         build: impl FnOnce(
             &dyn kanban_domain::DataStore,
         ) -> KanbanResult<Vec<kanban_domain::commands::Command>>,
-    ) -> KanbanResult<()> {
-        self.ctx.execute_with_extra(extra, build)?;
-        Ok(())
+    ) -> KanbanResult<Invalidation> {
+        self.ctx.execute_with_extra(extra, build)
     }
 }

--- a/crates/kanban-tui/src/app/lifecycle_tests.rs
+++ b/crates/kanban-tui/src/app/lifecycle_tests.rs
@@ -149,7 +149,8 @@ async fn test_adopt_storage_file_leaves_context_ready_for_mutations() {
         card_prefix: None,
         position: 0,
     }));
-    app.ctx
+    let _ = app
+        .ctx
         .execute_command(cmd)
         .expect("execute_command must succeed after adopt_storage_file");
 }

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -1,8 +1,8 @@
 use super::{App, AppMode, ViewScope};
 use crate::view_strategy::UnifiedViewStrategy;
 use kanban_domain::{
-    filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, KanbanResult,
-    LoadState, Snapshot,
+    filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, Invalidation,
+    KanbanResult, LoadState, Snapshot,
 };
 use kanban_view::view_strategy::{ViewRefreshContext, ViewStrategy};
 use std::collections::HashMap;
@@ -13,6 +13,14 @@ impl App {
     /// resyncing the controller's derived partitions.
     pub fn populate(&mut self, scope: ViewScope) {
         self.ctx.sync(&scope, &mut self.model, &mut self.controller);
+    }
+
+    /// Refetches what `inv` invalidated, plus whatever the current screen
+    /// reads, in place of a full `reload_model`.
+    pub fn resolve_after_command(&mut self, inv: Invalidation) {
+        let scope = self.view_scope();
+        self.ctx
+            .resync_invalidated(inv, &scope, &mut self.model, &mut self.controller);
     }
 
     /// Resolve the board the user is currently acting on / viewing, by identity.

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -542,17 +542,21 @@ impl App {
 
         // Single batch so undo reverses the whole "create a board"
         // action in one step.
-        if let Err(e) = self.execute_commands_batch(commands) {
-            tracing::error!("Failed to create board: {}", e);
-            self.set_error(format!("Failed to create board: {}", e));
-            return;
-        }
+        let inv = match self.execute_commands_batch(commands) {
+            Ok(inv) => inv,
+            Err(e) => {
+                tracing::error!("Failed to create board: {}", e);
+                self.set_error(format!("Failed to create board: {}", e));
+                return;
+            }
+        };
 
         tracing::info!("Created board: {} (id: {})", board_name, board_id);
 
-        // Resync `board_list` from the store so the new board is present, then
-        // select it by id (known up front — it was generated above).
-        self.reload_model();
+        let prior_active_board_id = self.selection.active_board_id;
+        self.selection.active_board_id = Some(board_id);
+        self.resolve_after_command(inv);
+        self.selection.active_board_id = prior_active_board_id;
         self.prepare_frame();
         self.board_list.select_board(board_id);
         self.switch_view_strategy(TaskListView::default());
@@ -571,13 +575,15 @@ impl App {
                 },
             }));
 
-            if let Err(e) = self.execute_command(cmd) {
-                tracing::error!("Failed to rename board: {}", e);
-                self.set_error(format!("Failed to rename board: {}", e));
-                return;
+            match self.execute_command(cmd) {
+                Ok(inv) => self.resolve_after_command(inv),
+                Err(e) => {
+                    tracing::error!("Failed to rename board: {}", e);
+                    self.set_error(format!("Failed to rename board: {}", e));
+                    return;
+                }
             }
 
-            self.reload_model();
             tracing::info!("Renamed board to: {}", new_name);
         }
     }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -4,7 +4,7 @@ use kanban_domain::commands::{
     BoardCommand, CardCommand, ColumnCommand, Command, CreateCard, CreateColumn, RestoreCard,
     SetBoardTaskSort, UpdateCard,
 };
-use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, KanbanOperations, LoadState};
+use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, LoadState};
 use kanban_view::card_list::CardListId;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
@@ -248,12 +248,14 @@ impl App {
                             order: new_order,
                         }));
 
-                        if let Err(e) = self.execute_command(cmd) {
-                            tracing::error!("Failed to set board task sort: {}", e);
-                            self.set_error(format!("Failed to set board task sort: {}", e));
-                            return;
+                        match self.execute_command(cmd) {
+                            Ok(inv) => self.resolve_after_command(inv),
+                            Err(e) => {
+                                tracing::error!("Failed to set board task sort: {}", e);
+                                self.set_error(format!("Failed to set board task sort: {}", e));
+                                return;
+                            }
                         }
-                        self.reload_model();
                     }
                 }
 
@@ -317,20 +319,22 @@ impl App {
             };
 
             // Service layer chains the column move automatically.
-            if let Err(e) = self.ctx.update_card(
+            let inv = match self.ctx.update_card_impl(
                 card_id,
                 CardUpdate {
                     status: Some(new_status),
                     ..Default::default()
                 },
             ) {
-                tracing::error!("Failed to toggle card completion: {}", e);
-                self.set_error(format!("Failed to toggle card completion: {}", e));
-                return;
-            }
+                Ok((_, inv)) => inv,
+                Err(e) => {
+                    tracing::error!("Failed to toggle card completion: {}", e);
+                    self.set_error(format!("Failed to toggle card completion: {}", e));
+                    return;
+                }
+            };
 
-            // Refresh the view-layer task list before selecting so column lists are current.
-            self.reload_model();
+            self.resolve_after_command(inv);
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -365,20 +369,26 @@ impl App {
             .collect();
 
         let toggled_count = updates.len();
-        if !updates.is_empty() {
-            if let Err(e) = self.ctx.update_cards(updates) {
-                tracing::error!("Failed to toggle card completion: {}", e);
-                self.set_error(format!("Failed to toggle card completion: {}", e));
-                return;
+        let invalidation = if updates.is_empty() {
+            None
+        } else {
+            match self.ctx.update_cards_impl(updates) {
+                Ok((_, inv)) => Some(inv),
+                Err(e) => {
+                    tracing::error!("Failed to toggle card completion: {}", e);
+                    self.set_error(format!("Failed to toggle card completion: {}", e));
+                    return;
+                }
             }
-        }
+        };
 
         tracing::info!("Toggled {} cards completion status", toggled_count);
         self.multi_select.selected_cards.clear();
         self.multi_select.selection_mode_active = false;
         if let Some(card_id) = first_card_id {
-            // Refresh the view-layer task list before selecting so column lists are current.
-            self.reload_model();
+            if let Some(inv) = invalidation {
+                self.resolve_after_command(inv);
+            }
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -518,15 +528,16 @@ impl App {
                     },
                 );
 
-                if let Err(e) = result {
-                    tracing::error!("Failed to create card: {}", e);
-                    self.set_error(format!("Failed to create card: {}", e));
-                    return;
-                }
+                let inv = match result {
+                    Ok(inv) => inv,
+                    Err(e) => {
+                        tracing::error!("Failed to create card: {}", e);
+                        self.set_error(format!("Failed to create card: {}", e));
+                        return;
+                    }
+                };
 
-                // Refresh the view-layer task list so the new card's ID is
-                // present before we try to select it.
-                self.reload_model();
+                self.resolve_after_command(inv);
                 self.prepare_frame();
                 self.select_card_by_id(card_id);
             }
@@ -576,18 +587,21 @@ impl App {
             };
 
             let card_id = card.id;
-            if let Err(e) = self
+            let inv = match self
                 .ctx
-                .move_card(card_id, move_result.target_column_id, None)
+                .move_card_impl(card_id, move_result.target_column_id, None)
             {
-                let dir = match direction {
-                    kanban_domain::card_lifecycle::MoveDirection::Left => "left",
-                    kanban_domain::card_lifecycle::MoveDirection::Right => "right",
-                };
-                tracing::error!("Failed to move card {}: {}", dir, e);
-                self.set_error(format!("Failed to move card {}: {}", dir, e));
-                return;
-            }
+                Ok((_, inv)) => inv,
+                Err(e) => {
+                    let dir = match direction {
+                        kanban_domain::card_lifecycle::MoveDirection::Left => "left",
+                        kanban_domain::card_lifecycle::MoveDirection::Right => "right",
+                    };
+                    tracing::error!("Failed to move card {}: {}", dir, e);
+                    self.set_error(format!("Failed to move card {}: {}", dir, e));
+                    return;
+                }
+            };
 
             match direction {
                 kanban_domain::card_lifecycle::MoveDirection::Right => {
@@ -623,7 +637,7 @@ impl App {
                 }
             }
 
-            self.reload_model();
+            self.resolve_after_command(inv);
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -666,17 +680,22 @@ impl App {
             .collect();
 
         let moved_count = updates.len();
-        if !updates.is_empty() {
-            if let Err(e) = self.ctx.update_cards(updates) {
-                let dir = match direction {
-                    kanban_domain::card_lifecycle::MoveDirection::Left => "left",
-                    kanban_domain::card_lifecycle::MoveDirection::Right => "right",
-                };
-                tracing::error!("Failed to move cards {}: {}", dir, e);
-                self.set_error(format!("Failed to move cards {}: {}", dir, e));
-                return;
+        let invalidation = if updates.is_empty() {
+            None
+        } else {
+            match self.ctx.update_cards_impl(updates) {
+                Ok((_, inv)) => Some(inv),
+                Err(e) => {
+                    let dir = match direction {
+                        kanban_domain::card_lifecycle::MoveDirection::Left => "left",
+                        kanban_domain::card_lifecycle::MoveDirection::Right => "right",
+                    };
+                    tracing::error!("Failed to move cards {}: {}", dir, e);
+                    self.set_error(format!("Failed to move cards {}: {}", dir, e));
+                    return;
+                }
             }
-        }
+        };
 
         tracing::info!("Moved {} cards", moved_count);
         self.multi_select.selected_cards.clear();
@@ -690,7 +709,9 @@ impl App {
             }
         }
         if let Some(card_id) = first_card_id {
-            self.reload_model();
+            if let Some(inv) = invalidation {
+                self.resolve_after_command(inv);
+            }
             self.prepare_frame();
             self.select_card_by_id(card_id);
         }
@@ -1347,18 +1368,21 @@ mod create_card_factory_tests {
 
         let (_save_rx, _completion_rx) = app.ctx.save_coordinator.reset_save_channels();
 
-        app.execute_with_extra(kanban_domain::EntityIds::default().with_prefixes(), |_| {
-            Ok(vec![kanban_domain::commands::Command::Card(
-                kanban_domain::commands::CardCommand::Update(kanban_domain::commands::UpdateCard {
-                    card_id: card.id,
-                    updates: kanban_domain::CardUpdate {
-                        title: Some("x".into()),
-                        ..Default::default()
-                    },
-                }),
-            )])
-        })
-        .unwrap();
+        let _ = app
+            .execute_with_extra(kanban_domain::EntityIds::default().with_prefixes(), |_| {
+                Ok(vec![kanban_domain::commands::Command::Card(
+                    kanban_domain::commands::CardCommand::Update(
+                        kanban_domain::commands::UpdateCard {
+                            card_id: card.id,
+                            updates: kanban_domain::CardUpdate {
+                                title: Some("x".into()),
+                                ..Default::default()
+                            },
+                        },
+                    ),
+                )])
+            })
+            .unwrap();
 
         assert!(app.ctx.save_coordinator.has_pending_saves());
 

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -139,12 +139,14 @@ impl App {
                                 },
                             }));
 
-                            if let Err(e) = self.execute_commands_batch(vec![cmd1, cmd2]) {
-                                tracing::error!("Failed to move column: {}", e);
-                                self.set_error(format!("Failed to move column: {}", e));
-                                return;
+                            match self.execute_commands_batch(vec![cmd1, cmd2]) {
+                                Ok(inv) => self.resolve_after_command(inv),
+                                Err(e) => {
+                                    tracing::error!("Failed to move column: {}", e);
+                                    self.set_error(format!("Failed to move column: {}", e));
+                                    return;
+                                }
                             }
-                            self.reload_model();
 
                             self.dialog_input
                                 .column_list
@@ -205,12 +207,14 @@ impl App {
                                 },
                             }));
 
-                            if let Err(e) = self.execute_commands_batch(vec![cmd1, cmd2]) {
-                                tracing::error!("Failed to move column: {}", e);
-                                self.set_error(format!("Failed to move column: {}", e));
-                                return;
+                            match self.execute_commands_batch(vec![cmd1, cmd2]) {
+                                Ok(inv) => self.resolve_after_command(inv),
+                                Err(e) => {
+                                    tracing::error!("Failed to move column: {}", e);
+                                    self.set_error(format!("Failed to move column: {}", e));
+                                    return;
+                                }
                             }
-                            self.reload_model();
 
                             let column_count = board_columns.len();
                             self.dialog_input
@@ -282,12 +286,14 @@ impl App {
 
                 let prior_column_count = columns.len();
 
-                if let Err(e) = self.execute_command(cmd) {
-                    tracing::error!("Failed to create column: {}", e);
-                    self.set_error(format!("Failed to create column: {}", e));
-                    return;
+                match self.execute_command(cmd) {
+                    Ok(inv) => self.resolve_after_command(inv),
+                    Err(e) => {
+                        tracing::error!("Failed to create column: {}", e);
+                        self.set_error(format!("Failed to create column: {}", e));
+                        return;
+                    }
                 }
-                self.reload_model();
 
                 tracing::info!("Created column: {} (position: {})", column_name, position);
 
@@ -333,12 +339,14 @@ impl App {
                     },
                 }));
 
-                if let Err(e) = self.execute_command(cmd) {
-                    tracing::error!("Failed to rename column: {}", e);
-                    self.set_error(format!("Failed to rename column: {}", e));
-                    return;
+                match self.execute_command(cmd) {
+                    Ok(inv) => self.resolve_after_command(inv),
+                    Err(e) => {
+                        tracing::error!("Failed to rename column: {}", e);
+                        self.set_error(format!("Failed to rename column: {}", e));
+                        return;
+                    }
                 }
-                self.reload_model();
 
                 tracing::info!("Renamed column to: {}", new_name);
             }
@@ -445,12 +453,14 @@ impl App {
                     column_id,
                 })));
 
-                if let Err(e) = self.execute_commands_batch(commands) {
-                    tracing::error!("Failed to delete column: {}", e);
-                    self.set_error(format!("Failed to delete column: {}", e));
-                    return;
+                match self.execute_commands_batch(commands) {
+                    Ok(inv) => self.resolve_after_command(inv),
+                    Err(e) => {
+                        tracing::error!("Failed to delete column: {}", e);
+                        self.set_error(format!("Failed to delete column: {}", e));
+                        return;
+                    }
                 }
-                self.reload_model();
 
                 tracing::info!("Deleted column: {}", column_name);
 
@@ -611,14 +621,16 @@ impl App {
                                 SetBoardTaskListView { board_id, view },
                             ));
 
-                            if let Err(e) = self.execute_command(cmd) {
-                                tracing::error!("Failed to set task list view: {}", e);
-                                self.set_error(format!("Failed to set task list view: {}", e));
-                                self.pop_mode();
-                                self.dialog_input.task_list_view_selection.clear();
-                                return;
+                            match self.execute_command(cmd) {
+                                Ok(inv) => self.resolve_after_command(inv),
+                                Err(e) => {
+                                    tracing::error!("Failed to set task list view: {}", e);
+                                    self.set_error(format!("Failed to set task list view: {}", e));
+                                    self.pop_mode();
+                                    self.dialog_input.task_list_view_selection.clear();
+                                    return;
+                                }
                             }
-                            self.reload_model();
 
                             self.switch_view_strategy(view);
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -416,11 +416,13 @@ impl App {
                 kanban_domain::commands::ApplyBoardSettings { board_id, dto },
             ),
         );
-        if let Err(e) = self.ctx.execute_command(cmd) {
-            tracing::error!("Failed to apply board settings: {}", e);
-            self.set_error(format!("Failed to apply board settings: {}", e));
+        match self.ctx.execute_command(cmd) {
+            Ok(inv) => self.resolve_after_command(inv),
+            Err(e) => {
+                tracing::error!("Failed to apply board settings: {}", e);
+                self.set_error(format!("Failed to apply board settings: {}", e));
+            }
         }
-        self.reload_model();
     }
 
     fn handle_board_detail_navigation_key(&mut self, key_code: KeyCode) -> bool {
@@ -729,11 +731,13 @@ impl App {
                 kanban_domain::commands::ApplyCardMetadata { card_id, dto },
             ),
         );
-        if let Err(e) = self.ctx.execute_command(cmd) {
-            tracing::error!("Failed to apply metadata: {}", e);
-            self.set_error(format!("Failed to apply metadata: {}", e));
+        match self.ctx.execute_command(cmd) {
+            Ok(inv) => self.resolve_after_command(inv),
+            Err(e) => {
+                tracing::error!("Failed to apply metadata: {}", e);
+                self.set_error(format!("Failed to apply metadata: {}", e));
+            }
         }
-        self.reload_model();
     }
 
     /// The single card highlighted in whichever sprint-detail panel is active
@@ -1372,7 +1376,7 @@ impl App {
     }
 
     pub fn toggle_completion_for_card_ids(&mut self, ids: Vec<uuid::Uuid>) {
-        use kanban_domain::{CardStatus, CardUpdate, KanbanOperations};
+        use kanban_domain::{CardStatus, CardUpdate};
 
         let LoadState::Loaded(all_cards) = self.model.cards_state() else {
             self.set_error("Cards are not loaded yet");
@@ -1399,11 +1403,12 @@ impl App {
             .collect();
 
         if !updates.is_empty() {
-            if let Err(e) = self.ctx.update_cards(updates) {
-                tracing::error!("Failed to toggle card completion: {}", e);
-                self.set_error(format!("Failed to toggle card completion: {}", e));
-            } else {
-                self.reload_model();
+            match self.ctx.update_cards_impl(updates) {
+                Ok((_, inv)) => self.resolve_after_command(inv),
+                Err(e) => {
+                    tracing::error!("Failed to toggle card completion: {}", e);
+                    self.set_error(format!("Failed to toggle card completion: {}", e));
+                }
             }
         }
     }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -380,25 +380,7 @@ impl App {
                             Ok(Some(new_content)) => {
                                 match serde_json::from_str::<BoardSettingsDto>(&new_content) {
                                     Ok(new_dto) => {
-                                        let cmd = kanban_domain::commands::Command::Board(
-                                            kanban_domain::commands::BoardCommand::ApplySettings(
-                                                kanban_domain::commands::ApplyBoardSettings {
-                                                    board_id,
-                                                    dto: new_dto,
-                                                },
-                                            ),
-                                        );
-                                        if let Err(e) = self.ctx.execute_command(cmd) {
-                                            tracing::error!(
-                                                "Failed to apply board settings: {}",
-                                                e
-                                            );
-                                            self.set_error(format!(
-                                                "Failed to apply board settings: {}",
-                                                e
-                                            ));
-                                        }
-                                        self.reload_model();
+                                        self.apply_board_settings(board_id, new_dto);
                                     }
                                     Err(e) => {
                                         tracing::error!(
@@ -426,6 +408,19 @@ impl App {
             BoardFocus::Columns => {}
         }
         should_restart
+    }
+
+    pub fn apply_board_settings(&mut self, board_id: uuid::Uuid, dto: BoardSettingsDto) {
+        let cmd = kanban_domain::commands::Command::Board(
+            kanban_domain::commands::BoardCommand::ApplySettings(
+                kanban_domain::commands::ApplyBoardSettings { board_id, dto },
+            ),
+        );
+        if let Err(e) = self.ctx.execute_command(cmd) {
+            tracing::error!("Failed to apply board settings: {}", e);
+            self.set_error(format!("Failed to apply board settings: {}", e));
+        }
+        self.reload_model();
     }
 
     fn handle_board_detail_navigation_key(&mut self, key_code: KeyCode) -> bool {
@@ -712,19 +707,7 @@ impl App {
         match edit_in_external_editor(terminal, event_handler, temp_file, &json) {
             Ok(Some(new_content)) => match serde_json::from_str::<CardMetadataDto>(&new_content) {
                 Ok(new_dto) => {
-                    let cmd = kanban_domain::commands::Command::Card(
-                        kanban_domain::commands::CardCommand::ApplyMetadata(
-                            kanban_domain::commands::ApplyCardMetadata {
-                                card_id,
-                                dto: new_dto,
-                            },
-                        ),
-                    );
-                    if let Err(e) = self.ctx.execute_command(cmd) {
-                        tracing::error!("Failed to apply metadata: {}", e);
-                        self.set_error(format!("Failed to apply metadata: {}", e));
-                    }
-                    self.reload_model();
+                    self.apply_card_metadata(card_id, new_dto);
                 }
                 Err(e) => {
                     tracing::error!("Failed to parse metadata JSON: {}", e);
@@ -738,6 +721,19 @@ impl App {
             }
         }
         true
+    }
+
+    pub fn apply_card_metadata(&mut self, card_id: uuid::Uuid, dto: CardMetadataDto) {
+        let cmd = kanban_domain::commands::Command::Card(
+            kanban_domain::commands::CardCommand::ApplyMetadata(
+                kanban_domain::commands::ApplyCardMetadata { card_id, dto },
+            ),
+        );
+        if let Err(e) = self.ctx.execute_command(cmd) {
+            tracing::error!("Failed to apply metadata: {}", e);
+            self.set_error(format!("Failed to apply metadata: {}", e));
+        }
+        self.reload_model();
     }
 
     /// The single card highlighted in whichever sprint-detail panel is active

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -37,22 +37,25 @@ impl TuiContext {
         Ok((tui_ctx, save_rx, completion_rx))
     }
 
-    pub fn execute_command(&mut self, command: Command) -> KanbanResult<()> {
+    pub fn execute_command(&mut self, command: Command) -> KanbanResult<kanban_domain::Invalidation> {
         self.execute_commands_batch(vec![command])
     }
 
-    pub fn execute_commands_batch(&mut self, commands: Vec<Command>) -> KanbanResult<()> {
-        let _ = self.inner.execute(commands)?;
+    pub fn execute_commands_batch(
+        &mut self,
+        commands: Vec<Command>,
+    ) -> KanbanResult<kanban_domain::Invalidation> {
+        let inv = self.inner.execute(commands)?;
         if self.save_coordinator.has_save_channel() {
             self.save_coordinator.queue_flush();
         }
-        Ok(())
+        Ok(inv)
     }
 
     pub fn execute_with(
         &mut self,
         build: impl FnOnce(&dyn kanban_domain::DataStore) -> KanbanResult<Vec<Command>>,
-    ) -> KanbanResult<()> {
+    ) -> KanbanResult<kanban_domain::Invalidation> {
         self.execute_with_extra(kanban_domain::EntityIds::default(), build)
     }
 
@@ -60,12 +63,39 @@ impl TuiContext {
         &mut self,
         extra: kanban_domain::EntityIds,
         build: impl FnOnce(&dyn kanban_domain::DataStore) -> KanbanResult<Vec<Command>>,
-    ) -> KanbanResult<()> {
-        let _ = self.inner.execute_with_extra(extra, build)?;
+    ) -> KanbanResult<kanban_domain::Invalidation> {
+        let inv = self.inner.execute_with_extra(extra, build)?;
         if self.save_coordinator.has_save_channel() {
             self.save_coordinator.queue_flush();
         }
-        Ok(())
+        Ok(inv)
+    }
+
+    pub fn update_card_impl(
+        &mut self,
+        id: Uuid,
+        updates: CardUpdate,
+    ) -> KanbanResult<(Card, kanban_domain::Invalidation)> {
+        let r = self.inner.update_card_impl(id, updates);
+        self.with_flush(r)
+    }
+
+    pub fn update_cards_impl(
+        &mut self,
+        updates: Vec<(Uuid, CardUpdate)>,
+    ) -> KanbanResult<(usize, kanban_domain::Invalidation)> {
+        let r = self.inner.update_cards_impl(updates);
+        self.with_flush(r)
+    }
+
+    pub fn move_card_impl(
+        &mut self,
+        id: Uuid,
+        column_id: Uuid,
+        position: Option<i32>,
+    ) -> KanbanResult<(Card, kanban_domain::Invalidation)> {
+        let r = self.inner.move_card_impl(id, column_id, position);
+        self.with_flush(r)
     }
 
     // --- Delegation: state methods ---
@@ -179,6 +209,16 @@ impl TuiContext {
         proj: &mut impl kanban_domain::DerivedProjections,
     ) {
         self.inner.sync_invalidated(inv, plan, model, proj);
+    }
+
+    pub fn resync_invalidated(
+        &self,
+        inv: kanban_domain::Invalidation,
+        plan: &dyn kanban_service::FetchPlan,
+        model: &mut kanban_domain::Model,
+        proj: &mut impl kanban_domain::DerivedProjections,
+    ) {
+        self.inner.resync_invalidated(inv, plan, model, proj);
     }
 
     pub fn persistence_metadata(&self) -> Option<kanban_persistence::PersistenceMetadata> {

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -37,7 +37,10 @@ impl TuiContext {
         Ok((tui_ctx, save_rx, completion_rx))
     }
 
-    pub fn execute_command(&mut self, command: Command) -> KanbanResult<kanban_domain::Invalidation> {
+    pub fn execute_command(
+        &mut self,
+        command: Command,
+    ) -> KanbanResult<kanban_domain::Invalidation> {
         self.execute_commands_batch(vec![command])
     }
 

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -107,7 +107,7 @@ fn test_card_description_preserved_after_edit() {
             updates,
         },
     ));
-    app.execute_command(cmd).unwrap();
+    let _ = app.execute_command(cmd).unwrap();
 
     // Verify description is still there after update
     app.reload_model();

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -93,7 +93,7 @@ fn test_model_reflects_mutation_after_prepare_frame() {
             },
         },
     ));
-    app.execute_command(cmd).unwrap();
+    let _ = app.execute_command(cmd).unwrap();
     app.reload_model();
     app.prepare_frame();
 
@@ -160,7 +160,7 @@ fn test_model_description_reflects_mutation() {
             },
         },
     ));
-    app.execute_command(cmd).unwrap();
+    let _ = app.execute_command(cmd).unwrap();
     app.reload_model();
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -697,9 +697,19 @@ fn test_no_converted_card_board_or_column_handler_still_reloads_wholesale() {
     assert_eq!(production_reload_model_count(board_handlers), 6);
     assert_eq!(production_reload_model_count(column_handlers), 0);
 
-    for src in [card_handlers, detail_view_handlers, board_handlers, column_handlers] {
+    let card_handlers_boundary = card_handlers.find("#[cfg(test)]").unwrap_or(card_handlers.len());
+    let entity_ids_count = card_handlers[..card_handlers_boundary].matches("EntityIds").count();
+    assert_eq!(
+        entity_ids_count, 1,
+        "the only production EntityIds construction left is create_card's with_prefixes() extra"
+    );
+
+    for src in [detail_view_handlers, board_handlers, column_handlers] {
         let boundary = src.find("#[cfg(test)]").unwrap_or(src.len());
         assert!(!src[..boundary].contains("EntityIds"), "handler built its own invalidation");
+    }
+    for src in [card_handlers, detail_view_handlers, board_handlers, column_handlers] {
+        let boundary = src.find("#[cfg(test)]").unwrap_or(src.len());
         assert!(
             !src[..boundary].contains("invalidation_from_inverse"),
             "handler built its own invalidation"

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -1,0 +1,708 @@
+mod helpers;
+
+use helpers::{CountingBackend, ReadOp, ReadOpLog};
+use kanban_core::Editable;
+use kanban_domain::{
+    commands::{CardCommand, Command, DeleteCard},
+    BoardSettingsDto, CardMetadataDto, CreateCardOptions, KanbanOperations,
+};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::mode::AppMode;
+use kanban_tui::app::BoardFocus;
+use kanban_tui::App;
+use uuid::Uuid;
+use crossterm::event::KeyCode;
+
+struct Seed {
+    board: Uuid,
+    c1: Uuid,
+    c2: Uuid,
+    k1: Uuid,
+    k2: Uuid,
+}
+
+fn seed_two_columns_two_cards(app: &mut App) -> Seed {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let c2 = app
+        .ctx
+        .create_column(board.id, "C2".to_string(), Some(1))
+        .unwrap();
+    let k1 = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "K1".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let k2 = app
+        .ctx
+        .create_card(
+            board.id,
+            c2.id,
+            "K2".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    Seed {
+        board: board.id,
+        c1: c1.id,
+        c2: c2.id,
+        k1: k1.id,
+        k2: k2.id,
+    }
+}
+
+/// Wraps the backend in a `CountingBackend`, runs `load_initial_state`
+/// (the scope-priming idiom every test in this module must use, never
+/// `reload_model`), and clears the op log so only the handler-under-test's
+/// reads are recorded.
+async fn prime(app: &mut App) -> ReadOpLog {
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+    app.load_initial_state().await;
+    ops.lock().unwrap().clear();
+    ops
+}
+
+/// Narrows the raw op log to the refetch-shaped reads: `snapshot`,
+/// `get_graph`, and every `list_*` except `list_prefixes` (issued by the
+/// create_card builder as part of the mutation itself, not the refetch).
+fn refetch_ops(log: &ReadOpLog) -> Vec<ReadOp> {
+    log.lock()
+        .unwrap()
+        .iter()
+        .filter(|op| {
+            (op.method == "snapshot" || op.method == "get_graph" || op.method.starts_with("list_"))
+                && op.method != "list_prefixes"
+        })
+        .cloned()
+        .collect()
+}
+
+fn has_op(ops: &[ReadOp], method: &str) -> bool {
+    ops.iter().any(|op| op.method == method)
+}
+
+fn has_op_with_id(ops: &[ReadOp], method: &str, id: Uuid) -> bool {
+    ops.iter()
+        .any(|op| op.method == method && op.ids.contains(&id))
+}
+
+fn select_column(app: &mut App, board_id: Uuid, column_id: Uuid) {
+    app.focus.board_focus = BoardFocus::Columns;
+    let columns = kanban_domain::card_lifecycle::sorted_board_columns(
+        board_id,
+        app.model.columns_state().loaded_or_empty(),
+    );
+    let idx = columns
+        .iter()
+        .position(|c| c.id == column_id)
+        .expect("column visible");
+    app.dialog_input.column_list.update_item_count(columns.len());
+    app.dialog_input.column_list.set_selected_index(Some(idx));
+}
+
+#[tokio::test]
+async fn test_rename_column_refetches_the_column_tiers_without_a_snapshot() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    select_column(&mut app, seed.board, seed.c1);
+    app.input.set("Renamed".to_string());
+    app.rename_column();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_boards"), "got {refetch:?}");
+    assert!(
+        !has_op_with_id(&refetch, "list_cards_by_column", seed.c2),
+        "got {refetch:?}"
+    );
+
+    assert!(app.model.column_cards_state(seed.c2).is_loaded());
+    assert!(app.model.column_cards_state(seed.c1).is_loaded());
+}
+
+#[tokio::test]
+async fn test_delete_column_refetches_the_card_tier_because_the_batch_moved_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let c2 = app
+        .ctx
+        .create_column(board.id, "C2".to_string(), Some(1))
+        .unwrap();
+    let c3 = app
+        .ctx
+        .create_column(board.id, "C3".to_string(), Some(2))
+        .unwrap();
+    for i in 0..3 {
+        app.ctx
+            .create_card(
+                board.id,
+                c2.id,
+                format!("K{i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+    }
+    for i in 0..2 {
+        app.ctx
+            .create_card(
+                board.id,
+                c3.id,
+                format!("M{i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+    }
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    select_column(&mut app, board.id, c2.id);
+    app.delete_column();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", board.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op(&refetch, "list_cards_by_column"),
+        "got {refetch:?}"
+    );
+
+    let moved: Vec<_> = app
+        .model
+        .cards_state()
+        .loaded_or_empty()
+        .iter()
+        .filter(|card| card.column_id == c1.id)
+        .collect();
+    assert_eq!(moved.len(), 3, "the three cards moved out of c2 must all report c1");
+    let _ = c3;
+}
+
+#[tokio::test]
+async fn test_move_column_up_leaves_an_untouched_columns_card_scope_loaded() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let c2 = app
+        .ctx
+        .create_column(board.id, "C2".to_string(), Some(1))
+        .unwrap();
+    let c3 = app
+        .ctx
+        .create_column(board.id, "C3".to_string(), Some(2))
+        .unwrap();
+    for (col, name) in [(&c1, "k1"), (&c2, "k2"), (&c3, "k3")] {
+        app.ctx
+            .create_card(board.id, col.id, name.to_string(), CreateCardOptions::default())
+            .unwrap();
+    }
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::BoardDetail;
+    select_column(&mut app, board.id, c3.id);
+    app.handle_move_column_up();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", board.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c2.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c3.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        !has_op_with_id(&refetch, "list_cards_by_column", c1.id),
+        "got {refetch:?}"
+    );
+    assert!(app.model.column_cards_state(c1.id).is_loaded());
+}
+
+#[tokio::test]
+async fn test_create_column_refetches_the_column_tier_and_the_new_columns_cards() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let _c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.focus.board_focus = BoardFocus::Columns;
+    app.input.set("New Column".to_string());
+    app.create_column();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", board.id),
+        "got {refetch:?}"
+    );
+    assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_rename_board_refetches_the_board_list_and_the_board_column_scope_only() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.board_list.select_board(seed.board);
+    app.input.set("Renamed Board".to_string());
+    app.rename_board();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_toggle_sort_order_refetches_the_board_list_without_a_snapshot() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.focus.active = Focus::Cards;
+    app.filter.current_sort_order = Some(kanban_domain::SortOrder::Ascending);
+    app.filter.current_sort_field = Some(kanban_domain::SortField::Position);
+    app.handle_toggle_sort_order_key();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_select_task_list_view_refetches_the_board_list_without_a_snapshot() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.dialog_input.task_list_view_selection.set(Some(0));
+    app.handle_select_task_list_view_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_create_board_refetches_the_board_and_column_tiers_without_a_snapshot() {
+    let mut app = App::test_default();
+    let _seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.focus.active = Focus::Boards;
+    app.input.set("New Board".to_string());
+    app.create_board();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_columns_by_board"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_boards"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_toggle_card_completion_refetches_the_card_tiers_and_repairs_the_visible_column_scopes(
+) {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.focus.active = Focus::Cards;
+    app.selection.active_card_id = Some(seed.k1);
+    app.handle_toggle_card_completion();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c2),
+        "got {refetch:?}"
+    );
+
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_boards"), "got {refetch:?}");
+
+    assert!(app.model.column_cards_state(seed.c1).is_loaded());
+    assert!(app.model.column_cards_state(seed.c2).is_loaded());
+}
+
+#[tokio::test]
+async fn test_move_card_refetches_the_card_tiers_and_leaves_the_column_tier_untouched() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let c2 = app
+        .ctx
+        .create_column(board.id, "C2".to_string(), Some(1))
+        .unwrap();
+    let mut last = None;
+    for i in 0..3 {
+        last = Some(
+            app.ctx
+                .create_card(board.id, c1.id, format!("K{i}"), CreateCardOptions::default())
+                .unwrap(),
+        );
+    }
+    let card = last.unwrap();
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.selection.active_card_id = Some(card.id);
+    app.handle_move_card_right();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c1.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c2.id),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_toggle_selected_cards_completion_refetches_once_for_the_whole_batch() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let mut ids = Vec::new();
+    for i in 0..4 {
+        let card = app
+            .ctx
+            .create_card(board.id, c1.id, format!("K{i}"), CreateCardOptions::default())
+            .unwrap();
+        ids.push(card.id);
+    }
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.multi_select.selected_cards.insert(ids[0]);
+    app.multi_select.selected_cards.insert(ids[1]);
+    app.handle_toggle_card_completion();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    let list_all_cards_count = refetch.iter().filter(|op| op.method == "list_all_cards").count();
+    assert_eq!(list_all_cards_count, 1, "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c1.id),
+        "got {refetch:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_toggle_selected_cards_completion_with_no_resolvable_cards_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.focus.active = Focus::Cards;
+    app.multi_select.selected_cards.insert(Uuid::new_v4());
+    app.handle_toggle_card_completion();
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_move_selected_cards_with_no_resolvable_cards_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.focus.active = Focus::Cards;
+    app.multi_select.selected_cards.insert(Uuid::new_v4());
+    app.handle_move_card_right();
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_toggle_completion_for_card_ids_refetches_the_card_tiers_without_a_snapshot() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.toggle_completion_for_card_ids(vec![seed.k1, seed.k2]);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c2),
+        "got {refetch:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_toggle_completion_for_card_ids_with_no_resolvable_cards_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.toggle_completion_for_card_ids(vec![Uuid::new_v4()]);
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_create_card_falls_back_to_a_whole_model_reset_because_its_inverse_is_unenumerable() {
+    let delete = Command::Card(CardCommand::Delete(DeleteCard {
+        card_id: Uuid::new_v4(),
+    }));
+    assert_eq!(delete.touched_entities(), None);
+
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.focus.active = Focus::Cards;
+    app.input.set("New Card".to_string());
+    app.create_card();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_boards"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_apply_board_settings_failure_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let _seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    let dto = BoardSettingsDto {
+        sprint_prefix: None,
+        card_prefix: None,
+        sprint_duration_days: None,
+        sprint_names: Vec::new(),
+    };
+    app.apply_board_settings(Uuid::new_v4(), dto);
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+    assert!(app.ui_state.banner.is_some());
+}
+
+#[tokio::test]
+async fn test_apply_board_settings_success_refetches_the_board_list_only() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    let board = app
+        .model
+        .board_by_id_state(seed.board)
+        .loaded()
+        .copied()
+        .unwrap()
+        .clone();
+    let dto = BoardSettingsDto::from_entity(&board);
+    app.apply_board_settings(seed.board, dto);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_apply_card_metadata_failure_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let _seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    let dto = CardMetadataDto {
+        priority: "Medium".to_string(),
+        status: "Todo".to_string(),
+        points: None,
+        due_date: None,
+    };
+    app.apply_card_metadata(Uuid::new_v4(), dto);
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+    assert!(app.ui_state.banner.is_some());
+}
+
+#[tokio::test]
+async fn test_apply_card_metadata_success_refetches_the_card_tiers() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    let card = app
+        .model
+        .cards_state()
+        .loaded()
+        .and_then(|cards| cards.iter().find(|c| c.id == seed.k1))
+        .cloned()
+        .unwrap();
+    let dto = CardMetadataDto::from_entity(&card);
+    app.apply_card_metadata(seed.k1, dto);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+}
+
+#[test]
+fn test_no_converted_card_board_or_column_handler_still_reloads_wholesale() {
+    let card_handlers = include_str!("../src/handlers/card_handlers.rs");
+    let detail_view_handlers = include_str!("../src/handlers/detail_view_handlers.rs");
+    let board_handlers = include_str!("../src/handlers/board_handlers.rs");
+    let column_handlers = include_str!("../src/handlers/column_handlers.rs");
+
+    fn production_reload_model_count(src: &str) -> usize {
+        let boundary = src.find("#[cfg(test)]").unwrap_or(src.len());
+        src[..boundary].matches("reload_model()").count()
+    }
+
+    assert_eq!(production_reload_model_count(card_handlers), 2);
+    assert_eq!(production_reload_model_count(detail_view_handlers), 2);
+    assert_eq!(production_reload_model_count(board_handlers), 6);
+    assert_eq!(production_reload_model_count(column_handlers), 0);
+
+    for src in [card_handlers, detail_view_handlers, board_handlers, column_handlers] {
+        let boundary = src.find("#[cfg(test)]").unwrap_or(src.len());
+        assert!(!src[..boundary].contains("EntityIds"), "handler built its own invalidation");
+        assert!(
+            !src[..boundary].contains("invalidation_from_inverse"),
+            "handler built its own invalidation"
+        );
+    }
+}

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -1,5 +1,6 @@
 mod helpers;
 
+use crossterm::event::KeyCode;
 use helpers::{CountingBackend, ReadOp, ReadOpLog};
 use kanban_core::Editable;
 use kanban_domain::{
@@ -11,7 +12,6 @@ use kanban_tui::app::mode::AppMode;
 use kanban_tui::app::BoardFocus;
 use kanban_tui::App;
 use uuid::Uuid;
-use crossterm::event::KeyCode;
 
 struct Seed {
     board: Uuid,
@@ -104,7 +104,9 @@ fn select_column(app: &mut App, board_id: Uuid, column_id: Uuid) {
         .iter()
         .position(|c| c.id == column_id)
         .expect("column visible");
-    app.dialog_input.column_list.update_item_count(columns.len());
+    app.dialog_input
+        .column_list
+        .update_item_count(columns.len());
     app.dialog_input.column_list.set_selected_index(Some(idx));
 }
 
@@ -197,10 +199,7 @@ async fn test_delete_column_refetches_the_card_tier_because_the_batch_moved_card
         has_op_with_id(&refetch, "list_columns_by_board", board.id),
         "got {refetch:?}"
     );
-    assert!(
-        has_op(&refetch, "list_cards_by_column"),
-        "got {refetch:?}"
-    );
+    assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
 
     let moved: Vec<_> = app
         .model
@@ -209,7 +208,11 @@ async fn test_delete_column_refetches_the_card_tier_because_the_batch_moved_card
         .iter()
         .filter(|card| card.column_id == c1.id)
         .collect();
-    assert_eq!(moved.len(), 3, "the three cards moved out of c2 must all report c1");
+    assert_eq!(
+        moved.len(),
+        3,
+        "the three cards moved out of c2 must all report c1"
+    );
     let _ = c3;
 }
 
@@ -231,7 +234,12 @@ async fn test_move_column_up_leaves_an_untouched_columns_card_scope_loaded() {
         .unwrap();
     for (col, name) in [(&c1, "k1"), (&c2, "k2"), (&c3, "k3")] {
         app.ctx
-            .create_card(board.id, col.id, name.to_string(), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                col.id,
+                name.to_string(),
+                CreateCardOptions::default(),
+            )
             .unwrap();
     }
 
@@ -424,7 +432,12 @@ async fn test_move_card_refetches_the_card_tiers_and_leaves_the_column_tier_unto
     for i in 0..3 {
         last = Some(
             app.ctx
-                .create_card(board.id, c1.id, format!("K{i}"), CreateCardOptions::default())
+                .create_card(
+                    board.id,
+                    c1.id,
+                    format!("K{i}"),
+                    CreateCardOptions::default(),
+                )
                 .unwrap(),
         );
     }
@@ -466,7 +479,12 @@ async fn test_toggle_selected_cards_completion_refetches_once_for_the_whole_batc
     for i in 0..4 {
         let card = app
             .ctx
-            .create_card(board.id, c1.id, format!("K{i}"), CreateCardOptions::default())
+            .create_card(
+                board.id,
+                c1.id,
+                format!("K{i}"),
+                CreateCardOptions::default(),
+            )
             .unwrap();
         ids.push(card.id);
     }
@@ -481,7 +499,10 @@ async fn test_toggle_selected_cards_completion_refetches_once_for_the_whole_batc
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    let list_all_cards_count = refetch.iter().filter(|op| op.method == "list_all_cards").count();
+    let list_all_cards_count = refetch
+        .iter()
+        .filter(|op| op.method == "list_all_cards")
+        .count();
     assert_eq!(list_all_cards_count, 1, "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", c1.id),
@@ -697,8 +718,12 @@ fn test_no_converted_card_board_or_column_handler_still_reloads_wholesale() {
     assert_eq!(production_reload_model_count(board_handlers), 6);
     assert_eq!(production_reload_model_count(column_handlers), 0);
 
-    let card_handlers_boundary = card_handlers.find("#[cfg(test)]").unwrap_or(card_handlers.len());
-    let entity_ids_count = card_handlers[..card_handlers_boundary].matches("EntityIds").count();
+    let card_handlers_boundary = card_handlers
+        .find("#[cfg(test)]")
+        .unwrap_or(card_handlers.len());
+    let entity_ids_count = card_handlers[..card_handlers_boundary]
+        .matches("EntityIds")
+        .count();
     assert_eq!(
         entity_ids_count, 1,
         "the only production EntityIds construction left is create_card's with_prefixes() extra"
@@ -706,9 +731,17 @@ fn test_no_converted_card_board_or_column_handler_still_reloads_wholesale() {
 
     for src in [detail_view_handlers, board_handlers, column_handlers] {
         let boundary = src.find("#[cfg(test)]").unwrap_or(src.len());
-        assert!(!src[..boundary].contains("EntityIds"), "handler built its own invalidation");
+        assert!(
+            !src[..boundary].contains("EntityIds"),
+            "handler built its own invalidation"
+        );
     }
-    for src in [card_handlers, detail_view_handlers, board_handlers, column_handlers] {
+    for src in [
+        card_handlers,
+        detail_view_handlers,
+        board_handlers,
+        column_handlers,
+    ] {
         let boundary = src.find("#[cfg(test)]").unwrap_or(src.len());
         assert!(
             !src[..boundary].contains("invalidation_from_inverse"),

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -698,15 +698,16 @@ fn test_move_card_right_syncs_column_list_count_to_filtered_columns_not_raw_boar
     // `is_kanban_view()` reads the board's persisted `task_list_view`, not
     // the app's local view strategy — both must be set for
     // `handle_move_card`'s column_list tracking block to actually run.
-    app.execute_command(kanban_domain::commands::Command::Board(
-        kanban_domain::commands::BoardCommand::SetTaskListView(
-            kanban_domain::commands::SetBoardTaskListView {
-                board_id: board.id,
-                view: kanban_domain::TaskListView::ColumnView,
-            },
-        ),
-    ))
-    .unwrap();
+    let _ = app
+        .execute_command(kanban_domain::commands::Command::Board(
+            kanban_domain::commands::BoardCommand::SetTaskListView(
+                kanban_domain::commands::SetBoardTaskListView {
+                    board_id: board.id,
+                    view: kanban_domain::TaskListView::ColumnView,
+                },
+            ),
+        ))
+        .unwrap();
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
     app.reload_model();
     app.prepare_frame();


### PR DESCRIPTION
## Summary

Replaces the wholesale `App::reload_model()` call at 17 card/board/column mutation sites with `App::resolve_after_command(inv)`, which feeds the mutation's own `Invalidation` into `KanbanContext::resync_invalidated` alongside the current `ViewScope`. A mutation now refetches only the tiers it dirtied plus the scoped tiers the current screen reads, instead of doing a full model reload (`ctx.snapshot()`) on every card, board or column edit.

- Widens `App`/`TuiContext` `execute_command`, `execute_commands_batch`, `execute_with`, `execute_with_extra` to return the batch's `Invalidation` instead of discarding it.
- Adds `TuiContext::resync_invalidated` plus `update_card_impl`/`update_cards_impl`/`move_card_impl` forwarders for the sites that previously mutated through the `KanbanOperations` trait.
- Adds `App::resolve_after_command(inv)` in `view_management.rs`, the new sink every converted handler calls in place of `reload_model()`.
- Converts 17 card/board/column handler sites (rename/create/delete/move for columns, create/rename board, toggle sort order, select task list view, create card, toggle/move card completion including the multi-select and empty-batch paths).
- Restructures the two empty-batch sites (`toggle_selected_cards_completion`, `move_selected_cards`) so a selection that resolves to nothing issues no refetch read.
- Extracts `apply_board_settings`/`apply_card_metadata` as `pub` `App` methods so a failed mutation on those two paths also issues no refetch read.
- `create_board` scopes the resolve to the newly created board (setting and restoring `selection.active_board_id` around the call) so the new board's column tier is populated even though it isn't the highlighted board yet when the resolve runs.
- Keeps `reload_model()` at the four archival read-then-toggle sites (`restore_card`, the archived-cards/archived-boards absorption toggles, `delete_board`), which need archival bodies no fetch plan can request.

## Test plan

- [x] New `crates/kanban-tui/tests/mutation_refetch_tests.rs`: 21 tests pinning the exact refetch shape (no `snapshot` op, the specific `list_*` tiers re-requested, the specific tiers left alone) for every converted handler, plus a census test asserting the four handler files carry exactly 10 remaining production `reload_model()` calls.
- [x] Confirmed every new test fails against the pre-change code (RED), all failures triggered by the intended discriminator (a `snapshot` op present, or the wrong `reload_model()` count).
- [x] Mutation-tested the central `delete_column` cascade assertion: hand-narrowing the resolve to `EntityIds::columns([id])` instead of the batch's real `Invalidation` kills the test; reverted.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace` (253 test-result blocks, all ok)
- [x] `cargo check --workspace --all-targets`
