### PR TITLE
KAN-1444 refactor(domain): remove snapshot/apply_snapshot from the DataStore requirement

### DIFF
--- a/.changeset/kan-1444-remove-snapshot-apply-snapshot-datastore-delete.md
+++ b/.changeset/kan-1444-remove-snapshot-apply-snapshot-datastore-delete.md
@@ -1,0 +1,13 @@
+---
+bump: minor
+---
+
+domain, backend, backend-http, backend-memory, cli, persistence-json,
+persistence-sqlite, service, tui: removes `snapshot`/`apply_snapshot` from
+the `DataStore` trait's required surface and deletes the 24 impl pairs
+across every backend and test double that satisfied it. Every whole-store
+read/write already went through `store_adapter::read_full_snapshot` /
+`write_full_snapshot`, which compose per-entity `DataStore` calls instead
+of a single whole-store method, so this is a pure trait-surface reduction
+with no caller to repair. `kanban_domain::Snapshot`, the type, is
+unaffected and stays.

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -9,7 +9,7 @@ use kanban_api::{
 };
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
-    KanbanResult, Prefix, Snapshot, Sprint,
+    KanbanResult, Prefix, Sprint,
 };
 use uuid::Uuid;
 
@@ -288,14 +288,6 @@ impl DataStore for HttpBackend {
 
     fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {
         Err(KanbanError::unsupported("set_graph"))
-    }
-
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        Err(KanbanError::unsupported("snapshot"))
-    }
-
-    fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
-        Err(KanbanError::unsupported("apply_snapshot"))
     }
 
     /// No route filters cards by a bare `board_id` + `card_number` pair, and

--- a/crates/kanban-backend-memory/src/in_memory_store/mod.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/mod.rs
@@ -39,7 +39,7 @@ use uuid::Uuid;
 use kanban_domain::command_batch::CommandBatch;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
-    ArchivedCard, Board, Card, Column, DependencyGraph, KanbanError, KanbanResult, Snapshot, Sprint,
+    ArchivedCard, Board, Card, Column, DependencyGraph, KanbanError, KanbanResult, Sprint,
 };
 
 use state::StoreState;
@@ -306,15 +306,5 @@ impl DataStore for InMemoryStore {
 
     fn modify_graph(&self, f: kanban_domain::data_store::GraphMutFn) -> KanbanResult<()> {
         self.modify_graph_impl(f)
-    }
-
-    // Snapshot
-
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.snapshot_impl()
-    }
-
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.apply_snapshot_impl(snapshot)
     }
 }

--- a/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
+++ b/crates/kanban-backend-memory/src/in_memory_store/snapshot.rs
@@ -302,10 +302,10 @@ mod tests {
         );
     }
 
-    /// JSON's whole-store replacing write was `DataStore::apply_snapshot`
-    /// delegating to its `InMemoryStore` mirror; the JSON backend has no
-    /// replacing write of its own, so this guarantee is asserted where the
-    /// logic actually lives.
+    /// JSON's whole-store replacing write delegates to `apply_snapshot_impl`
+    /// on its `InMemoryStore` mirror; the JSON backend has no replacing write
+    /// of its own, so this guarantee is checked where the logic actually
+    /// lives.
     #[test]
     fn test_a_replacing_write_that_drops_a_referenced_namespace_is_rejected() {
         let store = InMemoryStore::new();

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -282,12 +282,6 @@ mod tests {
         fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {
             unimplemented!()
         }
-        fn snapshot(&self) -> KanbanResult<Snapshot> {
-            unimplemented!()
-        }
-        fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
-            unimplemented!()
-        }
     }
 
     impl CommandStore for StubBackend {

--- a/crates/kanban-cli/src/handlers/card.rs
+++ b/crates/kanban-cli/src/handlers/card.rs
@@ -441,7 +441,7 @@ mod card_board_id_tests {
     use kanban_domain::data_store::DataStore;
     use kanban_domain::{
         ArchivedBoard, ArchivedCard, Board, Card, Column, CommandBatch, DependencyGraph,
-        KanbanOperations, KanbanResult, Snapshot, Sprint,
+        KanbanOperations, KanbanResult, Sprint,
     };
     use kanban_service::{AppConfig, KanbanContext};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -621,12 +621,6 @@ mod card_board_id_tests {
         }
         fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
             self.inner.set_graph(graph)
-        }
-        fn snapshot(&self) -> KanbanResult<Snapshot> {
-            self.inner.snapshot()
-        }
-        fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-            self.inner.apply_snapshot(snapshot)
         }
     }
 

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -1,8 +1,6 @@
 use uuid::Uuid;
 
