### PR TITLE
KAN-1505 feat(server): route card GET handlers through the session Model

### DIFF
--- a/.changeset/kan-1505-server-card-model-reads.md
+++ b/.changeset/kan-1505-server-card-model-reads.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: card GET routes read through the session Model via RouteScope

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -164,12 +164,6 @@ fn created_status(created: bool) -> StatusCode {
     }
 }
 
-pub(crate) fn do_get_card(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Card, AppError> {
-    ctx.get_card(id)
-        .map_err(|e| AppError::from(&e))?
-        .ok_or_else(|| AppError::from(&KanbanError::not_found("Card", id)))
-}
-
 fn do_update_card(
     ctx: &mut crate::state::Session,
     id: Uuid,

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -1,11 +1,14 @@
 use crate::error::{AppError, AppJson};
+use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
-use crate::state::AppState;
+use crate::scope::RouteScope;
+use crate::state::{AppState, Session};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
-use kanban_domain::{Card, CardListFilter};
+use chrono::{DateTime, Utc};
+use kanban_domain::{filter_and_sort_cards, ArchivedFilter, Card, CardListFilter, NoProjections};
 use kanban_service::api::ArchivedCardResponse;
 use kanban_service::api::ArchivedFilterDto;
 use kanban_service::api::CardResponse;
@@ -14,7 +17,7 @@ use kanban_service::api::{
 };
 use kanban_service::{CardUpdate, KanbanError, KanbanOperations};
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize)]
@@ -25,28 +28,84 @@ pub struct CardQuery {
     pub archived: ArchivedFilterDto,
 }
 
+fn optional_card<'a>(
+    state: kanban_domain::LoadState<&'a Card>,
+    what: &str,
+) -> Result<Option<&'a Card>, AppError> {
+    match state {
+        kanban_domain::LoadState::Missing => Ok(None),
+        other => require_loaded(other, what).map(Some),
+    }
+}
+
 async fn list_cards(
     State(state): State<AppState>,
     Path(board_id): Path<Uuid>,
     Query(q): Query<CardQuery>,
     Query(params): Query<PageParams>,
 ) -> Result<Json<Page<CardResponse>>, AppError> {
+    let archived: ArchivedFilter = q.archived.into();
+    let scope = RouteScope::BoardCards {
+        board_id,
+        column_id: q.column_id,
+        archived,
+    };
+
+    let mut guard = state.lock_session().await;
+    let Session { ctx, model } = &mut *guard;
+    ctx.sync(&scope, model, &mut NoProjections);
+
+    let board = require_loaded_entity(model.board_id_status(board_id), "Board", board_id)?;
+    let columns = require_loaded(model.board_columns_state(board_id), "columns of board")?;
+
+    let source_column_ids: Vec<Uuid> = match q.column_id {
+        Some(cid) => {
+            if columns.iter().any(|c| c.id == cid) {
+                vec![cid]
+            } else {
+                Vec::new()
+            }
+        }
+        None => columns.iter().map(|c| c.id).collect(),
+    };
+
+    let mut live: Vec<Card> = Vec::new();
+    for column_id in &source_column_ids {
+        let cards = require_loaded(model.column_cards_state(*column_id), "cards of column")?;
+        live.extend(cards.iter().cloned());
+    }
+
+    let mut cards = if archived == ArchivedFilter::ArchivedOnly {
+        Vec::new()
+    } else {
+        live
+    };
+    let mut archived_at: HashMap<Uuid, DateTime<Utc>> = HashMap::new();
+    if archived != ArchivedFilter::LiveOnly {
+        let markers = require_loaded(model.archived_cards_state(), "archived cards")?;
+        for marker in markers.iter().filter(|m| m.context.board_id == board_id) {
+            if let Some(card) = optional_card(model.card_by_id_state(marker.entity_id), "Card")? {
+                cards.push(card.clone());
+                archived_at.insert(marker.entity_id, marker.metadata.archived_at);
+            }
+        }
+    }
+
     let filter = CardListFilter {
-        board_id: Some(board_id),
+        board_id: if archived == ArchivedFilter::LiveOnly {
+            Some(board_id)
+        } else {
+            None
+        },
         column_id: q.column_id,
         sprint_ids: q.sprint_id.map(|id| HashSet::from([id])),
-        archived: q.archived.into(),
+        archived,
         ..Default::default()
     };
-    let ctx = state.ctx.lock().await;
-    ctx.require_board(board_id)
-        .map_err(|e| AppError::from(&e))?;
-    let cards = ctx
-        .list_cards_detailed(filter)
-        .map_err(|e| AppError::from(&e))?;
-    let responses: Vec<CardResponse> = cards
+    let filtered = filter_and_sort_cards(&cards, columns, &[], Some(board), &[], &filter);
+    let responses: Vec<CardResponse> = filtered
         .iter()
-        .map(|(card, archived_at)| CardResponse::with_archived_at(card, *archived_at))
+        .map(|c| CardResponse::with_archived_at(c, archived_at.get(&c.id).copied()))
         .collect();
     paginate_response(responses, &params)
 }
