### PR TITLE
KAN-1502 refactor(server): boards and graph read handlers read the session Model

### DIFF
--- a/.changeset/kan-1502-server-boards-graph-model-reads.md
+++ b/.changeset/kan-1502-server-boards-graph-model-reads.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+the board and card-graph read routes serve their responses from the shared session Model instead of reading the context directly

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -1,40 +1,52 @@
 use crate::error::{AppError, AppJson};
 use crate::handlers::boards::{create_board, create_or_replace_board};
+use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
-use crate::state::AppState;
+use crate::scope::RouteScope;
+use crate::state::{AppState, Session};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
+use kanban_domain::NoProjections;
 use kanban_service::api::{
     BoardResponse, ChangeKind, CreateBoardRequest, EntityType, Page, PageParams,
     ReplaceBoardRequest, UpdateBoardRequest,
 };
-use kanban_service::{KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 async fn list_boards(
     State(state): State<AppState>,
     Query(params): Query<PageParams>,
 ) -> Result<Json<Page<BoardResponse>>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let boards = ctx.list_boards().map_err(|e| AppError::from(&e))?;
-    paginate_response(boards.iter().map(BoardResponse::from).collect(), &params)
+    let mut guard = state.lock_session().await;
+    {
+        let Session { ctx, model } = &mut *guard;
+        ctx.sync(&RouteScope::BoardList, model, &mut NoProjections);
+    }
+    let boards = require_loaded(guard.model.live_boards_state(), "board list")?;
+    paginate_response(
+        boards.iter().map(|b| BoardResponse::from(*b)).collect(),
+        &params,
+    )
 }
 
 async fn get_board(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<BoardResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let board = ctx
-        .get_board(id)
-        .map_err(|e| AppError::from(&e))?
-        .ok_or_else(|| AppError::from(&KanbanError::not_found("Board", id)))?;
-    // get_board is unfiltered, so an archived board comes back looking live
-    // unless stamped with the marker's archived_at (mirrors kanban-cli/-mcp).
-    let archived_at = ctx.board_archived_at(id).map_err(|e| AppError::from(&e))?;
-    Ok(Json(BoardResponse::with_archived_at(&board, archived_at)))
+    let mut guard = state.lock_session().await;
+    {
+        let Session { ctx, model } = &mut *guard;
+        ctx.sync(&RouteScope::Board(id), model, &mut NoProjections);
+    }
+    let board = require_loaded_entity(guard.model.board_id_status(id), "Board", id)?;
+    let markers = require_loaded(guard.model.archived_boards_state(), "archived board list")?;
+    let archived_at = markers
+        .iter()
+        .find(|marker| marker.entity_id == id)
+        .map(|marker| marker.metadata.archived_at);
+    Ok(Json(BoardResponse::with_archived_at(board, archived_at)))
 }
 
 pub fn read_router() -> Router<AppState> {

--- a/crates/kanban-server/src/routes/graph.rs
+++ b/crates/kanban-server/src/routes/graph.rs
@@ -1,8 +1,11 @@
 use crate::error::AppError;
-use crate::state::AppState;
+use crate::model_read::{require_loaded, require_loaded_entity};
+use crate::scope::RouteScope;
+use crate::state::{AppState, Session};
 use axum::extract::{Path, State};
 use axum::routing::get;
 use axum::{Json, Router};
+use kanban_domain::NoProjections;
 use kanban_service::api::CardGraphResponse;
 use uuid::Uuid;
 
@@ -10,10 +13,14 @@ async fn get_card_graph(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<CardGraphResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    crate::routes::cards::do_get_card(&ctx, id)?;
-    let graph = ctx.graph().map_err(|e| AppError::from(&e))?;
-    Ok(Json(CardGraphResponse::from_graph(id, &graph)))
+    let mut guard = state.lock_session().await;
+    {
+        let Session { ctx, model } = &mut *guard;
+        ctx.sync(&RouteScope::CardGraph(id), model, &mut NoProjections);
+    }
+    require_loaded_entity(guard.model.card_id_status(id), "Card", id)?;
+    let graph = require_loaded(guard.model.graph_state().as_ref(), "card graph")?;
+    Ok(Json(CardGraphResponse::from_graph(id, graph)))
 }
 
 pub fn read_router() -> Router<AppState> {

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -5,7 +5,8 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_domain::LoadState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -166,4 +167,196 @@ async fn test_get_board_archived_board_response_has_archived_at_stamped() {
         json["archived_at"].is_string(),
         "an archived board's response must be stamped with archived_at, not look live: {json}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_populates_the_session_models_board_list_tier() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board 1".to_string(), Some("B1".to_string()))
+            .unwrap();
+    }
+
+    let response = send(&state, "GET", "/v1/boards", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["items"].as_array().unwrap().len(), 1);
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.boards_state(), LoadState::Loaded(_)),
+        "list_boards must sync the session Model's board_list tier"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_populates_the_per_id_board_and_archived_marker_tiers_not_the_flat_list() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("My Board".to_string(), Some("MB".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.board_id_status(board_id), LoadState::Loaded(_)),
+        "get_board must sync the per-id board tier"
+    );
+    assert!(
+        matches!(guard.model.archived_boards_state(), LoadState::Loaded(_)),
+        "get_board must sync the archived board marker tier"
+    );
+    assert!(
+        matches!(guard.model.boards_state(), LoadState::NotLoaded),
+        "get_board must not sync the flat board_list tier"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_archived_board_resolves_through_the_per_id_tier_and_stamps_archived_at() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Archived Board".to_string(), Some("AB".to_string()))
+            .unwrap()
+            .id;
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let response = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert!(json["archived_at"].is_string());
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.board_id_status(board_id), LoadState::Loaded(_)),
+        "the archived head must resolve through the unfiltered per-id tier"
+    );
+    assert!(matches!(
+        guard.model.archived_boards_state(),
+        LoadState::Loaded(_)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_unknown_id_records_missing_on_the_per_id_tier_and_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let random_id = Uuid::new_v4();
+    let response = send(&state, "GET", &format!("/v1/boards/{}", random_id), None).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.board_id_status(random_id), LoadState::Missing),
+        "an unknown id must be recorded Missing on the per-id tier"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_archived_board_on_a_sqlite_locator_stamps_archived_at_and_syncs_the_per_id_tier()
+{
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Archived Board".to_string(), Some("AB".to_string()))
+            .unwrap()
+            .id;
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let response = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert!(json["archived_at"].is_string());
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.board_id_status(board_id), LoadState::Loaded(_)),
+        "sqlite: the per-id tier must resolve the archived head"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_boards_after_reading_a_single_archived_board_still_omits_it() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Archived Board".to_string(), Some("AB".to_string()))
+            .unwrap()
+            .id;
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let first = json_of(send(&state, "GET", "/v1/boards", None).await).await;
+    assert_eq!(first["items"], serde_json::json!([]));
+
+    let get_resp = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    assert_eq!(get_resp.status(), StatusCode::OK);
+
+    let second = json_of(send(&state, "GET", "/v1/boards", None).await).await;
+    assert_eq!(
+        second["items"],
+        serde_json::json!([]),
+        "a re-list after reading the archived board by id must not leak it back in"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_board_then_get_board_returns_the_updated_name_across_requests() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Original".to_string(), Some("OG".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let get1 = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    assert_eq!(get1.status(), StatusCode::OK);
+
+    let patch_body = serde_json::json!({ "name": "Renamed" });
+    let patch_resp = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{}", board_id),
+        Some(&patch_body),
+    )
+    .await;
+    assert_eq!(patch_resp.status(), StatusCode::OK);
+
+    let get2 = json_of(send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await).await;
+    assert_eq!(get2["name"], "Renamed");
 }

