### PR TITLE
KAN-1533 fix(tui): scope delete-board confirm's transition fetch to the highlighted board

### DIFF
--- a/.changeset/kan-1533-tui-delete-highlighted-board-scope.md
+++ b/.changeset/kan-1533-tui-delete-highlighted-board-scope.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+tui: scope the delete-board confirmation's transition fetch to the highlighted board rather than the active one, so archiving a board other than the one currently open stops failing with "Board contents are not loaded yet"

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -131,18 +131,29 @@ impl App {
         }
     }
 
+    /// Opens the archive-confirmation dialog for the HIGHLIGHTED board. The
+    /// board is made active across the transition resolve and the count
+    /// snapshot so the fetch scope names it, then the prior active board is
+    /// restored.
     pub fn handle_delete_board_key(&mut self) {
-        if self.focus.active == Focus::Boards {
-            if let Some(board_id) = self.board_list.get_selected_board_id() {
-                self.open_dialog(DialogMode::DeleteBoardConfirm);
-                // Snapshot the counts once, here, rather than re-scanning the
-                // model on every frame the modal is open.
-                let Some(counts) = self.board_delete_counts(board_id) else {
-                    self.pop_mode();
-                    self.set_error("Board contents are not loaded yet".to_string());
-                    return;
-                };
-                self.dialog_input.board_delete_counts = Some(counts);
+        if self.focus.active != Focus::Boards {
+            return;
+        }
+        let Some(board_id) = self.board_list.get_selected_board_id() else {
+            return;
+        };
+
+        let prior_active_board_id = self.selection.active_board_id;
+        self.selection.active_board_id = Some(board_id);
+        self.open_dialog(DialogMode::DeleteBoardConfirm);
+        let counts = self.board_delete_counts(board_id);
+        self.selection.active_board_id = prior_active_board_id;
+
+        match counts {
+            Some(counts) => self.dialog_input.board_delete_counts = Some(counts),
+            None => {
+                self.pop_mode();
+                self.set_error("Board contents are not loaded yet".to_string());
             }
         }
     }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -1423,6 +1423,57 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_delete_key_on_a_non_active_highlighted_board_snapshots_that_boards_counts() {
+        let mut app = App::test_default();
+        create_named_board(&mut app, "A");
+        create_named_board(&mut app, "B");
+        let boards = app.ctx.data_store().list_boards().unwrap();
+        let a_id = boards.iter().find(|b| b.name == "A").unwrap().id;
+        let b_id = boards.iter().find(|b| b.name == "B").unwrap().id;
+        let b_column_id = first_column_id(&app, b_id);
+        app.ctx
+            .create_card(
+                b_id,
+                b_column_id,
+                "Task".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        app.ctx.create_sprint(b_id, None, None).unwrap();
+
+        app.selection.active_board_id = Some(a_id);
+        app.board_list.select_board(a_id);
+        refresh(&mut app);
+
+        app.board_list.select_board(b_id);
+        app.focus.active = Focus::Boards;
+        assert!(
+            !app.model.board_columns_state(b_id).is_loaded(),
+            "precondition: B's subtree is not loaded, only A's is"
+        );
+
+        app.handle_delete_board_key();
+
+        assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeleteBoardConfirm));
+        assert_eq!(
+            app.dialog_input.board_delete_counts,
+            Some(BoardDeleteCounts {
+                columns: 3,
+                cards: 1,
+                archived: 0,
+                sprints: 1,
+            }),
+            "counts belong to the highlighted board B, not the active board A"
+        );
+        assert!(app.ui_state.banner.is_none());
+        assert_eq!(
+            app.selection.active_board_id,
+            Some(a_id),
+            "the prior active board is restored"
+        );
+    }
+
     // KAN-891: archived-board drill-down tests
 
     fn seed_archived_board_with_cards(app: &mut App, name: &str) -> (uuid::Uuid, uuid::Uuid) {

--- a/crates/kanban-tui/tests/column_and_board_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/column_and_board_handlers_collapsing_accessor_tests.rs
@@ -333,6 +333,42 @@ fn test_handle_delete_board_key_still_opens_on_a_loaded_model() {
 }
 
 #[test]
+fn test_a_declined_delete_board_restores_the_prior_active_board() {
+    let mut app = App::test_default();
+    let a = app.ctx.create_board("A".into(), None).unwrap();
+    app.ctx.create_column(a.id, "Todo".into(), Some(0)).unwrap();
+    let b = app.ctx.create_board("B".into(), None).unwrap();
+    app.ctx.create_column(b.id, "Todo".into(), Some(0)).unwrap();
+    sync_model_from_store(&mut app);
+    app.prepare_frame();
+    app.selection.active_board_id = Some(a.id);
+    app.focus.active = Focus::Boards;
+    app.board_list.select_board(b.id);
+
+    invalidate_columns_tier(&mut app);
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_columns_by_board");
+    app.ctx.replace_backend(failing);
+
+    app.handle_delete_board_key();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("declining a NotLoaded columns tier must set an error banner");
+    assert!(banner.message.to_lowercase().contains("board"));
+    assert!(
+        !matches!(app.mode, AppMode::Dialog(DialogMode::DeleteBoardConfirm)),
+        "the delete-board confirm dialog must not open on a declined tier"
+    );
+    assert_eq!(
+        app.selection.active_board_id,
+        Some(a.id),
+        "the board active before the key press must still be active after the decline"
+    );
+}
+
+#[test]
 fn test_handle_delete_archived_board_key_declines_when_board_delete_counts_is_not_loaded() {
     let mut app = App::test_default();
     let board = app.ctx.create_board("Board".into(), None).unwrap();

--- a/crates/kanban-tui/tests/delete_board_scope_tests.rs
+++ b/crates/kanban-tui/tests/delete_board_scope_tests.rs
@@ -1,0 +1,129 @@
+use crossterm::event::{KeyCode, KeyEvent};
+use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::app::{AppMode, DialogMode};
+use kanban_tui::events::EventHandler;
+use kanban_tui::App;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::Rect;
+use ratatui::{Terminal, TerminalOptions, Viewport};
+use std::io;
+
+fn headless_terminal() -> Terminal<CrosstermBackend<io::Stdout>> {
+    Terminal::with_options(
+        CrosstermBackend::new(io::stdout()),
+        TerminalOptions {
+            viewport: Viewport::Fixed(Rect::new(0, 0, 80, 40)),
+        },
+    )
+    .unwrap()
+}
+
+fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
+    use ratatui::backend::TestBackend;
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            kanban_tui::ui::render(app, frame);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer().clone();
+    let mut result = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            result.push_str(buffer.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        result.push('\n');
+    }
+    result
+}
+
+#[tokio::test]
+async fn test_pressing_delete_after_navigating_off_the_active_board_opens_the_confirm() {
+    let mut app = App::test_default();
+
+    let board1 = app.ctx.create_board("Board 1".to_string(), None).unwrap();
+    let col1 = app
+        .ctx
+        .create_column(board1.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board1.id,
+            col1.id,
+            "Card 1".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
+        .create_sprint(board1.id, None, Some("Sprint 1".to_string()))
+        .unwrap();
+
+    let board2 = app.ctx.create_board("Board 2".to_string(), None).unwrap();
+    let col2 = app
+        .ctx
+        .create_column(board2.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board2.id,
+            col2.id,
+            "Card 2".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
+        .create_sprint(board2.id, None, Some("Sprint 2".to_string()))
+        .unwrap();
+
+    app.load_initial_state().await;
+
+    let mut terminal = headless_terminal();
+    let events = EventHandler::new();
+
+    app.focus.active = Focus::Boards;
+    app.board_list.inner_mut().set_selected_index(Some(0));
+
+    app.handle_key_event(KeyEvent::from(KeyCode::Enter), &mut terminal, &events);
+    assert_eq!(app.selection.active_board_id, Some(board1.id));
+
+    app.handle_key_event(KeyEvent::from(KeyCode::Char('1')), &mut terminal, &events);
+    assert_eq!(
+        app.focus.active,
+        Focus::Boards,
+        "focus is back on the projects panel"
+    );
+    assert_eq!(
+        app.selection.active_board_id,
+        Some(board1.id),
+        "board 1 stays active across the focus switch"
+    );
+
+    app.handle_key_event(KeyEvent::from(KeyCode::Char('j')), &mut terminal, &events);
+    assert_eq!(app.board_list.get_selected_board_id(), Some(board2.id));
+    assert!(
+        !app.model.board_columns_state(board2.id).is_loaded(),
+        "precondition: board 2's subtree is not yet loaded"
+    );
+
+    app.handle_key_event(KeyEvent::from(KeyCode::Char('d')), &mut terminal, &events);
+
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::DeleteBoardConfirm));
+    assert!(app.ui_state.banner.is_none());
+    assert_eq!(app.selection.active_board_id, Some(board1.id));
+
+    let output = render_to_string(&mut app, 140, 30);
+    assert!(
+        output.contains("1 task(s)"),
+        "expected board 2's task count, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("1 sprint(s)"),
+        "expected board 2's sprint count, got:\n{}",
+        output
+    );
+}


### PR DESCRIPTION
## Summary

- `handle_delete_board_key` opened the delete-board confirmation while the app's `active_board_id` was still whatever board was previously active, not the board highlighted in the projects panel. That scoped the transition resolve to the wrong board, so `board_delete_counts` declined for the highlighted board and the handler bounced back to normal mode with a "Board contents are not loaded yet" banner.
- The highlighted board is now made active for the duration of the transition resolve and the count snapshot, then the prior active board is restored before returning, on both the success and decline paths.
- `handle_delete_archived_board_key` and `App::view_scope()` are untouched: the archived sibling is only reachable when no board is active, so the same mismatch cannot occur there.

## Test plan

- [x] `test_delete_key_on_a_non_active_highlighted_board_snapshots_that_boards_counts` (inline in `board_handlers.rs`), red before the fix
- [x] `test_pressing_delete_after_navigating_off_the_active_board_opens_the_confirm` (`delete_board_scope_tests.rs`, end-to-end through the real key dispatcher), red before the fix
- [x] `test_a_declined_delete_board_restores_the_prior_active_board` (mutation guard on the restore-on-decline path)
- [x] `cargo test -p kanban-tui` green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features --workspace` green

