### PR TITLE
KAN-1542 feat(server): Session implements KanbanOperations and GraphOperations

### DIFF
--- a/.changeset/kan-1542-session-operations-trait-impl.md
+++ b/.changeset/kan-1542-session-operations-trait-impl.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: Session now implements KanbanOperations and GraphOperations itself, with mutators routed through state::mutate/state::mutate_unit; the server's read helpers take &Session instead of &KanbanContext. No route, request or response changes.

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -6,7 +6,7 @@ HTTP API server for kanban project management. Wraps `kanban-service` behind a R
 
 ## Architecture
 
-`kanban-server` holds a `Session` (just a `KanbanContext`) in memory behind a `tokio::sync::Mutex`, shared across all handlers via axum's `State`. No `kanban_domain::Model` is retained between requests: each read handler builds its own `Model::default()` for the duration of its own request and syncs it against the locked context, so every request sees the current state of the store regardless of backend.
+`kanban-server` holds a `Session` in memory behind a `tokio::sync::Mutex`, shared across all handlers via axum's `State`. `Session` wraps a `KanbanContext` and implements `KanbanOperations`/`GraphOperations` itself (mutators routed through a `state::mutate`/`state::mutate_unit` seam), while still `Deref`ing to `KanbanContext` for non-trait access. No `kanban_domain::Model` is retained between requests: each read handler builds its own `Model::default()` for the duration of its own request and syncs it against the locked context, so every request sees the current state of the store regardless of backend.
 
 ```mermaid
 graph TD

--- a/crates/kanban-server/src/handlers/cards.rs
+++ b/crates/kanban-server/src/handlers/cards.rs
@@ -10,7 +10,7 @@
 //! answer 201 (created) vs 200 (replaced).
 
 use kanban_service::api::{ApiError, CardResponse, CreateCardRequest};
-use kanban_service::{KanbanContext, KanbanError, KanbanOperations};
+use kanban_service::{KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 /// `POST /v1/columns/:column_id/cards`: append-create a card under the
@@ -63,7 +63,7 @@ pub fn create_or_replace_card(
 /// 404s when `id` already refers to a card outside `column_id`. A no-op when
 /// `id` doesn't exist yet (the create arm) or already belongs to `column_id`.
 fn require_card_in_column_if_present(
-    ctx: &KanbanContext,
+    ctx: &crate::state::Session,
     id: Uuid,
     column_id: Uuid,
 ) -> Result<(), ApiError> {

--- a/crates/kanban-server/src/handlers/columns.rs
+++ b/crates/kanban-server/src/handlers/columns.rs
@@ -9,7 +9,7 @@
 //! (created) vs 200 (replaced).
 
 use kanban_service::api::{ApiError, ColumnResponse, CreateColumnRequest, ReplaceColumnRequest};
-use kanban_service::{KanbanContext, KanbanError, KanbanOperations};
+use kanban_service::{KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 /// `POST /v1/boards/:board_id/columns`: append-create a column under the
@@ -63,7 +63,7 @@ pub fn create_or_replace_column(
 /// when `id` doesn't exist yet (the create arm) or already belongs to
 /// `board_id`.
 fn require_column_in_board_if_present(
-    ctx: &KanbanContext,
+    ctx: &crate::state::Session,
     id: Uuid,
     board_id: Uuid,
 ) -> Result<(), ApiError> {

--- a/crates/kanban-server/src/handlers/sprints.rs
+++ b/crates/kanban-server/src/handlers/sprints.rs
@@ -14,7 +14,7 @@
 //! [`SprintResponse`] via `kanban_service::resolve_sprint_name`.
 
 use kanban_service::api::{ApiError, CreateSprintRequest, ReplaceSprintRequest, SprintResponse};
-use kanban_service::{resolve_sprint_name, KanbanContext, KanbanError, KanbanOperations};
+use kanban_service::{resolve_sprint_name, KanbanError, KanbanOperations};
 use uuid::Uuid;
 
 /// `POST /v1/boards/:board_id/sprints`: create a sprint under the path-supplied
@@ -76,7 +76,7 @@ pub fn create_or_replace_sprint(
 /// Project the created/replaced domain sprint onto its wire response with
 /// its `name` resolved by the service.
 fn project(
-    ctx: &KanbanContext,
+    ctx: &crate::state::Session,
     sprint: kanban_service::Sprint,
     created: bool,
 ) -> Result<(SprintResponse, bool), ApiError> {

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod model_read;
 pub mod pagination;
 pub mod scope;
+mod session_ops;
 pub mod state;
 pub mod stores;
 pub mod watch;

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -186,7 +186,7 @@ fn do_delete_card(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), AppEr
 /// `KanbanOperations::{update_card, delete_card}` key on the global card id
 /// alone with no board scoping of their own.
 fn require_card_in_board(
-    ctx: &kanban_service::KanbanContext,
+    ctx: &crate::state::Session,
     board_id: Uuid,
     id: Uuid,
 ) -> Result<(), AppError> {

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -75,7 +75,7 @@ fn do_delete_column(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), App
 /// `KanbanOperations::{update_column, delete_column, reorder_column}` key on
 /// the global column id with no board scoping of their own.
 fn require_column_in_board(
-    ctx: &kanban_service::KanbanContext,
+    ctx: &crate::state::Session,
     board_id: Uuid,
     id: Uuid,
 ) -> Result<(), AppError> {

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -72,7 +72,7 @@ fn created_status(created: bool) -> StatusCode {
     }
 }
 
-fn do_get_sprint(ctx: &kanban_service::KanbanContext, id: Uuid) -> Result<Sprint, AppError> {
+fn do_get_sprint(ctx: &crate::state::Session, id: Uuid) -> Result<Sprint, AppError> {
     ctx.get_sprint(id)
         .map_err(|e| AppError::from(&e))?
         .ok_or_else(|| AppError::from(&KanbanError::not_found("Sprint", id)))
@@ -95,7 +95,7 @@ fn do_delete_sprint(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), App
 }
 
 fn require_sprint_in_board(
-    ctx: &kanban_service::KanbanContext,
+    ctx: &crate::state::Session,
     board_id: Uuid,
     id: Uuid,
 ) -> Result<(), AppError> {
@@ -106,10 +106,7 @@ fn require_sprint_in_board(
     Ok(())
 }
 
-fn respond(
-    ctx: &kanban_service::KanbanContext,
-    sprint: &Sprint,
-) -> Result<SprintResponse, AppError> {
+fn respond(ctx: &crate::state::Session, sprint: &Sprint) -> Result<SprintResponse, AppError> {
     let name = resolve_sprint_name(ctx, sprint).map_err(|e| AppError::from(&e))?;
     Ok(SprintResponse::new(sprint, name))
 }

--- a/crates/kanban-server/src/session_ops.rs
+++ b/crates/kanban-server/src/session_ops.rs
@@ -1,0 +1,234 @@
+//! `Session`'s own capability surface: adding a method to `KanbanOperations`
+//! or `GraphOperations` must be answered here, not silently inherited
+//! through `Deref` to `KanbanContext`.
+
+use crate::state::{mutate, mutate_unit, Session};
+use kanban_domain::{
+    ArchivedBoard, ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter,
+    CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
+    KanbanOperations, KanbanResult, RelatesKind, Severity, Sprint, SprintUpdate,
+};
+use uuid::Uuid;
+
+impl KanbanOperations for Session {
+    fn create_board(&mut self, name: String, card_prefix: Option<String>) -> KanbanResult<Board> {
+        mutate(self, |c| c.create_board_impl(name, card_prefix)).map(|(value, _)| value)
+    }
+    fn list_boards(&self) -> KanbanResult<Vec<Board>> {
+        self.ctx.list_boards()
+    }
+    fn list_boards_filtered(&self, filter: BoardListFilter) -> KanbanResult<Vec<Board>> {
+        self.ctx.list_boards_filtered(filter)
+    }
+    fn get_board(&self, id: Uuid) -> KanbanResult<Option<Board>> {
+        self.ctx.get_board(id)
+    }
+    fn update_board(&mut self, id: Uuid, updates: BoardUpdate) -> KanbanResult<Board> {
+        mutate(self, |c| c.update_board_impl(id, updates)).map(|(value, _)| value)
+    }
+    fn delete_board(&mut self, id: Uuid) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.delete_board_impl(id)).map(|_| ())
+    }
+    fn archive_board(&mut self, id: Uuid) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.archive_board_impl(id)).map(|_| ())
+    }
+    fn restore_board(&mut self, id: Uuid) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.restore_board_impl(id)).map(|_| ())
+    }
+    fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
+        self.ctx.list_archived_boards()
+    }
+
+    fn create_column(
+        &mut self,
+        board_id: Uuid,
+        name: String,
+        position: Option<i32>,
+    ) -> KanbanResult<Column> {
+        mutate(self, |c| c.create_column_impl(board_id, name, position)).map(|(value, _)| value)
+    }
+    fn list_columns(&self, board_id: Uuid) -> KanbanResult<Vec<Column>> {
+        self.ctx.list_columns(board_id)
+    }
+    fn get_column(&self, id: Uuid) -> KanbanResult<Option<Column>> {
+        self.ctx.get_column(id)
+    }
+    fn update_column(&mut self, id: Uuid, updates: ColumnUpdate) -> KanbanResult<Column> {
+        mutate(self, |c| c.update_column_impl(id, updates)).map(|(value, _)| value)
+    }
+    fn delete_column(&mut self, id: Uuid) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.delete_column_impl(id)).map(|_| ())
+    }
+    fn reorder_column(&mut self, id: Uuid, new_position: i32) -> KanbanResult<Column> {
+        mutate(self, |c| c.reorder_column_impl(id, new_position)).map(|(value, _)| value)
+    }
+
+    fn create_card(
+        &mut self,
+        board_id: Uuid,
+        column_id: Uuid,
+        title: String,
+        options: CreateCardOptions,
+    ) -> KanbanResult<Card> {
+        mutate(self, |c| {
+            c.create_card_impl(board_id, column_id, title, options)
+        })
+        .map(|(value, _)| value)
+    }
+    fn list_cards(&self, filter: CardListFilter) -> KanbanResult<Vec<CardSummary>> {
+        self.ctx.list_cards(filter)
+    }
+    fn get_card(&self, id: Uuid) -> KanbanResult<Option<Card>> {
+        self.ctx.get_card(id)
+    }
+    fn find_cards_by_identifier(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
+        self.ctx.find_cards_by_identifier(identifier)
+    }
+    fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
+        self.ctx.list_all_cards()
+    }
+    fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
+        self.ctx.list_all_columns()
+    }
+    fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
+        self.ctx.list_all_sprints()
+    }
+    fn update_card(&mut self, id: Uuid, updates: CardUpdate) -> KanbanResult<Card> {
+        mutate(self, |c| c.update_card_impl(id, updates)).map(|(value, _)| value)
+    }
+    fn move_card(
+        &mut self,
+        id: Uuid,
+        column_id: Uuid,
+        position: Option<i32>,
+    ) -> KanbanResult<Card> {
+        mutate(self, |c| c.move_card_impl(id, column_id, position)).map(|(value, _)| value)
+    }
+    fn archive_card(&mut self, id: Uuid) -> KanbanResult<()> {
+        mutate(self, |c| c.archive_card_impl(id)).map(|(value, _)| value)
+    }
+    fn restore_card(&mut self, id: Uuid, column_id: Option<Uuid>) -> KanbanResult<Card> {
+        mutate(self, |c| c.restore_card_impl(id, column_id)).map(|(value, _)| value)
+    }
+    fn delete_card(&mut self, id: Uuid) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.delete_card_impl(id)).map(|_| ())
+    }
+    fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
+        self.ctx.list_archived_cards()
+    }
+    fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
+        self.ctx.list_archived_cards_by_board(board_id)
+    }
+
+    fn assign_card_to_sprint(&mut self, card_id: Uuid, sprint_id: Uuid) -> KanbanResult<Card> {
+        mutate(self, |c| c.assign_card_to_sprint_impl(card_id, sprint_id)).map(|(value, _)| value)
+    }
+    fn unassign_card_from_sprint(&mut self, card_id: Uuid) -> KanbanResult<Card> {
+        mutate(self, |c| c.unassign_card_from_sprint_impl(card_id)).map(|(value, _)| value)
+    }
+
+    fn get_card_branch_name(&self, id: Uuid) -> KanbanResult<String> {
+        self.ctx.get_card_branch_name(id)
+    }
+    fn get_card_git_checkout(&self, id: Uuid) -> KanbanResult<String> {
+        self.ctx.get_card_git_checkout(id)
+    }
+
+    fn archive_cards(&mut self, ids: Vec<Uuid>) -> KanbanResult<usize> {
+        mutate(self, |c| c.archive_cards_impl(ids)).map(|(value, _)| value)
+    }
+    fn move_cards(&mut self, ids: Vec<Uuid>, column_id: Uuid) -> KanbanResult<usize> {
+        mutate(self, |c| c.move_cards_impl(ids, column_id)).map(|(value, _)| value)
+    }
+    fn update_cards(&mut self, updates: Vec<(Uuid, CardUpdate)>) -> KanbanResult<usize> {
+        mutate(self, |c| c.update_cards_impl(updates)).map(|(value, _)| value)
+    }
+    fn assign_cards_to_sprint(&mut self, ids: Vec<Uuid>, sprint_id: Uuid) -> KanbanResult<usize> {
+        mutate(self, |c| c.assign_cards_to_sprint_impl(ids, sprint_id)).map(|(value, _)| value)
+    }
+    fn carry_over_sprint_cards(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<usize> {
+        mutate(self, |c| {
+            c.carry_over_sprint_cards_impl(from_sprint_id, to_sprint_id)
+        })
+        .map(|(value, _)| value)
+    }
+
+    fn create_sprint(
+        &mut self,
+        board_id: Uuid,
+        prefix: Option<String>,
+        name: Option<String>,
+    ) -> KanbanResult<Sprint> {
+        mutate(self, |c| c.create_sprint_impl(board_id, prefix, name)).map(|(value, _)| value)
+    }
+    fn list_sprints(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
+        self.ctx.list_sprints(board_id)
+    }
+    fn get_sprint(&self, id: Uuid) -> KanbanResult<Option<Sprint>> {
+        self.ctx.get_sprint(id)
+    }
+    fn update_sprint(&mut self, id: Uuid, updates: SprintUpdate) -> KanbanResult<Sprint> {
+        mutate(self, |c| c.update_sprint_impl(id, updates)).map(|(value, _)| value)
+    }
+    fn activate_sprint(&mut self, id: Uuid, duration_days: Option<i32>) -> KanbanResult<Sprint> {
+        mutate(self, |c| c.activate_sprint_impl(id, duration_days)).map(|(value, _)| value)
+    }
+    fn complete_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
+        mutate(self, |c| c.complete_sprint_impl(id)).map(|(value, _)| value)
+    }
+    fn cancel_sprint(&mut self, id: Uuid) -> KanbanResult<Sprint> {
+        mutate(self, |c| c.cancel_sprint_impl(id)).map(|(value, _)| value)
+    }
+    fn delete_sprint(&mut self, id: Uuid) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.delete_sprint_impl(id)).map(|_| ())
+    }
+
+    fn export_board(&self, board_id: Option<Uuid>) -> KanbanResult<String> {
+        self.ctx.export_board(board_id)
+    }
+    fn import_board(&mut self, data: &str) -> KanbanResult<Board> {
+        mutate(self, |c| c.import_board_impl(data)).map(|(value, _)| value)
+    }
+}
+
+impl GraphOperations for Session {
+    fn attach_children(&mut self, parent: Uuid, children: Vec<Uuid>) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.attach_children_impl(parent, children)).map(|_| ())
+    }
+    fn detach_children(&mut self, parent: Uuid, children: Vec<Uuid>) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.detach_children_impl(parent, children)).map(|_| ())
+    }
+    fn list_children_of(&self, parent: Uuid) -> KanbanResult<Vec<Uuid>> {
+        self.ctx.list_children_of(parent)
+    }
+    fn list_parents_of(&self, child: Uuid) -> KanbanResult<Vec<Uuid>> {
+        self.ctx.list_parents_of(child)
+    }
+
+    fn block(&mut self, blocker: Uuid, blocked: Uuid, severity: Severity) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.block_impl(blocker, blocked, severity)).map(|_| ())
+    }
+    fn unblock(&mut self, blocker: Uuid, blocked: Uuid) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.unblock_impl(blocker, blocked)).map(|_| ())
+    }
+    fn list_blocked_by(&self, blocker: Uuid) -> KanbanResult<Vec<Uuid>> {
+        self.ctx.list_blocked_by(blocker)
+    }
+    fn list_blockers_of(&self, blocked: Uuid) -> KanbanResult<Vec<Uuid>> {
+        self.ctx.list_blockers_of(blocked)
+    }
+
+    fn relate(&mut self, a: Uuid, b: Uuid, kind: RelatesKind) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.relate_impl(a, b, kind)).map(|_| ())
+    }
+    fn dissociate(&mut self, a: Uuid, b: Uuid) -> KanbanResult<()> {
+        mutate_unit(self, |c| c.dissociate_impl(a, b)).map(|_| ())
+    }
+    fn list_related_to(&self, card: Uuid) -> KanbanResult<Vec<Uuid>> {
+        self.ctx.list_related_to(card)
+    }
+}

--- a/crates/kanban-server/tests/session_ops.rs
+++ b/crates/kanban-server/tests/session_ops.rs
@@ -6,7 +6,9 @@
 //! traits are satisfied, plus behavioral checks that the delegation actually
 //! reaches the store and the `sync` path sees the result.
 
-use kanban_domain::{BoardUpdate, GraphOperations, KanbanOperations, LoadState, Model, NoProjections};
+use kanban_domain::{
+    BoardUpdate, GraphOperations, KanbanOperations, LoadState, Model, NoProjections,
+};
 use kanban_server::scope::RouteScope;
 use kanban_server::state::Session;
 use kanban_server::test_helpers::{make_sqlite_state, make_state};
@@ -120,7 +122,10 @@ async fn test_session_graph_mutator_commits_through_the_seam() {
             .ctx
             .create_board("Board".into(), Some("KAN".into()))
             .unwrap();
-        let column = guard.ctx.create_column(board.id, "Todo".into(), None).unwrap();
+        let column = guard
+            .ctx
+            .create_column(board.id, "Todo".into(), None)
+            .unwrap();
         let parent = guard
             .ctx
             .create_card(board.id, column.id, "Parent".into(), Default::default())
@@ -142,7 +147,11 @@ async fn test_session_graph_mutator_commits_through_the_seam() {
     {
         let guard = state.lock_session().await;
         let mut model = Model::default();
-        guard.sync(&RouteScope::CardGraph(parent), &mut model, &mut NoProjections);
+        guard.sync(
+            &RouteScope::CardGraph(parent),
+            &mut model,
+            &mut NoProjections,
+        );
         match model.graph_state() {
             LoadState::Loaded(g) => {
                 assert_eq!(g.children(parent), vec![child]);

--- a/crates/kanban-server/tests/session_ops.rs
+++ b/crates/kanban-server/tests/session_ops.rs
@@ -1,0 +1,154 @@
+#![cfg(feature = "test-helpers")]
+
+//! `Session` must implement `KanbanOperations` and `GraphOperations` itself,
+//! with mutators routed through the `state::mutate`/`state::mutate_unit`
+//! seam. These tests lock the impls in place: a compile-time check that the
+//! traits are satisfied, plus behavioral checks that the delegation actually
+//! reaches the store and the `sync` path sees the result.
+
+use kanban_domain::{BoardUpdate, GraphOperations, KanbanOperations, LoadState, Model, NoProjections};
+use kanban_server::scope::RouteScope;
+use kanban_server::state::Session;
+use kanban_server::test_helpers::{make_sqlite_state, make_state};
+use tempfile::tempdir;
+
+#[test]
+fn test_session_implements_both_capability_traits() {
+    fn assert_impls<T: KanbanOperations + GraphOperations>() {}
+    assert_impls::<Session>();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_trait_mutator_commits_through_the_seam() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut guard = state.lock_session().await;
+        guard.ctx.create_board("Original".into(), None).unwrap().id
+    };
+
+    {
+        let mut guard = state.lock_session().await;
+        let updated = KanbanOperations::update_board(
+            &mut *guard,
+            board_id,
+            BoardUpdate {
+                name: Some("Renamed".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.name, "Renamed");
+    }
+
+    {
+        let guard = state.lock_session().await;
+        let mut model = Model::default();
+        guard.sync(&RouteScope::Board(board_id), &mut model, &mut NoProjections);
+        match model.board_id_status(board_id) {
+            LoadState::Loaded(b) => assert_eq!(b.name, "Renamed"),
+            other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_trait_mutator_commits_through_the_seam_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("s.sqlite")).await;
+
+    let board_id = {
+        let mut guard = state.lock_session().await;
+        guard.ctx.create_board("Original".into(), None).unwrap().id
+    };
+
+    {
+        let mut guard = state.lock_session().await;
+        let updated = KanbanOperations::update_board(
+            &mut *guard,
+            board_id,
+            BoardUpdate {
+                name: Some("Renamed".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.name, "Renamed");
+    }
+
+    {
+        let guard = state.lock_session().await;
+        let mut model = Model::default();
+        guard.sync(&RouteScope::Board(board_id), &mut model, &mut NoProjections);
+        match model.board_id_status(board_id) {
+            LoadState::Loaded(b) => assert_eq!(b.name, "Renamed"),
+            other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_trait_read_matches_context_read() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut guard = state.lock_session().await;
+        guard.ctx.create_board("Board1".into(), None).unwrap().id
+    };
+
+    let guard = state.lock_session().await;
+    let via_trait = KanbanOperations::get_board(&*guard, board_id).unwrap();
+    let via_ctx = guard.ctx.get_board(board_id).unwrap();
+
+    let via_trait = via_trait.expect("board should be found via trait");
+    let via_ctx = via_ctx.expect("board should be found via ctx");
+    assert_eq!(via_trait.id, via_ctx.id);
+    assert_eq!(via_trait.name, via_ctx.name);
+    assert_eq!(via_trait.card_prefix, via_ctx.card_prefix);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_graph_mutator_commits_through_the_seam() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (parent, child) = {
+        let mut guard = state.lock_session().await;
+        let board = guard
+            .ctx
+            .create_board("Board".into(), Some("KAN".into()))
+            .unwrap();
+        let column = guard.ctx.create_column(board.id, "Todo".into(), None).unwrap();
+        let parent = guard
+            .ctx
+            .create_card(board.id, column.id, "Parent".into(), Default::default())
+            .unwrap()
+            .id;
+        let child = guard
+            .ctx
+            .create_card(board.id, column.id, "Child".into(), Default::default())
+            .unwrap()
+            .id;
+        (parent, child)
+    };
+
+    {
+        let mut guard = state.lock_session().await;
+        GraphOperations::attach_children(&mut *guard, parent, vec![child]).unwrap();
+    }
+
+    {
+        let guard = state.lock_session().await;
+        let mut model = Model::default();
+        guard.sync(&RouteScope::CardGraph(parent), &mut model, &mut NoProjections);
+        match model.graph_state() {
+            LoadState::Loaded(g) => {
+                assert_eq!(g.children(parent), vec![child]);
+                assert!(g.children(child).is_empty());
+            }
+            other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `kanban_server::state::Session` now implements `KanbanOperations` (48 required methods) and `GraphOperations` (11 required methods) itself, in a new private `session_ops` module. Reads delegate to `self.ctx.<trait method>()`; mutators route through the existing `state::mutate`/`state::mutate_unit` seam.
- Retyped eight server helper functions from `&KanbanContext`/`&mut Session` mixed usage to a consistent `&Session`: `require_card_in_column_if_present`, `require_column_in_board_if_present`, `project` (handlers), and `require_card_in_board`, `require_column_in_board`, `do_get_sprint`, `require_sprint_in_board`, `respond` (routes). No production server code calls a `KanbanOperations`/`GraphOperations` method on a `KanbanContext` receiver any more.
- Updated `crates/kanban-server/README.md` to describe `Session` as the server's capability surface rather than "just a `KanbanContext`".
- Zero behavior change: `app.rs` and every router are untouched, `state.rs` is untouched, and the full pre-existing server test suite passes without a single test-body edit.

## Test plan

- [x] `crates/kanban-server/tests/session_ops.rs` (new): compile-lock that `Session: KanbanOperations + GraphOperations`, trait-qualified mutator commits through the seam on both JSON and SQLite backends, trait read matches ctx read, graph mutator effect visible through `sync`.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
