### PR TITLE
KAN-1553 fix(service,backend-http): open probes liveness instead of the command log

### DIFF
--- a/.changeset/kan-1553-backend-agnostic-open-probe.md
+++ b/.changeset/kan-1553-backend-agnostic-open-probe.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+kanban_context::open now probes backend liveness instead of the local command log, so opening a context over a remote HttpBackend succeeds instead of failing on batch_count

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -21,6 +21,20 @@ impl kanban_backend::KanbanBackend for HttpBackend {
         self.instance_id
     }
 
+    async fn probe(&self) -> kanban_domain::KanbanResult<()> {
+        let url = format!("{}/health", self.base_url());
+        let resp = self.client().get(&url).send().await.map_err(|e| {
+            kanban_domain::KanbanError::Transport(format!("health probe of '{url}' failed: {e}"))
+        })?;
+        if !resp.status().is_success() {
+            return Err(kanban_domain::KanbanError::Transport(format!(
+                "health probe of '{url}' returned HTTP {}",
+                resp.status()
+            )));
+        }
+        Ok(())
+    }
+
     /// Declines without running the closure. The remote server owns the state,
     /// so there is nothing local to roll back and no way to make the batch
     /// atomic from this side.

--- a/crates/kanban-backend-http/tests/open_probe.rs
+++ b/crates/kanban-backend-http/tests/open_probe.rs
@@ -1,0 +1,51 @@
+use kanban_backend_http::HttpBackend;
+use kanban_domain::KanbanError;
+use kanban_server::test_helpers::TestServer;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_open_over_http_backend_against_live_server_succeeds() {
+    let server = TestServer::start().await;
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+
+    let result = KanbanContext::open(Arc::clone(&backend), AppConfig::default()).await;
+
+    let ctx = match result {
+        Ok(ctx) => ctx,
+        Err(e) => panic!("expected open() to succeed against a live server, got: {e}"),
+    };
+
+    tokio::task::spawn_blocking(move || {
+        drop(ctx);
+        drop(backend);
+    })
+    .await
+    .unwrap();
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_open_over_http_backend_against_dead_server_fails_with_transport_error() {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(HttpBackend::new("http://127.0.0.1:1").unwrap());
+
+    let result = KanbanContext::open(Arc::clone(&backend), AppConfig::default()).await;
+
+    match result {
+        Err(KanbanError::Transport(msg)) => {
+            assert!(
+                msg.contains("/health"),
+                "expected the probed URL in the error message, got: {msg:?}"
+            );
+        }
+        Err(other) => panic!("expected KanbanError::Transport, got: {other:?}"),
+        Ok(_) => panic!("expected open() to fail against an unreachable server"),
+    }
+
+    tokio::task::spawn_blocking(move || drop(backend))
+        .await
+        .unwrap();
+}

--- a/crates/kanban-backend-http/tests/open_probe.rs
+++ b/crates/kanban-backend-http/tests/open_probe.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_open_over_http_backend_against_live_server_succeeds() {
     let server = TestServer::start().await;
-    let backend: Arc<dyn KanbanBackend> =
-        Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+    let backend: Arc<dyn KanbanBackend> = Arc::new(HttpBackend::new(&server.base_url()).unwrap());
 
     let result = KanbanContext::open(Arc::clone(&backend), AppConfig::default()).await;
 
@@ -29,8 +28,7 @@ async fn test_open_over_http_backend_against_live_server_succeeds() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_open_over_http_backend_against_dead_server_fails_with_transport_error() {
-    let backend: Arc<dyn KanbanBackend> =
-        Arc::new(HttpBackend::new("http://127.0.0.1:1").unwrap());
+    let backend: Arc<dyn KanbanBackend> = Arc::new(HttpBackend::new("http://127.0.0.1:1").unwrap());
 
     let result = KanbanContext::open(Arc::clone(&backend), AppConfig::default()).await;
 

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -163,7 +163,11 @@ mod tests {
         );
     }
 
-    struct StubBackend;
+    #[derive(Default)]
+    struct StubBackend {
+        batch_count_calls: std::sync::atomic::AtomicUsize,
+        batch_count_fails: bool,
+    }
 
     impl DataStore for StubBackend {
         fn get_prefix(&self, _name: &str) -> KanbanResult<Option<kanban_domain::Prefix>> {
@@ -289,7 +293,13 @@ mod tests {
             unimplemented!()
         }
         fn batch_count(&self) -> KanbanResult<u64> {
-            unimplemented!()
+            self.batch_count_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if self.batch_count_fails {
+                Err(KanbanError::Internal("stub batch_count boom".into()))
+            } else {
+                Ok(0)
+            }
         }
         fn load_batches(&self, _offset: u64, _limit: u64) -> KanbanResult<Vec<CommandBatch>> {
             unimplemented!()
@@ -307,15 +317,51 @@ mod tests {
 
     #[test]
     fn test_backend_without_local_persistence_returns_none() {
-        let backend = StubBackend;
+        let backend = StubBackend::default();
         let backend: &dyn KanbanBackend = &backend;
         assert!(backend.local_persistence().is_none());
     }
 
     #[test]
     fn test_mark_dirty_is_callable_on_a_backend_that_does_not_override_it() {
-        let backend = StubBackend;
+        let backend = StubBackend::default();
         let backend: &dyn KanbanBackend = &backend;
         backend.mark_dirty();
+    }
+
+    #[tokio::test]
+    async fn test_default_probe_delegates_to_batch_count() {
+        let backend = StubBackend::default();
+        let b: &dyn KanbanBackend = &backend;
+
+        let result = b.probe().await;
+
+        assert!(result.is_ok(), "expected probe() to succeed, got: {result:?}");
+        assert_eq!(
+            backend
+                .batch_count_calls
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "expected the default probe to call batch_count exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_probe_propagates_a_batch_count_error() {
+        let backend = StubBackend {
+            batch_count_fails: true,
+            ..Default::default()
+        };
+        let b: &dyn KanbanBackend = &backend;
+
+        let result = b.probe().await;
+
+        match result {
+            Err(e) => assert!(
+                e.to_string().contains("stub batch_count boom"),
+                "expected the batch_count error to propagate, got: {e}"
+            ),
+            Ok(_) => panic!("expected probe() to propagate the batch_count failure"),
+        }
     }
 }

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -42,6 +42,14 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
         Ok(())
     }
 
+    /// Forces one cheap I/O so a broken backend fails at construction
+    /// instead of on first use. The default reads the command log, which
+    /// every local backend loads lazily; a remote backend overrides this
+    /// with a network liveness check.
+    async fn probe(&self) -> KanbanResult<()> {
+        self.batch_count().map(|_| ())
+    }
+
     /// Marks the backend dirty without performing a write, so a subsequent
     /// `flush()` (or `needs_save_worker()`-driven background flush) picks it
     /// up. No-op by default for write-through backends that have no dirty

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -344,7 +344,10 @@ mod tests {
 
         let result = b.probe().await;
 
-        assert!(result.is_ok(), "expected probe() to succeed, got: {result:?}");
+        assert!(
+            result.is_ok(),
+            "expected probe() to succeed, got: {result:?}"
+        );
         assert_eq!(
             backend
                 .batch_count_calls

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -49,8 +49,10 @@ ctx.with_app_type(app_type: AppType) -> Self
 ```
 
 `open_deferred` is zero-I/O — it just wraps `backend`. `open` is async and
-additionally calls `backend.batch_count()` so a lazy backend's load/parse
-errors surface at construction time rather than on first use. `with_app_type`
+additionally awaits `backend.probe()` so a lazy backend's load/parse errors,
+or a remote backend's unreachable server, surface at construction time
+rather than on first use. The default `probe()` reads the command log;
+`HttpBackend` overrides it with a `GET /health` liveness check. `with_app_type`
 is a builder call made right after `open_deferred`/`open` to record which
 surface (CLI, MCP, TUI) owns the context, for command attribution.
 

--- a/crates/kanban-service/src/context/core.rs
+++ b/crates/kanban-service/src/context/core.rs
@@ -38,12 +38,12 @@ impl KanbanContext {
         self.session_id
     }
 
-    /// Wraps `backend` and forces a lazy backend's I/O so any
-    /// deserialization or read failure surfaces here, before the
-    /// caller starts mutating.
+    /// Wraps `backend` and awaits [`KanbanBackend::probe`], so a lazy
+    /// backend's load failure or a remote backend's unreachable server
+    /// surfaces here, before the caller starts mutating.
     pub async fn open(backend: Arc<dyn KanbanBackend>, config: AppConfig) -> KanbanResult<Self> {
         let ctx = Self::open_deferred(backend, config);
-        ctx.backend.batch_count()?;
+        ctx.backend.probe().await?;
         Ok(ctx)
     }
 

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -56,9 +56,9 @@ async fn test_context_open_returns_typed_unsupported_future_version_for_v99_json
     std::fs::write(&path, v99.to_string()).unwrap();
 
     // KanbanContext::open is what every surface (CLI, MCP, TUI) calls.
-    // The first batch_count() inside open() triggers ensure_loaded which
-    // hits the refusal guard. Use boards() to force the same load path via
-    // a non-deferred call too.
+    // The probe inside open() triggers ensure_loaded which hits the refusal
+    // guard. Use boards() to force the same load path via a non-deferred
+    // call too.
     let backend = make_json_backend(&path);
     let ctx = KanbanContext::open(backend, AppConfig::default()).await;
 


### PR DESCRIPTION
## What

Adds a defaulted async `KanbanBackend::probe()` whose default body delegates to `batch_count()`, exactly matching the behavior `KanbanContext::open` relied on before this change. `open` now awaits `backend.probe()` instead of calling `backend.batch_count()` directly. `HttpBackend` overrides `probe()` with a plain-await `GET {base_url}/health`, mapping any transport failure or non-2xx response to `KanbanError::Transport` naming the probed URL.

Net effect: every local backend (JSON, SQLite, in-memory) keeps byte-identical `open()` behavior, and a `KanbanContext` can finally be constructed over an `HttpBackend`, which previously failed unconditionally with `Unsupported("batch_count")`.

## Changes

- `crates/kanban-backend/src/lib.rs`: add `KanbanBackend::probe()` with its default delegating to `batch_count()`. Reworked the crate's `StubBackend` test double from a unit struct into one with a call counter and a fail flag, so the new default-probe behavior (and its error-propagation path) can be pinned without duplicating the trait's DataStore boilerplate.
- `crates/kanban-backend-http/src/lib.rs`: override `probe()` on `HttpBackend` with a `GET /health` request against the caller's ambient runtime (never `block_on`, which panics from inside a runtime).
- `crates/kanban-service/src/context/core.rs`: `open()` now awaits `probe()` instead of calling `batch_count()`.
- `crates/kanban-service/README.md`, `crates/kanban-service/tests/context_open.rs`: updated the two remaining references to `open()`'s old `batch_count()` call.
- `crates/kanban-backend-http/tests/open_probe.rs` (new): pins `open()` against a live `TestServer` (succeeds) and against an unreachable server (fails with `Transport`, message names `/health`).
- `crates/kanban-backend/src/lib.rs` tests: pins the default probe delegates to `batch_count()` exactly once and propagates its failure.

## Out of scope, reported not fixed

- `HttpBackend` owns its own `tokio::runtime::Runtime`; dropping it from inside an async context panics. `open()`'s error path over an `HttpBackend` already drops the just-built context on early return, which will panic today (pre-existing, not introduced by this change) once a real caller can reach that path. Worth a follow-up once HTTP locator wiring lands.
- `crates/kanban-tui/src/app/lifecycle.rs:296` still calls `batch_count()` directly. It's a post-backend-swap read-back check in the TUI's open-file flow (paired with its own `list_boards()` probe and a distinct user-facing error string), not a construction-time liveness probe, and it never runs against an `HttpBackend`. Left alone to avoid changing a user-visible message for no behavioral gain.

## Testing

- `cargo test -p kanban-backend-http --test open_probe` (2 new tests)
- `cargo test -p kanban-backend` (2 new tests, plus existing StubBackend tests updated for the reworked stub)
- `cargo test -p kanban-service`, `-p kanban-server`, `-p kanban-tui`, `-p kanban-cli`, `-p kanban-mcp` all green
- `git diff origin/develop --stat -- crates/kanban-persistence-json crates/kanban-persistence-sqlite crates/kanban-backend-memory` is empty
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --workspace` all clean
