### PR TITLE
KAN-1504 refactor(server): sprint read routes read the session Model

### DIFF
--- a/.changeset/kan-1504-server-sprint-model-reads.md
+++ b/.changeset/kan-1504-server-sprint-model-reads.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+server: sprint read routes now read the shared session Model instead of locking the context directly

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -1,15 +1,15 @@
 use crate::error::{AppError, AppJson};
+use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
-use crate::state::AppState;
+use crate::scope::RouteScope;
+use crate::state::{AppState, Session};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
-use kanban_domain::Sprint;
+use kanban_domain::{NoProjections, Sprint};
 use kanban_service::api::{ChangeKind, EntityType, Page, PageParams, SprintResponse};
-use kanban_service::{
-    resolve_sprint_name, resolve_sprint_names, KanbanError, KanbanOperations, SprintUpdate,
-};
+use kanban_service::{resolve_sprint_name, KanbanError, KanbanOperations, SprintUpdate};
 use uuid::Uuid;
 
 async fn list_sprints(
@@ -17,15 +17,23 @@ async fn list_sprints(
     Path(board_id): Path<Uuid>,
     Query(params): Query<PageParams>,
 ) -> Result<Json<Page<SprintResponse>>, AppError> {
-    let ctx = state.ctx.lock().await;
-    ctx.require_board(board_id)
-        .map_err(|e| AppError::from(&e))?;
-    let sprints = ctx.list_sprints(board_id).map_err(|e| AppError::from(&e))?;
-    let names = resolve_sprint_names(&**ctx, board_id, &sprints).map_err(|e| AppError::from(&e))?;
+    let mut guard = state.lock_session().await;
+    {
+        let Session { ctx, model } = &mut *guard;
+        ctx.sync(
+            &RouteScope::BoardSprints(board_id),
+            model,
+            &mut NoProjections,
+        );
+    }
+    let board = require_loaded_entity(guard.model.board_id_status(board_id), "Board", board_id)?;
+    let sprints = require_loaded(
+        guard.model.board_sprints_state(board_id),
+        "sprints of board",
+    )?;
     let responses: Vec<SprintResponse> = sprints
         .iter()
-        .zip(names)
-        .map(|(s, name)| SprintResponse::new(s, name))
+        .map(|s| SprintResponse::new(s, s.get_name(board).map(str::to_string)))
         .collect();
     paginate_response(responses, &params)
 }
@@ -34,10 +42,27 @@ async fn get_sprint(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<SprintResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    require_sprint_in_board(&ctx, board_id, id)?;
-    let sprint = do_get_sprint(&ctx, id)?;
-    Ok(Json(respond(&ctx, &sprint)?))
+    let mut guard = state.lock_session().await;
+    {
+        let Session { ctx, model } = &mut *guard;
+        ctx.sync(
+            &RouteScope::Sprint {
+                board_id: Some(board_id),
+                sprint_id: id,
+            },
+            model,
+            &mut NoProjections,
+        );
+    }
+    let sprint = require_loaded_entity(guard.model.sprint_by_id_state(id), "Sprint", id)?;
+    if sprint.board_id != board_id {
+        return Err(AppError::from(&KanbanError::not_found("Sprint", id)));
+    }
+    let board = require_loaded_entity(guard.model.board_id_status(board_id), "Board", board_id)?;
+    Ok(Json(SprintResponse::new(
+        sprint,
+        sprint.get_name(board).map(str::to_string),
+    )))
 }
 
 pub fn read_router() -> Router<AppState> {
@@ -190,9 +215,39 @@ async fn get_sprint_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<SprintResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let sprint = do_get_sprint(&ctx, id)?;
-    Ok(Json(respond(&ctx, &sprint)?))
+    let mut guard = state.lock_session().await;
+    {
+        let Session { ctx, model } = &mut *guard;
+        ctx.sync(
+            &RouteScope::Sprint {
+                board_id: None,
+                sprint_id: id,
+            },
+            model,
+            &mut NoProjections,
+        );
+    }
+    let sprint = require_loaded_entity(guard.model.sprint_by_id_state(id), "Sprint", id)?.clone();
+    {
+        let Session { ctx, model } = &mut *guard;
+        ctx.sync(
+            &RouteScope::Sprint {
+                board_id: Some(sprint.board_id),
+                sprint_id: id,
+            },
+            model,
+            &mut NoProjections,
+        );
+    }
+    let board = require_loaded_entity(
+        guard.model.board_id_status(sprint.board_id),
+        "Board",
+        sprint.board_id,
+    )?;
+    Ok(Json(SprintResponse::new(
+        &sprint,
+        sprint.get_name(board).map(str::to_string),
+    )))
 }
 
 async fn update_sprint_route_flat(

--- a/crates/kanban-server/tests/sprints_model_read.rs
+++ b/crates/kanban-server/tests/sprints_model_read.rs
@@ -1,0 +1,325 @@
+#![cfg(feature = "test-helpers")]
+
+//! Pins that the sprint read routes (`list_sprints`, `get_sprint`,
+//! `get_sprint_flat`) populate the session Model rather than reading the
+//! context directly.
+
+use axum::http::StatusCode;
+use kanban_domain::LoadState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use kanban_service::KanbanOperations;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_sprints_loads_the_board_head_and_the_scoped_sprint_tier_into_the_session_model()
+{
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap();
+        ctx.create_sprint(board_id, Some("SPR".to_string()), Some("Beta".to_string()))
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json["items"].as_array().expect("items should be an array");
+    let names: std::collections::HashSet<_> = arr
+        .iter()
+        .map(|s| s["name"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        names,
+        ["Alpha".to_string(), "Beta".to_string()]
+            .into_iter()
+            .collect()
+    );
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.board_sprints_state(board_id), LoadState::Loaded(s) if s.len() == 2),
+        "expected board_sprints_state to be Loaded with 2 sprints, got {:?}",
+        guard.model.board_sprints_state(board_id)
+    );
+    assert!(
+        guard.model.board_id_status(board_id).is_loaded(),
+        "expected board_id_status to be Loaded, got {:?}",
+        guard.model.board_id_status(board_id)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_loads_the_sprint_and_its_board_head_into_the_session_model() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let sprint_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        sprint_id = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints/{}", board_id, sprint_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"].as_str().unwrap(), "Alpha");
+    assert_eq!(json["board_id"].as_str().unwrap(), board_id.to_string());
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        guard.model.sprint_id_status(sprint_id).is_loaded(),
+        "expected sprint_id_status to be Loaded, got {:?}",
+        guard.model.sprint_id_status(sprint_id)
+    );
+    assert!(
+        guard.model.board_id_status(board_id).is_loaded(),
+        "expected board_id_status to be Loaded, got {:?}",
+        guard.model.board_id_status(board_id)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_the_flat_sprint_route_chains_a_second_round_for_its_owning_board_head() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let sprint_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        sprint_id = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(&state, "GET", &format!("/v1/sprints/{}", sprint_id), None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["name"].as_str().unwrap(), "Alpha");
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        guard.model.sprint_id_status(sprint_id).is_loaded(),
+        "expected sprint_id_status to be Loaded, got {:?}",
+        guard.model.sprint_id_status(sprint_id)
+    );
+    assert!(
+        guard.model.board_id_status(board_id).is_loaded(),
+        "expected board_id_status to be Loaded, got {:?}",
+        guard.model.board_id_status(board_id)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_reads_of_an_archived_board_resolve_the_name_and_load_its_head() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let sprint_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        sprint_id = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let list_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_json = json_of(list_response).await;
+    let arr = list_json["items"]
+        .as_array()
+        .expect("items should be an array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"].as_str().unwrap(), "Alpha");
+
+    let get_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints/{}", board_id, sprint_id),
+        None,
+    )
+    .await;
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_json = json_of(get_response).await;
+    assert_eq!(get_json["name"].as_str().unwrap(), "Alpha");
+
+    let flat_response = send(&state, "GET", &format!("/v1/sprints/{}", sprint_id), None).await;
+    assert_eq!(flat_response.status(), StatusCode::OK);
+    let flat_json = json_of(flat_response).await;
+    assert_eq!(flat_json["name"].as_str().unwrap(), "Alpha");
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        guard.model.board_id_status(board_id).is_loaded(),
+        "expected board_id_status to be Loaded, got {:?}",
+        guard.model.board_id_status(board_id)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_reads_populate_the_session_model_on_a_sqlite_locator_and_reset_between_requests(
+) {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("s.sqlite")).await;
+
+    let board_id: Uuid;
+    let sprint_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        sprint_id = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let get_response = send(&state, "GET", &format!("/v1/sprints/{}", sprint_id), None).await;
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_json = json_of(get_response).await;
+    assert_eq!(get_json["name"].as_str().unwrap(), "Alpha");
+
+    {
+        let guard = state.ctx.lock().await;
+        assert!(
+            guard.model.sprint_id_status(sprint_id).is_loaded(),
+            "expected sprint_id_status to be Loaded, got {:?}",
+            guard.model.sprint_id_status(sprint_id)
+        );
+        assert!(
+            guard.model.board_id_status(board_id).is_loaded(),
+            "expected board_id_status to be Loaded, got {:?}",
+            guard.model.board_id_status(board_id)
+        );
+    }
+
+    let list_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_json = json_of(list_response).await;
+    let arr = list_json["items"]
+        .as_array()
+        .expect("items should be an array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"].as_str().unwrap(), "Alpha");
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        matches!(guard.model.board_sprints_state(board_id), LoadState::Loaded(s) if s.len() == 1),
+        "expected board_sprints_state to be Loaded with 1 sprint, got {:?}",
+        guard.model.board_sprints_state(board_id)
+    );
+    assert!(
+        guard.model.board_id_status(board_id).is_loaded(),
+        "expected board_id_status to be Loaded, got {:?}",
+        guard.model.board_id_status(board_id)
+    );
+    assert!(
+        guard.model.sprint_id_status(sprint_id).is_not_loaded(),
+        "expected sprint_id_status to be reset to NotLoaded after lock_session, got {:?}",
+        guard.model.sprint_id_status(sprint_id)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_reads_of_an_archived_board_resolve_on_a_sqlite_locator() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("s.sqlite")).await;
+
+    let board_id: Uuid;
+    let sprint_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        sprint_id = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let list_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_json = json_of(list_response).await;
+    let arr = list_json["items"]
+        .as_array()
+        .expect("items should be an array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"].as_str().unwrap(), "Alpha");
+
+    let flat_response = send(&state, "GET", &format!("/v1/sprints/{}", sprint_id), None).await;
+    assert_eq!(flat_response.status(), StatusCode::OK);
+    let flat_json = json_of(flat_response).await;
+    assert_eq!(flat_json["name"].as_str().unwrap(), "Alpha");
+
+    let guard = state.ctx.lock().await;
+    assert!(
+        guard.model.board_id_status(board_id).is_loaded(),
+        "expected board_id_status to be Loaded, got {:?}",
+        guard.model.board_id_status(board_id)
+    );
+}