-use crate::{
-    ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult, Prefix, Sprint,
-};
+use crate::{ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult, Prefix, Sprint};
 
 pub type GraphMutFn = Box<dyn FnOnce(&mut DependencyGraph) -> KanbanResult<()>>;
 

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -301,10 +301,6 @@ pub trait DataStore: Send + Sync {
         f(&mut graph)?;
         self.set_graph(graph)
     }
-
-    // Snapshot (import/export, JSON file I/O, migration)
-    fn snapshot(&self) -> KanbanResult<Snapshot>;
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()>;
 }
 
 #[cfg(test)]

--- a/crates/kanban-domain/src/data_store.rs
+++ b/crates/kanban-domain/src/data_store.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 
 use crate::{
-    ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult, Prefix, Snapshot, Sprint,
+    ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult, Prefix, Sprint,
 };
 
 pub type GraphMutFn = Box<dyn FnOnce(&mut DependencyGraph) -> KanbanResult<()>>;
@@ -457,12 +457,6 @@ mod tests {
             unimplemented!()
         }
         fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {
-            unimplemented!()
-        }
-        fn snapshot(&self) -> KanbanResult<Snapshot> {
-            unimplemented!()
-        }
-        fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
             unimplemented!()
         }
     }

--- a/crates/kanban-domain/tests/common/prefix_write_order.rs
+++ b/crates/kanban-domain/tests/common/prefix_write_order.rs
@@ -1,7 +1,7 @@
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanResult,
-    Prefix, Snapshot, Sprint,
+    Prefix, Sprint,
 };
 use std::sync::Mutex;
 use uuid::Uuid;
@@ -202,12 +202,5 @@ impl DataStore for PrefixWriteOrderStore {
     }
     fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
         self.inner.set_graph(graph)
-    }
-
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
     }
 }

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -5,7 +5,7 @@ use kanban_domain::command_batch::CommandBatch;
 use kanban_domain::data_store::GraphMutFn;
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, CommandStore, DataStore, DependencyGraph,
-    KanbanError, KanbanResult, Snapshot, Sprint,
+    KanbanError, KanbanResult, Sprint,
 };
 use kanban_persistence::{
     snapshot_from_json_bytes, snapshot_to_json_bytes, PersistenceMetadata, PersistenceStore,
@@ -495,6 +495,7 @@ mod tests {
     use super::*;
     use crate::JsonFileStore;
     use kanban_domain::Board;
+    use kanban_domain::Snapshot;
     use tempfile::tempdir;
 
     fn make_store(path: &std::path::Path) -> JsonDataStore {

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -390,15 +390,6 @@ impl DataStore for JsonDataStore {
     fn modify_graph(&self, f: GraphMutFn) -> KanbanResult<()> {
         self.with_mutate(|s| s.modify_graph(f))
     }
-
-    // Snapshot
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.with_read(|s| s.snapshot())
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        kanban_domain::ensure_prefix_rows_exist(&snapshot.cards, &snapshot.prefixes)?;
-        self.with_mutate(|s| s.apply_snapshot(snapshot))
-    }
 }
 
 // ─── CommandStore ─────────────────────────────────────────────────────────────

--- a/crates/kanban-persistence-json/src/json_backend.rs
+++ b/crates/kanban-persistence-json/src/json_backend.rs
@@ -1080,10 +1080,8 @@ mod tests {
         assert_eq!(boards2[0].name, "ConcurrentBoard");
     }
 
-    // Characterization test for KAN-1070: `ensure_loaded`/`do_flush` swap onto
-    // `InMemoryStore::apply_snapshot_impl`/`snapshot_impl`. Behaviour-preserving
-    // by construction (`DataStore::apply_snapshot`/`snapshot` already delegate to
-    // these), so this passes identically before and after the swap; it pins the
+    // Characterization test: `ensure_loaded`/`do_flush` swap onto
+    // `InMemoryStore::apply_snapshot_impl`/`snapshot_impl`. Pins the
     // full-graph fidelity so a future change to either path cannot regress it.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_json_backend_load_flush_round_trip_preserves_full_graph() {

--- a/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_backend.rs
@@ -7,7 +7,7 @@ use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, GraphMutFn, KanbanError,
-    KanbanResult, Snapshot, Sprint,
+    KanbanResult, Sprint,
 };
 use kanban_persistence::{PersistenceMetadata, PersistenceStore};
 use uuid::Uuid;
@@ -236,13 +236,6 @@ impl DataStore for SqliteBackend {
     }
     fn modify_graph(&self, f: GraphMutFn) -> KanbanResult<()> {
         self.db.modify_graph(f)
-    }
-
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.db.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.db.apply_snapshot(snapshot)
     }
 }
 

