### PR TITLE
KAN-1366 refactor(tui): refetch only what a sprint, dialog or popup mutation invalidated

### DIFF
--- a/.changeset/kan-1366-tui-sprint-dialog-popup-refetch.md
+++ b/.changeset/kan-1366-tui-sprint-dialog-popup-refetch.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: refetch only what a sprint, dialog or popup mutation invalidated instead of reloading the whole model

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -979,28 +979,31 @@ impl App {
                         CardListAction::Complete(card_id) => {
                             if let LoadState::Loaded(cards) = self.model.cards_state() {
                                 if let Some(card) = cards.iter().find(|c| c.id == card_id) {
-                                    use kanban_domain::{CardStatus, CardUpdate, KanbanOperations};
+                                    use kanban_domain::CardStatus;
                                     let new_status = if card.status == CardStatus::Done {
                                         CardStatus::Todo
                                     } else {
                                         CardStatus::Done
                                     };
 
-                                    // Service layer chains the column move automatically.
-                                    if let Err(e) = self.ctx.update_card(
+                                    match self.ctx.update_card_impl(
                                         card_id,
-                                        CardUpdate {
+                                        kanban_domain::CardUpdate {
                                             status: Some(new_status),
                                             ..Default::default()
                                         },
                                     ) {
-                                        tracing::error!("Failed to toggle card completion: {}", e);
-                                        self.set_error(format!(
-                                            "Failed to toggle card completion: {}",
-                                            e
-                                        ));
-                                    } else {
-                                        self.reload_model();
+                                        Ok((_, inv)) => self.resolve_after_command(inv),
+                                        Err(e) => {
+                                            tracing::error!(
+                                                "Failed to toggle card completion: {}",
+                                                e
+                                            );
+                                            self.set_error(format!(
+                                                "Failed to toggle card completion: {}",
+                                                e
+                                            ));
+                                        }
                                     }
                                 }
                             } else {
@@ -1073,16 +1076,16 @@ impl App {
                             };
 
                             if let Some(result) = move_result {
-                                use kanban_domain::KanbanOperations;
-                                // Service layer chains the status flip when the
-                                // move crosses the completion-column boundary.
-                                if let Err(e) =
-                                    self.ctx.move_card(card_id, result.target_column_id, None)
-                                {
-                                    tracing::error!("Failed to move card: {}", e);
-                                    self.set_error(format!("Failed to move card: {}", e));
-                                } else {
-                                    self.reload_model();
+                                match self.ctx.move_card_impl(
+                                    card_id,
+                                    result.target_column_id,
+                                    None,
+                                ) {
+                                    Ok((_, inv)) => self.resolve_after_command(inv),
+                                    Err(e) => {
+                                        tracing::error!("Failed to move card: {}", e);
+                                        self.set_error(format!("Failed to move card: {}", e));
+                                    }
                                 }
                             }
                         }

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -223,13 +223,16 @@ impl App {
                             },
                         ),
                     );
-                    if let Err(e) = self.execute_command(cmd) {
-                        tracing::error!("Failed to set card points: {}", e);
-                        self.set_error(format!("Failed to set card points: {}", e));
-                    } else {
-                        tracing::info!("Set points to: {:?}", points);
+                    match self.execute_command(cmd) {
+                        Ok(inv) => {
+                            tracing::info!("Set points to: {:?}", points);
+                            self.resolve_after_command(inv);
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to set card points: {}", e);
+                            self.set_error(format!("Failed to set card points: {}", e));
+                        }
                     }
-                    self.reload_model();
                 }
                 self.pop_mode();
                 self.input.clear();
@@ -266,16 +269,19 @@ impl App {
                                             },
                                         ),
                                     );
-                                    if let Err(e) = self.execute_command(cmd) {
-                                        tracing::error!("Failed to clear sprint prefix: {}", e);
-                                        self.set_error(format!(
-                                            "Failed to clear sprint prefix: {}",
-                                            e
-                                        ));
-                                    } else {
-                                        tracing::info!("Cleared sprint prefix");
+                                    match self.execute_command(cmd) {
+                                        Ok(inv) => {
+                                            tracing::info!("Cleared sprint prefix");
+                                            self.resolve_after_command(inv);
+                                        }
+                                        Err(e) => {
+                                            tracing::error!("Failed to clear sprint prefix: {}", e);
+                                            self.set_error(format!(
+                                                "Failed to clear sprint prefix: {}",
+                                                e
+                                            ));
+                                        }
                                     }
-                                    self.reload_model();
                                 }
                             }
                         }
@@ -294,16 +300,22 @@ impl App {
                                                 },
                                             ),
                                         );
