### PR TITLE
KAN-1562 refactor(cli,mcp,server,tui): re-plumb mutation seams onto MutationOperations

### DIFF
--- a/.changeset/kan-1562-mutation-operations-replumb.md
+++ b/.changeset/kan-1562-mutation-operations-replumb.md
@@ -1,0 +1,10 @@
+---
+bump: minor
+---
+
+cli: the `mutate`/`mutate_unit` seam closures are now typed against `MutationOperations` instead of `KanbanContext`, so a seam closure can no longer reach a context read or an invalidation-stripping `KanbanOperations` mutator.
+mcp: the `mutate`/`mutate_unit` seam closures are now typed against `MutationOperations` instead of `KanbanContext`, same restriction as above.
+server: the `mutate`/`mutate_unit` seam closures are now typed against `MutationOperations` instead of `KanbanContext`, same restriction as above; the return shape is unchanged.
+tui: `TuiContext` implements `MutationOperations` directly (every method flushes through the existing save-coordinator path) in place of six hand-written inherent forwarders.
+
+Behaviour is unchanged across all four applications.

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -544,6 +544,20 @@ mod tests {
     }
 
     #[test]
+    fn test_mutate_seam_accepts_a_mutation_operations_closure() -> KanbanResult<()> {
+        let mut ctx = seam_context();
+        let board = ctx.mutate(|c: &mut dyn kanban_domain::MutationOperations| {
+            c.create_board_impl("Seam".to_string(), None)
+        })?;
+        assert_eq!(board.name, "Seam");
+        ctx.mutate_unit(|c: &mut dyn kanban_domain::MutationOperations| {
+            c.archive_board_impl(board.id)
+        })?;
+        assert!(ctx.list_boards()?.is_empty());
+        Ok(())
+    }
+
+    #[test]
     fn test_mutate_returns_the_operations_value() -> KanbanResult<()> {
         let mut ctx = seam_context();
         let board = ctx.mutate(|c| c.create_board_impl("Seam".to_string(), None))?;

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -3,7 +3,7 @@ use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
     CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
-    Invalidation, KanbanOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
+    Invalidation, KanbanOperations, MutationOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;
@@ -97,7 +97,7 @@ impl CliContext {
     /// invalidates nothing.
     pub(crate) fn mutate<T>(
         &mut self,
-        op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
+        op: impl FnOnce(&mut dyn MutationOperations) -> KanbanResult<(T, Invalidation)>,
     ) -> KanbanResult<T> {
         let (value, invalidation) = op(&mut self.inner)?;
         self.apply_invalidation(invalidation);
@@ -108,7 +108,7 @@ impl CliContext {
     /// `Invalidation`.
     pub(crate) fn mutate_unit(
         &mut self,
-        op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
+        op: impl FnOnce(&mut dyn MutationOperations) -> KanbanResult<Invalidation>,
     ) -> KanbanResult<()> {
         let invalidation = op(&mut self.inner)?;
         self.apply_invalidation(invalidation);
@@ -193,21 +193,19 @@ impl CliContext {
         match position {
             Some(position) => {
                 let id = Uuid::new_v4();
-                self.mutate(|c| {
-                    let invalidation =
-                        c.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
-                            id,
-                            board_id,
-                            name,
-                            position,
-                            default_status,
-                        }))])?;
-                    let column = KanbanOperations::get_column(c, id)?.ok_or_else(|| {
-                        kanban_domain::KanbanError::Internal(
-                            "Column creation succeeded but column not found".into(),
-                        )
-                    })?;
-                    Ok((column, invalidation))
+                self.mutate_unit(|c| {
+                    c.execute(vec![Command::Column(ColumnCommand::Create(CreateColumn {
+                        id,
+                        board_id,
+                        name,
+                        position,
+                        default_status,
+                    }))])
+                })?;
+                KanbanOperations::get_column(self, id)?.ok_or_else(|| {
+                    kanban_domain::KanbanError::Internal(
+                        "Column creation succeeded but column not found".into(),
+                    )
                 })
             }
             None => self.mutate(|c| {

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -3,7 +3,8 @@ use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
     CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
-    Invalidation, KanbanOperations, SortOrder, Sprint, SprintUpdate, DEFAULT_BOARD_SORT_LIVE,
+    Invalidation, KanbanOperations, MutationOperations, SortOrder, Sprint, SprintUpdate,
+    DEFAULT_BOARD_SORT_LIVE,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use std::str::FromStr;
@@ -169,7 +170,7 @@ impl McpContext {
     /// response is built entirely from `value`.
     pub(crate) fn mutate<T>(
         &mut self,
-        op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
+        op: impl FnOnce(&mut dyn MutationOperations) -> KanbanResult<(T, Invalidation)>,
     ) -> KanbanResult<(T, Invalidation)> {
         op(&mut self.inner)
     }
@@ -178,7 +179,7 @@ impl McpContext {
     /// `Invalidation`, with no separate result value.
     pub(crate) fn mutate_unit(
         &mut self,
-        op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
+        op: impl FnOnce(&mut dyn MutationOperations) -> KanbanResult<Invalidation>,
     ) -> KanbanResult<Invalidation> {
         op(&mut self.inner)
     }
@@ -517,10 +518,11 @@ mod tests {
             .unwrap();
         assert_eq!(board.name, "Seam");
 
-        ctx.mutate_unit(|c: &mut dyn kanban_domain::MutationOperations| {
-            c.delete_board_impl(board.id)
-        })
-        .unwrap();
+        let _inv = ctx
+            .mutate_unit(|c: &mut dyn kanban_domain::MutationOperations| {
+                c.delete_board_impl(board.id)
+            })
+            .unwrap();
         assert!(ctx.list_boards().unwrap().is_empty());
     }
 

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -507,6 +507,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mutate_seam_accepts_a_mutation_operations_closure() {
+        let (mut ctx, _dir) = test_context().await;
+
+        let (board, _inv) = ctx
+            .mutate(|c: &mut dyn kanban_domain::MutationOperations| {
+                c.create_board_impl("Seam".to_string(), None)
+            })
+            .unwrap();
+        assert_eq!(board.name, "Seam");
+
+        ctx.mutate_unit(|c: &mut dyn kanban_domain::MutationOperations| {
+            c.delete_board_impl(board.id)
+        })
+        .unwrap();
+        assert!(ctx.list_boards().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn test_mutate_returns_the_operations_value_and_invalidation() {
         let (mut ctx, _dir) = test_context().await;
 

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -154,6 +154,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mutate_seam_accepts_a_mutation_operations_closure() {
+        let (mut session, board_id) = seeded_ctx().await;
+
+        let (board, _inv) = mutate(&mut session, |c: &mut dyn kanban_domain::MutationOperations| {
+            c.update_board_impl(
+                board_id,
+                BoardUpdate {
+                    name: Some("Renamed".into()),
+                    ..Default::default()
+                },
+            )
+        })
+        .unwrap();
+        assert_eq!(board.name, "Renamed");
+
+        let _inv = mutate_unit(&mut session, |c: &mut dyn kanban_domain::MutationOperations| {
+            c.delete_board_impl(board_id)
+        })
+        .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_mutate_returns_the_invalidation_the_operation_produced() {
         let dir = tempfile::tempdir().unwrap();
         let state = json_state(dir.path());

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -1,5 +1,5 @@
 use kanban_core::ClientId;
-use kanban_domain::Invalidation;
+use kanban_domain::{Invalidation, MutationOperations};
 use kanban_service::api::{ChangeEventFrame, ChangeKind, EntityType};
 use kanban_service::{KanbanContext, KanbanResult};
 use std::sync::Arc;
@@ -32,7 +32,7 @@ impl std::ops::DerefMut for Session {
 /// describe the change with.
 pub(crate) fn mutate<T>(
     session: &mut Session,
-    op: impl FnOnce(&mut KanbanContext) -> KanbanResult<(T, Invalidation)>,
+    op: impl FnOnce(&mut dyn MutationOperations) -> KanbanResult<(T, Invalidation)>,
 ) -> KanbanResult<(T, Invalidation)> {
     op(&mut session.ctx)
 }
@@ -40,7 +40,7 @@ pub(crate) fn mutate<T>(
 /// Like [`mutate`], for operations that return only an `Invalidation`.
 pub(crate) fn mutate_unit(
     session: &mut Session,
-    op: impl FnOnce(&mut KanbanContext) -> KanbanResult<Invalidation>,
+    op: impl FnOnce(&mut dyn MutationOperations) -> KanbanResult<Invalidation>,
 ) -> KanbanResult<Invalidation> {
     op(&mut session.ctx)
 }

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -157,21 +157,25 @@ mod tests {
     async fn test_mutate_seam_accepts_a_mutation_operations_closure() {
         let (mut session, board_id) = seeded_ctx().await;
 
-        let (board, _inv) = mutate(&mut session, |c: &mut dyn kanban_domain::MutationOperations| {
-            c.update_board_impl(
-                board_id,
-                BoardUpdate {
-                    name: Some("Renamed".into()),
-                    ..Default::default()
-                },
-            )
-        })
+        let (board, _inv) = mutate(
+            &mut session,
+            |c: &mut dyn kanban_domain::MutationOperations| {
+                c.update_board_impl(
+                    board_id,
+                    BoardUpdate {
+                        name: Some("Renamed".into()),
+                        ..Default::default()
+                    },
+                )
+            },
+        )
         .unwrap();
         assert_eq!(board.name, "Renamed");
 
-        let _inv = mutate_unit(&mut session, |c: &mut dyn kanban_domain::MutationOperations| {
-            c.delete_board_impl(board_id)
-        })
+        let _inv = mutate_unit(
+            &mut session,
+            |c: &mut dyn kanban_domain::MutationOperations| c.delete_board_impl(board_id),
+        )
         .unwrap();
     }
 

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -4,7 +4,7 @@ use kanban_domain::commands::{
     BoardCommand, CardCommand, ColumnCommand, Command, CreateCard, CreateColumn, RestoreCard,
     SetBoardTaskSort, UpdateCard,
 };
-use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, LoadState};
+use kanban_domain::{ArchivedCard, CardStatus, CardUpdate, LoadState, MutationOperations};
 use kanban_view::card_list::CardListId;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -7,7 +7,8 @@ use crossterm::event::KeyCode;
 use kanban_core::Editable;
 use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::{
-    BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, LoadState, Searcher,
+    BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, LoadState, MutationOperations,
+    Searcher,
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1,7 +1,7 @@
 use crate::app::{App, AppMode};
 use crossterm::event::KeyCode;
 use kanban_domain::commands::{ColumnCommand, Command, UpdateColumn};
-use kanban_domain::{ColumnUpdate, LoadState, SortOrder};
+use kanban_domain::{ColumnUpdate, LoadState, MutationOperations, SortOrder};
 
 const PRIORITY_COUNT: usize = 4;
 const DEFAULT_STATUS_COUNT: usize = 5;

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -2,11 +2,10 @@ use crate::state::SaveCoordinator;
 use kanban_domain::commands::Command;
 use kanban_domain::KanbanResult;
 use kanban_domain::{
-    ArchivedCard, Board, BoardCreateOutcome, BoardListFilter, BoardUpdate, Card,
-    CardCreateOutcome, CardListFilter, CardSummary, CardUpdate, Column, ColumnCreateOutcome,
-    ColumnUpdate, CreateCardOptions, GraphOperations, Invalidation, KanbanOperations,
-    MutationOperations, NewBoard, NewCard, NewColumn, RelatesKind, Severity, Sprint,
-    SprintCreateOutcome, SprintUpdate,
+    ArchivedCard, Board, BoardCreateOutcome, BoardListFilter, BoardUpdate, Card, CardCreateOutcome,
+    CardListFilter, CardSummary, CardUpdate, Column, ColumnCreateOutcome, ColumnUpdate,
+    CreateCardOptions, GraphOperations, Invalidation, KanbanOperations, MutationOperations,
+    NewBoard, NewCard, NewColumn, RelatesKind, Severity, Sprint, SprintCreateOutcome, SprintUpdate,
 };
 use kanban_service::backend::KanbanBackend;
 use kanban_service::KanbanContext;
@@ -253,7 +252,9 @@ impl MutationOperations for TuiContext {
         title: String,
         options: CreateCardOptions,
     ) -> KanbanResult<(Card, Invalidation)> {
-        let r = self.inner.create_card_impl(board_id, column_id, title, options);
+        let r = self
+            .inner
+            .create_card_impl(board_id, column_id, title, options);
         self.with_flush(r)
     }
     fn update_card_impl(
@@ -297,7 +298,10 @@ impl MutationOperations for TuiContext {
         let r = self.inner.assign_card_to_sprint_impl(card_id, sprint_id);
         self.with_flush(r)
     }
-    fn unassign_card_from_sprint_impl(&mut self, card_id: Uuid) -> KanbanResult<(Card, Invalidation)> {
+    fn unassign_card_from_sprint_impl(
+        &mut self,
+        card_id: Uuid,
+    ) -> KanbanResult<(Card, Invalidation)> {
         let r = self.inner.unassign_card_from_sprint_impl(card_id);
         self.with_flush(r)
     }

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -2,9 +2,11 @@ use crate::state::SaveCoordinator;
 use kanban_domain::commands::Command;
 use kanban_domain::KanbanResult;
 use kanban_domain::{
-    ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter, CardSummary,
-    CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations, KanbanOperations, Sprint,
-    SprintUpdate,
+    ArchivedCard, Board, BoardCreateOutcome, BoardListFilter, BoardUpdate, Card,
+    CardCreateOutcome, CardListFilter, CardSummary, CardUpdate, Column, ColumnCreateOutcome,
+    ColumnUpdate, CreateCardOptions, GraphOperations, Invalidation, KanbanOperations,
+    MutationOperations, NewBoard, NewCard, NewColumn, RelatesKind, Severity, Sprint,
+    SprintCreateOutcome, SprintUpdate,
 };
 use kanban_service::backend::KanbanBackend;
 use kanban_service::KanbanContext;
@@ -72,62 +74,6 @@ impl TuiContext {
             self.save_coordinator.queue_flush();
         }
         Ok(inv)
-    }
-
-    pub fn update_card_impl(
-        &mut self,
-        id: Uuid,
-        updates: CardUpdate,
-    ) -> KanbanResult<(Card, kanban_domain::Invalidation)> {
-        let r = self.inner.update_card_impl(id, updates);
-        self.with_flush(r)
-    }
-
-    pub fn update_cards_impl(
-        &mut self,
-        updates: Vec<(Uuid, CardUpdate)>,
-    ) -> KanbanResult<(usize, kanban_domain::Invalidation)> {
-        let r = self.inner.update_cards_impl(updates);
-        self.with_flush(r)
-    }
-
-    pub fn move_card_impl(
-        &mut self,
-        id: Uuid,
-        column_id: Uuid,
-        position: Option<i32>,
-    ) -> KanbanResult<(Card, kanban_domain::Invalidation)> {
-        let r = self.inner.move_card_impl(id, column_id, position);
-        self.with_flush(r)
-    }
-
-    pub fn carry_over_sprint_cards_impl(
-        &mut self,
-        from_sprint_id: Uuid,
-        to_sprint_id: Uuid,
-    ) -> KanbanResult<(usize, kanban_domain::Invalidation)> {
-        let r = self
-            .inner
-            .carry_over_sprint_cards_impl(from_sprint_id, to_sprint_id);
-        self.with_flush(r)
-    }
-
-    pub fn attach_children_impl(
-        &mut self,
-        parent: Uuid,
-        children: Vec<Uuid>,
-    ) -> KanbanResult<kanban_domain::Invalidation> {
-        let r = self.inner.attach_children_impl(parent, children);
-        self.with_flush(r)
-    }
-
-    pub fn detach_children_impl(
-        &mut self,
-        parent: Uuid,
-        children: Vec<Uuid>,
-    ) -> KanbanResult<kanban_domain::Invalidation> {
-        let r = self.inner.detach_children_impl(parent, children);
-        self.with_flush(r)
     }
 
     // --- Delegation: state methods ---
@@ -267,6 +213,322 @@ impl TuiContext {
             self.save_coordinator.queue_flush();
         }
         result
+    }
+}
+
+impl MutationOperations for TuiContext {
+    fn create_board_impl(
+        &mut self,
+        name: String,
+        card_prefix: Option<String>,
+    ) -> KanbanResult<(Board, Invalidation)> {
+        let r = self.inner.create_board_impl(name, card_prefix);
+        self.with_flush(r)
+    }
+    fn update_board_impl(
+        &mut self,
+        id: Uuid,
+        updates: BoardUpdate,
+    ) -> KanbanResult<(Board, Invalidation)> {
+        let r = self.inner.update_board_impl(id, updates);
+        self.with_flush(r)
+    }
+    fn delete_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        let r = self.inner.delete_board_impl(id);
+        self.with_flush(r)
+    }
+    fn archive_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        let r = self.inner.archive_board_impl(id);
+        self.with_flush(r)
+    }
+    fn restore_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        let r = self.inner.restore_board_impl(id);
+        self.with_flush(r)
+    }
+
+    fn create_card_impl(
+        &mut self,
+        board_id: Uuid,
+        column_id: Uuid,
+        title: String,
+        options: CreateCardOptions,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        let r = self.inner.create_card_impl(board_id, column_id, title, options);
+        self.with_flush(r)
+    }
+    fn update_card_impl(
+        &mut self,
+        id: Uuid,
+        updates: CardUpdate,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        let r = self.inner.update_card_impl(id, updates);
+        self.with_flush(r)
+    }
+    fn move_card_impl(
+        &mut self,
+        id: Uuid,
+        column_id: Uuid,
+        position: Option<i32>,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        let r = self.inner.move_card_impl(id, column_id, position);
+        self.with_flush(r)
+    }
+    fn archive_card_impl(&mut self, id: Uuid) -> KanbanResult<((), Invalidation)> {
+        let r = self.inner.archive_card_impl(id);
+        self.with_flush(r)
+    }
+    fn restore_card_impl(
+        &mut self,
+        id: Uuid,
+        column_id: Option<Uuid>,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        let r = self.inner.restore_card_impl(id, column_id);
+        self.with_flush(r)
+    }
+    fn delete_card_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        let r = self.inner.delete_card_impl(id);
+        self.with_flush(r)
+    }
+    fn assign_card_to_sprint_impl(
+        &mut self,
+        card_id: Uuid,
+        sprint_id: Uuid,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        let r = self.inner.assign_card_to_sprint_impl(card_id, sprint_id);
+        self.with_flush(r)
+    }
+    fn unassign_card_from_sprint_impl(&mut self, card_id: Uuid) -> KanbanResult<(Card, Invalidation)> {
+        let r = self.inner.unassign_card_from_sprint_impl(card_id);
+        self.with_flush(r)
+    }
+
+    fn archive_cards_impl(&mut self, ids: Vec<Uuid>) -> KanbanResult<(usize, Invalidation)> {
+        let r = self.inner.archive_cards_impl(ids);
+        self.with_flush(r)
+    }
+    fn move_cards_impl(
+        &mut self,
+        ids: Vec<Uuid>,
+        column_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)> {
+        let r = self.inner.move_cards_impl(ids, column_id);
+        self.with_flush(r)
+    }
+    fn update_cards_impl(
+        &mut self,
+        updates: Vec<(Uuid, CardUpdate)>,
+    ) -> KanbanResult<(usize, Invalidation)> {
+        let r = self.inner.update_cards_impl(updates);
+        self.with_flush(r)
+    }
+    fn assign_cards_to_sprint_impl(
+        &mut self,
+        ids: Vec<Uuid>,
+        sprint_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)> {
+        let r = self.inner.assign_cards_to_sprint_impl(ids, sprint_id);
+        self.with_flush(r)
+    }
+
+    fn create_column_impl(
+        &mut self,
+        board_id: Uuid,
+        name: String,
+        position: Option<i32>,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        let r = self.inner.create_column_impl(board_id, name, position);
+        self.with_flush(r)
+    }
+    fn update_column_impl(
+        &mut self,
+        id: Uuid,
+        updates: ColumnUpdate,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        let r = self.inner.update_column_impl(id, updates);
+        self.with_flush(r)
+    }
+    fn delete_column_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        let r = self.inner.delete_column_impl(id);
+        self.with_flush(r)
+    }
+    fn reorder_column_impl(
+        &mut self,
+        id: Uuid,
+        new_position: i32,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        let r = self.inner.reorder_column_impl(id, new_position);
+        self.with_flush(r)
+    }
+
+    fn carry_over_sprint_cards_impl(
+        &mut self,
+        from_sprint_id: Uuid,
+        to_sprint_id: Uuid,
+    ) -> KanbanResult<(usize, Invalidation)> {
+        let r = self
+            .inner
+            .carry_over_sprint_cards_impl(from_sprint_id, to_sprint_id);
+        self.with_flush(r)
+    }
+    fn create_sprint_impl(
+        &mut self,
+        board_id: Uuid,
+        prefix: Option<String>,
+        name: Option<String>,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        let r = self.inner.create_sprint_impl(board_id, prefix, name);
+        self.with_flush(r)
+    }
+    fn update_sprint_impl(
+        &mut self,
+        id: Uuid,
+        updates: SprintUpdate,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        let r = self.inner.update_sprint_impl(id, updates);
+        self.with_flush(r)
+    }
+    fn activate_sprint_impl(
+        &mut self,
+        id: Uuid,
+        duration_days: Option<i32>,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        let r = self.inner.activate_sprint_impl(id, duration_days);
+        self.with_flush(r)
+    }
+    fn complete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<(Sprint, Invalidation)> {
+        let r = self.inner.complete_sprint_impl(id);
+        self.with_flush(r)
+    }
+    fn cancel_sprint_impl(&mut self, id: Uuid) -> KanbanResult<(Sprint, Invalidation)> {
+        let r = self.inner.cancel_sprint_impl(id);
+        self.with_flush(r)
+    }
+    fn delete_sprint_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        let r = self.inner.delete_sprint_impl(id);
+        self.with_flush(r)
+    }
+    fn import_board_impl(&mut self, data: &str) -> KanbanResult<(Board, Invalidation)> {
+        let r = self.inner.import_board_impl(data);
+        self.with_flush(r)
+    }
+
+    fn attach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<Invalidation> {
+        let r = self.inner.attach_children_impl(parent, children);
+        self.with_flush(r)
+    }
+    fn detach_children_impl(
+        &mut self,
+        parent: Uuid,
+        children: Vec<Uuid>,
+    ) -> KanbanResult<Invalidation> {
+        let r = self.inner.detach_children_impl(parent, children);
+        self.with_flush(r)
+    }
+    fn block_impl(
+        &mut self,
+        blocker: Uuid,
+        blocked: Uuid,
+        severity: Severity,
+    ) -> KanbanResult<Invalidation> {
+        let r = self.inner.block_impl(blocker, blocked, severity);
+        self.with_flush(r)
+    }
+    fn unblock_impl(&mut self, blocker: Uuid, blocked: Uuid) -> KanbanResult<Invalidation> {
+        let r = self.inner.unblock_impl(blocker, blocked);
+        self.with_flush(r)
+    }
+    fn relate_impl(&mut self, a: Uuid, b: Uuid, kind: RelatesKind) -> KanbanResult<Invalidation> {
+        let r = self.inner.relate_impl(a, b, kind);
+        self.with_flush(r)
+    }
+    fn dissociate_impl(&mut self, a: Uuid, b: Uuid) -> KanbanResult<Invalidation> {
+        let r = self.inner.dissociate_impl(a, b);
+        self.with_flush(r)
+    }
+
+    fn create_board_from_spec(
+        &mut self,
+        id: Option<Uuid>,
+        spec: NewBoard,
+    ) -> KanbanResult<(Board, Invalidation)> {
+        let r = self.inner.create_board_from_spec(id, spec);
+        self.with_flush(r)
+    }
+    fn create_or_replace_board(
+        &mut self,
+        id: Uuid,
+        spec: NewBoard,
+    ) -> KanbanResult<(BoardCreateOutcome, Invalidation)> {
+        let r = self.inner.create_or_replace_board(id, spec);
+        self.with_flush(r)
+    }
+    fn create_card_from_spec(
+        &mut self,
+        client_id: Option<Uuid>,
+        spec: NewCard,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        let r = self.inner.create_card_from_spec(client_id, spec);
+        self.with_flush(r)
+    }
+    fn create_or_replace_card(
+        &mut self,
+        id: Uuid,
+        spec: NewCard,
+    ) -> KanbanResult<(CardCreateOutcome, Invalidation)> {
+        let r = self.inner.create_or_replace_card(id, spec);
+        self.with_flush(r)
+    }
+    fn create_column_from_spec(
+        &mut self,
+        id: Option<Uuid>,
+        spec: NewColumn,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        let r = self.inner.create_column_from_spec(id, spec);
+        self.with_flush(r)
+    }
+    fn create_or_replace_column(
+        &mut self,
+        id: Uuid,
+        spec: NewColumn,
+        position: Option<i32>,
+    ) -> KanbanResult<(ColumnCreateOutcome, Invalidation)> {
+        let r = self.inner.create_or_replace_column(id, spec, position);
+        self.with_flush(r)
+    }
+    fn create_sprint_from_spec(
+        &mut self,
+        board_id: Uuid,
+        id: Option<Uuid>,
+        name: Option<String>,
+        prefix: Option<String>,
+        auto_consume_name: bool,
+    ) -> KanbanResult<(Sprint, Invalidation)> {
+        let r = self
+            .inner
+            .create_sprint_from_spec(board_id, id, name, prefix, auto_consume_name);
+        self.with_flush(r)
+    }
+    fn create_or_replace_sprint(
+        &mut self,
+        board_id: Uuid,
+        id: Uuid,
+        name: Option<String>,
+        prefix: Option<String>,
+        auto_consume_name: bool,
+    ) -> KanbanResult<(SprintCreateOutcome, Invalidation)> {
+        let r = self
+            .inner
+            .create_or_replace_sprint(board_id, id, name, prefix, auto_consume_name);
+        self.with_flush(r)
+    }
+
+    fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<Invalidation> {
+        let r = self.inner.execute(commands);
+        self.with_flush(r)
     }
 }
 

--- a/crates/kanban-tui/tests/tui_context_sync.rs
+++ b/crates/kanban-tui/tests/tui_context_sync.rs
@@ -1,4 +1,4 @@
-use kanban_domain::{CreateCardOptions, KanbanOperations, Model, NoProjections};
+use kanban_domain::{CreateCardOptions, KanbanOperations, Model, MutationOperations, NoProjections};
 use kanban_service::{
     fetch_plan::{requestable, FetchPlan, FetchRound, LoadedEntities},
     AppConfig, KanbanContext, StoreManager,
@@ -140,5 +140,70 @@ fn test_tui_context_has_no_whole_store_snapshot_pass_throughs() {
     assert!(
         !src.contains("pub fn apply_snapshot(&mut self,"),
         "TuiContext::apply_snapshot must be deleted; callers should use kanban_service::write_full_snapshot(ctx.data_store(), snapshot)"
+    );
+}
+
+#[test]
+fn test_tui_context_has_no_inherent_impl_forwarders() {
+    let src = include_str!("../src/tui_context.rs");
+    for name in [
+        "pub fn update_card_impl",
+        "pub fn update_cards_impl",
+        "pub fn move_card_impl",
+        "pub fn carry_over_sprint_cards_impl",
+        "pub fn attach_children_impl",
+        "pub fn detach_children_impl",
+    ] {
+        assert!(
+            !src.contains(name),
+            "TuiContext must not carry a hand-written inherent forwarder for {name}; it should come from impl MutationOperations for TuiContext instead"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_tui_context_mutation_operations_queues_a_flush() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("mutate.json");
+    let sm = test_store_manager();
+    let backend = sm
+        .make_backend(path.to_str().unwrap(), &AppConfig::default())
+        .await
+        .unwrap();
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let (mut tui_ctx, save_rx, _completion_rx) = TuiContext::new(ctx).unwrap();
+    let mut save_rx = save_rx.expect("json backend must provide a save channel");
+
+    let board = tui_ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let column = tui_ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let card = tui_ctx
+        .create_card(
+            board.id,
+            column.id,
+            "before".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    while save_rx.try_recv().is_ok() {}
+
+    let (updated, _invalidation) = MutationOperations::update_card_impl(
+        &mut tui_ctx,
+        card.id,
+        kanban_domain::CardUpdate {
+            title: Some("after".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(updated.title, "after");
+    assert!(
+        save_rx.try_recv().is_ok(),
+        "MutationOperations::update_card_impl must queue a save flush"
     );
 }

--- a/crates/kanban-tui/tests/tui_context_sync.rs
+++ b/crates/kanban-tui/tests/tui_context_sync.rs
@@ -1,4 +1,6 @@
-use kanban_domain::{CreateCardOptions, KanbanOperations, Model, MutationOperations, NoProjections};
+use kanban_domain::{
+    CreateCardOptions, KanbanOperations, Model, MutationOperations, NoProjections,
+};
 use kanban_service::{
     fetch_plan::{requestable, FetchPlan, FetchRound, LoadedEntities},
     AppConfig, KanbanContext, StoreManager,


### PR DESCRIPTION
## Summary

Re-plumbs the four application mutation seams onto the `MutationOperations` trait that KAN-1543 landed additively at origin/develop.

- `cli`: `CliContext::mutate`/`mutate_unit` closures change from `&mut KanbanContext` to `&mut dyn MutationOperations`. `create_column_with_default_status`'s `Some(position)` arm is restructured behavior-neutrally: the `KanbanOperations::get_column` read now happens after `apply_invalidation` (via `mutate_unit`) rather than inside the mutation closure. Verified safe because `get_column_impl` reads the backend, not the model.
- `mcp`: `McpContext::mutate`/`mutate_unit` closures change from `&mut KanbanContext` to `&mut dyn MutationOperations`. Return shapes unchanged.
- `server`: `kanban_server::state::mutate`/`mutate_unit` closures change from `&mut KanbanContext` to `&mut dyn MutationOperations`. Return shape `(T, Invalidation)` / `Invalidation` unchanged; all 52 existing call sites (17 in handlers/routes, 35 in session_ops.rs) compile untouched.
- `tui`: `TuiContext`'s six hand-written inherent `*_impl` forwarders are replaced by a single `impl MutationOperations for TuiContext` covering all 44 trait methods, each routed through `self.inner.<name>(...)` and `self.with_flush(r)` to preserve the queue-flush behavior.

Behavior-neutral apart from the one CLI restructure noted above.

## Compile-guard proof (Red)

Before implementation, each seam closure typed against `&mut dyn MutationOperations` failed to compile against the old `&mut KanbanContext` signature:

```
error[E0631]: type mismatch in closure arguments
   --> crates/kanban-cli/src/context.rs:553:13
    = note: expected closure signature `for<'a> fn(&'a mut kanban_service::KanbanContext) -> _`
               found closure signature `fn(&mut dyn MutationOperations) -> _`

error[E0631]: type mismatch in closure arguments
   --> crates/kanban-mcp/src/context.rs:520:13
    = note: expected closure signature `for<'a> fn(&'a mut KanbanContext) -> _`
               found closure signature `fn(&mut dyn MutationOperations) -> _`

error[E0631]: type mismatch in closure arguments
   --> crates/kanban-server/src/state.rs:172:20
    = note: expected closure signature `for<'a> fn(&'a mut kanban_service::KanbanContext) -> _`
               found closure signature `fn(&mut dyn MutationOperations) -> _`
```

And `TuiContext` failed `MutationOperations::update_card_impl(&mut tui_ctx, ...)` with:

```
error[E0277]: the trait bound `TuiContext: MutationOperations` is not satisfied
```

All four are green after the flip.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` (265 test-result blocks, 0 failed)
- Mutation-checked the TUI source guard: reintroduced a `pub fn update_card_impl` forwarder, confirmed `test_tui_context_has_no_inherent_impl_forwarders` failed, then reverted.
- `test_create_column_with_default_status_and_position_creates_one_undo_entry` still passes: one undo entry, position 1, `default_status == Some(CardStatus::InProgress)`.

No new `MutationOperations` methods added or removed; `impl KanbanOperations for KanbanContext` in kanban-service left untouched per KAN-1543's KEEP ruling.