### PR DESCRIPTION
## Summary

Converts the three sprint READ handlers in `crates/kanban-server/src/routes/sprints.rs` (`list_sprints`, `get_sprint`, `get_sprint_flat`) from raw `state.ctx.lock()` context reads onto the shared session Model, via `lock_session()` plus `ctx.sync(&RouteScope::..., model, &mut NoProjections)` and the `model_read.rs` require helpers. Each sprint's wire `name` is now resolved from the board head read out of the Model (`Sprint::get_name`) instead of `resolve_sprint_name`/`resolve_sprint_names`.

- `list_sprints`: one round via `RouteScope::BoardSprints(board_id)`, planning the board head plus the scoped `sprints_by_board` tier.
- `get_sprint`: one round via `RouteScope::Sprint { board_id: Some(board_id), sprint_id }`. The sprint is read and the cross-board 404 check applied before the board head read, so a sprint belonging to another board still 404s as "Sprint" rather than "Board".
- `get_sprint_flat`: two rounds. The first resolves the sprint by id alone (`RouteScope::Sprint { board_id: None, sprint_id }`); the sprint is cloned to release the Model borrow, then a second round (`RouteScope::Sprint { board_id: Some(sprint.board_id), sprint_id }`) fetches the owning board head. No fallback to a raw `ctx.get_board` point read.