--- a/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
+++ b/crates/kanban-persistence-sqlite/src/sqlite_store/data_store.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
     Archived, ArchivedBoard, ArchivedCard, Board, Card, Column, DependencyGraph, KanbanResult,
-    Snapshot, Sprint,
+    Sprint,
 };
 use sqlx::Row;
 use uuid::Uuid;
@@ -726,15 +726,5 @@ impl DataStore for SqliteStore {
 
     fn modify_graph(&self, f: kanban_domain::GraphMutFn) -> KanbanResult<()> {
         run(self.modify_graph_async(f))
-    }
-
-    // Snapshot
-
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        run(self.snapshot_async())
-    }
-
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        run(self.apply_snapshot_async(snapshot))
     }
 }

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -90,8 +90,6 @@ each query the backend fresh and return an owned, `KanbanResult`-wrapped
 ctx.save() -> KanbanResult<()>                 // async; backend.flush().await
 ctx.reload() -> KanbanResult<Invalidation>     // async; backend.reload().await, clears undo_stack
 ctx.replace_backend(backend: Arc<dyn KanbanBackend>) -> Invalidation  // clears undo_stack, marks clean
-ctx.snapshot() -> KanbanResult<Snapshot>
-ctx.apply_snapshot(snapshot: Snapshot) -> KanbanResult<()>
 ctx.migrate_sprint_logs() -> KanbanResult<(usize, Option<Invalidation>)>  // one-time backfill utility, bypasses undo on purpose
 ```
 
@@ -275,8 +273,8 @@ Returned by the `*_detailed` bulk operation methods.
 
 ## `Snapshot`
 
-There is no `kanban-service`-local snapshot type. `KanbanContext::snapshot()` /
-`apply_snapshot()` and `StoreManager`'s export/migrate helpers all operate
+There is no `kanban-service`-local snapshot type. `store_adapter::read_full_snapshot`
+/ `write_full_snapshot` and `StoreManager`'s export/migrate helpers all operate
 directly on `kanban_domain::Snapshot` (`crates/kanban-domain/src/snapshot.rs`):
 
 ```rust
