### PR TITLE
KAN-1503 refactor(server): column read routes read the session Model

### DIFF
--- a/.changeset/kan-1503-server-column-model-reads.md
+++ b/.changeset/kan-1503-server-column-model-reads.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+server: the column read routes (list, get, and the flat get) now read the shared session Model instead of calling the KanbanContext directly, keeping every response byte-identical while populating the Model for later reads in the same request.

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -1,11 +1,13 @@
 use crate::error::{AppError, AppJson};
+use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
-use crate::state::AppState;
+use crate::scope::RouteScope;
+use crate::state::{AppState, Session};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
-use kanban_domain::Column;
+use kanban_domain::{Column, NoProjections};
 use kanban_service::api::{ChangeKind, ColumnResponse, EntityType, Page, PageParams};
 use kanban_service::{ColumnUpdate, KanbanError, KanbanOperations};
 use uuid::Uuid;
@@ -15,10 +17,12 @@ async fn list_columns(
     Path(board_id): Path<Uuid>,
     Query(params): Query<PageParams>,
 ) -> Result<Json<Page<ColumnResponse>>, AppError> {
-    let ctx = state.ctx.lock().await;
-    ctx.require_board(board_id)
-        .map_err(|e| AppError::from(&e))?;
-    let cols = ctx.list_columns(board_id).map_err(|e| AppError::from(&e))?;
+    let mut session = state.lock_session().await;
+    let scope = RouteScope::BoardColumns(board_id);
+    let Session { ctx, model } = &mut *session;
+    ctx.sync(&scope, model, &mut NoProjections);
+    require_loaded_entity(model.board_id_status(board_id), "Board", board_id)?;
+    let cols = require_loaded(model.board_columns_state(board_id), "columns")?;
     paginate_response(cols.iter().map(ColumnResponse::from).collect(), &params)
 }
 
@@ -26,10 +30,15 @@ async fn get_column(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<ColumnResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    require_column_in_board(&ctx, board_id, id)?;
-    let column = do_get_column(&ctx, id)?;
-    Ok(Json(ColumnResponse::from(&column)))
+    let mut session = state.lock_session().await;
+    let scope = RouteScope::Column(id);
+    let Session { ctx, model } = &mut *session;
+    ctx.sync(&scope, model, &mut NoProjections);
+    let column = require_loaded_entity(model.column_id_status(id), "Column", id)?;
+    if column.board_id != board_id {
+        return Err(AppError::from(&KanbanError::not_found("Column", id)));
+    }
+    Ok(Json(ColumnResponse::from(column)))
 }
 
 pub fn read_router() -> Router<AppState> {
@@ -46,12 +55,6 @@ fn created_status(created: bool) -> StatusCode {
     }
 }
 
