### PR TITLE
KAN-1543 feat(domain,service): add MutationOperations trait and KanbanContext delegation

### DIFF
--- a/.changeset/kan-1543-mutation-operations-trait.md
+++ b/.changeset/kan-1543-mutation-operations-trait.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+---
+
+domain: adds a `MutationOperations` trait over the invalidation-carrying mutation surface (the 35 `*_impl` mutators, the eight spec-shaped create/create-or-replace entry points, and `execute`) plus the four `*CreateOutcome` types, moved here from kanban-service.
+service: `KanbanContext` implements `MutationOperations` by pure delegation to its existing inherent methods; re-exports the outcome types so no importer changes. No behaviour change and no call site is re-plumbed onto the trait yet.

--- a/crates/kanban-domain/src/create_outcome.rs
+++ b/crates/kanban-domain/src/create_outcome.rs
@@ -1,0 +1,41 @@
+use crate::{Board, Card, Column, Sprint};
+
+/// Result of an idempotent PUT-create for a board: the resulting board plus
+/// whether this call created it (`true`, HTTP 201) or replaced an existing
+/// one (`false`, HTTP 200). The HTTP binding lives in the server seam; the
+/// domain and service tiers only report which arm ran.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BoardCreateOutcome {
+    pub board: Board,
+    pub created: bool,
+}
+
+/// Result of an idempotent PUT-create for a card: the resulting card plus
+/// whether this call created it (`true`, HTTP 201) or replaced an existing
+/// one (`false`, HTTP 200). The HTTP binding lives in the server seam; the
+/// domain and service tiers only report which arm ran.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CardCreateOutcome {
+    pub card: Card,
+    pub created: bool,
+}
+
+/// Result of an idempotent PUT-create for a column: the resulting column plus
+/// whether this call created it (`true`, HTTP 201) or replaced an existing
+/// one (`false`, HTTP 200). The HTTP binding lives in the server seam; the
+/// domain and service tiers only report which arm ran.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnCreateOutcome {
+    pub column: Column,
+    pub created: bool,
+}
+
+/// Result of an idempotent PUT-create for a sprint: the resulting sprint plus
+/// whether this call created it (`true`, HTTP 201) or replaced an existing
+/// one (`false`, HTTP 200). The HTTP binding lives in the server seam; the
+/// domain and service tiers only report which arm ran.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SprintCreateOutcome {
+    pub sprint: Sprint,
+    pub created: bool,
+}

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -16,6 +16,7 @@ pub mod commands;
 pub mod completion_derivation;
 pub mod controller;
 pub mod counter_derivation;
+pub mod create_outcome;
 pub mod data_store;
 pub mod dependencies;
 pub mod editable;
@@ -26,6 +27,7 @@ pub mod graph_operations;
 pub mod invalidation;
 pub mod load_state;
 pub mod model;
+pub mod mutation_operations;
 pub mod operations;
 pub mod prefix;
 pub mod prefix_backfill;
@@ -62,6 +64,9 @@ pub use column_factory::{ColumnRecord, NewColumn};
 pub use counter_derivation::{
     counters_implied_by, merge_counter_rows, namespaces_addressed_by, stamp_card_prefix,
 };
+pub use create_outcome::{
+    BoardCreateOutcome, CardCreateOutcome, ColumnCreateOutcome, SprintCreateOutcome,
+};
 pub use dependencies::{
     BlocksEdge, CardEdgeType, DependencyGraph, RelatesEdge, RelatesKind, Severity, SpawnsEdge,
 };
@@ -75,6 +80,7 @@ pub use load_state::LoadState;
 #[cfg(any(test, feature = "test-helpers"))]
 pub use model::ModelLoadStates;
 pub use model::{DerivedProjections, Model, ModelChanged, NoProjections};