@@ -288,6 +286,7 @@ pub struct Snapshot {
     pub sprints: Vec<Sprint>,
     pub archived_boards: Vec<ArchivedBoard>,
     pub graph: DependencyGraph,
+    pub prefixes: Vec<Prefix>,
 }
 ```
 

--- a/crates/kanban-service/src/backend_test_support.rs
+++ b/crates/kanban-service/src/backend_test_support.rs
@@ -2,7 +2,7 @@ use kanban_backend::{KanbanBackend, RemoteWrites, TransactionFn};
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
     Board, BoardUpdate, Card, CardUpdate, Column, ColumnUpdate, CommandBatch, CommandStore,
-    DataStore, KanbanResult, NewBoard, NewCard, NewColumn, Snapshot,
+    DataStore, KanbanResult, NewBoard, NewCard, NewColumn,
 };
 use uuid::Uuid;
 
@@ -193,12 +193,6 @@ impl DataStore for MockBackend {
     }
     fn set_graph(&self, graph: kanban_domain::DependencyGraph) -> KanbanResult<()> {
         self.inner.set_graph(graph)
-    }
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
     }
 }
 

--- a/crates/kanban-service/src/read_recorder.rs
+++ b/crates/kanban-service/src/read_recorder.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
-    KanbanResult, Prefix, Snapshot, Sprint,
+    KanbanResult, Prefix, Sprint,
 };
 use uuid::Uuid;
 
@@ -270,13 +270,6 @@ impl DataStore for RecordingStore {
     }
     fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
         self.inner.set_graph(graph)
-    }
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.record("snapshot", vec![]);
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
     }
 }
 

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -170,13 +170,6 @@ mod tests {
             self.0.upsert_prefix(prefix)
         }
 
-        fn snapshot(&self) -> KanbanResult<Snapshot> {
-            panic!("read_full_snapshot must compose per-entity reads, not call snapshot()")
-        }
-        fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
-            panic!("write_full_snapshot must compose per-entity writes, not call apply_snapshot()")
-        }
-
         fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
             self.0.get_board(id)
         }
@@ -769,12 +762,6 @@ mod tests {
             timestamp: chrono::DateTime<chrono::Utc>,
         ) -> KanbanResult<()> {
             self.inner.clear_sprint_from_cards(sprint_id, timestamp)
-        }
-        fn snapshot(&self) -> KanbanResult<Snapshot> {
-            panic!("write_full_snapshot must compose per-entity writes, not call apply_snapshot()")
-        }
-        fn apply_snapshot(&self, _snapshot: Snapshot) -> KanbanResult<()> {
-            panic!("write_full_snapshot must compose per-entity writes, not call apply_snapshot()")
         }
     }
 

--- a/crates/kanban-service/src/store_adapter.rs
+++ b/crates/kanban-service/src/store_adapter.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use uuid::Uuid;
 
 /// Reads a whole workspace through per-entity `DataStore` calls rather than
-/// `DataStore::snapshot`.
+/// a single whole-store read.
 ///
 /// Archived boards are absent from `list_boards`, so their heads are recovered
 /// individually through the unfiltered `get_board`. Archived cards are likewise
@@ -56,7 +56,7 @@ pub fn read_full_snapshot(store: &dyn DataStore) -> KanbanResult<Snapshot> {
 }
 
 /// Writes a whole workspace through per-entity `DataStore` calls rather than
-/// `DataStore::apply_snapshot`. The caller supplies the transaction.
+/// a single whole-store write. The caller supplies the transaction.
 ///
 /// Order is load-bearing on a relational backend, which checks foreign keys as
 /// each row lands: sprints precede cards because `cards.sprint_id` references

--- a/crates/kanban-service/src/test_helpers/fault.rs
+++ b/crates/kanban-service/src/test_helpers/fault.rs
@@ -8,7 +8,7 @@ use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::{DataStore, GraphMutFn};
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, ArchivedFilter, Board, Card, Column, DependencyGraph, KanbanError,
-    KanbanResult, Prefix, Snapshot, Sprint,
+    KanbanResult, Prefix, Sprint,
 };
 use uuid::Uuid;
 
@@ -384,13 +384,6 @@ impl DataStore for FaultInjectingBackend {
     }
     fn modify_graph(&self, f: GraphMutFn) -> KanbanResult<()> {
         self.inner.modify_graph(f)
-    }
-
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
     }
 }
 

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -5,7 +5,7 @@ use kanban_domain::command_store::CommandStore;
 use kanban_domain::data_store::DataStore;
 use kanban_domain::{
     ArchivedCard, Board, Card, Column, CommandBatch, DependencyGraph, KanbanOperations,
-    KanbanResult, Snapshot, Sprint,
+    KanbanResult, Sprint,
 };
 use kanban_service::{AppConfig, KanbanContext};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -206,12 +206,6 @@ impl DataStore for CountingBackend {
     }
     fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {
         self.inner.set_graph(graph)
-    }
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
     }
 }
 

--- a/crates/kanban-service/tests/transfer_pairs.rs
+++ b/crates/kanban-service/tests/transfer_pairs.rs
@@ -386,12 +386,6 @@ impl DataStore for NoWholeStoreReads {
     fn upsert_prefix(&self, prefix: Prefix) -> KanbanResult<()> {
         self.0.upsert_prefix(prefix)
     }
-    fn snapshot(&self) -> KanbanResult<kanban_domain::Snapshot> {
-        panic!("transfer_state_to must compose per-entity reads, not call snapshot()")
-    }
-    fn apply_snapshot(&self, _snapshot: kanban_domain::Snapshot) -> KanbanResult<()> {
-        panic!("transfer_state_to must compose per-entity writes, not call apply_snapshot()")
-    }
     fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
         self.0.get_board(id)
     }
@@ -777,12 +771,6 @@ impl DataStore for UnsupportedArchivedBoards {
     // Uses the trait default: Err(unsupported("insert_archived_board")).
     fn delete_archived_board(&self, board_id: Uuid) -> KanbanResult<()> {
         self.0.delete_archived_board(board_id)
-    }
-    fn snapshot(&self) -> KanbanResult<kanban_domain::Snapshot> {
-        self.0.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: kanban_domain::Snapshot) -> KanbanResult<()> {
-        self.0.apply_snapshot(snapshot)
     }
     fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
         self.0.get_sprint(id)

--- a/crates/kanban-tui/src/app/lifecycle_tests.rs
+++ b/crates/kanban-tui/src/app/lifecycle_tests.rs
@@ -336,14 +336,6 @@ impl kanban_domain::DataStore for HostileSourceBackend {
     fn list_boards(&self) -> kanban_domain::KanbanResult<Vec<kanban_domain::Board>> {
         self.inner.as_data_store().list_boards()
     }
-    fn snapshot(&self) -> kanban_domain::KanbanResult<kanban_domain::Snapshot> {
-        Err(kanban_domain::KanbanError::Database(
-            "HostileSourceBackend: snapshot must not be called".into(),
-        ))
-    }
-    fn apply_snapshot(&self, snapshot: kanban_domain::Snapshot) -> kanban_domain::KanbanResult<()> {
-        self.inner.as_data_store().apply_snapshot(snapshot)
-    }
 }
 
 impl kanban_domain::command_store::CommandStore for HostileSourceBackend {
@@ -406,17 +398,6 @@ impl kanban_domain::DataStore for HostileTargetBackend {
 
     fn list_boards(&self) -> kanban_domain::KanbanResult<Vec<kanban_domain::Board>> {
         self.inner.as_data_store().list_boards()
-    }
-    fn snapshot(&self) -> kanban_domain::KanbanResult<kanban_domain::Snapshot> {
-        self.inner.as_data_store().snapshot()
-    }
-    fn apply_snapshot(
-        &self,
-        _snapshot: kanban_domain::Snapshot,
-    ) -> kanban_domain::KanbanResult<()> {
-        Err(kanban_domain::KanbanError::Database(
-            "HostileTargetBackend: apply_snapshot must not be called".into(),
-        ))
     }
 }
 
@@ -533,12 +514,6 @@ struct UnreadableTargetBackend {
 impl kanban_domain::DataStore for UnreadableTargetBackend {
     delegate_data_store!();
 
-    fn snapshot(&self) -> kanban_domain::KanbanResult<kanban_domain::Snapshot> {
-        self.inner.as_data_store().snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: kanban_domain::Snapshot) -> kanban_domain::KanbanResult<()> {
-        self.inner.as_data_store().apply_snapshot(snapshot)
-    }
     fn list_boards(&self) -> kanban_domain::KanbanResult<Vec<kanban_domain::Board>> {
         Err(kanban_domain::KanbanError::Database(
             "UnreadableTargetBackend: list_boards must not be called".into(),

--- a/crates/kanban-tui/src/app/lifecycle_tests.rs
+++ b/crates/kanban-tui/src/app/lifecycle_tests.rs
@@ -325,7 +325,6 @@ macro_rules! delegate_data_store {
     };
 }
 
-/// Delegates to `inner` except `DataStore::snapshot`, which always errors.
 struct HostileSourceBackend {
     inner: std::sync::Arc<dyn kanban_backend::KanbanBackend>,
 }
@@ -388,7 +387,6 @@ impl kanban_backend::KanbanBackend for HostileSourceBackend {
     }
 }
 
-/// Delegates to `inner` except `DataStore::apply_snapshot`, which always errors.
 struct HostileTargetBackend {
     inner: std::sync::Arc<dyn kanban_backend::KanbanBackend>,
 }

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -763,9 +763,9 @@ mod tests {
             .unwrap();
 
         // Feed the model a snapshot with the tied pair's relative order
-        // swapped from canonical, instead of going through the normal
-        // ctx.snapshot() pipeline -- proving handle_move_column_up no longer
-        // depends on the model happening to already be canonically ordered.
+        // swapped from canonical, instead of the normal load pipeline --
+        // proving handle_move_column_up no longer depends on the model
+        // happening to already be canonically ordered.
         let mut snapshot = kanban_service::read_full_snapshot(app.ctx.data_store()).unwrap();
         let doing_idx = snapshot
             .columns

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -312,11 +312,7 @@ impl KanbanBackend for CountingBackend {
     }
 }
 
-/// A `KanbanBackend` decorator that counts only `DataStore::snapshot` calls
-/// (what `App::reload_model` issues), delegating everything else verbatim to
-/// `inner`. Unlike `CountingBackend`, this does not count the incidental
-/// reads a command's own validation/execution performs, so it isolates "how
-/// many whole-model reloads happened" from "how many store reads happened".
+/// A `KanbanBackend` decorator that delegates everything verbatim to `inner`.
 pub struct SnapshotCountingBackend {
     inner: Arc<dyn KanbanBackend>,
     snapshot_reads: Arc<AtomicUsize>,
@@ -525,12 +521,8 @@ impl KanbanBackend for SnapshotCountingBackend {
     }
 }
 
-/// A `KanbanBackend` decorator whose `snapshot()` always fails, delegating
-/// every other `DataStore`/`CommandStore` method verbatim to `inner`. Used to
-/// simulate a transient read failure (SQLite busy, I/O error) on the
-/// destination backend right after a storage-location swap, while still
-/// allowing direct entity reads against `inner` to prove the destination's
-/// data survived.
+/// A `KanbanBackend` decorator that delegates every `DataStore`/`CommandStore`
+/// method verbatim to `inner`.
 pub struct FailingSnapshotBackend {
     inner: Arc<dyn KanbanBackend>,
 }

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -4,7 +4,7 @@ use kanban_backend::{KanbanBackend, RemoteWrites, TransactionFn};
 use kanban_domain::KanbanError;
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, Card, Column, CommandBatch, CommandStore, DataStore,
-    DependencyGraph, KanbanResult, Snapshot, Sprint,
+    DependencyGraph, KanbanResult, Sprint,
 };
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::{AppMode, DialogMode};
@@ -282,13 +282,6 @@ impl DataStore for CountingBackend {
         self.record("modify_graph", vec![]);
         self.inner.modify_graph(f)
     }
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.record("snapshot", vec![]);
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
-    }
 }
 
 impl CommandStore for CountingBackend {
@@ -504,13 +497,6 @@ impl DataStore for SnapshotCountingBackend {
     fn modify_graph(&self, f: kanban_domain::GraphMutFn) -> KanbanResult<()> {
         self.inner.modify_graph(f)
     }
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.snapshot_reads.fetch_add(1, Ordering::SeqCst);
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
-    }
 }
 
 impl CommandStore for SnapshotCountingBackend {
@@ -718,14 +704,6 @@ impl DataStore for FailingSnapshotBackend {
     fn modify_graph(&self, f: kanban_domain::GraphMutFn) -> KanbanResult<()> {
         self.inner.modify_graph(f)
     }
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        Err(kanban_domain::KanbanError::Database(
-            "simulated transient read failure".to_string(),
-        ))
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
-    }
 }
 
 impl CommandStore for FailingSnapshotBackend {
@@ -928,12 +906,6 @@ impl DataStore for FailingBoardListBackend {
     }
     fn modify_graph(&self, f: kanban_domain::GraphMutFn) -> KanbanResult<()> {
         self.inner.modify_graph(f)
-    }
-    fn snapshot(&self) -> KanbanResult<Snapshot> {
-        self.inner.snapshot()
-    }
-    fn apply_snapshot(&self, snapshot: Snapshot) -> KanbanResult<()> {
-        self.inner.apply_snapshot(snapshot)
     }
 }
 

--- a/crates/kanban-tui/tests/settings_storage_tests.rs
+++ b/crates/kanban-tui/tests/settings_storage_tests.rs
@@ -383,9 +383,9 @@ async fn test_storage_swap_still_syncs_the_view_when_the_read_succeeds() {
     assert_eq!(app.model.boards_state().loaded_or_empty()[0].id, board_id);
 }
 
-/// The counter never observes `apply_snapshot`: both `SnapshotCountingBackend`
-/// and `FailingSnapshotBackend` delegate it verbatim to `inner`. It only pins
-/// that the migration probe itself stops reading a whole `Snapshot`.
+/// Both `SnapshotCountingBackend` and `FailingSnapshotBackend` delegate every
+/// `DataStore` method verbatim to `inner`. This pins that the migration probe
+/// itself stops reading a whole `Snapshot`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_migration_complete_does_not_call_the_whole_store_trait_methods() {
     let dir = tempfile::tempdir().unwrap();
@@ -419,7 +419,7 @@ async fn test_migration_complete_does_not_call_the_whole_store_trait_methods() {
         snapshot_reads.load(Ordering::SeqCst),
         0,
         "reload_model's post-swap sync is scope-driven, not a whole-Snapshot \
-         read, so migration must call ctx.snapshot() zero times"
+         read, so the migration probe must observe zero snapshot reads"
     );
 }
 


### PR DESCRIPTION
## Summary

- Deletes `snapshot`/`apply_snapshot` from the `DataStore` trait's required surface in `kanban-domain` and every one of the 24 impls across nine crates that satisfied it.
- Sweeps the now-unused `Snapshot` imports and the doc comments / assert message that still named the deleted methods.
- Adds a `minor` changeset (breaking: removes required trait methods from a published crate).

`kanban_domain::Snapshot`, the type, is untouched. Only the trait requirement goes.

## Precondition

KAN-1464 (merged as `b6feb811`, PR #786) deleted the last four `KanbanContext`/`TuiContext` pass-throughs. Pre-flight on this branch confirmed:

- `git grep -n 'DataStore for' -- crates | wc -l` -> 24
- `git grep -nE 'fn (snapshot|apply_snapshot)\(' -- crates/ | grep -v '"pub fn' | wc -l` -> 50 (2 trait decls + 24 impl pairs)
- `git grep -n '\.snapshot()\|\.apply_snapshot(' -- crates | grep -v 'snapshot_async\|snapshot_impl\|apply_snapshot_impl'` returned only delegation lines inside the 24 census impl bodies, plus `kanban-service/README.md:93,94`, a comment in `column_handlers.rs:767`, and an assert-message string in `settings_storage_tests.rs:422`, with no production or test call site.
- `git grep -rn 'AlwaysFailsSnapshotBackend' -- crates` -> nothing (KAN-1415 landed).

This card had zero callers to repair.

## Red

Deleted only the trait declaration pair in `crates/kanban-domain/src/data_store.rs` and ran the build. Workspace-wide `--all-features --all-targets --keep-going` surfaced 6 `E0407` errors (`kanban-backend`, `kanban-backend-memory`, `kanban-backend-http`, two each) before cargo's dependency-ordering truncation stopped it from reaching downstream crates whose own dependencies had already failed to build. Per-crate checks on `kanban-persistence-sqlite`, `kanban-persistence-json`, and `kanban-service --features test-helpers` each independently confirmed the same `kanban-backend-memory` `E0407` pair as their blocking dependency failure. Full detail is in the Red commit body.

## Green

Deleted all 48 impl fn bodies (24 impls x 2 methods), including the ones invisible to a plain `cargo check`: three in `tests/` crates (`kanban-domain/tests/common/prefix_write_order.rs`, `kanban-service/tests/{transfer_pairs,card_archived_at_scan}.rs`, `kanban-tui/tests/helpers.rs`), and one that only compiles into the `kanban-service` library under `--features test-helpers` (`test_helpers/fault.rs`).

Removed the now-unused `Snapshot` import from 11 files. Kept it in two: `kanban-service/src/store_adapter.rs` (still used by `read_full_snapshot`/`write_full_snapshot`/`repair_fks`) and `kanban-persistence-json/src/json_backend.rs`, where it moved into the crate's `#[cfg(test)]` module (clippy's plain-lib target flagged the top-level import unused once its only remaining consumers were `#[cfg(test)]`-gated).

