### PR TITLE
KAN-1501 feat(server): add RouteScope FetchPlan and model_read helpers

### DIFF
--- a/.changeset/kan-1501-server-routescope.md
+++ b/.changeset/kan-1501-server-routescope.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: add RouteScope FetchPlan and model_read helpers over the shared Model, unconsumed until slices c-g wire the routes

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -5,7 +5,9 @@
 
 pub mod app;
 pub mod error;
+pub mod model_read;
 pub mod pagination;
+pub mod scope;
 pub mod state;
 pub mod watch;
 

--- a/crates/kanban-server/src/model_read.rs
+++ b/crates/kanban-server/src/model_read.rs
@@ -1,3 +1,56 @@
+use std::sync::Arc;
+
+use kanban_domain::{KanbanError, LoadState};
+use uuid::Uuid;
+
+use crate::error::AppError;
+
+fn failed(err: &Arc<KanbanError>) -> AppError {
+    AppError::from(err.as_ref())
+}
+
+/// Reads a Model tier the request's `RouteScope` was responsible for
+/// planning. `NotLoaded` means the scope failed to request it and renders
+/// as a 500, never as an empty body.
+pub fn require_loaded<T>(state: LoadState<T>, what: &str) -> Result<T, AppError> {
+    match state {
+        LoadState::Loaded(value) => Ok(value),
+        LoadState::NotLoaded => {
+            tracing::error!(tier = what, "model tier was not planned by the route scope");
+            Err(AppError::from(&KanbanError::Internal(format!(
+                "{what} was not fetched for this request"
+            ))))
+        }
+        LoadState::Missing => Err(AppError::from(&KanbanError::Internal(format!(
+            "{what} is unavailable"
+        )))),
+        LoadState::Failed(e) => Err(failed(&e)),
+    }
+}
+
+/// Reads a per-id Model tier, where `Missing` is the route's 404.
+pub fn require_loaded_entity<T>(
+    state: LoadState<T>,
+    entity: &'static str,
+    id: Uuid,
+) -> Result<T, AppError> {
+    match state {
+        LoadState::Loaded(value) => Ok(value),
+        LoadState::NotLoaded => {
+            tracing::error!(
+                tier = entity,
+                %id,
+                "model tier was not planned by the route scope"
+            );
+            Err(AppError::from(&KanbanError::Internal(format!(
+                "{entity} was not fetched for this request"
+            ))))
+        }
+        LoadState::Missing => Err(AppError::from(&KanbanError::not_found(entity, id))),
+        LoadState::Failed(e) => Err(failed(&e)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -10,7 +63,10 @@ mod tests {
 
     #[test]
     fn test_require_loaded_returns_the_value_and_maps_a_not_loaded_tier_to_a_500() {
-        let value = require_loaded(LoadState::Loaded(7u32), "board list").unwrap();
+        let value = match require_loaded(LoadState::Loaded(7u32), "board list") {
+            Ok(value) => value,
+            Err(_) => panic!("expected Ok"),
+        };
         assert_eq!(value, 7);
 
         let err = require_loaded(LoadState::<u32>::NotLoaded, "board list").unwrap_err();
@@ -37,8 +93,8 @@ mod tests {
     }
 
     #[test]
-    fn test_require_loaded_preserves_a_failed_tiers_underlying_error_code_without_leaking_its_message()
-     {
+    fn test_require_loaded_preserves_a_failed_tiers_underlying_error_code_without_leaking_its_message(
+    ) {
         let id = Uuid::new_v4();
         let err = require_loaded(
             LoadState::<u32>::Failed(Arc::new(KanbanError::Database("boom".into()))),

--- a/crates/kanban-server/src/model_read.rs
+++ b/crates/kanban-server/src/model_read.rs
@@ -1,0 +1,60 @@
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use kanban_domain::{KanbanError, LoadState};
+    use uuid::Uuid;
+
+    use super::*;
+    use kanban_service::api::ErrorCode;
+
+    #[test]
+    fn test_require_loaded_returns_the_value_and_maps_a_not_loaded_tier_to_a_500() {
+        let value = require_loaded(LoadState::Loaded(7u32), "board list").unwrap();
+        assert_eq!(value, 7);
+
+        let err = require_loaded(LoadState::<u32>::NotLoaded, "board list").unwrap_err();
+        assert_eq!(err.0.code, ErrorCode::InternalError);
+        assert_eq!(err.0.code.http_status(), 500);
+    }
+
+    #[test]
+    fn test_require_loaded_entity_maps_a_missing_entity_to_a_404_naming_it() {
+        let id = Uuid::new_v4();
+        let err = require_loaded_entity(LoadState::<u32>::Missing, "Board", id).unwrap_err();
+        assert_eq!(err.0.code, ErrorCode::NotFound);
+        assert_eq!(err.0.code.http_status(), 404);
+        assert!(err.0.message.contains("Board"));
+        assert!(err.0.message.contains(&id.to_string()));
+    }
+
+    #[test]
+    fn test_require_loaded_entity_maps_a_not_loaded_tier_to_a_500_not_a_404() {
+        let id = Uuid::new_v4();
+        let err = require_loaded_entity(LoadState::<u32>::NotLoaded, "Board", id).unwrap_err();
+        assert_eq!(err.0.code, ErrorCode::InternalError);
+        assert_eq!(err.0.code.http_status(), 500);
+    }
+
+    #[test]
+    fn test_require_loaded_preserves_a_failed_tiers_underlying_error_code_without_leaking_its_message()
+     {
+        let id = Uuid::new_v4();
+        let err = require_loaded(
+            LoadState::<u32>::Failed(Arc::new(KanbanError::Database("boom".into()))),
+            "board list",
+        )
+        .unwrap_err();
+        assert_eq!(err.0.code, ErrorCode::DatabaseError);
+        assert_eq!(err.0.message, "internal server error");
+
+        let err = require_loaded_entity(
+            LoadState::<u32>::Failed(Arc::new(KanbanError::Database("boom".into()))),
+            "Board",
+            id,
+        )
+        .unwrap_err();
+        assert_eq!(err.0.code, ErrorCode::DatabaseError);
+        assert_eq!(err.0.message, "internal server error");
+    }
+}

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -1,3 +1,131 @@
+//! A `RouteScope` is built from the matched route plus its path/query
+//! params. The tiers a variant names are the tiers that route's response
+//! body reads; `GET /v1/prefixes` has no variant because no prefix tier
+//! exists in `FetchRound` at any level, so that route stays a lock-only
+//! read outside this plan.
+
+use kanban_service::{requestable, FetchPlan, FetchRound, LoadedEntities};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteScope {
+    BoardList,
+    Board(Uuid),
+    BoardColumns(Uuid),
+    BoardCards {
+        board_id: Uuid,
+        column_id: Option<Uuid>,
+    },
+    BoardArchivedCards(Uuid),
+    BoardSprints(Uuid),
+    Card(Uuid),
+    Column(Uuid),
+    /// `board_id` is `Some` only for the nested route, where the path
+    /// already names the board whose name pool the response needs.
+    Sprint {
+        board_id: Option<Uuid>,
+        sprint_id: Uuid,
+    },
+    CardGraph(Uuid),
+}
+
+fn want_board(round: &mut FetchRound, loaded: &dyn LoadedEntities, board_id: Uuid) {
+    if requestable(loaded.board(board_id)) {
+        round.boards.push(board_id);
+    }
+}
+
+impl FetchPlan for RouteScope {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        let mut round = FetchRound::default();
+
+        match *self {
+            RouteScope::BoardList => {
+                round.board_list = requestable(loaded.board_list());
+            }
+            RouteScope::Board(id) => {
+                want_board(&mut round, loaded, id);
+                round.archived_board_list = requestable(loaded.archived_board_list());
+            }
+            RouteScope::BoardColumns(board_id) => {
+                want_board(&mut round, loaded, board_id);
+                if requestable(loaded.columns_of_board(board_id)) {
+                    round.columns_by_board.push(board_id);
+                }
+            }
+            RouteScope::BoardCards {
+                board_id,
+                column_id,
+            } => {
+                want_board(&mut round, loaded, board_id);
+                if requestable(loaded.columns_of_board(board_id)) {
+                    round.columns_by_board.push(board_id);
+                }
+                if requestable(loaded.archived_cards_of_board(board_id)) {
+                    round.archived_cards_by_board.push(board_id);
+                }
+                match column_id {
+                    Some(column_id) => {
+                        if requestable(loaded.cards_of_column(column_id)) {
+                            round.cards_by_column.push(column_id);
+                        }
+                    }
+                    None => {
+                        if let Some(columns) = loaded.loaded_columns_of_board(board_id) {
+                            for column in columns {
+                                if requestable(loaded.cards_of_column(column.id)) {
+                                    round.cards_by_column.push(column.id);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            RouteScope::BoardArchivedCards(board_id) => {
+                want_board(&mut round, loaded, board_id);
+                if requestable(loaded.archived_cards_of_board(board_id)) {
+                    round.archived_cards_by_board.push(board_id);
+                }
+            }
+            RouteScope::BoardSprints(board_id) => {
+                want_board(&mut round, loaded, board_id);
+                if requestable(loaded.sprints_of_board(board_id)) {
+                    round.sprints_by_board.push(board_id);
+                }
+            }
+            RouteScope::Card(id) => {
+                if requestable(loaded.card(id)) {
+                    round.cards.push(id);
+                }
+            }
+            RouteScope::Column(id) => {
+                if requestable(loaded.column(id)) {
+                    round.columns.push(id);
+                }
+            }
+            RouteScope::Sprint {
+                board_id,
+                sprint_id,
+            } => {
+                if requestable(loaded.sprint(sprint_id)) {
+                    round.sprints.push(sprint_id);
+                }
+                if let Some(board_id) = board_id {
+                    want_board(&mut round, loaded, board_id);
+                }
+            }
+            RouteScope::CardGraph(id) => {
+                round.graph = requestable(loaded.graph());
+                if requestable(loaded.card(id)) {
+                    round.cards.push(id);
+                }
+            }
+        }
+
+        round
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -103,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_route_scope_for_board_cards_filtered_by_column_requests_that_column_in_the_first_round()
-     {
+    {
         let board_id = Uuid::new_v4();
         let column_id = Uuid::new_v4();
         let round = RouteScope::BoardCards {

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -1,0 +1,237 @@
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use kanban_domain::resolved::Collection;
+    use kanban_domain::{Board, Column, KanbanError, LoadState, Model, Resolved};
+    use uuid::Uuid;
+
+    use super::*;
+    use kanban_service::FetchPlan;
+
+    #[test]
+    fn test_route_scope_for_board_list_requests_only_the_board_list() {
+        let round = RouteScope::BoardList.next_round(&Model::default());
+
+        assert_eq!(
+            round,
+            FetchRound {
+                board_list: true,
+                ..Default::default()
+            }
+        );
+        assert!(!round.archived_board_list);
+        assert!(round.boards.is_empty());
+    }
+
+    #[test]
+    fn test_route_scope_for_single_board_requests_the_board_by_id_and_archived_markers() {
+        let id = Uuid::new_v4();
+        let round = RouteScope::Board(id).next_round(&Model::default());
+
+        assert_eq!(round.boards, vec![id]);
+        assert!(round.archived_board_list);
+        assert!(!round.board_list);
+    }
+
+    #[test]
+    fn test_route_scope_for_board_cards_requests_only_board_scoped_tiers() {
+        let board_id = Uuid::new_v4();
+        let round = RouteScope::BoardCards {
+            board_id,
+            column_id: None,
+        }
+        .next_round(&Model::default());
+
+        assert_eq!(round.boards, vec![board_id]);
+        assert_eq!(round.columns_by_board, vec![board_id]);
+        assert_eq!(round.archived_cards_by_board, vec![board_id]);
+        assert!(!round.card_list);
+        assert!(!round.board_list);
+        assert!(!round.column_list);
+        assert!(round.cards_by_column.is_empty());
+    }
+
+    #[test]
+    fn test_route_scope_for_board_cards_walks_loaded_columns_into_a_second_round_then_halts() {
+        let board = Board::new("Kanban", None::<String>);
+        let board_id = board.id;
+        let column = Column::new(board_id, "TODO", 0);
+        let column_id = column.id;
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: Collection {
+                by_id: [(board_id, LoadState::Loaded(board))].into(),
+                ..Default::default()
+            },
+            columns: Collection {
+                by_parent: [(board_id, LoadState::Loaded(vec![column]))].into(),
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                by_parent: [(board_id, LoadState::Loaded(vec![]))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let scope = RouteScope::BoardCards {
+            board_id,
+            column_id: None,
+        };
+        let round2 = scope.next_round(&model);
+        assert_eq!(
+            round2,
+            FetchRound {
+                cards_by_column: vec![column_id],
+                ..Default::default()
+            }
+        );
+
+        let mut model2 = model;
+        let _ = model2.apply_resolved(Resolved {
+            cards: Collection {
+                by_parent: [(column_id, LoadState::Loaded(vec![]))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let round3 = scope.next_round(&model2);
+        assert!(round3.is_empty());
+    }
+
+    #[test]
+    fn test_route_scope_for_board_cards_filtered_by_column_requests_that_column_in_the_first_round()
+     {
+        let board_id = Uuid::new_v4();
+        let column_id = Uuid::new_v4();
+        let round = RouteScope::BoardCards {
+            board_id,
+            column_id: Some(column_id),
+        }
+        .next_round(&Model::default());
+
+        assert_eq!(round.cards_by_column, vec![column_id]);
+        assert_eq!(round.boards, vec![board_id]);
+        assert_eq!(round.columns_by_board, vec![board_id]);
+    }
+
+    #[test]
+    fn test_route_scope_for_board_archived_cards_requests_the_board_and_its_markers() {
+        let board_id = Uuid::new_v4();
+        let round = RouteScope::BoardArchivedCards(board_id).next_round(&Model::default());
+
+        assert_eq!(round.boards, vec![board_id]);
+        assert_eq!(round.archived_cards_by_board, vec![board_id]);
+        assert!(!round.board_list);
+        assert!(!round.archived_card_list);
+    }
+
+    #[test]
+    fn test_route_scope_for_board_columns_and_board_sprints_request_the_board_and_its_scope() {
+        let board_id = Uuid::new_v4();
+
+        let columns_round = RouteScope::BoardColumns(board_id).next_round(&Model::default());
+        assert_eq!(columns_round.boards, vec![board_id]);
+        assert_eq!(columns_round.columns_by_board, vec![board_id]);
+        assert_eq!(
+            columns_round,
+            FetchRound {
+                boards: vec![board_id],
+                columns_by_board: vec![board_id],
+                ..Default::default()
+            }
+        );
+
+        let sprints_round = RouteScope::BoardSprints(board_id).next_round(&Model::default());
+        assert_eq!(
+            sprints_round,
+            FetchRound {
+                boards: vec![board_id],
+                sprints_by_board: vec![board_id],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_route_scope_for_a_nested_sprint_requests_its_board_but_the_flat_form_cannot() {
+        let board_id = Uuid::new_v4();
+        let sprint_id = Uuid::new_v4();
+
+        let nested_round = RouteScope::Sprint {
+            board_id: Some(board_id),
+            sprint_id,
+        }
+        .next_round(&Model::default());
+        assert_eq!(nested_round.sprints, vec![sprint_id]);
+        assert_eq!(nested_round.boards, vec![board_id]);
+
+        let flat_round = RouteScope::Sprint {
+            board_id: None,
+            sprint_id,
+        }
+        .next_round(&Model::default());
+        assert_eq!(flat_round.sprints, vec![sprint_id]);
+        assert!(flat_round.boards.is_empty());
+        assert!(!flat_round.board_list);
+    }
+
+    #[test]
+    fn test_route_scope_for_a_card_or_column_requests_only_that_entitys_per_id_tier() {
+        let card_id = Uuid::new_v4();
+        let card_round = RouteScope::Card(card_id).next_round(&Model::default());
+        assert_eq!(card_round.cards, vec![card_id]);
+        assert!(!card_round.is_empty());
+        assert!(!card_round.card_list);
+        assert!(!card_round.board_list);
+        assert!(card_round.boards.is_empty());
+        assert!(card_round.columns_by_board.is_empty());
+
+        let column_id = Uuid::new_v4();
+        let column_round = RouteScope::Column(column_id).next_round(&Model::default());
+        assert_eq!(column_round.columns, vec![column_id]);
+    }
+
+    #[test]
+    fn test_route_scope_for_card_graph_requests_the_graph_and_the_card() {
+        let card_id = Uuid::new_v4();
+        let round = RouteScope::CardGraph(card_id).next_round(&Model::default());
+
+        assert!(round.graph);
+        assert_eq!(round.cards, vec![card_id]);
+        assert!(!round.card_list);
+    }
+
+    #[test]
+    fn test_route_scope_retries_a_failed_tier_but_not_a_missing_one() {
+        let id = Uuid::new_v4();
+
+        let mut missing_model = Model::default();
+        let _ = missing_model.apply_resolved(Resolved {
+            boards: Collection {
+                by_id: [(id, LoadState::Missing)].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let missing_round = RouteScope::Board(id).next_round(&missing_model);
+        assert!(missing_round.boards.is_empty());
+
+        let mut failed_model = Model::default();
+        let _ = failed_model.apply_resolved(Resolved {
+            boards: Collection {
+                by_id: [(
+                    id,
+                    LoadState::Failed(Arc::new(KanbanError::Database("boom".into()))),
+                )]
+                .into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let failed_round = RouteScope::Board(id).next_round(&failed_model);
+        assert_eq!(failed_round.boards, vec![id]);
+    }
+}


### PR DESCRIPTION
Slice b of KAN-1448.

Adds `crates/kanban-server/src/scope.rs` with a public `RouteScope` enum (10 variants, one per read-route family) implementing `kanban_service::FetchPlan` over `&dyn LoadedEntities`, plus `crates/kanban-server/src/model_read.rs` with the server's `LoadState` to `AppError` read helpers, and registers both in `lib.rs`.

Two new files and two module declarations only, zero handler edits. `crates/kanban-server/tests/`, `state.rs`, `watch.rs`, `main.rs`, `error.rs`, `routes/` and `handlers/` are all unchanged, so the crate compiles and every existing test passes unchanged while slices c-g get their consumable seam.

## What this covers

- `RouteScope::BoardList` / `Board` / `BoardColumns` / `BoardCards` / `BoardArchivedCards` / `BoardSprints` / `Card` / `Column` / `Sprint` / `CardGraph`, one variant per read-route family. Re-derived read-route census against `crates/kanban-server/src/app.rs`: 14 read routes (boards 2, cards 4, columns 3, sprints 3, graph 1, prefixes 1). `GET /v1/prefixes` has no variant: no prefix tier exists in `FetchRound`, `LoadedState` or `Model`, so that route stays a lock-only read.
- `RouteScope::Board(id)` plans the per-id `boards` tier plus `archived_board_list`, not `board_list`. The per-id boards tier exists at `FetchRound.boards: Vec<Uuid>` and is served unfiltered at `resolve.rs:270-277`, and `get_board` needs both the per-id read and the archived-at stamp. `GET /v1/boards` (the collection route) deliberately does not stamp `archived_at`, so `RouteScope::BoardList` does not plan `archived_board_list`.
- `RouteScope::BoardCards` walks `loaded_columns_of_board` into a second round of `cards_by_column` requests when no `column_id` filter is given, mirroring the multi-round pattern in `kanban-tui/src/app/view_scope.rs`, and halts once every column's cards are loaded.
- `model_read::require_loaded` and `model_read::require_loaded_entity` map a route's `LoadState` reads to `AppError`: `NotLoaded` is a plan bug and renders 500 (logged via `tracing::error!` since the tier name is scrubbed from the client-facing message), a `Missing` per-id tier is the route's 404, and `Failed` forwards the underlying `KanbanError`'s wire error code without leaking its message, matching `ApiError::from(&KanbanError)`'s server-fault message scrubbing.

## Verification

- `cargo test -p kanban-server`: all 16 new tests green, existing suite unaffected.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo test --all-features --workspace`: green.
- `git diff origin/develop --stat`: touches exactly `crates/kanban-server/src/scope.rs`, `crates/kanban-server/src/model_read.rs`, `crates/kanban-server/src/lib.rs` (two `pub mod` lines), and the new changeset. No `Cargo.toml` diff.