+pub use mutation_operations::MutationOperations;
 pub use operations::KanbanOperations;
 pub use prefix::{
     allocate_card_number, allocate_sprint_number, effective_card_prefix, effective_prefixes,

--- a/crates/kanban-domain/src/mutation_operations.rs
+++ b/crates/kanban-domain/src/mutation_operations.rs
@@ -1,0 +1,221 @@
+use crate::commands::Command;
+use crate::dependencies::{RelatesKind, Severity};
+use crate::{
+    Board, BoardCreateOutcome, BoardUpdate, Card, CardCreateOutcome, CardUpdate, Column,
+    ColumnCreateOutcome, ColumnUpdate, CreateCardOptions, Invalidation, KanbanResult, NewBoard,
+    NewCard, NewColumn, Sprint, SprintCreateOutcome, SprintUpdate,
+};
+use uuid::Uuid;
+
+/// The invalidation-carrying mutation surface `KanbanContext` exposes today:
+/// every `*_impl` mutator that returns a domain [`Invalidation`], the eight
+/// spec-shaped create/create-or-replace entry points, and `execute`. Every
+/// method returns its `Invalidation` (or the value it wraps); implementers
+/// must not discard it.
+///
+/// Object-safe by construction: no default bodies, no generic methods.
+pub trait MutationOperations {
+    fn create_board_impl(
+        &mut self,
+        name: String,
+        card_prefix: Option<String>,
+    ) -> KanbanResult<(Board, Invalidation)>;
+    fn update_board_impl(
+        &mut self,
+        id: Uuid,
+        updates: BoardUpdate,
+    ) -> KanbanResult<(Board, Invalidation)>;
+    fn delete_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation>;
+    fn archive_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation>;
+    fn restore_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation>;
+
+    fn create_card_impl(
+        &mut self,
+        board_id: Uuid,
+        column_id: Uuid,
+        title: String,
+        options: CreateCardOptions,
+    ) -> KanbanResult<(Card, Invalidation)>;
+    fn update_card_impl(
+        &mut self,
+        id: Uuid,
+        updates: CardUpdate,
+    ) -> KanbanResult<(Card, Invalidation)>;
+    fn move_card_impl(
+        &mut self,
+        id: Uuid,
+        column_id: Uuid,
+        position: Option<i32>,
+    ) -> KanbanResult<(Card, Invalidation)>;
+    fn archive_card_impl(&mut self, id: Uuid) -> KanbanResult<((), Invalidation)>;
+    fn restore_card_impl(
+        &mut self,
+        id: Uuid,
+        column_id: Option<Uuid>,
+    ) -> KanbanResult<(Card, Invalidation)>;
+    fn delete_card_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation>;
+    fn assign_card_to_sprint_impl(
+        &mut self,
+        card_id: Uuid,
+        sprint_id: Uuid,
+    ) -> KanbanResult<(Card, Invalidation)>;
+    fn unassign_card_from_sprint_impl(
+        &mut self,
+        card_id: Uuid,
+    ) -> KanbanResult<(Card, Invalidation)>;
+
+    fn archive_cards_impl(&mut self, ids: Vec<Uuid>) -> KanbanResult<(usize, Invalidation)>;
+    fn move_cards_impl(
+        &mut self,
+        ids: Vec<Uuid>,
+        column_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)>;
+    fn update_cards_impl(
+        &mut self,
+        updates: Vec<(Uuid, CardUpdate)>,
+    ) -> KanbanResult<(usize, Invalidation)>;
+    fn assign_cards_to_sprint_impl(
+        &mut self,
+        ids: Vec<Uuid>,
+        sprint_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)>;
+
+    fn create_column_impl(
+        &mut self,
+        board_id: Uuid,
+        name: String,
+        position: Option<i32>,
+    ) -> KanbanResult<(Column, Invalidation)>;
+    fn update_column_impl(
+        &mut self,
+        id: Uuid,
+        updates: ColumnUpdate,
+    ) -> KanbanResult<(Column, Invalidation)>;
+    fn delete_column_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation>;
+    fn reorder_column_impl(
+        &mut self,
+        id: Uuid,
+        new_position: i32,
+    ) -> KanbanResult<(Column, Invalidation)>;
+
+    fn carry_over_sprint_cards_impl(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)>;
+    fn create_sprint_impl(
+        &mut self,
+        board_id: Uuid,
+        prefix: Option<String>,
+        name: Option<String>,
+    ) -> KanbanResult<(Sprint, Invalidation)>;
+    fn update_sprint_impl(
+        &mut self,
+        id: Uuid,
+        updates: SprintUpdate,
+    ) -> KanbanResult<(Sprint, Invalidation)>;
+    fn activate_sprint_impl(
+        &mut self,
+        id: Uuid,
+        duration_days: Option<i32>,
+    ) -> KanbanResult<(Sprint, Invalidation)>;
+    fn complete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<(Sprint, Invalidation)>;
+    fn cancel_sprint_impl(&mut self, id: Uuid) -> KanbanResult<(Sprint, Invalidation)>;
+    fn delete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation>;
+    fn import_board_impl(&mut self, data: &str) -> KanbanResult<(Board, Invalidation)>;
+
+    fn attach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<Invalidation>;
+    fn detach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<Invalidation>;
+    fn block_impl(
+        &mut self,
+        blocker: Uuid,
+        blocked: Uuid,
+        severity: Severity,
+    ) -> KanbanResult<Invalidation>;
+    fn unblock_impl(&mut self, blocker: Uuid, blocked: Uuid) -> KanbanResult<Invalidation>;
+    fn relate_impl(&mut self, a: Uuid, b: Uuid, kind: RelatesKind) -> KanbanResult<Invalidation>;
+    fn dissociate_impl(&mut self, a: Uuid, b: Uuid) -> KanbanResult<Invalidation>;
+
+    fn create_board_from_spec(
+        &mut self,
+        id: Option<Uuid>,
+        spec: NewBoard,
+    ) -> KanbanResult<(Board, Invalidation)>;
+    fn create_or_replace_board(
+        &mut self,
+        id: Uuid,
+        spec: NewBoard,
+    ) -> KanbanResult<(BoardCreateOutcome, Invalidation)>;
+    fn create_card_from_spec(
+        &mut self,
+        client_id: Option<Uuid>,
+        spec: NewCard,
+    ) -> KanbanResult<(Card, Invalidation)>;
+    fn create_or_replace_card(
+        &mut self,
+        id: Uuid,
+        spec: NewCard,
+    ) -> KanbanResult<(CardCreateOutcome, Invalidation)>;
+    fn create_column_from_spec(
+        &mut self,
+        id: Option<Uuid>,
+        spec: NewColumn,
+    ) -> KanbanResult<(Column, Invalidation)>;
+    fn create_or_replace_column(
+        &mut self,
+        id: Uuid,
+        spec: NewColumn,
+        position: Option<i32>,
+    ) -> KanbanResult<(ColumnCreateOutcome, Invalidation)>;
+    fn create_sprint_from_spec(
+        &mut self,
+        board_id: Uuid,
+        id: Option<Uuid>,
+        name: Option<String>,
+        prefix: Option<String>,
+        auto_consume_name: bool,
+    ) -> KanbanResult<(Sprint, Invalidation)>;
+    fn create_or_replace_sprint(
+        &mut self,
+        board_id: Uuid,
+        id: Uuid,
+        name: Option<String>,
+        prefix: Option<String>,
+        auto_consume_name: bool,
+    ) -> KanbanResult<(SprintCreateOutcome, Invalidation)>;
+
+    fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<Invalidation>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_is_object_safe() {
+        fn _accepts_dyn(_: &mut dyn MutationOperations) {}
+    }
+
+    #[test]
+    fn test_mutation_operations_declares_every_invalidation_carrying_mutation() {
+        let src = include_str!("mutation_operations.rs");
+        let decl = &src[..src.find("#[cfg(test)]").unwrap()];
+        assert_eq!(
+            decl.matches("\n    fn ").count(),
+            44,
+            "MutationOperations must declare exactly 44 methods"
+        );
+        assert!(
+            !decl.contains("\n    }"),
+            "MutationOperations methods must have no default bodies"
+        );
+    }
+}

--- a/crates/kanban-domain/tests/mutation_operations_contract.rs
+++ b/crates/kanban-domain/tests/mutation_operations_contract.rs
@@ -1,0 +1,52 @@
+use kanban_domain::{Board, BoardCreateOutcome, Card, CardCreateOutcome};
+use kanban_domain::{Column, ColumnCreateOutcome, Sprint, SprintCreateOutcome};
+
+fn _accepts_dyn(_: &mut dyn kanban_domain::MutationOperations) {}
+
+#[test]
+fn test_mutation_operations_is_object_safe() {
+    fn _use(_: &mut dyn kanban_domain::MutationOperations) {}
+}
+
+#[test]
+fn test_create_outcome_types_live_in_domain() {
+    let board = Board::new("B", None::<String>);
+    let outcome = BoardCreateOutcome {
+        board: board.clone(),
+        created: true,
+    };
+    assert!(outcome.created);
+    assert_eq!(outcome.board.name, "B");
+    assert_eq!(outcome.clone(), outcome);
+    assert!(format!("{outcome:?}").contains("BoardCreateOutcome"));
+
+    let column = Column::new(board.id, "Todo", 0);
+    let column_outcome = ColumnCreateOutcome {
+        column: column.clone(),
+        created: false,
+    };
+    assert!(!column_outcome.created);
+    assert_eq!(column_outcome.column.name, "Todo");
+    assert_eq!(column_outcome.clone(), column_outcome);
+    assert!(format!("{column_outcome:?}").contains("ColumnCreateOutcome"));
+
+    let card = Card::new(board.id, column.id, "Task", 0);
+    let card_outcome = CardCreateOutcome {
+        card: card.clone(),
+        created: true,
+    };
+    assert!(card_outcome.created);
+    assert_eq!(card_outcome.card.title, "Task");
+    assert_eq!(card_outcome.clone(), card_outcome);
+    assert!(format!("{card_outcome:?}").contains("CardCreateOutcome"));
+
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+    let sprint_outcome = SprintCreateOutcome {
+        sprint: sprint.clone(),
+        created: false,
+    };
+    assert!(!sprint_outcome.created);
+    assert_eq!(sprint_outcome.sprint.board_id, board.id);
+    assert_eq!(sprint_outcome.clone(), sprint_outcome);
+    assert!(format!("{sprint_outcome:?}").contains("SprintCreateOutcome"));
+}

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -3,22 +3,13 @@ use chrono::{DateTime, Utc};
 use kanban_domain::commands::{ArchiveBoards, BoardCommand, Command, ImportEntities, RestoreBoard};
 use kanban_domain::{
     filter_and_sort_boards, resolve_board_sort, ArchivedBoard, ArchivedFilter, Board,
-    BoardListFilter, BoardSortField, BoardUpdate, FieldUpdate, Invalidation, KanbanError,
-    KanbanResult, NewBoard, SortOrder, DEFAULT_ARCHIVED_BOARD_SORT, DEFAULT_BOARD_SORT_LIVE,
+    BoardCreateOutcome, BoardListFilter, BoardSortField, BoardUpdate, FieldUpdate, Invalidation,
+    KanbanError, KanbanResult, NewBoard, SortOrder, DEFAULT_ARCHIVED_BOARD_SORT,
+    DEFAULT_BOARD_SORT_LIVE,
 };
 use std::collections::HashMap;
 use std::str::FromStr;
 use uuid::Uuid;
-
-/// Result of an idempotent PUT-create ([`KanbanContext::create_or_replace_board`]):
-/// the resulting board plus whether this call created it (`true`, HTTP 201) or
-/// replaced an existing one (`false`, HTTP 200). The HTTP binding lives in the
-/// server seam; the service tier only reports which arm ran.
-#[derive(Debug, Clone, PartialEq)]
-pub struct BoardCreateOutcome {
-    pub board: Board,
-    pub created: bool,
-}
 
 impl KanbanContext {
     /// Create a board from a full `NewBoard` spec plus an optional client-supplied

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -1,21 +1,11 @@
 use super::KanbanContext;
 use kanban_domain::commands::{CardCommand, Command};
 use kanban_domain::{
-    ArchivedCard, ArchivedEntity, Card, CardListFilter, CardSummary, CardUpdate, Column,
-    CreateCardOptions, DomainError, FieldUpdate, Invalidation, KanbanError, KanbanResult, NewCard,
-    Sprint,
+    ArchivedCard, ArchivedEntity, Card, CardCreateOutcome, CardListFilter, CardSummary, CardUpdate,
+    Column, CreateCardOptions, DomainError, FieldUpdate, Invalidation, KanbanError, KanbanResult,
+    NewCard, Sprint,
 };
 use uuid::Uuid;
-
-/// Result of an idempotent PUT-create ([`KanbanContext::create_or_replace_card`]):
-/// the resulting card plus whether this call created it (`true`, HTTP 201) or
-/// replaced an existing one (`false`, HTTP 200). The HTTP binding lives in the
-/// server seam; the service tier only reports which arm ran.
-#[derive(Debug, Clone, PartialEq)]
-pub struct CardCreateOutcome {
-    pub card: Card,
-    pub created: bool,
-}
 
 impl KanbanContext {
     /// The archival marker's `archived_at` for a card, or `None` if the card is

--- a/crates/kanban-service/src/context/columns.rs
+++ b/crates/kanban-service/src/context/columns.rs
@@ -2,19 +2,10 @@ use super::KanbanContext;
 use chrono::Utc;
 use kanban_domain::commands::{BoardCommand, ColumnCommand, Command, ImportEntities};
 use kanban_domain::{
-    Column, ColumnUpdate, FieldUpdate, Invalidation, KanbanError, KanbanResult, NewColumn,
+    Column, ColumnCreateOutcome, ColumnUpdate, FieldUpdate, Invalidation, KanbanError,
+    KanbanResult, NewColumn,
 };
 use uuid::Uuid;
-
-/// Result of an idempotent PUT-create ([`KanbanContext::create_or_replace_column`]):
-/// the resulting column plus whether this call created it (`true`, HTTP 201) or
-/// replaced an existing one (`false`, HTTP 200). The HTTP binding lives in the
-/// server seam; the service tier only reports which arm ran.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ColumnCreateOutcome {
-    pub column: Column,
-    pub created: bool,
-}
 
 impl KanbanContext {
     /// Create a column from a full `NewColumn` spec plus an optional

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -5,25 +5,25 @@ use kanban_domain::{
     CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, KanbanOperations,
     KanbanResult, Sprint, SprintUpdate,
 };
+pub use kanban_domain::{
+    BoardCreateOutcome, CardCreateOutcome, ColumnCreateOutcome, SprintCreateOutcome,
+};
 use serde::Serialize;
 use std::sync::Arc;
 use uuid::Uuid;
 
 mod boards;
-pub use boards::BoardCreateOutcome;
 mod cards;
-pub use cards::CardCreateOutcome;
 mod cards_batch;
 mod cards_batch_detailed;
 mod columns;
-pub use columns::ColumnCreateOutcome;
 mod core;
 mod filters;
 mod graph;
 pub use graph::BoardRelations;
+mod mutation_ops;
 mod persistence;
 mod sprints;
-pub use sprints::SprintCreateOutcome;
 mod sync;
 mod undo;
 

--- a/crates/kanban-service/src/context/mutation_ops.rs
+++ b/crates/kanban-service/src/context/mutation_ops.rs
@@ -1,0 +1,278 @@
+use super::KanbanContext;
+use kanban_domain::commands::Command;
+use kanban_domain::{
+    Board, BoardCreateOutcome, BoardUpdate, Card, CardCreateOutcome, CardUpdate, Column,
+    ColumnCreateOutcome, ColumnUpdate, CreateCardOptions, Invalidation, KanbanResult,
+    MutationOperations, NewBoard, NewCard, NewColumn, RelatesKind, Severity, Sprint,
+    SprintCreateOutcome, SprintUpdate,
+};
+use uuid::Uuid;
+
+impl MutationOperations for KanbanContext {
+    fn create_board_impl(
+        &mut self,
+        name: String,
+        card_prefix: Option<String>,
+    ) -> KanbanResult<(Board, Invalidation)> {
+        KanbanContext::create_board_impl(self, name, card_prefix)
+    }
+    fn update_board_impl(
+        &mut self,
+        id: Uuid,
+        updates: BoardUpdate,
+    ) -> KanbanResult<(Board, Invalidation)> {
+        KanbanContext::update_board_impl(self, id, updates)
+    }
+    fn delete_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        KanbanContext::delete_board_impl(self, id)
+    }
+    fn archive_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        KanbanContext::archive_board_impl(self, id)
+    }
+    fn restore_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        KanbanContext::restore_board_impl(self, id)
+    }
+
+    fn create_card_impl(
+        &mut self,
+        board_id: Uuid,
+        column_id: Uuid,
+        title: String,
+        options: CreateCardOptions,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        KanbanContext::create_card_impl(self, board_id, column_id, title, options)
+    }
+    fn update_card_impl(
+        &mut self,
+        id: Uuid,
+        updates: CardUpdate,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        KanbanContext::update_card_impl(self, id, updates)
+    }
+    fn move_card_impl(
+        &mut self,
+        id: Uuid,
+        column_id: Uuid,
+        position: Option<i32>,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        KanbanContext::move_card_impl(self, id, column_id, position)
+    }
+    fn archive_card_impl(&mut self, id: Uuid) -> KanbanResult<((), Invalidation)> {
+        KanbanContext::archive_card_impl(self, id)
+    }
+    fn restore_card_impl(
+        &mut self,
+        id: Uuid,
+        column_id: Option<Uuid>,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        KanbanContext::restore_card_impl(self, id, column_id)
+    }
+    fn delete_card_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        KanbanContext::delete_card_impl(self, id)
+    }
+    fn assign_card_to_sprint_impl(
+        &mut self,
+        card_id: Uuid,
+        sprint_id: Uuid,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        KanbanContext::assign_card_to_sprint_impl(self, card_id, sprint_id)
+    }
+    fn unassign_card_from_sprint_impl(
+        &mut self,
+        card_id: Uuid,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        KanbanContext::unassign_card_from_sprint_impl(self, card_id)
+    }
+
+    fn archive_cards_impl(&mut self, ids: Vec<Uuid>) -> KanbanResult<(usize, Invalidation)> {
+        KanbanContext::archive_cards_impl(self, ids)
+    }
+    fn move_cards_impl(
+        &mut self,
+        ids: Vec<Uuid>,
+        column_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)> {
+        KanbanContext::move_cards_impl(self, ids, column_id)
+    }
+    fn update_cards_impl(
+        &mut self,
+        updates: Vec<(Uuid, CardUpdate)>,
+    ) -> KanbanResult<(usize, Invalidation)> {
+        KanbanContext::update_cards_impl(self, updates)
+    }
+    fn assign_cards_to_sprint_impl(
+        &mut self,
+        ids: Vec<Uuid>,
+        sprint_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)> {
+        KanbanContext::assign_cards_to_sprint_impl(self, ids, sprint_id)
+    }
+
+    fn create_column_impl(
+        &mut self,
+        board_id: Uuid,
+        name: String,
+        position: Option<i32>,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        KanbanContext::create_column_impl(self, board_id, name, position)
+    }
+    fn update_column_impl(
+        &mut self,
+        id: Uuid,
+        updates: ColumnUpdate,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        KanbanContext::update_column_impl(self, id, updates)
+    }
+    fn delete_column_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        KanbanContext::delete_column_impl(self, id)
+    }
+    fn reorder_column_impl(
+        &mut self,
+        id: Uuid,
+        new_position: i32,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        KanbanContext::reorder_column_impl(self, id, new_position)
+    }
+
+    fn carry_over_sprint_cards_impl(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)> {
+        KanbanContext::carry_over_sprint_cards_impl(self, from_sprint_id, to_sprint_id)
+    }
+    fn create_sprint_impl(
+        &mut self,
+        board_id: Uuid,
+        prefix: Option<String>,
+        name: Option<String>,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        KanbanContext::create_sprint_impl(self, board_id, prefix, name)
+    }
+    fn update_sprint_impl(
+        &mut self,
+        id: Uuid,
+        updates: SprintUpdate,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        KanbanContext::update_sprint_impl(self, id, updates)
+    }
+    fn activate_sprint_impl(
+        &mut self,
+        id: Uuid,
+        duration_days: Option<i32>,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        KanbanContext::activate_sprint_impl(self, id, duration_days)
+    }
+    fn complete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<(Sprint, Invalidation)> {
+        KanbanContext::complete_sprint_impl(self, id)
+    }
+    fn cancel_sprint_impl(&mut self, id: Uuid) -> KanbanResult<(Sprint, Invalidation)> {
+        KanbanContext::cancel_sprint_impl(self, id)
+    }
+    fn delete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        KanbanContext::delete_sprint_impl(self, id)
+    }
+    fn import_board_impl(&mut self, data: &str) -> KanbanResult<(Board, Invalidation)> {
+        KanbanContext::import_board_impl(self, data)
+    }
+
+    fn attach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<Invalidation> {
+        KanbanContext::attach_children_impl(self, parent, children)
+    }
+    fn detach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<Invalidation> {
+        KanbanContext::detach_children_impl(self, parent, children)
+    }
+    fn block_impl(
+        &mut self,
+        blocker: Uuid,
+        blocked: Uuid,
+        severity: Severity,
+    ) -> KanbanResult<Invalidation> {
+        KanbanContext::block_impl(self, blocker, blocked, severity)
+    }
+    fn unblock_impl(&mut self, blocker: Uuid, blocked: Uuid) -> KanbanResult<Invalidation> {
+        KanbanContext::unblock_impl(self, blocker, blocked)
+    }
+    fn relate_impl(&mut self, a: Uuid, b: Uuid, kind: RelatesKind) -> KanbanResult<Invalidation> {
+        KanbanContext::relate_impl(self, a, b, kind)
+    }
+    fn dissociate_impl(&mut self, a: Uuid, b: Uuid) -> KanbanResult<Invalidation> {
+        KanbanContext::dissociate_impl(self, a, b)
+    }
+
+    fn create_board_from_spec(
+        &mut self,
+        id: Option<Uuid>,
+        spec: NewBoard,
+    ) -> KanbanResult<(Board, Invalidation)> {
+        KanbanContext::create_board_from_spec(self, id, spec)
+    }
+    fn create_or_replace_board(
+        &mut self,
+        id: Uuid,
+        spec: NewBoard,
+    ) -> KanbanResult<(BoardCreateOutcome, Invalidation)> {
+        KanbanContext::create_or_replace_board(self, id, spec)
+    }
+    fn create_card_from_spec(
+        &mut self,
+        client_id: Option<Uuid>,
+        spec: NewCard,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        KanbanContext::create_card_from_spec(self, client_id, spec)
+    }
+    fn create_or_replace_card(
+        &mut self,
+        id: Uuid,
+        spec: NewCard,
+    ) -> KanbanResult<(CardCreateOutcome, Invalidation)> {
+        KanbanContext::create_or_replace_card(self, id, spec)
+    }
+    fn create_column_from_spec(
+        &mut self,
+        id: Option<Uuid>,
+        spec: NewColumn,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        KanbanContext::create_column_from_spec(self, id, spec)
+    }
+    fn create_or_replace_column(
+        &mut self,
+        id: Uuid,
+        spec: NewColumn,
+        position: Option<i32>,
+    ) -> KanbanResult<(ColumnCreateOutcome, Invalidation)> {
+        KanbanContext::create_or_replace_column(self, id, spec, position)
+    }
+    fn create_sprint_from_spec(
+        &mut self,
+        board_id: Uuid,
+        id: Option<Uuid>,
+        name: Option<String>,
+        prefix: Option<String>,
+        auto_consume_name: bool,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        KanbanContext::create_sprint_from_spec(self, board_id, id, name, prefix, auto_consume_name)
+    }
+    fn create_or_replace_sprint(
+        &mut self,
+        board_id: Uuid,
+        id: Uuid,
+        name: Option<String>,
+        prefix: Option<String>,
+        auto_consume_name: bool,
+    ) -> KanbanResult<(SprintCreateOutcome, Invalidation)> {
+        KanbanContext::create_or_replace_sprint(self, board_id, id, name, prefix, auto_consume_name)
+    }
+
+    fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<Invalidation> {
+        KanbanContext::execute(self, commands)
+    }
+}

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -5,20 +5,10 @@ use kanban_domain::commands::{Command, SprintCommand};
 use kanban_domain::export::{AllBoardsExport, BoardImporter};
 use kanban_domain::{
     invalidation_from_inverse, Board, DataStore, FieldUpdate, Invalidation, KanbanError,
-    KanbanResult, Snapshot, Sprint, SprintUpdate,
+    KanbanResult, Snapshot, Sprint, SprintCreateOutcome, SprintUpdate,
 };
 use kanban_persistence::PersistenceError;
 use uuid::Uuid;