## Refactor

Reworded doc comments and the one assert message string (`settings_storage_tests.rs:422`, message text only, its comparison is untouched) that still named `DataStore::snapshot`/`apply_snapshot` as existing methods. Updated `kanban-service/README.md`: dropped the `ctx.snapshot()`/`apply_snapshot()` lines from the Persistence block, repointed the `Snapshot` section at `store_adapter::read_full_snapshot`/`write_full_snapshot`, and added the missing `prefixes: Vec<Prefix>` field to the struct listing.

## Verification

- `cargo test --all-features --workspace`: 258 test binaries, all green, zero failures.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `git grep -n 'DataStore for' -- crates | wc -l` -> still 24.
- `git grep -nE 'fn (snapshot|apply_snapshot)\(' -- crates/ | grep -v '"pub fn'` -> empty (was 50 at branch point).
- `git grep -n '\.snapshot()\|\.apply_snapshot(\|fn snapshot(\|fn apply_snapshot(' -- crates | grep -v 'snapshot_async\|snapshot_impl\|apply_snapshot_impl'` -> only the four `pub fn snapshot(&self)` / `pub fn apply_snapshot(...)` guard-test string literals from KAN-1464.
- `git diff $(git merge-base origin/develop HEAD) -- crates | grep -E '^\+.*assert'` -> empty.
- Scope guards confirmed intact: `snapshot_impl`/`apply_snapshot_impl` in `kanban-backend-memory`, `snapshot_async`/`apply_snapshot_async` in `kanban-persistence-sqlite`, `read_full_snapshot`/`write_full_snapshot` in `kanban-service`, `kanban_domain::Snapshot` untouched.

## Reported, not fixed (out of scope for this card)

Several test doubles and assertions become vacuous now that no `DataStore` impl can override `snapshot`/`apply_snapshot`, but still pass because they were asserting *absence* of a call to a method that no longer exists to call:

- `SnapshotCountingBackend` (`kanban-tui/tests/helpers.rs`) and its `snapshot_reads` counter can never increment again.
- `FailingSnapshotBackend` (same file) is now a pure delegator; it can no longer inject a snapshot-read failure.
- The `snapshot_reads.load(...) == 0` assertion in `settings_storage_tests.rs` and the `HostileSourceBackend`/`HostileTargetBackend` doubles in `kanban-tui/src/app/lifecycle_tests.rs` are in the same position: green by construction, not by coverage.
- There is no source-text guard asserting the trait no longer declares these methods (the KAN-1464 pattern in `context/mod.rs`/`tui_context_sync.rs` checks for pass-throughs, not for the trait requirement itself), so nothing stops a future PR from re-adding `fn snapshot` to `DataStore` with a default body.

Also noted but out of scope: the assert message at `settings_storage_tests.rs:450` ("a failed snapshot() read...") is similarly stale but wasn't in this card's explicit sweep list, so it's left as-is.