--- a/crates/kanban-server/tests/graph_read.rs
+++ b/crates/kanban-server/tests/graph_read.rs
@@ -4,8 +4,8 @@
 //! Established via `tower::ServiceExt::oneshot` against the router directly,
 //! with no real TCP socket.
 
-use kanban_domain::{GraphOperations, RelatesKind, Severity};
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_domain::{GraphOperations, LoadState, RelatesKind, Severity};
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
 use kanban_service::KanbanOperations;
 use serde_json::json;
 use tempfile::tempdir;
@@ -170,4 +170,134 @@ async fn test_get_card_graph_existing_card_with_no_edges_returns_200_empty_array
             "related": [],
         })
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_graph_populates_the_graph_and_per_id_card_tiers() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let subject: Uuid;
+    let child: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        let board = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap();
+        let column = ctx
+            .create_column(board.id, "Todo".to_string(), None)
+            .unwrap();
+        subject = ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Subject".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        child = ctx
+            .create_card(board.id, column.id, "Child".to_string(), Default::default())
+            .unwrap()
+            .id;
+        ctx.attach_children(subject, vec![child]).unwrap();
+    }
+
+    let response = send(&state, "GET", &format!("/v1/cards/{subject}/graph"), None).await;
+    assert_eq!(response.status(), 200);
+    let response_json = json_of(response).await;
+    assert_eq!(response_json["children"], json!([child]));
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.graph_state(), LoadState::Loaded(_)),
+        "get_card_graph must sync the graph tier"
+    );
+    assert!(
+        matches!(guard.model.card_id_status(subject), LoadState::Loaded(_)),
+        "get_card_graph must sync the per-id card tier"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_graph_unknown_card_records_missing_on_the_per_id_card_tier_and_returns_404()
+{
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        let board = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap();
+        ctx.create_column(board.id, "Todo".to_string(), None)
+            .unwrap();
+    }
+
+    let unknown_id = Uuid::new_v4();
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/cards/{unknown_id}/graph"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), 404);
+    let response_json = json_of(response).await;
+    assert_eq!(response_json["code"], "NOT_FOUND");
+    assert!(response_json.get("children").is_none());
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.card_id_status(unknown_id), LoadState::Missing),
+        "an unknown card id must be recorded Missing on the per-id tier"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_graph_on_a_sqlite_locator_syncs_the_graph_tier() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+
+    let subject: Uuid;
+    let child: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        let board = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap();
+        let column = ctx
+            .create_column(board.id, "Todo".to_string(), None)
+            .unwrap();
+        subject = ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Subject".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        child = ctx
+            .create_card(board.id, column.id, "Child".to_string(), Default::default())
+            .unwrap()
+            .id;
+        ctx.attach_children(subject, vec![child]).unwrap();
+    }
+
+    let response = send(&state, "GET", &format!("/v1/cards/{subject}/graph"), None).await;
+    assert_eq!(response.status(), 200);
+    let response_json = json_of(response).await;
+    assert_eq!(response_json["children"], json!([child]));
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.graph_state(), LoadState::Loaded(_)),
+        "sqlite: get_card_graph must sync the graph tier"
+    );
+    assert!(matches!(
+        guard.model.card_id_status(subject),
+        LoadState::Loaded(_)
+    ));
 }