-                                        if let Err(e) = self.execute_command(cmd) {
-                                            tracing::error!("Failed to clear sprint prefix: {}", e);
-                                            self.set_error(format!(
-                                                "Failed to clear sprint prefix: {}",
-                                                e
-                                            ));
-                                        } else {
-                                            tracing::info!("Cleared sprint prefix");
+                                        match self.execute_command(cmd) {
+                                            Ok(inv) => {
+                                                tracing::info!("Cleared sprint prefix");
+                                                self.resolve_after_command(inv);
+                                            }
+                                            Err(e) => {
+                                                tracing::error!(
+                                                    "Failed to clear sprint prefix: {}",
+                                                    e
+                                                );
+                                                self.set_error(format!(
+                                                    "Failed to clear sprint prefix: {}",
+                                                    e
+                                                ));
+                                            }
                                         }
-                                        self.reload_model();
                                     }
                                     LoadState::Missing => {}
                                     _ => {
@@ -327,19 +339,24 @@ impl App {
                                                 },
                                             ),
                                         );
-                                        if let Err(e) = self.execute_command(cmd) {
-                                            tracing::error!(
-                                                "Failed to clear sprint card prefix override: {}",
-                                                e
-                                            );
-                                            self.set_error(format!(
-                                                "Failed to clear sprint card prefix override: {}",
-                                                e
-                                            ));
-                                        } else {
-                                            tracing::info!("Cleared sprint card prefix override");
+                                        match self.execute_command(cmd) {
+                                            Ok(inv) => {
+                                                tracing::info!(
+                                                    "Cleared sprint card prefix override"
+                                                );
+                                                self.resolve_after_command(inv);
+                                            }
+                                            Err(e) => {
+                                                tracing::error!(
+                                                    "Failed to clear sprint card prefix override: {}",
+                                                    e
+                                                );
+                                                self.set_error(format!(
+                                                    "Failed to clear sprint card prefix override: {}",
+                                                    e
+                                                ));
+                                            }
                                         }
-                                        self.reload_model();
                                     }
                                     LoadState::Missing => {}
                                     _ => {
@@ -367,16 +384,19 @@ impl App {
                                             },
                                         ),
                                     );
-                                    if let Err(e) = self.execute_command(cmd) {
-                                        tracing::error!("Failed to set sprint prefix: {}", e);
-                                        self.set_error(format!(
-                                            "Failed to set sprint prefix: {}",
-                                            e
-                                        ));
-                                    } else {
-                                        tracing::info!("Set sprint prefix to: {}", prefix_str);
+                                    match self.execute_command(cmd) {
+                                        Ok(inv) => {
+                                            tracing::info!("Set sprint prefix to: {}", prefix_str);
+                                            self.resolve_after_command(inv);
+                                        }
+                                        Err(e) => {
+                                            tracing::error!("Failed to set sprint prefix: {}", e);
+                                            self.set_error(format!(
+                                                "Failed to set sprint prefix: {}",
+                                                e
+                                            ));
+                                        }
                                     }
-                                    self.reload_model();
                                 }
                             }
                         }
@@ -397,16 +417,25 @@ impl App {
                                                 },
                                             ),
                                         );
-                                        if let Err(e) = self.execute_command(cmd) {
-                                            tracing::error!("Failed to set sprint prefix: {}", e);
-                                            self.set_error(format!(
-                                                "Failed to set sprint prefix: {}",
-                                                e
-                                            ));
-                                        } else {
-                                            tracing::info!("Set sprint prefix to: {}", prefix_str);
+                                        match self.execute_command(cmd) {
+                                            Ok(inv) => {
+                                                tracing::info!(
+                                                    "Set sprint prefix to: {}",
+                                                    prefix_str
+                                                );
+                                                self.resolve_after_command(inv);
+                                            }
+                                            Err(e) => {
+                                                tracing::error!(
+                                                    "Failed to set sprint prefix: {}",
+                                                    e
+                                                );
+                                                self.set_error(format!(
+                                                    "Failed to set sprint prefix: {}",
+                                                    e
+                                                ));
+                                            }
                                         }
-                                        self.reload_model();
                                     }
                                     LoadState::Missing => {}
                                     _ => {
@@ -432,22 +461,25 @@ impl App {
                                                 },
                                             ),
                                         );
-                                        if let Err(e) = self.execute_command(cmd) {
-                                            tracing::error!(
-                                                "Failed to set sprint card prefix override: {}",
-                                                e
-                                            );
-                                            self.set_error(format!(
-                                                "Failed to set sprint card prefix override: {}",
-                                                e
-                                            ));
-                                        } else {
-                                            tracing::info!(
-                                                "Set sprint card prefix override to: {}",
-                                                prefix_str
-                                            );
+                                        match self.execute_command(cmd) {
+                                            Ok(inv) => {
+                                                tracing::info!(
+                                                    "Set sprint card prefix override to: {}",
+                                                    prefix_str
+                                                );
+                                                self.resolve_after_command(inv);
+                                            }
+                                            Err(e) => {
+                                                tracing::error!(
+                                                    "Failed to set sprint card prefix override: {}",
+                                                    e
+                                                );
+                                                self.set_error(format!(
+                                                    "Failed to set sprint card prefix override: {}",
+                                                    e
+                                                ));
+                                            }
                                         }
-                                        self.reload_model();
                                     }
                                     LoadState::Missing => {}
                                     _ => {

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,7 +1,7 @@
 use crate::app::{App, AppMode};
 use crossterm::event::KeyCode;
 use kanban_domain::commands::{ColumnCommand, Command, UpdateColumn};
-use kanban_domain::{ColumnUpdate, GraphOperations, KanbanOperations, LoadState, SortOrder};
+use kanban_domain::{ColumnUpdate, LoadState, SortOrder};
 
 const PRIORITY_COUNT: usize = 4;
 const DEFAULT_STATUS_COUNT: usize = 5;
@@ -73,11 +73,16 @@ impl App {
                                     },
                                 ),
                             );