The six mutating lock sites in the same file, and `handlers/sprints.rs` entirely, are untouched; they are scoped to the parent's residual-checklist sweep. `scope.rs` and `model_read.rs` needed no changes: their `BoardSprints`/`Sprint{board_id: Option<Uuid>}` variants and both require helpers already existed at `origin/develop` tip.

## Deviations from the card

- The card's DESIGN CORRECTION 2 suggested copying the MCP `board_head` precedent with an unfiltered `ctx.get_board` fallback. This contradicted the card's own GAP NOTE ("do not fall back to a raw ctx read"), which is the later, authoritative block. No fallback was added; both the flat route and every other handler read the board head only through `Model::board_id_status`, never `board_by_id_state` (which reads only the flat `boards` collection and would leave every sprint route erroring on an archived board's sprints).
- For `get_sprint_flat`'s second round, `RouteScope::Sprint { board_id: Some(...), sprint_id }` was used instead of the GAP NOTE's literal `RouteScope::Board(sprint.board_id)`, because `RouteScope::Board` also plans the whole-store `archived_board_list` tier, which this route's response body never reads.

## Verification

- `cargo test -p kanban-server --features test-helpers`: all pre-existing tests unchanged and green, plus the 6 new tests in `crates/kanban-server/tests/sprints_model_read.rs`.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo test --all-features --workspace`: green.
- Mutation check: removing the `ctx.sync` call from `list_sprints` reproduces 4 of the 6 new tests failing with 500s (Model tier not planned), confirming the tests catch a regression; restored before commit.
- Lock-site counts on `crates/kanban-server/src/routes/sprints.rs`: `ctx.lock().await` 9 -> 6, `state.lock_session().await` 0 -> 3. Whole-crate `ctx.lock().await` count: 40 (`boards.rs` 6, `cards.rs` 10, `columns.rs` 10, `graph.rs` 1, `prefixes.rs` 1, `sprints.rs` 6, `state.rs` 1, `watch.rs` 2, down from 43 at `origin/develop` counting `sprints.rs` at 9).
- KAN-1506 (the mutation seam applying its Invalidation to the session Model) is already merged at `origin/develop` tip, so there is no stale-tier sequencing caveat to note for this PR.
