### PR TITLE
KAN-1535 fix(server): the file watcher and the reset flag share one backend-kind decision

### DIFF
--- a/.changeset/kan-1535-server-one-backend-kind-decision.md
+++ b/.changeset/kan-1535-server-one-backend-kind-decision.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+the file watcher and the per-request Model reset now share one backend-kind decision derived from the registered store manager, so a JSON file at a .db name is watched for external writes instead of silently serving stale data

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod model_read;
 pub mod pagination;
 pub mod scope;
 pub mod state;
+pub mod stores;
 pub mod watch;
 
 #[cfg(feature = "test-helpers")]

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -47,18 +47,14 @@ async fn run(
     addr: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut config = config;
-    let mut stores = kanban_persistence::StoreRegistry::new();
-    let mut backends = kanban_backend::KanbanBackendRegistry::new();
-    backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
-    stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
-    backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
-    let sm = kanban_service::StoreManager::new(stores, backends);
+    let sm = kanban_server::stores::registered_store_manager();
     sm.sync_backend_with_file(locator, &mut config);
     let backend = sm.make_backend(locator, &config).await?;
     let ctx = kanban_service::KanbanContext::open(backend, config).await?;
-    let state = AppState::with_reset(ctx, sm.is_sqlite(locator));
+    let is_sqlite = sm.is_sqlite(locator);
+    let state = AppState::with_reset(ctx, is_sqlite);
 
-    kanban_server::watch::watch_for_external_changes(state.clone(), locator).await?;
+    kanban_server::watch::watch_for_external_changes(state.clone(), locator, is_sqlite).await?;
 
     let socket_addr: std::net::SocketAddr = addr.parse().map_err(|_| {
         std::io::Error::new(

--- a/crates/kanban-server/src/stores.rs
+++ b/crates/kanban-server/src/stores.rs
@@ -1,0 +1,14 @@
+/// Builds the `StoreManager` with every store and backend factory the
+/// server supports registered, in the order that decides which factory
+/// claims an ambiguous locator. This is the single place kanban-server
+/// derives a backend-kind decision from; every caller that needs to know
+/// whether a locator is SQLite or JSON goes through the manager this
+/// returns.
+pub fn registered_store_manager() -> kanban_service::StoreManager {
+    let mut stores = kanban_persistence::StoreRegistry::new();
+    let mut backends = kanban_backend::KanbanBackendRegistry::new();
+    backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+    stores.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+    backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+    kanban_service::StoreManager::new(stores, backends)
+}

--- a/crates/kanban-server/src/watch.rs
+++ b/crates/kanban-server/src/watch.rs
@@ -1,26 +1,24 @@
 use crate::state::AppState;
 use kanban_persistence::ChangeDetector;
-use kanban_service::StoreManager;
 use std::path::PathBuf;
 
 /// Watch `locator` for external changes (writes from another process — TUI,
 /// CLI, MCP) and reload `state.ctx` when they happen, broadcasting a change
 /// event afterward so any connected SSE clients see it too.
 ///
-/// No-op for a SQLite locator (queries hit the live DB on every call, no
-/// in-memory cache to go stale) and safe to call with a locator whose file
+/// `is_sqlite` must be the same backend-kind decision the caller used for
+/// `AppState::reset_model_per_request`; a `true` value is a no-op here
+/// because SQLite queries hit the live DB on every call, leaving no
+/// in-memory cache to go stale. Safe to call with a locator whose file
 /// doesn't exist yet — `FileWatcher::start_watching` resolves the parent
 /// directory rather than the file itself, so it can watch for the file's
 /// first creation as well as later external writes.
 pub async fn watch_for_external_changes(
     state: AppState,
     locator: &str,
+    is_sqlite: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let sm = StoreManager::new(
-        kanban_persistence::StoreRegistry::new(),
-        kanban_backend::KanbanBackendRegistry::new(),
-    );
-    if sm.is_sqlite(locator) {
+    if is_sqlite {
         return Ok(());
     }
 

--- a/crates/kanban-server/tests/backend_kind_decision.rs
+++ b/crates/kanban-server/tests/backend_kind_decision.rs
@@ -1,0 +1,56 @@
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use std::sync::Arc;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_content_at_db_extension_is_not_sqlite() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("board.db");
+
+    {
+        let backend: Arc<dyn KanbanBackend> =
+            Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+        let mut ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        ctx.create_board("Seed".to_string(), None).unwrap();
+        ctx.save().await.unwrap();
+    }
+    assert!(path.exists());
+
+    assert!(!kanban_server::stores::registered_store_manager().is_sqlite(path.to_str().unwrap()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sqlite_content_at_db_extension_is_sqlite() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("board.db");
+
+    {
+        let _backend = kanban_persistence_sqlite::SqliteBackend::open(path.to_str().unwrap())
+            .await
+            .unwrap();
+    }
+    assert!(path.exists());
+
+    assert!(kanban_server::stores::registered_store_manager().is_sqlite(path.to_str().unwrap()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_plain_json_locator_is_not_sqlite() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("board.json");
+
+    {
+        let backend: Arc<dyn KanbanBackend> =
+            Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+        let mut ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        ctx.create_board("Seed".to_string(), None).unwrap();
+        ctx.save().await.unwrap();
+    }
+    assert!(path.exists());
+
+    assert!(!kanban_server::stores::registered_store_manager().is_sqlite(path.to_str().unwrap()));
+}

--- a/crates/kanban-server/tests/external_reload.rs
+++ b/crates/kanban-server/tests/external_reload.rs
@@ -21,7 +21,7 @@ async fn test_get_boards_reflects_board_created_by_external_writer() {
         .await
         .unwrap();
     let state = AppState::new(ctx);
-    watch_for_external_changes(state.clone(), path.to_str().unwrap())
+    watch_for_external_changes(state.clone(), path.to_str().unwrap(), false)
         .await
         .unwrap();
 
@@ -67,7 +67,7 @@ async fn test_external_file_change_broadcasts_unscoped_frame() {
         .await
         .unwrap();
     let state = AppState::new(ctx);
-    watch_for_external_changes(state.clone(), path.to_str().unwrap())
+    watch_for_external_changes(state.clone(), path.to_str().unwrap(), false)
         .await
         .unwrap();
 
@@ -111,9 +111,62 @@ async fn test_watch_for_external_changes_is_noop_for_sqlite_locator() {
 
     // Must return Ok and must NOT attempt to watch a path notify can't
     // meaningfully treat the same way — confirms the is_sqlite() guard.
-    watch_for_external_changes(state, path.to_str().unwrap())
+    watch_for_external_changes(state, path.to_str().unwrap(), true)
         .await
         .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_json_content_at_db_extension_is_watched() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("board.db");
+
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    ctx.create_board("Seed".to_string(), None).unwrap();
+    ctx.save().await.unwrap();
+    assert!(path.exists());
+
+    let state = AppState::new(ctx);
+
+    let sm = kanban_server::stores::registered_store_manager();
+    let is_sqlite = sm.is_sqlite(path.to_str().unwrap());
+    assert!(
+        !is_sqlite,
+        "registered manager must content-sniff json at a .db name"
+    );
+
+    watch_for_external_changes(state.clone(), path.to_str().unwrap(), is_sqlite)
+        .await
+        .unwrap();
+
+    {
+        let backend: Arc<dyn KanbanBackend> =
+            Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(&path))));
+        let mut external_ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        external_ctx
+            .create_board("External Board".to_string(), Some("EXT".to_string()))
+            .unwrap();
+        external_ctx.save().await.unwrap();
+    }
+
+    let mut boards_len = 0;
+    for _ in 0..50 {
+        boards_len = state.ctx.lock().await.list_boards().unwrap().len();
+        if boards_len == 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(
+        boards_len, 2,
+        "server must reflect the externally-created board within 5s"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -131,7 +184,7 @@ async fn test_own_write_does_not_trigger_external_reload_path() {
 
     // Start watching for external changes — this spawns a background task that
     // will reload + broadcast when it detects file changes.
-    watch_for_external_changes(state.clone(), path.to_str().unwrap())
+    watch_for_external_changes(state.clone(), path.to_str().unwrap(), false)
         .await
         .unwrap();
 

--- a/crates/kanban-server/tests/shared_model.rs
+++ b/crates/kanban-server/tests/shared_model.rs
@@ -87,7 +87,7 @@ async fn test_external_file_change_invalidates_the_shared_model() {
         .unwrap();
     let state = AppState::new(ctx);
 
-    kanban_server::watch::watch_for_external_changes(state.clone(), path.to_str().unwrap())
+    kanban_server::watch::watch_for_external_changes(state.clone(), path.to_str().unwrap(), false)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

- Deletes the empty-registry `StoreManager` that `watch.rs` built privately for its `is_sqlite` check, which could disagree with the manager `main.rs` actually uses to open the backend (an existing JSON file at a `.db`/`.sqlite`/`.sqlite3` name would content-sniff as JSON via the registered manager but extension-fallback to SQLite via the empty one, silently disabling the watcher).
- Extracts the registered-factory construction from `main.rs::run` into `kanban_server::stores::registered_store_manager()`, the single place kanban-server registers store and backend factories, so both `main.rs` and the test suite share one registration order and one backend-kind decision.
- `watch_for_external_changes` now takes an `is_sqlite: bool` parameter instead of building its own manager, computed once in `main.rs` and reused for `AppState::with_reset`.

## Test plan

- [x] `cargo test -p kanban-server --all-features`
- [x] `cargo clippy -p kanban-server --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features --workspace`
- [x] New regression coverage: `crates/kanban-server/tests/backend_kind_decision.rs` pins the three-way locator matrix (JSON content at `.db`, real SQLite content at `.db`, plain `.json`) against the registered manager, and `test_json_content_at_db_extension_is_watched` in `external_reload.rs` proves the watcher actually gets installed for that case end to end.