-
-/// Result of an idempotent PUT-create ([`KanbanContext::create_or_replace_sprint`]):
-/// the resulting sprint plus whether this call created it (`true`, HTTP 201) or
-/// replaced an existing one (`false`, HTTP 200). The HTTP binding lives in the
-/// server seam; the service tier only reports which arm ran.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SprintCreateOutcome {
-    pub sprint: Sprint,
-    pub created: bool,
-}
 
 impl KanbanContext {
     pub fn carry_over_sprint_cards_impl(

--- a/crates/kanban-service/tests/mutation_operations_trait.rs
+++ b/crates/kanban-service/tests/mutation_operations_trait.rs
@@ -32,7 +32,9 @@ fn board_spec(name: &str) -> NewBoard {
 #[tokio::test]
 async fn test_mutation_operations_delegates_to_the_inherent_mutators() {
     let mut ctx = make_ctx().await;
-    let (board, _inv) = ctx.create_board_from_spec(None, board_spec("Alpha")).unwrap();
+    let (board, _inv) = ctx
+        .create_board_from_spec(None, board_spec("Alpha"))
+        .unwrap();
 
     let updates = BoardUpdate {
         name: Some("Renamed".into()),
@@ -62,17 +64,17 @@ async fn test_mutation_operations_delegates_to_the_inherent_mutators() {
     );
 
     let unit_inv = MutationOperations::delete_board_impl(&mut ctx, board.id).unwrap();
-    assert_eq!(unit_inv, Invalidation::Entities(EntityIds::boards([board.id])));
+    assert_eq!(
+        unit_inv,
+        Invalidation::Entities(EntityIds::boards([board.id]).with_prefixes())
+    );
     assert!(ctx.get_board(board.id).unwrap().is_none());
 
     let fresh_id = Uuid::new_v4();
     let (outcome1, _inv) =
         MutationOperations::create_or_replace_board(&mut ctx, fresh_id, board_spec("Beta"))
             .unwrap();
-    assert!(matches!(
-        outcome1,
-        BoardCreateOutcome { created: true, .. }
-    ));
+    assert!(matches!(outcome1, BoardCreateOutcome { created: true, .. }));
 
     let (outcome2, _inv) =
         MutationOperations::create_or_replace_board(&mut ctx, fresh_id, board_spec("Beta v2"))
@@ -86,7 +88,9 @@ async fn test_mutation_operations_delegates_to_the_inherent_mutators() {
 #[tokio::test]
 async fn test_mutation_operations_trait_object_reaches_the_store() {
     let mut ctx = make_ctx().await;
-    let (board, _inv) = ctx.create_board_from_spec(None, board_spec("Gamma")).unwrap();
+    let (board, _inv) = ctx
+        .create_board_from_spec(None, board_spec("Gamma"))
+        .unwrap();
 
     let ops: &mut dyn MutationOperations = &mut ctx;
     let (column, _inv) = ops
@@ -108,7 +112,7 @@ async fn test_mutation_operations_trait_object_reaches_the_store() {
             kanban_domain::CreateCardOptions::default(),
         )
         .unwrap();
-    ops.attach_children_impl(parent.id, vec![child.id]).unwrap();
+    let _ = ops.attach_children_impl(parent.id, vec![child.id]).unwrap();
 
     assert!(ctx.get_column(column.id).unwrap().is_some());
     let relations = ctx.list_relations_for_board(board.id).unwrap();

--- a/crates/kanban-service/tests/mutation_operations_trait.rs
+++ b/crates/kanban-service/tests/mutation_operations_trait.rs
@@ -1,0 +1,116 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::commands::{BoardCommand, Command, UpdateBoard};
+use kanban_domain::{
+    BoardUpdate, EntityIds, Invalidation, KanbanOperations, MutationOperations, NewBoard,
+};
+use kanban_service::{BoardCreateOutcome, KanbanContext};
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn make_ctx() -> KanbanContext {
+    KanbanContext::open(
+        Arc::new(InMemoryStore::new()),
+        kanban_core::AppConfig::default(),
+    )
+    .await
+    .unwrap()
+}
+
+fn board_spec(name: &str) -> NewBoard {
+    NewBoard {
+        name: name.to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: Some("KAN".into()),
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    }
+}
+
+#[tokio::test]
+async fn test_mutation_operations_delegates_to_the_inherent_mutators() {
+    let mut ctx = make_ctx().await;
+    let (board, _inv) = ctx.create_board_from_spec(None, board_spec("Alpha")).unwrap();
+
+    let updates = BoardUpdate {
+        name: Some("Renamed".into()),
+        ..Default::default()
+    };
+    let inv = MutationOperations::execute(
+        &mut ctx,
+        vec![Command::Board(BoardCommand::Update(UpdateBoard {
+            board_id: board.id,
+            updates: updates.clone(),
+        }))],
+    )
+    .unwrap();
+    assert_eq!(inv, Invalidation::Entities(EntityIds::boards([board.id])));
+    assert_eq!(ctx.get_board(board.id).unwrap().unwrap().name, "Renamed");
+
+    let updates2 = BoardUpdate {
+        name: Some("Renamed Again".into()),
+        ..Default::default()
+    };
+    let (updated_board, tuple_inv) =
+        MutationOperations::update_board_impl(&mut ctx, board.id, updates2).unwrap();
+    assert_eq!(updated_board.name, "Renamed Again");
+    assert_eq!(
+        tuple_inv,
+        Invalidation::Entities(EntityIds::boards([board.id]))
+    );
+
+    let unit_inv = MutationOperations::delete_board_impl(&mut ctx, board.id).unwrap();
+    assert_eq!(unit_inv, Invalidation::Entities(EntityIds::boards([board.id])));
+    assert!(ctx.get_board(board.id).unwrap().is_none());
+
+    let fresh_id = Uuid::new_v4();
+    let (outcome1, _inv) =
+        MutationOperations::create_or_replace_board(&mut ctx, fresh_id, board_spec("Beta"))
+            .unwrap();
+    assert!(matches!(
+        outcome1,
+        BoardCreateOutcome { created: true, .. }
+    ));
+
+    let (outcome2, _inv) =
+        MutationOperations::create_or_replace_board(&mut ctx, fresh_id, board_spec("Beta v2"))
+            .unwrap();
+    assert!(matches!(
+        outcome2,
+        BoardCreateOutcome { created: false, .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_mutation_operations_trait_object_reaches_the_store() {
+    let mut ctx = make_ctx().await;
+    let (board, _inv) = ctx.create_board_from_spec(None, board_spec("Gamma")).unwrap();
+
+    let ops: &mut dyn MutationOperations = &mut ctx;
+    let (column, _inv) = ops
+        .create_column_impl(board.id, "Todo".into(), None)
+        .unwrap();
+    let (parent, _inv) = ops
+        .create_card_impl(
+            board.id,
+            column.id,
+            "Parent".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    let (child, _inv) = ops
+        .create_card_impl(
+            board.id,
+            column.id,
+            "Child".into(),
+            kanban_domain::CreateCardOptions::default(),
+        )
+        .unwrap();
+    ops.attach_children_impl(parent.id, vec![child.id]).unwrap();
+
+    assert!(ctx.get_column(column.id).unwrap().is_some());
+    let relations = ctx.list_relations_for_board(board.id).unwrap();
+    assert_eq!(relations.spawns.len(), 1);
+}


### PR DESCRIPTION
## Summary

Purely additive core of the `MutationOperations` lock:

- Adds `kanban_domain::MutationOperations`, a 44-method trait covering the invalidation-carrying mutation surface `KanbanContext` already exposes: the 35 `*_impl` mutators that return `Invalidation`, the 8 spec-shaped create/create-or-replace entry points, and `execute`. Zero default bodies, object-safe by construction.
- Moves `BoardCreateOutcome`, `CardCreateOutcome`, `ColumnCreateOutcome`, `SprintCreateOutcome` from `kanban-service` into `kanban-domain`. `kanban-service` re-exports them unchanged (`kanban_service::BoardCreateOutcome` etc. still resolve), so no importer changes.
- `impl MutationOperations for KanbanContext` in `crates/kanban-service/src/context/mutation_ops.rs`: pure one-line delegation (`KanbanContext::<name>(self, ...)`) to the existing inherent `*_impl` methods. No behaviour change, no seam re-plumbed, no call site touched.

The CLI/MCP/server/TUI dyn flip onto this trait is a separate follow-up card. This PR only adds the trait and the impl; nothing outside `kanban-domain`/`kanban-service` changes.

## Inventory re-derivation

Re-ran the count at the real tip (`cfe9e695`, not the `dc109854` the card was originally scouted against):

```
for f in boards cards cards_batch columns sprints graph; do
  git show origin/develop:crates/kanban-service/src/context/$f.rs | awk -v fname="$f" '
    /^    pub(\(super\))? fn [a-z_]*_impl/{sig="";collect=1}
    collect{sig=sig " " $0; if (/\{$/) {collect=0; gsub(/\{.*/,"",sig); if (sig ~ /Invalidation/) print fname" "sig}}
  '
done | wc -l
```

Result: `35`. Plus the 8 spec-family functions (`create_*_from_spec` / `create_or_replace_*`) and `undo.rs`'s `execute`, for 35 + 8 + 1 = 44, matching the trait's method count.

## Zero call-site churn

```
git diff --stat origin/develop -- crates/
```

```
 crates/kanban-domain/src/create_outcome.rs         |  41 +++
 crates/kanban-domain/src/lib.rs                    |   6 +
 crates/kanban-domain/src/mutation_operations.rs    | 221 ++++++++++++++++
 .../tests/mutation_operations_contract.rs          |  52 ++++
 crates/kanban-service/src/context/boards.rs        |  15 +-
 crates/kanban-service/src/context/cards.rs         |  16 +-
 crates/kanban-service/src/context/columns.rs       |  13 +-
 crates/kanban-service/src/context/mod.rs           |   8 +-
 crates/kanban-service/src/context/mutation_ops.rs  | 278 +++++++++++++++++++++
 crates/kanban-service/src/context/sprints.rs       |  12 +-
 .../tests/mutation_operations_trait.rs             | 120 +++++++++
 11 files changed, 731 insertions(+), 51 deletions(-)
```

Only `kanban-domain` and `kanban-service` are touched. `kanban-cli`, `kanban-mcp`, `kanban-server` and `kanban-tui` are byte-identical to `origin/develop`.

## Notable corrections made while implementing

- The card's inline test `assert!(!decl.contains("\n        "))` for "no default bodies" is unsound against `cargo fmt`: several of the 44 signatures exceed the 100-char line width and rustfmt wraps their parameters onto 8-space-indented continuation lines, which the literal check would flag as a false positive. Replaced it with `assert!(!decl.contains("\n    }"))`, which only matches a default body's closing brace at the trait's own indent and is immune to parameter wrapping.
- `test_mutation_operations_delegates_to_the_inherent_mutators`'s unit arm originally asserted `delete_board_impl` invalidates only `boards`; the real behaviour also flips `prefixes: true` (deleting a board frees its prefix namespace), so the assertion now matches `EntityIds::boards([id]).with_prefixes()`, derived from the actual return value rather than an assumed constant.

## Mutation check

Temporarily made the trait's `execute` delegate to itself (`MutationOperations::execute(self, commands)` instead of the inherent `KanbanContext::execute(self, commands)`). `test_mutation_operations_delegates_to_the_inherent_mutators` immediately stack-overflowed and aborted (SIGABRT), confirming the test actually exercises the delegation rather than passing vacuously. Reverted before committing.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features --workspace`: 265 test binaries, all green, zero failures
- `cargo test -p kanban-service --test create_column_from_spec`: 14/14 green, proving the `kanban_service::ColumnCreateOutcome` re-export chain survived the move unchanged