### PR DESCRIPTION
## Summary

- `list_boards`, `get_board`, and `get_card_graph` in kanban-server now plan and read through the session `Model` via `RouteScope` instead of reading `KanbanContext` directly.
- `list_boards` reads `Model::live_boards_state()`, not `boards_state()`. The flat `boards` collection merges a per-id `Loaded` board into itself once already loaded, so reading the unfiltered flat tier would leak an archived board into a later list response after it had been fetched by id in the same session. `live_boards_state()` filters archived heads and is a strict no-op parity with `ctx.list_boards()` when no archived-marker tier has been loaded yet.
- `get_board` reads the per-id `boards` tier (`Model::board_id_status`) plus the archived-board marker tier, not the flat board list, so an archived board still resolves and gets its `archived_at` stamp.
- `get_card_graph` reads the graph tier and the per-id card tier, replacing the `do_get_card` existence check with `require_loaded_entity` on the Model.
- The four write handlers in `boards.rs` are untouched; they stay on `state.ctx.lock()` per the parent card's residual checklist for a later mechanical sweep.

The card's DRIFT CORRECTION 4 block, which described KAN-1500/1501/1506 as unmerged and `mutate`/`mutate_unit` as discarding their `Invalidation`, was stale: all three are merged at origin/develop tip, `scope.rs` and `model_read.rs` already exist, and `mutate`/`mutate_unit` already apply the `Invalidation` to the session Model.

## Test plan

- [x] New Red tests in `boards_read.rs` and `graph_read.rs` confirmed failing before the implementation, then passing after
- [x] `cargo test -p kanban-server --features test-helpers` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --all-features --workspace` green