-                            if let Err(e) = self.execute_command(cmd) {
-                                tracing::error!("Failed to update card priority: {}", e);
-                                self.set_error(format!("Failed to update card priority: {}", e));
+                            match self.execute_command(cmd) {
+                                Ok(inv) => self.resolve_after_command(inv),
+                                Err(e) => {
+                                    tracing::error!("Failed to update card priority: {}", e);
+                                    self.set_error(format!(
+                                        "Failed to update card priority: {}",
+                                        e
+                                    ));
+                                }
                             }
-                            self.reload_model();
                         }
                     }
                 }
@@ -124,17 +129,19 @@ impl App {
                                                     },
                                                 },
                                             ));
-                                            if let Err(e) = self.execute_command(cmd) {
-                                                tracing::error!(
-                                                    "Failed to update column default status: {}",
-                                                    e
-                                                );
-                                                self.set_error(format!(
-                                                    "Failed to update column default status: {}",
-                                                    e
-                                                ));
+                                            match self.execute_command(cmd) {
+                                                Ok(inv) => self.resolve_after_command(inv),
+                                                Err(e) => {
+                                                    tracing::error!(
+                                                        "Failed to update column default status: {}",
+                                                        e
+                                                    );
+                                                    self.set_error(format!(
+                                                        "Failed to update column default status: {}",
+                                                        e
+                                                    ));
+                                                }
                                             }
-                                            self.reload_model();
                                         }
                                     }
                                     _ => {
@@ -195,17 +202,20 @@ impl App {
                     }
 
                     if !commands.is_empty() {
-                        if let Err(e) = self.execute_commands_batch(commands) {
-                            tracing::error!("Failed to update cards priority: {}", e);
-                            self.set_error(format!("Failed to update cards priority: {}", e));
-                        } else {
-                            tracing::info!(
-                                "Set priority to {:?} for {} cards",
-                                priority,
-                                card_ids.len()
-                            );
+                        match self.execute_commands_batch(commands) {
+                            Ok(inv) => {
+                                tracing::info!(
+                                    "Set priority to {:?} for {} cards",
+                                    priority,
+                                    card_ids.len()
+                                );
+                                self.resolve_after_command(inv);
+                            }
+                            Err(e) => {
+                                tracing::error!("Failed to update cards priority: {}", e);
+                                self.set_error(format!("Failed to update cards priority: {}", e));
+                            }
                         }
-                        self.reload_model();
                     }
 
                     self.multi_select.selected_cards.clear();
@@ -271,11 +281,13 @@ impl App {
                                 },
                             ),
                         );
-                        if let Err(e) = self.execute_command(cmd) {
-                            tracing::error!("Failed to set board task sort: {}", e);
-                            self.set_error(format!("Failed to set board task sort: {}", e));
+                        match self.execute_command(cmd) {
+                            Ok(inv) => self.resolve_after_command(inv),
+                            Err(e) => {
+                                tracing::error!("Failed to set board task sort: {}", e);
+                                self.set_error(format!("Failed to set board task sort: {}", e));
+                            }
                         }
-                        self.reload_model();
                     }
 
                     let is_sprint_detail = self.selection.active_sprint_id.is_some();