@@ -55,10 +114,16 @@ async fn get_card(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<CardResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    require_card_in_board(&ctx, board_id, id)?;
-    let card = do_get_card(&ctx, id)?;
-    Ok(Json(CardResponse::from(&card)))
+    let scope = RouteScope::Card(id);
+    let mut guard = state.lock_session().await;
+    let Session { ctx, model } = &mut *guard;
+    ctx.sync(&scope, model, &mut NoProjections);
+
+    let card = require_loaded_entity(model.card_by_id_state(id), "Card", id)?;
+    if card.board_id != board_id {
+        return Err(AppError::from(&KanbanError::not_found("Card", id)));
+    }
+    Ok(Json(CardResponse::from(card)))
 }
 
 async fn list_archived_cards(
@@ -66,12 +131,16 @@ async fn list_archived_cards(
     Path(board_id): Path<Uuid>,
     Query(params): Query<PageParams>,
 ) -> Result<Json<Page<ArchivedCardResponse>>, AppError> {
-    let ctx = state.ctx.lock().await;
-    ctx.require_board(board_id)
-        .map_err(|e| AppError::from(&e))?;
-    let markers = ctx
-        .list_archived_cards_by_board(board_id)
-        .map_err(|e| AppError::from(&e))?;
+    let scope = RouteScope::BoardArchivedCards(board_id);
+    let mut guard = state.lock_session().await;
+    let Session { ctx, model } = &mut *guard;
+    ctx.sync(&scope, model, &mut NoProjections);
+
+    require_loaded_entity(model.board_id_status(board_id), "Board", board_id)?;
+    let markers = require_loaded(
+        model.board_archived_cards_state(board_id),
+        "archived cards of board",
+    )?;
     let responses: Vec<ArchivedCardResponse> =
         markers.iter().map(ArchivedCardResponse::from).collect();
     paginate_response(responses, &params)
@@ -113,10 +182,9 @@ fn do_delete_card(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), AppEr
     crate::state::mutate_unit(ctx, |c| c.delete_card_impl(id)).map_err(|e| AppError::from(&e))
 }
 
-/// Fetch a card and 404 unless it belongs to `board_id` — the same
-/// cross-board guard `get_card` (read route, above) applies, needed here
-/// too since `KanbanOperations::{update_card, delete_card}` key on the
-/// global card id alone with no board scoping of their own.
+/// Fetch a card and 404 unless it belongs to `board_id`, since
+/// `KanbanOperations::{update_card, delete_card}` key on the global card id
+/// alone with no board scoping of their own.
 fn require_card_in_board(
     ctx: &kanban_service::KanbanContext,
     board_id: Uuid,
@@ -224,9 +292,13 @@ async fn get_card_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<CardResponse>, AppError> {
-    let ctx = state.ctx.lock().await;
-    let card = do_get_card(&ctx, id)?;
-    Ok(Json(CardResponse::from(&card)))
+    let scope = RouteScope::Card(id);
+    let mut guard = state.lock_session().await;
+    let Session { ctx, model } = &mut *guard;
+    ctx.sync(&scope, model, &mut NoProjections);
+
+    let card = require_loaded_entity(model.card_by_id_state(id), "Card", id)?;
+    Ok(Json(CardResponse::from(card)))
 }
 
 async fn update_card_route_flat(

--- a/crates/kanban-server/src/routes/prefixes.rs
+++ b/crates/kanban-server/src/routes/prefixes.rs
@@ -20,7 +20,7 @@ async fn prefixes_route(
     State(state): State<AppState>,
     Query(query): Query<PrefixesQuery>,
 ) -> Result<Response, AppError> {
-    let ctx = state.ctx.lock().await;
+    let ctx = state.lock_session().await;
     match query.name {
         Some(name) => {
             let normalized = Prefix::normalize(&name);

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -60,13 +60,9 @@ impl FetchPlan for RouteScope {
                 column_id,
                 archived,
             } => {
-                let _ = archived;
                 want_board(&mut round, loaded, board_id);
                 if requestable(loaded.columns_of_board(board_id)) {
                     round.columns_by_board.push(board_id);
-                }
-                if requestable(loaded.archived_cards_of_board(board_id)) {
-                    round.archived_cards_by_board.push(board_id);
                 }
                 match column_id {
                     Some(column_id) => {
@@ -80,6 +76,18 @@ impl FetchPlan for RouteScope {
                                 if requestable(loaded.cards_of_column(column.id)) {
                                     round.cards_by_column.push(column.id);
                                 }
+                            }
+                        }
+                    }
+                }
+                if archived != ArchivedFilter::LiveOnly {
+                    round.archived_card_list = requestable(loaded.archived_card_list());
+                    if let Some(markers) = loaded.loaded_archived_card_markers() {
+                        for marker in markers {
+                            if marker.context.board_id == board_id
+                                && requestable(loaded.card(marker.entity_id))
+                            {
+                                round.cards.push(marker.entity_id);
                             }
                         }
                     }

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -4,6 +4,7 @@
 //! exists in `FetchRound` at any level, so that route stays a lock-only
 //! read outside this plan.
 
+use kanban_domain::ArchivedFilter;
 use kanban_service::{requestable, FetchPlan, FetchRound, LoadedEntities};
 use uuid::Uuid;
 
@@ -15,6 +16,7 @@ pub enum RouteScope {
     BoardCards {
         board_id: Uuid,
         column_id: Option<Uuid>,
+        archived: ArchivedFilter,
     },
     BoardArchivedCards(Uuid),
     BoardSprints(Uuid),
@@ -56,7 +58,9 @@ impl FetchPlan for RouteScope {
             RouteScope::BoardCards {
                 board_id,
                 column_id,
+                archived,
             } => {
+                let _ = archived;
                 want_board(&mut round, loaded, board_id);
                 if requestable(loaded.columns_of_board(board_id)) {
                     round.columns_by_board.push(board_id);
@@ -131,7 +135,9 @@ mod tests {
     use std::sync::Arc;
 
     use kanban_domain::resolved::Collection;
-    use kanban_domain::{Board, Column, KanbanError, LoadState, Model, Resolved};
+    use kanban_domain::{
+        ArchivedFilter, Board, Card, Column, KanbanError, LoadState, Model, Resolved,
+    };
     use uuid::Uuid;
 
     use super::*;
@@ -168,12 +174,13 @@ mod tests {
         let round = RouteScope::BoardCards {
             board_id,
             column_id: None,
+            archived: ArchivedFilter::LiveOnly,
         }
         .next_round(&Model::default());
 
         assert_eq!(round.boards, vec![board_id]);
         assert_eq!(round.columns_by_board, vec![board_id]);
-        assert_eq!(round.archived_cards_by_board, vec![board_id]);
+        assert!(round.archived_cards_by_board.is_empty());
         assert!(!round.card_list);
         assert!(!round.board_list);
         assert!(!round.column_list);
@@ -207,6 +214,7 @@ mod tests {
         let scope = RouteScope::BoardCards {
             board_id,
             column_id: None,
+            archived: ArchivedFilter::LiveOnly,
         };
         let round2 = scope.next_round(&model);
         assert_eq!(
@@ -237,12 +245,116 @@ mod tests {
         let round = RouteScope::BoardCards {
             board_id,
             column_id: Some(column_id),
+            archived: ArchivedFilter::LiveOnly,
         }
         .next_round(&Model::default());
 
         assert_eq!(round.cards_by_column, vec![column_id]);
         assert_eq!(round.boards, vec![board_id]);
         assert_eq!(round.columns_by_board, vec![board_id]);
+    }
+
+    #[test]
+    fn test_route_scope_for_board_cards_live_only_plans_no_archived_tier() {
+        let board_id = Uuid::new_v4();
+        let round = RouteScope::BoardCards {
+            board_id,
+            column_id: None,
+            archived: ArchivedFilter::LiveOnly,
+        }
+        .next_round(&Model::default());
+
+        assert_eq!(round.boards, vec![board_id]);
+        assert_eq!(round.columns_by_board, vec![board_id]);
+        assert!(round.archived_cards_by_board.is_empty());
+        assert!(!round.archived_card_list);
+        assert!(round.cards.is_empty());
+        assert!(!round.card_list);
+        assert!(!round.board_list);
+    }
+
+    #[test]
+    fn test_route_scope_for_board_cards_including_archived_walks_global_markers_of_that_board_into_a_card_round(
+    ) {
+        use kanban_domain::ArchivedCard;
+
+        let board_id = Uuid::new_v4();
+        let other_board_id = Uuid::new_v4();
+        let column = Column::new(board_id, "TODO", 0);
+        let column_id = column.id;
+        let marker_for_this_board = ArchivedCard::new(Uuid::new_v4(), board_id);
+        let marker_for_other_board = ArchivedCard::new(Uuid::new_v4(), other_board_id);
+        let this_board_entity_id = marker_for_this_board.entity_id;
+
+        let scope = RouteScope::BoardCards {
+            board_id,
+            column_id: None,
+            archived: ArchivedFilter::Include,
+        };
+
+        let round1 = scope.next_round(&Model::default());
+        assert!(round1.archived_card_list);
+        assert!(round1.cards.is_empty());
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            boards: Collection {
+                by_id: [(
+                    board_id,
+                    LoadState::Loaded(Board::new("Kanban", None::<String>)),
+                )]
+                .into(),
+                ..Default::default()
+            },
+            columns: Collection {
+                by_parent: [(board_id, LoadState::Loaded(vec![column]))].into(),
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                all: LoadState::Loaded(vec![marker_for_this_board, marker_for_other_board]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let round2 = scope.next_round(&model);
+        assert_eq!(round2.cards, vec![this_board_entity_id]);
+        assert_eq!(round2.cards_by_column, vec![column_id]);
+
+        let mut model2 = model;
+        let _ = model2.apply_resolved(Resolved {
+            cards: Collection {
+                by_id: [(
+                    this_board_entity_id,
+                    LoadState::Loaded(Card::new(board_id, column_id, "archived", 0)),
+                )]
+                .into(),
+                by_parent: [(column_id, LoadState::Loaded(vec![]))].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let round3 = scope.next_round(&model2);
+        assert!(round3.is_empty());
+    }
+
+    #[test]
+    fn test_route_scope_for_board_cards_archived_only_plans_the_same_rounds_as_include() {
+        let board_id = Uuid::new_v4();
+        let include_round = RouteScope::BoardCards {
+            board_id,
+            column_id: None,
+            archived: ArchivedFilter::Include,
+        }
+        .next_round(&Model::default());
+        let archived_only_round = RouteScope::BoardCards {
+            board_id,
+            column_id: None,
+            archived: ArchivedFilter::ArchivedOnly,
+        }
+        .next_round(&Model::default());
+
+        assert_eq!(include_round, archived_only_round);
     }
 
     #[test]

--- a/crates/kanban-server/tests/archived_cards_read.rs
+++ b/crates/kanban-server/tests/archived_cards_read.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "test-helpers")]
 
 use axum::http::StatusCode;
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_domain::LoadState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
 use kanban_service::api::{ArchivedCardResponse, Page};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
@@ -93,4 +94,107 @@ async fn test_get_board_archived_cards_unknown_board_returns_404() {
     .await;
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_archived_cards_404s_an_unknown_board_from_the_board_tier_not_from_an_empty_marker_tier(
+) {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("s.sqlite")).await;
+
+    let random_board_id = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/archived-cards", random_board_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let guard = state.ctx.lock().await;
+    assert!(matches!(
+        guard.model.board_id_status(random_board_id),
+        LoadState::Missing
+    ));
+    match guard.model.board_archived_cards_state(random_board_id) {
+        LoadState::Loaded(markers) => assert!(markers.is_empty()),
+        other => panic!("expected Loaded([]), got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_archived_cards_serves_the_markers_from_the_board_scoped_model_tier() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_a_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_a_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        let board_b_id = ctx
+            .create_board("Board B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        let col_a_id = ctx
+            .create_column(board_a_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        let col_b_id = ctx
+            .create_column(board_b_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        let archived_a_id = ctx
+            .create_card(
+                board_a_id,
+                col_a_id,
+                "Archived in A".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let archived_b_id = ctx
+            .create_card(
+                board_b_id,
+                col_b_id,
+                "Archived in B".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.archive_card(archived_a_id).unwrap();
+        ctx.archive_card(archived_b_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/archived-cards", board_a_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let page: Page<ArchivedCardResponse> = serde_json::from_value(json)
+        .expect("body should deserialize as Page<ArchivedCardResponse>");
+    assert_eq!(page.items.len(), 1);
+
+    let guard = state.ctx.lock().await;
+    match guard.model.board_archived_cards_state(board_a_id) {
+        LoadState::Loaded(markers) => assert_eq!(markers.len(), 1),
+        other => panic!("expected Loaded, got {other:?}"),
+    }
+    assert!(matches!(
+        guard.model.board_id_status(board_a_id),
+        LoadState::Loaded(_)
+    ));
+    assert!(matches!(
+        guard.model.archived_cards_state(),
+        LoadState::NotLoaded
+    ));
 }

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -5,8 +5,8 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_domain::{CardPriority, CardUpdate, CreateCardOptions};
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_domain::{CardPriority, CardUpdate, CreateCardOptions, LoadState};
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
 use kanban_service::api::CardResponse;
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
@@ -727,4 +727,320 @@ async fn test_list_cards_and_get_card_agree_for_a_live_card() {
 
     assert_eq!(list.items.len(), 1);
     assert_eq!(list.items[0], single);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_loads_the_board_scoped_tiers_into_the_shared_model() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let col1_id: Uuid;
+    let col2_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        col1_id = ctx
+            .create_column(board_id, "Column 1".to_string(), None)
+            .unwrap()
+            .id;
+        col2_id = ctx
+            .create_column(board_id, "Column 2".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(board_id, col1_id, "Card 1".to_string(), Default::default())
+            .unwrap();
+        ctx.create_card(board_id, col2_id, "Card 2".to_string(), Default::default())
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let guard = state.ctx.lock().await;
+    assert!(matches!(
+        guard.model.board_id_status(board_id),
+        LoadState::Loaded(_)
+    ));
+    assert!(matches!(
+        guard.model.board_columns_state(board_id),
+        LoadState::Loaded(_)
+    ));
+    assert!(matches!(
+        guard.model.column_cards_state(col1_id),
+        LoadState::Loaded(_)
+    ));
+    assert!(matches!(
+        guard.model.column_cards_state(col2_id),
+        LoadState::Loaded(_)
+    ));
+    assert!(matches!(
+        guard.model.archived_cards_state(),
+        LoadState::NotLoaded
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_archived_include_loads_archived_bodies_through_the_per_id_card_tier() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let archived_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Live Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+        archived_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Archived Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.archive_card(archived_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?archived=include", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json["items"].as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+
+    let guard = state.ctx.lock().await;
+    assert!(matches!(
+        guard.model.archived_cards_state(),
+        LoadState::Loaded(_)
+    ));
+    assert!(matches!(
+        guard.model.card_id_status(archived_id),
+        LoadState::Loaded(_)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_archived_only_over_a_sqlite_locator_serves_the_archived_body_from_the_model(
+) {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("s.sqlite")).await;
+
+    let board_id: Uuid;
+    let archived_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Live Card".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+        archived_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Archived Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.archive_card(archived_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?archived=archived_only", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let arr = json["items"].as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], archived_id.to_string());
+    assert!(!arr[0]["archived_at"].is_null());
+
+    let guard = state.ctx.lock().await;
+    assert!(matches!(
+        guard.model.card_id_status(archived_id),
+        LoadState::Loaded(_)
+    ));
+    assert!(matches!(
+        guard.model.archived_cards_state(),
+        LoadState::Loaded(_)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_resolves_through_the_per_id_card_tier_and_still_404s_a_card_of_another_board(
+) {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_a_id: Uuid;
+    let board_b_id: Uuid;
+    let card_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_a_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        board_b_id = ctx
+            .create_board("Board B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        let col_a_id = ctx
+            .create_column(board_a_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        card_id = ctx
+            .create_card(
+                board_a_id,
+                col_a_id,
+                "Card in A".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+    }
+
+    let wrong_board_response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards/{}", board_b_id, card_id),
+        None,
+    )
+    .await;
+    assert_eq!(wrong_board_response.status(), StatusCode::NOT_FOUND);
+    let wrong_board_json = json_of(wrong_board_response).await;
+    assert_eq!(wrong_board_json["code"], "NOT_FOUND");
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards/{}", board_a_id, card_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let guard = state.ctx.lock().await;
+    assert!(matches!(
+        guard.model.card_id_status(card_id),
+        LoadState::Loaded(_)
+    ));
+    assert!(matches!(guard.model.cards_state(), LoadState::NotLoaded));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_with_a_column_from_another_board_returns_an_empty_page_for_every_archived_selector(
+) {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_a_id: Uuid;
+    let col_b_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_a_id = ctx
+            .create_board("Board A".to_string(), Some("BA".to_string()))
+            .unwrap()
+            .id;
+        let board_b_id = ctx
+            .create_board("Board B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        let col_a_id = ctx
+            .create_column(board_a_id, "Column A".to_string(), None)
+            .unwrap()
+            .id;
+        col_b_id = ctx
+            .create_column(board_b_id, "Column B".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(
+            board_a_id,
+            col_a_id,
+            "Card in A".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+        let card_in_b = ctx
+            .create_card(
+                board_b_id,
+                col_b_id,
+                "Card in B".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.archive_card(card_in_b).unwrap();
+        ctx.create_card(
+            board_b_id,
+            col_b_id,
+            "Live card in B".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    }
+
+    for query in ["", "&archived=include", "&archived=archived_only"] {
+        let response = send(
+            &state,
+            "GET",
+            &format!(
+                "/v1/boards/{}/cards?column_id={}{}",
+                board_a_id, col_b_id, query
+            ),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = json_of(response).await;
+        assert_eq!(
+            json["items"],
+            serde_json::json!([]),
+            "query {query:?} should return no cards from another board's column"
+        );
+    }
 }

--- a/crates/kanban-server/tests/flat_routes.rs
+++ b/crates/kanban-server/tests/flat_routes.rs
@@ -5,7 +5,7 @@
 //! to know the owning board id. Response shape is identical to board-scoped routes.
 
 use axum::http::StatusCode;
-use kanban_domain::KanbanOperations;
+use kanban_domain::{KanbanOperations, LoadState};
 use kanban_server::state::AppState;
 use kanban_server::test_helpers::{json_of, make_state, send};
 use serde_json::json;
@@ -329,6 +329,43 @@ async fn test_get_sprint_flat_missing_returns_404() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let json = json_of(response).await;
     assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_flat_serves_an_archived_card_from_the_per_id_tier_without_stamping_archived_at(
+) {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let card_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col = ctx
+            .create_column(board_id, "To Do".to_string(), None)
+            .unwrap();
+        let card = ctx
+            .create_card(board_id, col.id, "Task".to_string(), Default::default())
+            .unwrap();
+        card_id = card.id;
+        ctx.archive_card(card_id).unwrap();
+    }
+
+    let response = send(&state, "GET", &format!("/v1/cards/{card_id}"), None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert!(
+        json.get("archived_at").is_none(),
+        "flat get_card must not stamp archived_at"
+    );
+
+    let guard = state.ctx.lock().await;
+    assert!(matches!(
+        guard.model.card_id_status(card_id),
+        LoadState::Loaded(_)
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Retargets the four card GET handlers in `kanban-server` off direct `KanbanContext` reads and onto the session `Model` via a `RouteScope` `FetchPlan` and `ctx.sync`, and converts `/v1/prefixes` to `lock_session` (lock-only, no Model tier exists for prefixes).

- `RouteScope::BoardCards` gains an `archived: ArchivedFilter` field. When the filter is not `LiveOnly` the arm now plans the global archived-card-marker tier plus a per-id card round for the requesting board's markers, and it drops the unread `archived_cards_by_board` tier it used to plan unconditionally.
- `list_cards` syncs the scope, reads board/columns/cards through the Model, restricts its live-card gather to the requesting board's own columns (so a foreign `column_id` cannot leak cards once `archived != LiveOnly` clears `board_id` from the effective filter), and stamps `archived_at` only for markers whose `board_id` matches the route.
- `get_card` and `get_card_flat` read the card through the per-id tier; `get_card` still 404s a card that belongs to a different board. Neither stamps `archived_at`, preserving the existing wire asymmetry against `list_cards`.
- `list_archived_cards` reads the board (for its 404) and the board-scoped archived-card tier through the Model.
- `/v1/prefixes` now locks through `lock_session` since no prefix tier exists in `FetchRound` for it to plan.
- Reworded `require_card_in_board`'s doc comment since `get_card` no longer calls it.
- Adds a changeset (`minor`) for the breaking `RouteScope::BoardCards` field addition.

Lock-site counts before: `cards.rs` 10, `prefixes.rs` 1 (`git grep -c 'ctx.lock().await' -- crates/kanban-server/src`). After this change those four card-GET call sites and the prefixes call site route through `lock_session` instead.

## Test plan

- [x] `cargo test -p kanban-server --features test-helpers` (red before, green after; red proof captured for all 10 new tests across `scope.rs`, `cards_read.rs`, `archived_cards_read.rs`, `flat_routes.rs`)
- [x] Mutation check: temporarily reverted the `source_column_ids` board-ownership restriction in `list_cards`, confirmed the foreign-column parity guard test failed with a leaked live card from the other board's column, then restored the fix and confirmed it passes again
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features --workspace`
