### PR TITLE
KAN-1506 feat(server): the mutation seam applies its Invalidation to the session Model

### DIFF
--- a/.changeset/kan-1506-server-mutation-applies-invalidation.md
+++ b/.changeset/kan-1506-server-mutation-applies-invalidation.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: apply the mutation seam's Invalidation to the shared session Model so a mutating request drops exactly the tiers it touched

--- a/crates/kanban-server/src/handlers/boards.rs
+++ b/crates/kanban-server/src/handlers/boards.rs
@@ -7,14 +7,13 @@
 //! [`BoardResponse`].
 
 use kanban_service::api::{ApiError, BoardResponse, CreateBoardRequest, ReplaceBoardRequest};
-use kanban_service::KanbanContext;
 use uuid::Uuid;
 
 /// `POST /v1/boards`: pure create. The body id is honoured when present
 /// (idempotent create with that exact id); a present id that already exists
 /// is a conflict (`AlreadyExists` -> 409), not a silent replace.
 pub fn create_board(
-    ctx: &mut KanbanContext,
+    ctx: &mut crate::state::Session,
     req: CreateBoardRequest,
 ) -> Result<BoardResponse, ApiError> {
     let (id, spec) = req.into_new_board();
@@ -27,7 +26,7 @@ pub fn create_board(
 /// the path `id`. Returns the wire projection plus whether the board was
 /// created (`true`, 201) or replaced (`false`, 200).
 pub fn create_or_replace_board(
-    ctx: &mut KanbanContext,
+    ctx: &mut crate::state::Session,
     id: Uuid,
     req: ReplaceBoardRequest,
 ) -> Result<(BoardResponse, bool), ApiError> {

--- a/crates/kanban-server/src/handlers/cards.rs
+++ b/crates/kanban-server/src/handlers/cards.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 /// exists under a *different* column, this 404s rather than silently
 /// relocating it — see [`create_or_replace_card`].
 pub fn create_card(
-    ctx: &mut KanbanContext,
+    ctx: &mut crate::state::Session,
     column_id: Uuid,
     req: CreateCardRequest,
 ) -> Result<(CardResponse, bool), ApiError> {
@@ -44,7 +44,7 @@ pub fn create_card(
 /// `create_or_replace_card`'s replace arm never checks the existing card's
 /// column on its own.
 pub fn create_or_replace_card(
-    ctx: &mut KanbanContext,
+    ctx: &mut crate::state::Session,
     column_id: Uuid,
     id: Uuid,
     req: CreateCardRequest,

--- a/crates/kanban-server/src/handlers/columns.rs
+++ b/crates/kanban-server/src/handlers/columns.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 /// exists under a *different* board, this 404s rather than silently
 /// relocating it — see [`create_or_replace_column`].
 pub fn create_column(
-    ctx: &mut KanbanContext,
+    ctx: &mut crate::state::Session,
     board_id: Uuid,
     req: CreateColumnRequest,
 ) -> Result<(ColumnResponse, bool), ApiError> {
@@ -42,7 +42,7 @@ pub fn create_column(
 /// guard (`routes/columns.rs::get_column`) since `create_or_replace_column`'s
 /// replace arm never checks the existing column's board on its own.
 pub fn create_or_replace_column(
-    ctx: &mut KanbanContext,
+    ctx: &mut crate::state::Session,
     board_id: Uuid,
     id: Uuid,
     req: ReplaceColumnRequest,

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 /// wire projection plus whether the sprint was created (`true`) or replaced an
 /// existing id (`false`).
 pub fn create_sprint(
-    ctx: &mut KanbanContext,
+    ctx: &mut crate::state::Session,
     board_id: Uuid,
     req: CreateSprintRequest,
 ) -> Result<(SprintResponse, bool), ApiError> {
@@ -51,7 +51,7 @@ pub fn create_sprint(
 /// `KanbanContext::create_or_replace_sprint`'s replace arm never checks the
 /// existing sprint's board on its own.
 pub fn create_or_replace_sprint(
-    ctx: &mut KanbanContext,
+    ctx: &mut crate::state::Session,
     board_id: Uuid,
     id: Uuid,
     req: ReplaceSprintRequest,

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -102,14 +102,14 @@ pub(crate) fn do_get_card(ctx: &kanban_service::KanbanContext, id: Uuid) -> Resu
 }
 
 fn do_update_card(
-    ctx: &mut kanban_service::KanbanContext,
+    ctx: &mut crate::state::Session,
     id: Uuid,
     updates: CardUpdate,
 ) -> Result<Card, AppError> {
     crate::state::mutate(ctx, |c| c.update_card_impl(id, updates)).map_err(|e| AppError::from(&e))
 }
 
-fn do_delete_card(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
+fn do_delete_card(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), AppError> {
     crate::state::mutate_unit(ctx, |c| c.delete_card_impl(id)).map_err(|e| AppError::from(&e))
 }
 

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -53,14 +53,14 @@ fn do_get_column(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Column
 }
 
 fn do_update_column(
-    ctx: &mut kanban_service::KanbanContext,
+    ctx: &mut crate::state::Session,
     id: Uuid,
     updates: ColumnUpdate,
 ) -> Result<Column, AppError> {
     crate::state::mutate(ctx, |c| c.update_column_impl(id, updates)).map_err(|e| AppError::from(&e))
 }
 
-fn do_delete_column(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
+fn do_delete_column(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), AppError> {
     crate::state::mutate_unit(ctx, |c| c.delete_column_impl(id)).map_err(|e| AppError::from(&e))
 }
 

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -61,14 +61,14 @@ fn do_get_sprint(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Sprint
 }
 
 fn do_update_sprint(
-    ctx: &mut kanban_service::KanbanContext,
+    ctx: &mut crate::state::Session,
     id: Uuid,
     updates: SprintUpdate,
 ) -> Result<Sprint, AppError> {
     crate::state::mutate(ctx, |c| c.update_sprint_impl(id, updates)).map_err(|e| AppError::from(&e))
 }
 
-fn do_delete_sprint(ctx: &mut kanban_service::KanbanContext, id: Uuid) -> Result<(), AppError> {
+fn do_delete_sprint(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), AppError> {
     crate::state::mutate_unit(ctx, |c| c.delete_sprint_impl(id)).map_err(|e| AppError::from(&e))
 }
 

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -6,27 +6,6 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};
 use uuid::Uuid;
 
-/// Run a mutation against `ctx`, returning its value and discarding the
-/// `Invalidation` it produced.
-pub(crate) fn mutate<T>(
-    ctx: &mut KanbanContext,
-    op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
-) -> KanbanResult<T> {
-    let (value, invalidation) = op(ctx)?;
-    let _ = invalidation;
-    Ok(value)
-}
-
-/// Like [`mutate`], for operations that return only an `Invalidation`.
-pub(crate) fn mutate_unit(
-    ctx: &mut KanbanContext,
-    op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
-) -> KanbanResult<()> {
-    let invalidation = op(ctx)?;
-    let _ = invalidation;
-    Ok(())
-}
-
 /// The context and the Model it feeds live under one guard, so a reader can
 /// never observe a Model that a committed mutation has already invalidated.
 /// `Deref`/`DerefMut` to the context keep every existing `state.ctx.lock()`
@@ -48,6 +27,29 @@ impl std::ops::DerefMut for Session {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.ctx
     }
+}
+
+/// Run a mutation against the session's context, then apply the
+/// `Invalidation` it produced to the session's Model before the guard
+/// drops, so the next reader replans exactly the tiers this mutation
+/// touched.
+pub(crate) fn mutate<T>(
+    session: &mut Session,
+    op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
+) -> KanbanResult<T> {
+    let (value, invalidation) = op(&mut session.ctx)?;
+    let _changed = session.model.invalidate(invalidation);
+    Ok(value)
+}
+
+/// Like [`mutate`], for operations that return only an `Invalidation`.
+pub(crate) fn mutate_unit(
+    session: &mut Session,
+    op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
+) -> KanbanResult<()> {
+    let invalidation = op(&mut session.ctx)?;
+    let _changed = session.model.invalidate(invalidation);
+    Ok(())
 }
 
 /// Shared state for every axum handler.
@@ -159,20 +161,25 @@ mod tests {
     use kanban_service::{AppConfig, KanbanBackend, KanbanOperations};
     use std::cell::Cell;
 
-    async fn seeded_ctx() -> (KanbanContext, Uuid) {
+    async fn seeded_ctx() -> (Session, Uuid) {
         let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
         let mut ctx = KanbanContext::open(backend, AppConfig::default())
             .await
             .unwrap();
         let board = ctx.create_board("Board1".into(), None).unwrap();
-        (ctx, board.id)
+        (
+            Session {
+                ctx,
+                model: Model::default(),
+            },
+            board.id,
+        )
     }
 
     fn json_state(dir: &std::path::Path) -> AppState {
-        let backend: Arc<dyn KanbanBackend> =
-            Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(
-                &dir.join("s.json"),
-            ))));
+        let backend: Arc<dyn KanbanBackend> = Arc::new(JsonDataStore::new(Arc::new(
+            JsonFileStore::new(dir.join("s.json")),
+        )));
         let ctx = KanbanContext::open_deferred(backend, AppConfig::default());
         AppState::new(ctx)
     }
@@ -283,15 +290,22 @@ mod tests {
 
     #[tokio::test]
     async fn test_mutate_propagates_the_error_and_invalidates_nothing() {
-        let (mut ctx, _board_id) = seeded_ctx().await;
+        let (mut session, _board_id) = seeded_ctx().await;
         let absent_id = Uuid::new_v4();
+        session.ctx.sync(
+            &RouteScope::BoardList,
+            &mut session.model,
+            &mut NoProjections,
+        );
+        assert!(matches!(session.model.boards_state(), LoadState::Loaded(_)));
 
-        let result = mutate(&mut ctx, |c| {
+        let result = mutate(&mut session, |c| {
             c.update_board_impl(absent_id, kanban_domain::BoardUpdate::default())
         });
 
         assert!(result.is_err());
-        assert_eq!(ctx.list_boards().unwrap().len(), 1);
+        assert_eq!(session.ctx.list_boards().unwrap().len(), 1);
+        assert!(matches!(session.model.boards_state(), LoadState::Loaded(_)));
     }
 
     #[tokio::test]

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -152,7 +152,10 @@ impl AppState {
 #[cfg(all(test, feature = "test-helpers"))]
 mod tests {
     use super::*;
+    use crate::scope::RouteScope;
     use kanban_backend_memory::InMemoryStore;
+    use kanban_domain::{BoardUpdate, LoadState, NoProjections};
+    use kanban_persistence_json::{JsonDataStore, JsonFileStore};
     use kanban_service::{AppConfig, KanbanBackend, KanbanOperations};
     use std::cell::Cell;
 
@@ -163,6 +166,101 @@ mod tests {
             .unwrap();
         let board = ctx.create_board("Board1".into(), None).unwrap();
         (ctx, board.id)
+    }
+
+    fn json_state(dir: &std::path::Path) -> AppState {
+        let backend: Arc<dyn KanbanBackend> =
+            Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(
+                &dir.join("s.json"),
+            ))));
+        let ctx = KanbanContext::open_deferred(backend, AppConfig::default());
+        AppState::new(ctx)
+    }
+
+    #[tokio::test]
+    async fn test_mutate_blanks_the_session_model_tier_the_invalidation_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = json_state(dir.path());
+        let mut guard = state.lock_session().await;
+
+        let board_id = guard.ctx.create_board("A".into(), None).unwrap().id;
+        {
+            let Session { ctx, model } = &mut *guard;
+            ctx.sync(&RouteScope::BoardList, model, &mut NoProjections);
+        }
+        assert!(matches!(guard.model.boards_state(), LoadState::Loaded(_)));
+
+        mutate(&mut guard, |c| {
+            c.update_board_impl(
+                board_id,
+                BoardUpdate {
+                    name: Some("Renamed".into()),
+                    ..Default::default()
+                },
+            )
+        })
+        .unwrap();
+
+        assert!(matches!(guard.model.boards_state(), LoadState::NotLoaded));
+    }
+
+    #[tokio::test]
+    async fn test_mutate_blanks_only_the_tiers_the_invalidation_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = json_state(dir.path());
+        let mut guard = state.lock_session().await;
+
+        let board_a = guard.ctx.create_board("A".into(), None).unwrap().id;
+        let board_b = guard.ctx.create_board("B".into(), None).unwrap().id;
+        {
+            let Session { ctx, model } = &mut *guard;
+            ctx.sync(
+                &RouteScope::BoardColumns(board_b),
+                model,
+                &mut NoProjections,
+            );
+            ctx.sync(&RouteScope::BoardList, model, &mut NoProjections);
+        }
+        assert!(matches!(
+            guard.model.board_columns_state(board_b),
+            LoadState::Loaded(_)
+        ));
+        assert!(matches!(guard.model.boards_state(), LoadState::Loaded(_)));
+
+        mutate(&mut guard, |c| {
+            c.update_board_impl(
+                board_a,
+                BoardUpdate {
+                    name: Some("Renamed".into()),
+                    ..Default::default()
+                },
+            )
+        })
+        .unwrap();
+
+        assert!(matches!(guard.model.boards_state(), LoadState::NotLoaded));
+        assert!(matches!(
+            guard.model.board_columns_state(board_b),
+            LoadState::Loaded(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_mutate_unit_blanks_the_session_model_tier_the_invalidation_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = json_state(dir.path());
+        let mut guard = state.lock_session().await;
+
+        let board_id = guard.ctx.create_board("A".into(), None).unwrap().id;
+        {
+            let Session { ctx, model } = &mut *guard;
+            ctx.sync(&RouteScope::BoardList, model, &mut NoProjections);
+        }
+        assert!(matches!(guard.model.boards_state(), LoadState::Loaded(_)));
+
+        mutate_unit(&mut guard, |c| c.delete_board_impl(board_id)).unwrap();
+
+        assert!(matches!(guard.model.boards_state(), LoadState::NotLoaded));
     }
 
     #[tokio::test]

--- a/crates/kanban-server/tests/board_create_seam.rs
+++ b/crates/kanban-server/tests/board_create_seam.rs
@@ -3,6 +3,7 @@
 
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_server::handlers::boards::{create_board, create_or_replace_board};
+use kanban_server::state::Session;
 use kanban_service::api::{
     CreateBoardRequest, ReplaceBoardRequest, SortFieldDto, SortOrderDto, TaskListViewDto,
 };
@@ -11,10 +12,13 @@ use std::sync::Arc;
 use tempfile::tempdir;
 use uuid::Uuid;
 
-fn make_ctx(path: &std::path::Path) -> KanbanContext {
+fn make_ctx(path: &std::path::Path) -> Session {
     let backend: Arc<dyn KanbanBackend> =
         Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
-    KanbanContext::open_deferred(backend, AppConfig::default())
+    Session {
+        ctx: KanbanContext::open_deferred(backend, AppConfig::default()),
+        model: Default::default(),
+    }
 }
 
 fn create_req(id: Option<Uuid>, name: &str) -> CreateBoardRequest {

--- a/crates/kanban-server/tests/card_create_seam.rs
+++ b/crates/kanban-server/tests/card_create_seam.rs
@@ -6,16 +6,20 @@
 
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_server::handlers::cards::{create_card, create_or_replace_card};
+use kanban_server::state::Session;
 use kanban_service::api::CreateCardRequest;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use std::sync::Arc;
 use tempfile::tempdir;
 use uuid::Uuid;
 
-fn make_ctx(path: &std::path::Path) -> KanbanContext {
+fn make_ctx(path: &std::path::Path) -> Session {
     let backend: Arc<dyn KanbanBackend> =
         Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
-    KanbanContext::open_deferred(backend, AppConfig::default())
+    Session {
+        ctx: KanbanContext::open_deferred(backend, AppConfig::default()),
+        model: Default::default(),
+    }
 }
 
 /// Seed a board with a single column; the card seam takes the column id as the

--- a/crates/kanban-server/tests/column_create_seam.rs
+++ b/crates/kanban-server/tests/column_create_seam.rs
@@ -6,16 +6,20 @@
 
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_server::handlers::columns::{create_column, create_or_replace_column};
+use kanban_server::state::Session;
 use kanban_service::api::ReplaceColumnRequest;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use std::sync::Arc;
 use tempfile::tempdir;
 use uuid::Uuid;
 
-fn make_ctx(path: &std::path::Path) -> KanbanContext {
+fn make_ctx(path: &std::path::Path) -> Session {
     let backend: Arc<dyn KanbanBackend> =
         Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
-    KanbanContext::open_deferred(backend, AppConfig::default())
+    Session {
+        ctx: KanbanContext::open_deferred(backend, AppConfig::default()),
+        model: Default::default(),
+    }
 }
 
 fn seed_board(ctx: &mut KanbanContext) -> Uuid {

--- a/crates/kanban-server/tests/shared_model.rs
+++ b/crates/kanban-server/tests/shared_model.rs
@@ -2,8 +2,10 @@
 
 use kanban_domain::{LoadState, NoProjections};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_server::scope::RouteScope;
 use kanban_server::state::{AppState, Session};
 use kanban_server::test_helpers::make_sqlite_state;
+use kanban_service::api::CreateBoardRequest;
 use kanban_service::{
     requestable, AppConfig, FetchPlan, FetchRound, KanbanBackend, KanbanContext, KanbanOperations,
     LoadedEntities,
@@ -126,4 +128,33 @@ async fn test_external_file_change_invalidates_the_shared_model() {
 
     let guard = state.ctx.lock().await;
     assert_eq!(guard.ctx.list_boards().unwrap().len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_the_board_create_handler_seam_invalidates_the_shared_model() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("board.json");
+    let state = json_state(&path);
+
+    let mut guard = state.lock_session().await;
+    {
+        let Session { ctx, model } = &mut *guard;
+        ctx.sync(&RouteScope::BoardList, model, &mut NoProjections);
+    }
+    assert!(matches!(guard.model.boards_state(), LoadState::Loaded(_)));
+
+    let req = CreateBoardRequest {
+        id: None,
+        name: "Fresh".to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    };
+    kanban_server::handlers::boards::create_board(&mut guard, req).unwrap();
+
+    assert!(matches!(guard.model.boards_state(), LoadState::NotLoaded));
 }

--- a/crates/kanban-server/tests/sprint_create_seam.rs
+++ b/crates/kanban-server/tests/sprint_create_seam.rs
@@ -9,16 +9,20 @@
 
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_server::handlers::sprints::{create_or_replace_sprint, create_sprint};
+use kanban_server::state::Session;
 use kanban_service::api::{CreateSprintRequest, ErrorCode, ReplaceSprintRequest};
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use std::sync::Arc;
 use tempfile::tempdir;
 use uuid::Uuid;
 
-fn make_ctx(path: &std::path::Path) -> KanbanContext {
+fn make_ctx(path: &std::path::Path) -> Session {
     let backend: Arc<dyn KanbanBackend> =
         Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
-    KanbanContext::open_deferred(backend, AppConfig::default())
+    Session {
+        ctx: KanbanContext::open_deferred(backend, AppConfig::default()),
+        model: Default::default(),
+    }
 }
 
 fn seed_board(ctx: &mut KanbanContext) -> Uuid {


### PR DESCRIPTION
## Summary

- `crate::state::mutate`/`mutate_unit` now take `&mut Session` instead of `&mut KanbanContext` and apply `session.model.invalidate(invalidation)` in-lock after the wrapped operation succeeds, so a mutation drops exactly the tiers its `Invalidation` names before the guard drops for the next reader.
- Widened the 8 public `handlers::{boards,cards,columns,sprints}::{create_*, create_or_replace_*}` fns and the 6 private `routes::{cards,columns,sprints}::do_{update,delete}_*` helpers to `&mut Session` to follow the seam; `routes/boards.rs` needed no edit since its call sites already coerce through `MutexGuard<Session>`.
- Fixed the four `tests/*_create_seam.rs` fixtures' `make_ctx` to build a `Session` instead of a bare `KanbanContext`.

## Re-derived call-site count

`git grep -nE "crate::state::(mutate|mutate_unit)\(" origin/develop -- crates/kanban-server/src | wc -l` = 17

Per file (against origin/develop):
- handlers/boards.rs: 2
- handlers/cards.rs: 2
- handlers/columns.rs: 2
- handlers/sprints.rs: 2
- routes/boards.rs: 2
- routes/cards.rs: 2
- routes/columns.rs: 3
- routes/sprints.rs: 2

## Test plan

- [x] `test_mutate_blanks_the_session_model_tier_the_invalidation_names` (state.rs)
- [x] `test_mutate_blanks_only_the_tiers_the_invalidation_names` (state.rs, proves scoped not `Invalidation::All`)
- [x] `test_mutate_unit_blanks_the_session_model_tier_the_invalidation_names` (state.rs)
- [x] `test_the_board_create_handler_seam_invalidates_the_shared_model` (tests/shared_model.rs, pins the public HTTP-facing seam)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`

## Notes

- `persist_and_broadcast` is unchanged (`ctx: &KanbanContext`); SSE `ChangeEventFrame` scope is out of this card's scope.
- Mutating routes still lock via `state.ctx.lock().await`, not `lock_session()`; on a SQLite locator the applied Invalidation is narrower than the per-request reset, so the Model can only end up fresher, never staler. This is a residual gap against the parent epic's "no handler locks except through lock_session()" acceptance criterion, reported here rather than fixed, since resolving it would widen the diff into files the still-unmerged read slices (KAN-1502-1505) also rewrite.