@@ -407,11 +419,13 @@ impl App {
                     None
                 };
                 if let Some(cmd) = cmd {
-                    if let Err(e) = self.execute_commands_batch(vec![cmd]) {
-                        tracing::error!("Failed to update card sprint: {}", e);
-                        self.set_error(format!("Failed to update card sprint: {}", e));
+                    match self.execute_commands_batch(vec![cmd]) {
+                        Ok(inv) => self.resolve_after_command(inv),
+                        Err(e) => {
+                            tracing::error!("Failed to update card sprint: {}", e);
+                            self.set_error(format!("Failed to update card sprint: {}", e));
+                        }
                     }
-                    self.reload_model();
                 }
                 self.pop_mode();
                 self.dialog_input.assign_sprint_picker.clear();
@@ -486,11 +500,13 @@ impl App {
                     Vec::new()
                 };
                 if !cmds.is_empty() {
-                    if let Err(e) = self.execute_commands_batch(cmds) {
-                        tracing::error!("Failed to update cards' sprint: {}", e);
-                        self.set_error(format!("Failed to update cards' sprint: {}", e));
+                    match self.execute_commands_batch(cmds) {
+                        Ok(inv) => self.resolve_after_command(inv),
+                        Err(e) => {
+                            tracing::error!("Failed to update cards' sprint: {}", e);
+                            self.set_error(format!("Failed to update cards' sprint: {}", e));
+                        }
                     }
-                    self.reload_model();
                 }
                 self.pop_mode();
                 self.dialog_input.assign_sprint_picker.clear();
@@ -598,12 +614,12 @@ impl App {
                                                 _ => "sprint".to_string(),
                                             };
 
-                                            match self
-                                                .ctx
-                                                .carry_over_sprint_cards(source_id, to_sprint_id)
-                                            {
-                                                Ok(count) => {
-                                                    self.reload_model();
+                                            match self.ctx.carry_over_sprint_cards_impl(
+                                                source_id,
+                                                to_sprint_id,
+                                            ) {
+                                                Ok((count, inv)) => {
+                                                    self.resolve_after_command(inv);
                                                     self.set_success(format!(
                                                         "Carried over {} card(s) to {}",
                                                         count, sprint_label
@@ -731,13 +747,13 @@ impl App {
                                 let was_selected =
                                     self.relationship.selected.contains(&selected_card_id);
                                 let result = if was_selected {
-                                    self.ctx.detach_child(parent_id, child_id)
+                                    self.ctx.detach_children_impl(parent_id, vec![child_id])
                                 } else {
-                                    self.ctx.attach_child(parent_id, child_id)
+                                    self.ctx.attach_children_impl(parent_id, vec![child_id])
                                 };
                                 match result {
-                                    Ok(()) => {
-                                        self.reload_model();
+                                    Ok(inv) => {
+                                        self.resolve_after_command(inv);
                                         if was_selected {
                                             self.relationship.selected.remove(&selected_card_id);
                                         } else {

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -60,12 +60,15 @@ impl App {
                             },
                         }));
 
-                        if let Err(e) = self.execute_commands_batch(vec![activate_cmd, board_cmd]) {
-                            tracing::error!("Failed to activate sprint: {}", e);
-                            self.set_error(format!("Failed to activate sprint: {}", e));
-                            return;
-                        }
-                        self.reload_model();
+                        let inv = match self.execute_commands_batch(vec![activate_cmd, board_cmd]) {
+                            Ok(inv) => inv,
+                            Err(e) => {
+                                tracing::error!("Failed to activate sprint: {}", e);
+                                self.set_error(format!("Failed to activate sprint: {}", e));
+                                return;
+                            }
+                        };
+                        self.resolve_after_command(inv);
 
                         tracing::info!("Activated sprint: {}", sprint_name);
                     }
@@ -115,12 +118,15 @@ impl App {
                     },
                 }));
 
-                if let Err(e) = self.execute_commands_batch(vec![complete_cmd, board_cmd]) {
-                    tracing::error!("Failed to complete sprint: {}", e);
-                    self.set_error(format!("Failed to complete sprint: {}", e));
-                    return;
-                }
-                self.reload_model();
+                let inv = match self.execute_commands_batch(vec![complete_cmd, board_cmd]) {
+                    Ok(inv) => inv,
+                    Err(e) => {
+                        tracing::error!("Failed to complete sprint: {}", e);
+                        self.set_error(format!("Failed to complete sprint: {}", e));
+                        return;
+                    }
+                };
+                self.resolve_after_command(inv);
 
                 self.filter.active_sprint_filters.remove(&sprint_id);
 
@@ -232,12 +238,15 @@ impl App {
                 auto_consume_name: true,
             }));
 
-            if let Err(e) = self.execute_command(cmd) {
-                tracing::error!("Failed to create sprint: {}", e);
-                self.set_error(format!("Failed to create sprint: {}", e));
-                return;
-            }
-            self.reload_model();
+            let inv = match self.execute_command(cmd) {
+                Ok(inv) => inv,
+                Err(e) => {
+                    tracing::error!("Failed to create sprint: {}", e);
+                    self.set_error(format!("Failed to create sprint: {}", e));
+                    return;
+                }
+            };
+            self.resolve_after_command(inv);
 
             tracing::info!("Created sprint (id: {})", sprint_id);
 

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -101,6 +101,35 @@ impl TuiContext {
         self.with_flush(r)
     }
 
+    pub fn carry_over_sprint_cards_impl(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<(usize, kanban_domain::Invalidation)> {
+        let r = self
+            .inner
+            .carry_over_sprint_cards_impl(from_sprint_id, to_sprint_id);
+        self.with_flush(r)
+    }
+
+    pub fn attach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<kanban_domain::Invalidation> {
+        let r = self.inner.attach_children_impl(parent, children);
+        self.with_flush(r)
+    }
+
+    pub fn detach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<kanban_domain::Invalidation> {
+        let r = self.inner.detach_children_impl(parent, children);
+        self.with_flush(r)
+    }
+
     // --- Delegation: state methods ---
 
     pub fn undo(&mut self) -> KanbanResult<bool> {

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -714,7 +714,7 @@ fn test_no_converted_card_board_or_column_handler_still_reloads_wholesale() {
     }
 
     assert_eq!(production_reload_model_count(card_handlers), 2);
-    assert_eq!(production_reload_model_count(detail_view_handlers), 2);
+    assert_eq!(production_reload_model_count(detail_view_handlers), 0);
     assert_eq!(production_reload_model_count(board_handlers), 6);
     assert_eq!(production_reload_model_count(column_handlers), 0);
 

--- a/crates/kanban-tui/tests/sprint_dialog_refetch_tests.rs
+++ b/crates/kanban-tui/tests/sprint_dialog_refetch_tests.rs
@@ -1,0 +1,917 @@
+//! Every test here drives its handler method directly, never through
+//! `handle_key_event`, and never asserts a per-id `get_card`/`get_sprint`
+//! op: `InvalidationPlan` only keeps a per-id tier that a prior per-id read
+//! populated, and none of these code paths issue one.
+
+mod helpers;
+
+use crossterm::event::KeyCode;
+use helpers::{CountingBackend, ReadOp, ReadOpLog};
+use kanban_domain::commands::{Command, DeleteSprint, SprintCommand};
+use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+use uuid::Uuid;
+
+struct Seed {
+    board: Uuid,
+    c1: Uuid,
+    c2: Uuid,
+    k1: Uuid,
+    k2: Uuid,
+    sprint_a: Uuid,
+}
+
+fn seed_board_two_columns_two_cards_one_sprint(app: &mut App) -> Seed {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let c2 = app
+        .ctx
+        .create_column(board.id, "C2".to_string(), Some(1))
+        .unwrap();
+    let k1 = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "K1".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let k2 = app
+        .ctx
+        .create_card(
+            board.id,
+            c2.id,
+            "K2".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let sprint_a = app.ctx.create_sprint(board.id, None, None).unwrap();
+    Seed {
+        board: board.id,
+        c1: c1.id,
+        c2: c2.id,
+        k1: k1.id,
+        k2: k2.id,
+        sprint_a: sprint_a.id,
+    }
+}
+
+/// Wraps the backend in a `CountingBackend`, runs `load_initial_state`
+/// (the scope-priming idiom every test in this module must use, never
+/// `reload_model`), and clears the op log so only the handler-under-test's
+/// reads are recorded.
+async fn prime(app: &mut App) -> ReadOpLog {
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+    app.load_initial_state().await;
+    ops.lock().unwrap().clear();
+    ops
+}
+
+/// Narrows the raw op log to the refetch-shaped reads: `snapshot`,
+/// `get_graph`, and every `list_*` except `list_prefixes` (issued by
+/// create-time builders as part of the mutation itself, not the refetch).
+fn refetch_ops(log: &ReadOpLog) -> Vec<ReadOp> {
+    log.lock()
+        .unwrap()
+        .iter()
+        .filter(|op| {
+            (op.method == "snapshot" || op.method == "get_graph" || op.method.starts_with("list_"))
+                && op.method != "list_prefixes"
+        })
+        .cloned()
+        .collect()
+}
+
+fn has_op(ops: &[ReadOp], method: &str) -> bool {
+    ops.iter().any(|op| op.method == method)
+}
+
+fn has_op_with_id(ops: &[ReadOp], method: &str, id: Uuid) -> bool {
+    ops.iter()
+        .any(|op| op.method == method && op.ids.contains(&id))
+}
+
+fn select_column(app: &mut App, board_id: Uuid, column_id: Uuid) {
+    let columns = kanban_domain::card_lifecycle::sorted_board_columns(
+        board_id,
+        app.model.columns_state().loaded_or_empty(),
+    );
+    let idx = columns
+        .iter()
+        .position(|c| c.id == column_id)
+        .expect("column visible");
+    app.dialog_input
+        .column_list
+        .update_item_count(columns.len());
+    app.dialog_input.column_list.set_selected_index(Some(idx));
+}
+
+#[tokio::test]
+async fn test_activate_sprint_refetches_the_sprint_and_board_tiers_without_a_snapshot() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_sprint_id = Some(seed.sprint_a);
+    app.mode = AppMode::BoardDetail;
+
+    app.handle_activate_sprint_key();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_sprints_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_boards"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_complete_sprint_refetches_the_sprint_and_board_tiers_but_not_the_card_tier() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx
+        .activate_sprint(sprint.id, Some(14))
+        .expect("activate");
+    let k1 = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "K1".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.assign_card_to_sprint(k1.id, sprint.id).unwrap();
+    let k2 = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "K2".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.assign_card_to_sprint(k2.id, sprint.id).unwrap();
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.selection.active_sprint_id = Some(sprint.id);
+    app.mode = AppMode::SprintDetail;
+
+    app.handle_complete_sprint_key();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_create_sprint_falls_back_to_a_whole_model_reset_because_its_inverse_is_unenumerable()
+{
+    assert_eq!(
+        Command::Sprint(SprintCommand::Delete(DeleteSprint {
+            sprint_id: Uuid::new_v4(),
+            timestamp: chrono::Utc::now(),
+        }))
+        .touched_entities(),
+        None
+    );
+
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.input.set("Alpha".to_string());
+    app.create_sprint();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", board.id),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_boards"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_set_card_points_refetches_the_card_tiers_only() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_card_id = Some(seed.k1);
+    app.input.set("3".to_string());
+    app.handle_set_card_points_dialog(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c2),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_set_card_points_failure_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+
+    let ops = prime(&mut app).await;
+    app.ctx.data_store().delete_card(seed.k1).unwrap();
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_card_id = Some(seed.k1);
+    app.input.set("3".to_string());
+    app.handle_set_card_points_dialog(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+    assert!(app.ui_state.banner.is_some());
+}
+
+#[tokio::test]
+async fn test_prefix_dialog_board_branches_refetch_the_board_list_and_never_the_sprint_list() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.mode = AppMode::Dialog(DialogMode::SetBranchPrefix);
+
+    app.input.set("ABC".to_string());
+    app.handle_set_branch_prefix_dialog(KeyCode::Enter);
+
+    {
+        let refetch = refetch_ops(&ops);
+        assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+        assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+        assert!(
+            has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+            "got {refetch:?}"
+        );
+        assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+        assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+        assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+        assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+    }
+
+    ops.lock().unwrap().clear();
+    app.mode = AppMode::Dialog(DialogMode::SetBranchPrefix);
+    app.input.set(String::new());
+    app.handle_set_branch_prefix_dialog(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_prefix_dialog_sprint_branches_refetch_the_sprint_list_and_never_the_board_list() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_sprint_id = Some(seed.sprint_a);
+    app.mode = AppMode::Dialog(DialogMode::SetSprintPrefix);
+
+    app.input.set("ABC".to_string());
+    app.handle_set_sprint_prefix_dialog(KeyCode::Enter);
+
+    {
+        let refetch = refetch_ops(&ops);
+        assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+        assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+        assert!(
+            has_op_with_id(&refetch, "list_sprints_by_board", seed.board),
+            "got {refetch:?}"
+        );
+        assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+        assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+        assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    }
+    assert!(app.model.board_sprints_state(seed.board).is_loaded());
+
+    ops.lock().unwrap().clear();
+    app.mode = AppMode::Dialog(DialogMode::SetSprintPrefix);
+    app.input.set(String::new());
+    app.handle_set_sprint_prefix_dialog(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_sprints_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_prefix_dialog_sprint_card_branches_refetch_the_sprint_list_and_never_the_card_tier() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_sprint_id = Some(seed.sprint_a);
+    app.mode = AppMode::Dialog(DialogMode::SetSprintCardPrefix);
+
+    app.input.set("XYZ".to_string());
+    app.handle_set_sprint_card_prefix_dialog(KeyCode::Enter);
+
+    {
+        let refetch = refetch_ops(&ops);
+        assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+        assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+        assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+        assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+    }
+
+    ops.lock().unwrap().clear();
+    app.mode = AppMode::Dialog(DialogMode::SetSprintCardPrefix);
+    app.input.set(String::new());
+    app.handle_set_sprint_card_prefix_dialog(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_prefix_dialog_board_branch_failure_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+
+    let ops = prime(&mut app).await;
+    app.ctx.data_store().delete_board(seed.board).unwrap();
+
+    app.selection.active_board_id = Some(seed.board);
+    app.mode = AppMode::Dialog(DialogMode::SetBranchPrefix);
+    app.input.set("ABC".to_string());
+    app.handle_set_branch_prefix_dialog(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+    assert!(app.ui_state.banner.is_some());
+}
+
+#[tokio::test]
+async fn test_prefix_dialog_sprint_branch_failure_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+
+    let ops = prime(&mut app).await;
+    app.ctx.data_store().delete_sprint(seed.sprint_a).unwrap();
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_sprint_id = Some(seed.sprint_a);
+    app.mode = AppMode::Dialog(DialogMode::SetSprintPrefix);
+    app.input.set("ABC".to_string());
+    app.handle_set_sprint_prefix_dialog(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+    assert!(app.ui_state.banner.is_some());
+}
+
+#[tokio::test]
+async fn test_set_card_priority_refetches_the_card_tiers_only() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_card_id = Some(seed.k1);
+    app.dialog_input.priority_selection.set(Some(3));
+    app.handle_set_card_priority_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c2),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_set_card_priority_failure_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+
+    let ops = prime(&mut app).await;
+    app.ctx.data_store().delete_card(seed.k1).unwrap();
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_card_id = Some(seed.k1);
+    app.dialog_input.priority_selection.set(Some(3));
+    app.handle_set_card_priority_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+    assert!(app.ui_state.banner.is_some());
+}
+
+#[tokio::test]
+async fn test_set_column_default_status_refetches_the_column_tiers_not_the_card_list() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    select_column(&mut app, seed.board, seed.c1);
+    app.dialog_input.default_status_selection.set(Some(0));
+    app.handle_set_column_default_status_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+    assert!(
+        !has_op_with_id(&refetch, "list_cards_by_column", seed.c2),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_set_multiple_cards_priority_refetches_the_card_tiers_once_for_the_whole_batch() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let mut ids = Vec::new();
+    for i in 0..4 {
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                c1.id,
+                format!("K{i}"),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        ids.push(card.id);
+    }
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.multi_select.selected_cards.insert(ids[0]);
+    app.multi_select.selected_cards.insert(ids[1]);
+    app.dialog_input.priority_selection.set(Some(2));
+    app.handle_set_multiple_cards_priority_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert_eq!(
+        refetch
+            .iter()
+            .filter(|op| op.method == "list_all_cards")
+            .count(),
+        1,
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c1.id),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_order_cards_popup_refetches_the_board_list_not_the_card_tier() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_sprint_id = None;
+    app.filter.sort_field_selection.set(Some(0));
+    app.handle_order_cards_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_assign_card_to_sprint_refetches_the_card_tiers_not_the_sprint_list() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_card_id = Some(seed.k1);
+    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+    let board = app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .iter()
+        .find(|b| b.id == seed.board)
+        .cloned()
+        .expect("board loaded");
+    app.dialog_input
+        .assign_sprint_picker
+        .reset_for_card_assignment(Some(seed.sprint_a), &sprints, &board, chrono::Utc::now());
+
+    app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(
+        !has_op(&refetch, "list_sprints_by_board"),
+        "got {refetch:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_assign_card_to_sprint_failure_issues_no_refetch_read() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.selection.active_card_id = Some(seed.k1);
+    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+    let board = app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .iter()
+        .find(|b| b.id == seed.board)
+        .cloned()
+        .expect("board loaded");
+    app.dialog_input
+        .assign_sprint_picker
+        .reset_for_card_assignment(Some(seed.sprint_a), &sprints, &board, chrono::Utc::now());
+
+    app.ctx.data_store().delete_sprint(seed.sprint_a).unwrap();
+
+    app.handle_assign_card_to_sprint_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(refetch.is_empty(), "got {refetch:?}");
+    assert!(app.ui_state.banner.is_some());
+}
+
+#[tokio::test]
+async fn test_assign_multiple_cards_to_sprint_refetches_the_card_tiers_not_the_sprint_list() {
+    let mut app = App::test_default();
+    let seed = seed_board_two_columns_two_cards_one_sprint(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(seed.board);
+    app.multi_select.selected_cards.insert(seed.k1);
+    app.multi_select.selected_cards.insert(seed.k2);
+    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+    let board = app
+        .model
+        .boards_state()
+        .loaded_or_empty()
+        .iter()
+        .find(|b| b.id == seed.board)
+        .cloned()
+        .expect("board loaded");
+    app.dialog_input
+        .assign_sprint_picker
+        .reset_for_card_assignment(Some(seed.sprint_a), &sprints, &board, chrono::Utc::now());
+
+    app.handle_assign_multiple_cards_to_sprint_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert_eq!(
+        refetch
+            .iter()
+            .filter(|op| op.method == "list_all_cards")
+            .count(),
+        1,
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(
+        !has_op(&refetch, "list_sprints_by_board"),
+        "got {refetch:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_carry_over_sprint_refetches_the_card_tiers_not_the_sprint_list() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let source = app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx.activate_sprint(source.id, Some(14)).unwrap();
+    app.ctx.complete_sprint(source.id).unwrap();
+    let target = app.ctx.create_sprint(board.id, None, None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "K1".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.assign_card_to_sprint(card.id, source.id).unwrap();
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.dialog_input.carry_over_source_sprint_id = Some(source.id);
+    app.dialog_input.carry_over_sprint_selection.set(Some(0));
+    app.handle_carry_over_sprint_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    let _ = target;
+}
+
+#[tokio::test]
+async fn test_relationship_popup_add_edge_refetches_the_graph_and_the_card_tiers() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let a = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "A".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let b = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "B".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_card_id = Some(a.id);
+    app.relationship.card_ids = vec![b.id];
+    app.relationship.selected.clear();
+    app.relationship.selection.set(Some(0));
+    app.mode = AppMode::Dialog(DialogMode::ManageChildren);
+
+    app.handle_manage_children_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_relationship_popup_remove_edge_refetches_the_graph_and_the_card_tiers() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let a = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "A".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let b = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "B".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.attach_child(b.id, a.id).unwrap();
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_card_id = Some(a.id);
+    app.relationship.card_ids = vec![b.id];
+    app.relationship.selected = std::collections::HashSet::from([b.id]);
+    app.relationship.selection.set(Some(0));
+    app.mode = AppMode::Dialog(DialogMode::ManageParents);
+
+    app.handle_manage_parents_popup(KeyCode::Enter);
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "get_graph"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+}
+
+#[tokio::test]
+async fn test_sprint_detail_move_card_refetches_the_card_tiers_not_the_column_list() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let c2 = app
+        .ctx
+        .create_column(board.id, "C2".to_string(), Some(1))
+        .unwrap();
+    let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            c1.id,
+            "K1".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.assign_card_to_sprint(card.id, sprint.id).unwrap();
+
+    let snap = kanban_domain::Snapshot {
+        archived_boards: Vec::new(),
+        boards: app.ctx.data_store().list_boards().unwrap(),
+        columns: app.ctx.data_store().list_all_columns().unwrap(),
+        cards: app.ctx.data_store().list_all_cards().unwrap(),
+        archived_cards: app.ctx.data_store().list_archived_cards().unwrap(),
+        sprints: app.ctx.data_store().list_all_sprints().unwrap(),
+        graph: app.ctx.data_store().get_graph().unwrap(),
+        prefixes: Vec::new(),
+    };
+    app.load_snapshot(snap);
+    app.populate_sprint_task_lists(sprint.id);
+    app.sprint_view.panel = kanban_tui::app::sprint_view::SprintTaskPanel::Uncompleted;
+    app.sprint_view
+        .uncompleted_component
+        .update_cards(vec![card.id]);
+    app.sprint_view
+        .uncompleted_component
+        .set_selected_index(Some(0));
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.selection.active_sprint_id = Some(sprint.id);
+    app.mode = AppMode::SprintDetail;
+
+    app.handle_sprint_detail_key(KeyCode::Char('L'));
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c1.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c2.id),
+        "got {refetch:?}"
+    );
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+}
+
+#[test]
+fn test_no_sprint_dialog_or_popup_handler_still_reloads_wholesale() {
+    let sprint_handlers = include_str!("../src/handlers/sprint_handlers.rs");
+    let dialog_handlers = include_str!("../src/handlers/dialog_handlers.rs");
+    let popup_handlers = include_str!("../src/handlers/popup_handlers.rs");
+    let detail_view_handlers = include_str!("../src/handlers/detail_view_handlers.rs");
+
+    fn production_region(src: &str) -> &str {
+        let boundary = src.find("#[cfg(test)]").unwrap_or(src.len());
+        &src[..boundary]
+    }
+
+    for (name, src) in [
+        ("sprint_handlers.rs", sprint_handlers),
+        ("dialog_handlers.rs", dialog_handlers),
+        ("popup_handlers.rs", popup_handlers),
+        ("detail_view_handlers.rs", detail_view_handlers),
+    ] {
+        let region = production_region(src);
+        assert_eq!(
+            region.matches("reload_model()").count(),
+            0,
+            "{name} still reloads wholesale"
+        );
+        assert!(
+            !region.contains("EntityIds") && !region.contains("invalidation_from_inverse"),
+            "{name} introduced a hand-rolled invalidation instead of using resolve_after_command"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Converts the 20 remaining wholesale `App::reload_model()` calls in `sprint_handlers.rs` (3), `dialog_handlers.rs` (7), `popup_handlers.rs` (8) and `detail_view_handlers.rs` (2) to KAN-1365's `App::resolve_after_command(inv)` sink, so each sprint, dialog and popup mutation refetches only what it invalidated instead of resetting the whole model.

Adds three `TuiContext` forwarders (`carry_over_sprint_cards_impl`, `attach_children_impl`, `detach_children_impl`) so the carry-over and manage-relationship popups can surface the `Invalidation` their service call already returns instead of discarding it through the plural `KanbanOperations`/`GraphOperations` trait methods.

Restructures 13 sites whose refetch previously fell through on the error path, so a rejected command now issues no read at all:

| Site | Handler | Shape |
|---|---|---|
| 4 | `handle_set_card_points_dialog` | A |
| 5 | `handle_prefix_dialog_impl` (board sprint, clear) | B |
| 6 | `handle_prefix_dialog_impl` (sprint, clear) | B |
| 7 | `handle_prefix_dialog_impl` (sprint card, clear) | B |
| 8 | `handle_prefix_dialog_impl` (board sprint, set) | B |
| 9 | `handle_prefix_dialog_impl` (sprint, set) | B |
| 10 | `handle_prefix_dialog_impl` (sprint card, set) | B |
| 11 | `handle_set_card_priority_popup` | A |
| 12 | `handle_set_column_default_status_popup` | A |
| 13 | `handle_set_multiple_cards_priority_popup` | A |
| 14 | `handle_order_cards_popup` | A |
| 15 | `handle_assign_card_to_sprint_popup` | A |
| 16 | `handle_assign_multiple_cards_to_sprint_popup` | A |

Sites 1, 2, 3, 17, 18, 19, 20 already gated their reload behind success and needed only the sink swap.

## Tests


Updates `mutation_refetch_tests.rs`'s `test_no_converted_card_board_or_column_handler_still_reloads_wholesale` expectation for `detail_view_handlers.rs` from 2 to 0, since its two remaining `reload_model()` sites are this change's sites 19 and 20.

## Notes

- `CardListAction::Complete` in `detail_view_handlers.rs`'s `handle_sprint_detail_key` is unreachable in practice: the outer key match intercepts `Char('c')` for the sprint-complete / multi-select-toggle flow before it can fall through to the card-list component's own `'c'` binding. The `reload_model()` call inside that branch was still converted for consistency with the rest of the file, but no behavioral test could be written against it through the public dispatcher (there is no reachable key that reaches that arm). Flagging as a possible follow-up: either remove the dead branch or resolve the key shadowing.

## Test plan

- [x] `cargo test -p kanban-tui`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features --workspace`