-fn do_get_column(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Column, AppError> {
-    ctx.get_column(id)
-        .map_err(|e| AppError::from(&e))?
-        .ok_or_else(|| AppError::from(&KanbanError::not_found("Column", id)))
-}
-
 fn do_update_column(
     ctx: &mut crate::state::Session,
     id: Uuid,
@@ -64,10 +67,9 @@ fn do_delete_column(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), App
     crate::state::mutate_unit(ctx, |c| c.delete_column_impl(id)).map_err(|e| AppError::from(&e))
 }
 
-/// Fetch a column and 404 unless it belongs to `board_id` — the same
-/// cross-board guard `get_column` (read route, above) applies, needed here
-/// too since `KanbanOperations::{update_column, delete_column, reorder_column}`
-/// key on the global column id alone with no board scoping of their own.
+/// Fetch a column and 404 unless it belongs to `board_id`, needed because
+/// `KanbanOperations::{update_column, delete_column, reorder_column}` key on
+/// the global column id with no board scoping of their own.
 fn require_column_in_board(
     ctx: &kanban_service::KanbanContext,
     board_id: Uuid,
@@ -201,9 +203,12 @@ async fn get_column_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ColumnResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let column = do_get_column(&ctx, id)?;
-    Ok(Json(ColumnResponse::from(&column)))
+    let mut session = state.lock_session().await;
+    let scope = RouteScope::Column(id);
+    let Session { ctx, model } = &mut *session;
+    ctx.sync(&scope, model, &mut NoProjections);
+    let column = require_loaded_entity(model.column_id_status(id), "Column", id)?;
+    Ok(Json(ColumnResponse::from(column)))
 }
 
 async fn update_column_route_flat(

--- a/crates/kanban-server/tests/columns_read.rs
+++ b/crates/kanban-server/tests/columns_read.rs
@@ -5,7 +5,8 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_domain::LoadState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -254,4 +255,164 @@ async fn test_get_column_wrong_board_returns_404() {
     );
     let json = json_of(response).await;
     assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_columns_populates_the_session_model_board_and_column_tiers() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_column(board_id, "Column 1".to_string(), Some(0))
+            .unwrap();
+        ctx.create_column(board_id, "Column 2".to_string(), Some(1))
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/columns", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json["items"].as_array().expect("items should be an array");
+    assert_eq!(arr.len(), 2);
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.board_id_status(board_id), LoadState::Loaded(_)),
+        "board tier should be populated after list_columns"
+    );
+    match guard.model.board_columns_state(board_id) {
+        LoadState::Loaded(cols) => assert_eq!(cols.len(), 2),
+        other => panic!("expected columns tier to be Loaded, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_column_populates_the_session_models_per_id_column_tier() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let column_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        column_id = ctx
+            .create_column(board_id, "Test Column".to_string(), None)
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/columns/{}", board_id, column_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let guard = state.ctx.lock().await;
+    match guard.model.column_id_status(column_id) {
+        LoadState::Loaded(c) => {
+            assert_eq!(c.id, column_id);
+            assert_eq!(c.board_id, board_id);
+        }
+        other => panic!("expected column tier to be Loaded, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_column_flat_populates_the_session_models_per_id_column_tier() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let column_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        column_id = ctx
+            .create_column(board_id, "Test Column".to_string(), None)
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/columns/{}", column_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let guard = state.ctx.lock().await;
+    assert!(matches!(
+        guard.model.column_id_status(column_id),
+        LoadState::Loaded(_)
+    ));
+    assert!(
+        matches!(guard.model.board_id_status(board_id), LoadState::NotLoaded),
+        "the flat route has no board in its path and must not plan a board tier"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_columns_on_sqlite_serves_an_archived_boards_columns_from_the_model() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("board.sqlite")).await;
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Archived Board".to_string(), Some("AB".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_column(board_id, "Column 1".to_string(), Some(0))
+            .unwrap();
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/columns", board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json["items"].as_array().expect("items should be an array");
+    assert_eq!(arr.len(), 1);
+
+    let guard = state.ctx.lock().await;
+    assert!(matches!(
+        guard.model.board_id_status(board_id),
+        LoadState::Loaded(_)
+    ));
+    match guard.model.board_columns_state(board_id) {
+        LoadState::Loaded(cols) => assert_eq!(cols.len(), 1),
+        other => panic!("expected columns tier to be Loaded, got {other:?}"),
+    }
 }

--- a/crates/kanban-server/tests/columns_read.rs
+++ b/crates/kanban-server/tests/columns_read.rs
@@ -356,13 +356,7 @@ async fn test_get_column_flat_populates_the_session_models_per_id_column_tier() 
             .id;
     }
 
-    let response = send(
-        &state,
-        "GET",
-        &format!("/v1/columns/{}", column_id),
-        None,
-    )
-    .await;
+    let response = send(&state, "GET", &format!("/v1/columns/{}", column_id), None).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     let guard = state.ctx.lock().await;


### PR DESCRIPTION
## Summary

Retargets the three column READ handlers in `crates/kanban-server/src/routes/columns.rs` (`list_columns`, `get_column`, `get_column_flat`) so they acquire the session via `AppState::lock_session()`, build a `RouteScope`, call `KanbanContext::sync`, and read the shared Model through `model_read::require_loaded` / `require_loaded_entity` instead of calling `ctx.require_board` / `ctx.list_columns` / `ctx.get_column`.

Every HTTP path, method, status code and response body stays byte-identical. The write routes and `crates/kanban-server/src/handlers/columns.rs` are untouched in this slice; converting their `state.ctx.lock()` sites to `lock_session()` is deferred to the parent KAN-1448 residual-checklist sweep that runs once all the read slices (1502-1505) have merged.

- `list_columns` now plans `RouteScope::BoardColumns(board_id)`, checks the per-id board tier before reading the columns tier (this ordering matters: reading the columns tier alone would silently turn an unknown board into a 200 empty page instead of a 404), then reads `board_columns_state`.
- `get_column` now plans `RouteScope::Column(id)`, reads the per-id column tier, and explicitly 404s when the column's `board_id` does not match the path's board id (the Model read alone cannot express the cross-board check).
- `get_column_flat` now plans `RouteScope::Column(id)` and reads the per-id column tier with no board check, matching its route shape.
- Removed the now-dead `do_get_column` helper (its two callers were both retargeted).
- Corrected the stale doc comment on `require_column_in_board`, which referenced a `get_column` guard that this change removes.

## Verification

- `git show origin/develop:crates/kanban-server/src/routes/columns.rs | grep -c 'ctx.lock().await'` -> 10 at base
- `grep -c 'ctx.lock().await' crates/kanban-server/src/routes/columns.rs` -> 7 after (3 read sites converted to `lock_session`)
- `grep -c 'lock_session' crates/kanban-server/src/routes/columns.rs` -> 3
- `crates/kanban-server/src/handlers/columns.rs` -> 0 diff, unchanged
- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --all-features --workspace` green
- Mutation-tested both guards by hand: disabling the wrong-board 404 check and disabling the board-existence guard each broke exactly the test that pins that behavior, then reverted before committing.

## Test plan

- [x] `cargo test -p kanban-server --features test-helpers --test columns_read` green, including the 4 new tests that pin the Model tiers get populated and the SQLite backend serves an archived board's columns correctly
- [x] `cargo test --all-features --workspace` green with zero diff to any test file other than `columns_read.rs`
