### PR TITLE
KAN-1362 feat(tui): drive Model population from navigation

### DIFF
--- a/.changeset/kan-1362-tui-navigation-population.md
+++ b/.changeset/kan-1362-tui-navigation-population.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+tui: fetch a board's subtree on activation, on projects-panel navigation, and on every key that reaches the dispatcher, so a lazily-populated Model stops missing tiers for boards the user selects without changing AppMode

--- a/crates/kanban-tui/src/app/input_router.rs
+++ b/crates/kanban-tui/src/app/input_router.rs
@@ -5,7 +5,21 @@ use std::io;
 use std::time::Instant;
 
 impl App {
-    pub(in crate::app) fn handle_key_event(
+    /// Dispatches `key`, then resolves whatever the resulting view state
+    /// needs. Wraps `dispatch_key_event` rather than folding the resolve into
+    /// it because the dispatcher has six early returns before its main match.
+    pub fn handle_key_event(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        event_handler: &EventHandler,
+    ) -> bool {
+        let should_restart = self.dispatch_key_event(key, terminal, event_handler);
+        self.resolve_for_view();
+        should_restart
+    }
+
+    fn dispatch_key_event(
         &mut self,
         key: crossterm::event::KeyEvent,
         terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,

--- a/crates/kanban-tui/src/app/mode_stack.rs
+++ b/crates/kanban-tui/src/app/mode_stack.rs
@@ -39,23 +39,18 @@ impl App {
 
     pub fn set_mode(&mut self, new_mode: AppMode) {
         self.mode = new_mode;
-        self.populate_for_current_mode();
+        self.resolve_for_view();
     }
 
     pub fn push_mode(&mut self, new_mode: AppMode) {
         self.mode_stack.push(self.mode.clone());
         self.mode = new_mode;
-        self.populate_for_current_mode();
+        self.resolve_for_view();
     }
 
     pub fn pop_mode(&mut self) {
         self.mode = self.mode_stack.pop().unwrap_or(AppMode::Normal);
-        self.populate_for_current_mode();
-    }
-
-    fn populate_for_current_mode(&mut self) {
-        let scope = self.view_scope();
-        self.populate(scope);
+        self.resolve_for_view();
     }
 
     pub fn is_dialog_mode(&self) -> bool {

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -15,6 +15,18 @@ impl App {
         self.ctx.sync(&scope, &mut self.model, &mut self.controller);
     }
 
+    /// Fetches whatever the current view scope still needs.
+    pub fn resolve_for_view(&mut self) {
+        let scope = self.view_scope();
+        self.populate(scope);
+    }
+
+    /// `resolve_for_view` followed by a `prepare_frame` rebuild.
+    pub fn refresh_view(&mut self) {
+        self.resolve_for_view();
+        self.prepare_frame();
+    }
+
     /// Refetches what `inv` invalidated, plus whatever the current screen
     /// reads, in place of a full `reload_model`.
     pub fn resolve_after_command(&mut self, inv: Invalidation) {

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -123,7 +123,8 @@ impl App {
     }
 
     /// Rebuild the display partitions and task lists from the cached model.
-    /// Pure: performs no store access.
+    /// Pure: performs no store access, unlike `refresh_view`, which fetches
+    /// first.
     pub fn prepare_frame(&mut self) {
         // Single card-side selector: borrow the cached displayed subset (stack-
         // aware base mode). No per-frame filter/clone — the partition was built

--- a/crates/kanban-tui/src/handlers/navigation_handlers.rs
+++ b/crates/kanban-tui/src/handlers/navigation_handlers.rs
@@ -467,9 +467,10 @@ impl App {
                     self.filter.current_sort_field = Some(task_sort_field);
                     self.filter.current_sort_order = Some(task_sort_order);
                     self.switch_view_strategy(task_list_view);
-                    // Populate the tasks panel from the now-active board's subtree
-                    // immediately, so the first item can be selected this tick.
-                    self.prepare_frame();
+                    // Fetch the now-active board's subtree and rebuild the tasks
+                    // panel from it immediately, so the first item can be
+                    // selected this tick.
+                    self.refresh_view();
 
                     if let Some(list) = self.view.strategy.get_active_task_list_mut() {
                         if !list.is_empty() {

--- a/crates/kanban-tui/tests/navigation_fetch.rs
+++ b/crates/kanban-tui/tests/navigation_fetch.rs
@@ -1,0 +1,306 @@
+mod helpers;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use helpers::{CountingBackend, ReadOp, ReadOpLog};
+use kanban_domain::{CreateCardOptions, KanbanOperations, LoadState};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::events::EventHandler;
+use kanban_tui::App;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::Rect;
+use ratatui::{Terminal, TerminalOptions, Viewport};
+use std::io;
+use uuid::Uuid;
+
+struct Seed {
+    b1: Uuid,
+    b2: Uuid,
+    b2_col: Uuid,
+}
+
+fn seed_two_boards(app: &mut App) -> Seed {
+    let board1 = app.ctx.create_board("Board 1".to_string(), None).unwrap();
+    let col1 = app
+        .ctx
+        .create_column(board1.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board1.id,
+            col1.id,
+            "Card 1".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
+        .create_sprint(board1.id, None, Some("Sprint 1".to_string()))
+        .unwrap();
+
+    let board2 = app.ctx.create_board("Board 2".to_string(), None).unwrap();
+    let col2 = app
+        .ctx
+        .create_column(board2.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board2.id,
+            col2.id,
+            "Card 2".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
+        .create_sprint(board2.id, None, Some("Sprint 2".to_string()))
+        .unwrap();
+
+    Seed {
+        b1: board1.id,
+        b2: board2.id,
+        b2_col: col2.id,
+    }
+}
+
+async fn prime(app: &mut App) -> ReadOpLog {
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+    app.load_initial_state().await;
+    ops.lock().unwrap().clear();
+    ops
+}
+
+fn refetch_ops(log: &ReadOpLog) -> Vec<ReadOp> {
+    log.lock()
+        .unwrap()
+        .iter()
+        .filter(|op| {
+            (op.method == "snapshot" || op.method == "get_graph" || op.method.starts_with("list_"))
+                && op.method != "list_prefixes"
+        })
+        .cloned()
+        .collect()
+}
+
+fn has_op_with_id(ops: &[ReadOp], method: &str, id: Uuid) -> bool {
+    ops.iter()
+        .any(|op| op.method == method && op.ids.contains(&id))
+}
+
+fn has_op(ops: &[ReadOp], method: &str) -> bool {
+    ops.iter().any(|op| op.method == method)
+}
+
+fn headless_terminal() -> Terminal<CrosstermBackend<io::Stdout>> {
+    Terminal::with_options(
+        CrosstermBackend::new(io::stdout()),
+        TerminalOptions {
+            viewport: Viewport::Fixed(Rect::new(0, 0, 80, 40)),
+        },
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_activating_a_highlighted_board_fetches_only_that_boards_subtree() {
+    let mut app = App::test_default();
+    let seed = seed_two_boards(&mut app);
+
+    let ops = prime(&mut app).await;
+
+    assert!(app.model.board_columns_state(seed.b1).is_loaded());
+    assert!(!app.model.board_columns_state(seed.b2).is_loaded());
+
+    app.board_list.inner_mut().set_selected_index(Some(1));
+    ops.lock().unwrap().clear();
+    app.focus.active = Focus::Boards;
+    app.handle_selection_activate();
+
+    let ops = refetch_ops(&ops);
+
+    assert!(
+        has_op_with_id(&ops, "list_columns_by_board", seed.b2),
+        "expected list_columns_by_board for board 2, got {ops:?}"
+    );
+    assert!(
+        has_op_with_id(&ops, "list_cards_by_column", seed.b2_col),
+        "expected list_cards_by_column for board 2's column, got {ops:?}"
+    );
+    assert!(!has_op(&ops, "list_boards"), "got {ops:?}");
+    assert!(!has_op(&ops, "list_all_columns"), "got {ops:?}");
+    assert!(!has_op(&ops, "list_all_cards"), "got {ops:?}");
+    assert!(!has_op(&ops, "list_all_sprints"), "got {ops:?}");
+    assert!(!has_op(&ops, "snapshot"), "got {ops:?}");
+}
+
+#[tokio::test]
+async fn test_activating_a_board_loads_its_columns_and_their_cards_in_one_action() {
+    let mut app = App::test_default();
+    let seed = seed_two_boards(&mut app);
+
+    prime(&mut app).await;
+
+    app.board_list.inner_mut().set_selected_index(Some(1));
+    app.focus.active = Focus::Boards;
+    app.handle_selection_activate();
+
+    assert!(app.model.board_columns_state(seed.b2).is_loaded());
+    assert!(matches!(
+        app.model.column_cards_state(seed.b2_col),
+        LoadState::Loaded(_)
+    ));
+}
+
+#[tokio::test]
+async fn test_moving_the_projects_highlight_fetches_the_newly_highlighted_boards_subtree() {
+    let mut app = App::test_default();
+    let seed = seed_two_boards(&mut app);
+
+    let ops = prime(&mut app).await;
+
+    app.focus.active = Focus::Boards;
+    ops.lock().unwrap().clear();
+
+    let mut terminal = headless_terminal();
+    let events = EventHandler::new();
+    app.handle_key_event(KeyEvent::from(KeyCode::Char('j')), &mut terminal, &events);
+
+    assert_eq!(app.board_list.get_selected_board_id(), Some(seed.b2));
+    assert!(app.model.board_columns_state(seed.b2).is_loaded());
+    assert!(matches!(
+        app.model.column_cards_state(seed.b2_col),
+        LoadState::Loaded(_)
+    ));
+
+    let log = ops.lock().unwrap().clone();
+    assert!(
+        has_op_with_id(&log, "list_columns_by_board", seed.b2),
+        "expected list_columns_by_board for board 2, got {log:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_every_early_return_in_the_key_dispatcher_still_fetches_the_view() {
+    async fn fresh_primed_app() -> (App, Seed) {
+        let mut app = App::test_default();
+        let seed = seed_two_boards(&mut app);
+        prime(&mut app).await;
+        app.focus.active = Focus::Boards;
+        app.board_list.inner_mut().set_selected_index(Some(1));
+        (app, seed)
+    }
+
+    let mut terminal = headless_terminal();
+    let events = EventHandler::new();
+
+    // (a) banner clear
+    {
+        let (mut app, seed) = fresh_primed_app().await;
+        app.set_error("x");
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('x')), &mut terminal, &events);
+        assert!(
+            app.model.board_columns_state(seed.b2).is_loaded(),
+            "banner-clear early return must still fetch"
+        );
+    }
+
+    // (b) Ctrl+a
+    {
+        let (mut app, seed) = fresh_primed_app().await;
+        app.handle_key_event(
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL),
+            &mut terminal,
+            &events,
+        );
+        assert!(
+            app.model.board_columns_state(seed.b2).is_loaded(),
+            "ctrl+a early return must still fetch"
+        );
+    }
+
+    // (c) 'q' with no pending saves
+    {
+        let (mut app, seed) = fresh_primed_app().await;
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('q')), &mut terminal, &events);
+        assert!(
+            app.model.board_columns_state(seed.b2).is_loaded(),
+            "quit early return must still fetch"
+        );
+    }
+
+    // (d) F12 already resolves via open_error_log/push_mode
+    {
+        let (mut app, seed) = fresh_primed_app().await;
+        app.handle_key_event(KeyEvent::from(KeyCode::F(12)), &mut terminal, &events);
+        assert!(
+            app.model.board_columns_state(seed.b2).is_loaded(),
+            "F12 must stay Loaded"
+        );
+    }
+
+    // (e) '?' already resolves via set_mode(Help)
+    {
+        let (mut app, seed) = fresh_primed_app().await;
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('?')), &mut terminal, &events);
+        assert!(
+            app.model.board_columns_state(seed.b2).is_loaded(),
+            "'?' must stay Loaded"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_a_failed_scoped_fetch_is_recorded_once_and_retried_on_the_next_key() {
+    let mut app = App::test_default();
+    let seed = seed_two_boards(&mut app);
+    app.load_initial_state().await;
+
+    let inner = app.ctx.backend();
+    let failing = CountingBackend::wrap_failing(inner.clone(), "list_columns_by_board");
+    let (outer, _reads, ops) = CountingBackend::wrap(failing);
+    app.ctx.replace_backend(outer);
+
+    app.focus.active = Focus::Boards;
+    app.board_list.inner_mut().set_selected_index(Some(1));
+    ops.lock().unwrap().clear();
+
+    let mut terminal = headless_terminal();
+    let events = EventHandler::new();
+    app.handle_key_event(KeyEvent::from(KeyCode::Char('j')), &mut terminal, &events);
+
+    assert!(app.model.board_columns_state(seed.b2).is_failed());
+    let log = ops.lock().unwrap().clone();
+    let failing_reads: Vec<_> = log
+        .iter()
+        .filter(|op| op.method == "list_columns_by_board" && op.ids.contains(&seed.b2))
+        .collect();
+    assert_eq!(
+        failing_reads.len(),
+        1,
+        "expected exactly one failing read, got {log:?}"
+    );
+
+    for _ in 0..5 {
+        app.prepare_frame();
+    }
+    let log_after_frames = ops.lock().unwrap().clone();
+    assert_eq!(
+        log_after_frames.len(),
+        log.len(),
+        "prepare_frame must never fetch"
+    );
+
+    let (healthy, _reads2, ops2) = CountingBackend::wrap(inner.clone());
+    app.ctx.replace_backend(healthy);
+    app.handle_key_event(KeyEvent::from(KeyCode::Char('j')), &mut terminal, &events);
+
+    assert!(app.model.board_columns_state(seed.b2).is_loaded());
+    let retry_log = ops2.lock().unwrap().clone();
+    let retries: Vec<_> = retry_log
+        .iter()
+        .filter(|op| op.method == "list_columns_by_board" && op.ids.contains(&seed.b2))
+        .collect();
+    assert_eq!(
+        retries.len(),
+        1,
+        "expected exactly one retry read, got {retry_log:?}"
+    );
+}

--- a/crates/kanban-tui/tests/navigation_fetch.rs
+++ b/crates/kanban-tui/tests/navigation_fetch.rs
@@ -304,3 +304,50 @@ async fn test_a_failed_scoped_fetch_is_recorded_once_and_retried_on_the_next_key
         "expected exactly one retry read, got {retry_log:?}"
     );
 }
+
+#[tokio::test]
+async fn test_reactivating_an_already_loaded_board_reads_nothing() {
+    let mut app = App::test_default();
+    let seed = seed_two_boards(&mut app);
+    let ops = prime(&mut app).await;
+
+    app.board_list.inner_mut().set_selected_index(Some(1));
+    app.focus.active = Focus::Boards;
+    app.handle_selection_activate();
+    assert!(app.model.board_columns_state(seed.b2).is_loaded());
+
+    ops.lock().unwrap().clear();
+    app.handle_escape_key();
+    app.handle_selection_activate();
+
+    let ops = refetch_ops(&ops);
+    assert!(ops.is_empty(), "expected no refetch reads, got {ops:?}");
+}
+
+#[tokio::test]
+async fn test_navigating_away_from_a_failed_panel_does_not_refetch_it() {
+    let mut app = App::test_default();
+    let seed = seed_two_boards(&mut app);
+    app.load_initial_state().await;
+
+    let inner = app.ctx.backend();
+    let failing = CountingBackend::wrap_failing(inner.clone(), "list_columns_by_board");
+    let (outer, _reads, ops) = CountingBackend::wrap(failing);
+    app.ctx.replace_backend(outer);
+
+    app.focus.active = Focus::Boards;
+    app.board_list.inner_mut().set_selected_index(Some(1));
+    app.handle_selection_activate();
+    assert!(app.model.board_columns_state(seed.b2).is_failed());
+
+    ops.lock().unwrap().clear();
+    app.handle_escape_key();
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.handle_selection_activate();
+
+    let log = ops.lock().unwrap().clone();
+    assert!(
+        !has_op_with_id(&log, "list_columns_by_board", seed.b2),
+        "expected no re-read of board 2's failed tier, got {log:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the last missing population seam in the TUI. Selection changes that do
not change `AppMode` (activating a board with Enter, moving the
projects-panel highlight with j/k, and every key that returns early from the
dispatcher) currently fetch nothing, so a lazily-populated Model never gains
an unvisited board's scoped tiers.

- `App::resolve_for_view` (fetch what the current view scope still needs)
  and `App::refresh_view` (`resolve_for_view` then `prepare_frame`), composed
  from the existing `view_scope()` + `populate()` plumbing.
- Hoisted the mode-stack seam onto `resolve_for_view`: `set_mode`,
  `push_mode` and `pop_mode` now call it in place of the private
  `populate_for_current_mode` they each duplicated.
- Split `handle_key_event` into a public wrapper and a private
  `dispatch_key_event`. The wrapper dispatches the key, then calls
  `resolve_for_view`, so every key that changes what the view needs -
  including the six early returns before the dispatcher's main match -
  fetches it. Of those six, only three (banner clear, quit, Ctrl+a) were
  previously uncovered; F12 and `?` already resolved via
  `open_error_log`/`set_mode`.
- `handle_selection_activate`'s `Focus::Boards` arm now calls `refresh_view`
  instead of a bare `prepare_frame`, so activating a highlighted board
  fetches its columns and their cards before the first item is selected.

## Verification

- `git grep -n 'resolve_for_view\|refresh_view' -- crates/kanban-tui/src`
  shows exactly five production call sites (three in `mode_stack.rs`, one in
  `input_router.rs`, one in `navigation_handlers.rs`) plus the two
  definitions in `view_management.rs`.
- `git grep -n 'populate_for_current_mode' -- crates/kanban-tui/src` returns
  nothing.
- `git grep -c 'reload_model' -- crates/kanban-tui/src` (test modules
  excluded) is unchanged at 20 production sites; this PR converts none of
  them.
- `resolve_for_view`/`refresh_view` are two-statement compositions with no
  `?`, `Result`, `match`, loop, `RefCell`, `Mutex` or `Model` clone.

## Test plan

- [x] `cargo test -p kanban-tui --test navigation_fetch` - 7 tests (5 red
      tests specified before implementation, plus 2 green idempotence pins
      added in the refactor commit)
- [x] Mutation-checked the central assertions: reverting `refresh_view` to
      `prepare_frame` in `handle_selection_activate` fails the two activation tests plus the two idempotence pins, which also drive handle_selection_activate (4 failed, 3 passed); removing the `resolve_for_view` call from the
      `handle_key_event` wrapper fails exactly the three dispatcher-driven
      tests. Both reverted back to the fix afterward.
- [x] `cargo test --all-features --workspace` - all green, including
      `frame_reload_tests.rs`, `mode_transition_populate_tests.rs`,
      `startup_lazy_load_tests.rs`, `mutation_refetch_tests.rs` and
      `animation_tick_reload_tests.rs`, none of which were modified.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Changeset added: `.changeset/kan-1362-tui-navigation-population.md`
      (minor - `resolve_for_view`/`refresh_view` are new public items on
      `App`, and `handle_key_event`'s visibility widens from
      `pub(in crate::app)` to `pub`).

## Out of scope

Per-batch animation-tick resolve (the N4 item from the card) is deliberately
left for a follow-up: `animation_tick.rs`'s restore path returns `bool` and
discards its `Invalidation`, six tests in
`tests/animation_tick_reload_tests.rs` pin exact read counts that would need
rewriting, and resolving mid-batch would change the ordering
`test_animation_tick_archive_selection_skips_a_card_restored_in_the_same_tick`
depends on. Bundling that with this navigation seam would violate the
one-reviewable-PR rule.

