### PR TITLE
KAN-1544 feat(domain,service,tui,mcp,cli,server): add UndoOperations trait, implemented or declined by every application

### DIFF
--- a/.changeset/kan-1544-undo-operations-trait.md
+++ b/.changeset/kan-1544-undo-operations-trait.md
@@ -1,0 +1,10 @@
+---
+bump: minor
+---
+
+domain: adds an `UndoOperations` trait (`undo`, `redo`, `can_undo`, `can_redo`, no default bodies, object-safe) over the per-session undo/redo capability.
+service: `KanbanContext`'s undo/redo/can_undo/can_redo move from an inherent impl onto `impl UndoOperations for KanbanContext`; behaviour is unchanged.
+tui: `TuiContext` implements `UndoOperations` directly, now returning the full `Option<Invalidation>` instead of a bool, and still queues a save flush only when something was actually undone or redone.
+mcp: `McpContext` implements `UndoOperations` by delegating to the inner context; `tool_undo`/`tool_redo` are unchanged.
+cli: `CliContext` implements `UndoOperations` by declining undo and redo with `KanbanError::unsupported`, since the CLI opens a fresh context per invocation.
+server: `Session` implements `UndoOperations` by declining undo and redo with `KanbanError::unsupported`, since a session is shared across clients and must not silently inherit the inner context's undo history through `Deref`.

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -3,7 +3,8 @@ use kanban_domain::KanbanResult;
 use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
     CardStatus, CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
-    Invalidation, KanbanOperations, MutationOperations, NewColumn, SortOrder, Sprint, SprintUpdate,
+    Invalidation, KanbanError, KanbanOperations, MutationOperations, NewColumn, SortOrder, Sprint,
+    SprintUpdate, UndoOperations,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use uuid::Uuid;
@@ -828,6 +829,21 @@ mod tests {
         let result = ctx.archive_cards_detailed(vec![Uuid::new_v4()]);
         assert!(result.succeeded.is_empty());
         assert_eq!(ctx.list_children_of(parent.id)?, vec![child.id]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_undo_declines_with_unsupported() -> KanbanResult<()> {
+        let mut ctx = seam_context();
+        ctx.mutate(|c| c.create_board_impl("Seam".to_string(), None))?;
+
+        let undo_err = UndoOperations::undo(&mut ctx).unwrap_err();
+        assert!(undo_err.is_unsupported());
+        let redo_err = UndoOperations::redo(&mut ctx).unwrap_err();
+        assert!(redo_err.is_unsupported());
+        assert!(!UndoOperations::can_undo(&ctx));
+        assert!(!UndoOperations::can_redo(&ctx));
 
         Ok(())
     }

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -530,6 +530,28 @@ impl GraphOperations for CliContext {
     }
 }
 
+impl UndoOperations for CliContext {
+    fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
+        Err(KanbanError::unsupported(
+            "undo: the CLI opens a fresh context per invocation, so the per-process undo history is always empty",
+        ))
+    }
+
+    fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
+        Err(KanbanError::unsupported(
+            "redo: the CLI opens a fresh context per invocation, so the per-process undo history is always empty",
+        ))
+    }
+
+    fn can_undo(&self) -> bool {
+        false
+    }
+
+    fn can_redo(&self) -> bool {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -43,6 +43,7 @@ pub mod sprint_factory;
 pub mod sprint_log;
 pub mod tag;
 pub mod task_list_view;
+pub mod undo_operations;
 pub mod wip;
 
 pub use archival::{ArchiveMetadata, Archived, ArchivedEntity, NoContext};

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -120,6 +120,7 @@ pub use sprint_factory::{NewSprint, SprintRecord};
 pub use sprint_log::SprintLog;
 pub use tag::{Tag, TagId};
 pub use task_list_view::TaskListView;
+pub use undo_operations::UndoOperations;
 pub use wip::check_wip_limit;
 
 pub use command_batch::CommandBatch;

--- a/crates/kanban-domain/src/undo_operations.rs
+++ b/crates/kanban-domain/src/undo_operations.rs
@@ -1,3 +1,20 @@
+use crate::{Invalidation, KanbanResult};
+
+/// The undo/redo capability surface every application answers.
+///
+/// `undo`/`redo` return `None` when there is nothing to undo/redo, and
+/// `Some(invalidation)` naming what the inverse execution touched;
+/// implementers must not discard it. `can_undo`/`can_redo` are cheap
+/// capability probes.
+///
+/// Object-safe by construction: no default bodies, no generic methods.
+pub trait UndoOperations {
+    fn undo(&mut self) -> KanbanResult<Option<Invalidation>>;
+    fn redo(&mut self) -> KanbanResult<Option<Invalidation>>;
+    fn can_undo(&self) -> bool;
+    fn can_redo(&self) -> bool;
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/kanban-domain/src/undo_operations.rs
+++ b/crates/kanban-domain/src/undo_operations.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn trait_is_object_safe() {
+        fn _accepts_dyn(_: &mut dyn super::UndoOperations) {}
+    }
+
+    #[test]
+    fn test_undo_operations_declares_every_method() {
+        let src = include_str!("undo_operations.rs");
+        let decl = &src[..src.find("#[cfg(test)]").unwrap()];
+        assert_eq!(
+            decl.matches("\n    fn ").count(),
+            4,
+            "UndoOperations must declare exactly 4 methods"
+        );
+        assert!(
+            !decl.contains("\n    }"),
+            "UndoOperations methods must have no default bodies"
+        );
+    }
+}

--- a/crates/kanban-mcp/src/context.rs
+++ b/crates/kanban-mcp/src/context.rs
@@ -4,7 +4,7 @@ use kanban_domain::{
     ArchivedCard, Board, BoardListFilter, BoardSortField, BoardUpdate, Card, CardListFilter,
     CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
     Invalidation, KanbanOperations, MutationOperations, SortOrder, Sprint, SprintUpdate,
-    DEFAULT_BOARD_SORT_LIVE,
+    UndoOperations, DEFAULT_BOARD_SORT_LIVE,
 };
 use kanban_service::{AppType, KanbanContext, StoreManager};
 use std::str::FromStr;
@@ -100,22 +100,6 @@ impl McpContext {
 
     pub fn clear_history(&mut self) -> KanbanResult<()> {
         self.inner.clear_history()
-    }
-
-    pub fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
-        self.inner.undo()
-    }
-
-    pub fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
-        self.inner.redo()
-    }
-
-    pub fn can_undo(&self) -> bool {
-        self.inner.can_undo()
-    }
-
-    pub fn can_redo(&self) -> bool {
-        self.inner.can_redo()
     }
 
     pub async fn save(&self) -> KanbanResult<()> {
@@ -474,6 +458,24 @@ impl GraphOperations for McpContext {
     }
     fn list_related_to(&self, card: Uuid) -> KanbanResult<Vec<Uuid>> {
         self.inner.list_related_to(card)
+    }
+}
+
+impl UndoOperations for McpContext {
+    fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
+        self.inner.undo()
+    }
+
+    fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
+        self.inner.redo()
+    }
+
+    fn can_undo(&self) -> bool {
+        self.inner.can_undo()
+    }
+
+    fn can_redo(&self) -> bool {
+        self.inner.can_redo()
     }
 }
 

--- a/crates/kanban-mcp/src/tools/transfer.rs
+++ b/crates/kanban-mcp/src/tools/transfer.rs
@@ -3,7 +3,7 @@ use crate::helpers::{kanban_err_to_mcp, locked_read, locked_write, to_call_tool_
 use crate::requests::transfer::{ExportBoardRequest, ImportBoardRequest};
 use crate::scope::{Ref, ToolScope, ToolScoped};
 use crate::KanbanMcpServer;
-use kanban_domain::KanbanOperations;
+use kanban_domain::{KanbanOperations, UndoOperations};
 use kanban_service::api::BoardResponse;
 use rmcp::{
     handler::server::wrapper::Parameters,

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -1,5 +1,5 @@
 use kanban_core::AppConfig;
-use kanban_domain::{Invalidation, KanbanOperations, KanbanResult};
+use kanban_domain::{Invalidation, KanbanOperations, KanbanResult, UndoOperations};
 use kanban_mcp::context::McpContext;
 use kanban_service::{KanbanContext, StoreManager};
 use tempfile::TempDir;

--- a/crates/kanban-server/src/session_ops.rs
+++ b/crates/kanban-server/src/session_ops.rs
@@ -1,12 +1,13 @@
-//! `Session`'s own capability surface: adding a method to `KanbanOperations`
-//! or `GraphOperations` must be answered here, not silently inherited
-//! through `Deref` to `KanbanContext`.
+//! `Session`'s own capability surface: adding a method to `KanbanOperations`,
+//! `GraphOperations`, or `UndoOperations` must be answered here, not
+//! silently inherited through `Deref` to `KanbanContext`.
 
 use crate::state::{mutate, mutate_unit, Session};
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, BoardListFilter, BoardUpdate, Card, CardListFilter,
     CardSummary, CardUpdate, Column, ColumnUpdate, CreateCardOptions, GraphOperations,
-    KanbanOperations, KanbanResult, RelatesKind, Severity, Sprint, SprintUpdate,
+    Invalidation, KanbanError, KanbanOperations, KanbanResult, RelatesKind, Severity, Sprint,
+    SprintUpdate, UndoOperations,
 };
 use uuid::Uuid;
 
@@ -230,6 +231,28 @@ impl GraphOperations for Session {
     }
     fn list_related_to(&self, card: Uuid) -> KanbanResult<Vec<Uuid>> {
         self.ctx.list_related_to(card)
+    }
+}
+
+impl UndoOperations for Session {
+    fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
+        Err(KanbanError::unsupported(
+            "sessions are shared across clients",
+        ))
+    }
+
+    fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
+        Err(KanbanError::unsupported(
+            "sessions are shared across clients",
+        ))
+    }
+
+    fn can_undo(&self) -> bool {
+        false
+    }
+
+    fn can_redo(&self) -> bool {
+        false
     }
 }
 

--- a/crates/kanban-server/src/session_ops.rs
+++ b/crates/kanban-server/src/session_ops.rs
@@ -232,3 +232,35 @@ impl GraphOperations for Session {
         self.ctx.list_related_to(card)
     }
 }
+
+#[cfg(all(test, feature = "test-helpers"))]
+mod tests {
+    use super::*;
+    use kanban_backend_memory::InMemoryStore;
+    use kanban_domain::UndoOperations;
+    use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+    use std::sync::Arc;
+
+    async fn seeded_ctx() -> Session {
+        let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
+        let mut ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+        ctx.create_board("Board1".into(), None).unwrap();
+        Session { ctx }
+    }
+
+    #[tokio::test]
+    async fn test_session_undo_declines_with_unsupported() {
+        let mut session = seeded_ctx().await;
+
+        assert!(UndoOperations::can_undo(&session.ctx));
+
+        let undo_err = UndoOperations::undo(&mut session).unwrap_err();
+        assert!(undo_err.is_unsupported());
+        let redo_err = UndoOperations::redo(&mut session).unwrap_err();
+        assert!(redo_err.is_unsupported());
+        assert!(!UndoOperations::can_undo(&session));
+        assert!(!UndoOperations::can_redo(&session));
+    }
+}

--- a/crates/kanban-service/README.md
+++ b/crates/kanban-service/README.md
@@ -106,13 +106,19 @@ entity ids from before the reload may no longer exist.
 ctx.execute(commands: Vec<Command>) -> KanbanResult<Invalidation>
 ctx.execute_with(build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<Invalidation>
 ctx.execute_with_extra(extra: EntityIds, build: impl FnOnce(&dyn DataStore) -> KanbanResult<Vec<Command>>) -> KanbanResult<Invalidation>
-ctx.undo() -> KanbanResult<Option<Invalidation>>   // None if there was nothing to undo
-ctx.redo() -> KanbanResult<Option<Invalidation>>   // None if there was nothing to redo
-ctx.can_undo() -> bool
-ctx.can_redo() -> bool
 ctx.undo_depth() -> usize
 ctx.redo_depth() -> usize
 ctx.clear_history() -> KanbanResult<()>
+```
+
+`undo`/`redo`/`can_undo`/`can_redo` come from the `UndoOperations` trait
+(`kanban-domain`), which `KanbanContext` implements:
+
+```rust
+UndoOperations::undo(&mut ctx) -> KanbanResult<Option<Invalidation>>   // None if there was nothing to undo
+UndoOperations::redo(&mut ctx) -> KanbanResult<Option<Invalidation>>   // None if there was nothing to redo
+UndoOperations::can_undo(&ctx) -> bool
+UndoOperations::can_redo(&ctx) -> bool
 ```
 
 Every undoable command captures an inverse at `execute` time; the

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -2,7 +2,7 @@ use super::KanbanContext;
 use kanban_core::{ClientId, KANBAN_VERSION};
 use kanban_domain::commands::{Command, CommandContext};
 use kanban_domain::{
-    invalidation_from_inverse, DataStore, Invalidation, KanbanError, KanbanResult,
+    invalidation_from_inverse, DataStore, Invalidation, KanbanError, KanbanResult, UndoOperations,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -101,10 +101,27 @@ impl KanbanContext {
         Ok(invalidation)
     }
 
+    /// Drop the per-session undo/redo history. The audit log is
+    /// append-only and is not touched.
+    pub fn clear_history(&mut self) -> KanbanResult<()> {
+        self.undo_stack.clear();
+        Ok(())
+    }
+
+    pub fn undo_depth(&self) -> usize {
+        self.undo_stack.undo_depth()
+    }
+
+    pub fn redo_depth(&self) -> usize {
+        self.undo_stack.redo_depth()
+    }
+}
+
+impl UndoOperations for KanbanContext {
     /// Undo the most recent batch via inverse-command execution.
     /// The cursor advances only if the inverse commits successfully —
     /// a failed undo leaves the stack ready to retry the same entry.
-    pub fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
+    fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
         let inverse = match self.undo_stack.peek_undo() {
             Some(entry) => entry.inverse.clone(),
             None => return Ok(None),
@@ -124,7 +141,7 @@ impl KanbanContext {
     /// Redo the next undone batch via forward-command execution.
     /// The cursor advances only if the forward batch commits — a failed
     /// redo leaves the stack ready to retry the same entry.
-    pub fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
+    fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
         let forward = match self.undo_stack.peek_redo() {
             Some(entry) => entry.forward.clone(),
             None => return Ok(None),
@@ -141,27 +158,12 @@ impl KanbanContext {
         Ok(Some(invalidation))
     }
 
-    pub fn can_undo(&self) -> bool {
+    fn can_undo(&self) -> bool {
         self.undo_stack.can_undo()
     }
 
-    pub fn can_redo(&self) -> bool {
+    fn can_redo(&self) -> bool {
         self.undo_stack.can_redo()
-    }
-
-    /// Drop the per-session undo/redo history. The audit log is
-    /// append-only and is not touched.
-    pub fn clear_history(&mut self) -> KanbanResult<()> {
-        self.undo_stack.clear();
-        Ok(())
-    }
-
-    pub fn undo_depth(&self) -> usize {
-        self.undo_stack.undo_depth()
-    }
-
-    pub fn redo_depth(&self) -> usize {
-        self.undo_stack.redo_depth()
     }
 }
 

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -5,7 +5,7 @@ use kanban_core::AppConfig;
 use kanban_domain::archival::ArchivedEntity;
 use kanban_domain::card::CardPriority;
 use kanban_domain::{
-    CardListFilter, CreateCardOptions, GraphOperations, KanbanOperations, Severity,
+    CardListFilter, CreateCardOptions, GraphOperations, KanbanOperations, Severity, UndoOperations,
 };
 use std::collections::{HashMap, HashSet};
 use tempfile::TempDir;

--- a/crates/kanban-service/src/test_helpers/contract/board.rs
+++ b/crates/kanban-service/src/test_helpers/contract/board.rs
@@ -4,7 +4,7 @@ use kanban_core::AppConfig;
 use kanban_domain::board::{SortField, SortOrder};
 use kanban_domain::task_list_view::TaskListView;
 use kanban_domain::{
-    BoardUpdate, EntityIds, FieldUpdate, Invalidation, KanbanOperations, NewBoard,
+    BoardUpdate, EntityIds, FieldUpdate, Invalidation, KanbanOperations, NewBoard, UndoOperations,
 };
 use tempfile::TempDir;
 

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -7,7 +7,7 @@ use kanban_core::graph::Edge as _;
 use kanban_core::AppConfig;
 use kanban_domain::{
     CardUpdate, DependencyGraph, DerivedProjections, EntityIds, Invalidation, KanbanOperations,
-    Model, NoProjections, Resolved, Severity,
+    Model, NoProjections, Resolved, Severity, UndoOperations,
 };
 use tempfile::TempDir;
 use uuid::Uuid;

--- a/crates/kanban-service/tests/audit_log_append_only.rs
+++ b/crates/kanban-service/tests/audit_log_append_only.rs
@@ -5,7 +5,7 @@
 use kanban_backend_memory::InMemoryStore;
 use kanban_core::AppConfig;
 use kanban_domain::commands::{BoardCommand, Command, CreateBoard};
-use kanban_domain::KanbanResult;
+use kanban_domain::{KanbanResult, UndoOperations};
 use kanban_service::KanbanContext;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/kanban-service/tests/board_archive.rs
+++ b/crates/kanban-service/tests/board_archive.rs
@@ -1,5 +1,5 @@
 use kanban_backend_memory::InMemoryStore;
-use kanban_domain::{KanbanOperations, KanbanResult};
+use kanban_domain::{KanbanOperations, KanbanResult, UndoOperations};
 use kanban_service::{read_full_snapshot, KanbanContext};
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/kanban-service/tests/board_archive_sqlite.rs
+++ b/crates/kanban-service/tests/board_archive_sqlite.rs
@@ -4,7 +4,7 @@
 //! store-only test would miss the `SqliteBackend` forwards and the
 //! `RestoreBoard` command ordering.
 
-use kanban_domain::{KanbanOperations, KanbanResult};
+use kanban_domain::{KanbanOperations, KanbanResult, UndoOperations};
 use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
 use uuid::Uuid;

--- a/crates/kanban-service/tests/card_graph.rs
+++ b/crates/kanban-service/tests/card_graph.rs
@@ -7,7 +7,9 @@
 //! divergence; the underlying graph behavior (cycle detection, self-reference
 //! rejection) is unit-tested in `kanban_domain::dependencies::card_graph`.
 
-use kanban_domain::{Board, Card, CardEdgeType, Column, GraphOperations, KanbanOperations};
+use kanban_domain::{
+    Board, Card, CardEdgeType, Column, GraphOperations, KanbanOperations, UndoOperations,
+};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext};

--- a/crates/kanban-service/tests/completion_sync.rs
+++ b/crates/kanban-service/tests/completion_sync.rs
@@ -1,7 +1,9 @@
 //! KAN-394: status ↔ completion-column auto-sync orchestrated at the service layer.
 
 use kanban_backend_memory::InMemoryStore;
-use kanban_domain::{CardStatus, CardUpdate, ColumnUpdate, KanbanOperations, KanbanResult};
+use kanban_domain::{
+    CardStatus, CardUpdate, ColumnUpdate, KanbanOperations, KanbanResult, UndoOperations,
+};
 use kanban_service::KanbanContext;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/kanban-service/tests/context_open.rs
+++ b/crates/kanban-service/tests/context_open.rs
@@ -4,7 +4,7 @@
 /// SQLite tests use `#[tokio::test(flavor = "multi_thread")]` because sqlx
 /// connection pools spawn background tasks that deadlock on single-threaded
 /// runtimes. JSON tests no longer require `multi_thread`.
-use kanban_domain::DataStore;
+use kanban_domain::{DataStore, UndoOperations};
 use kanban_persistence::PersistenceStore;
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations, KanbanResult};

--- a/crates/kanban-service/tests/create_card_with_sprint.rs
+++ b/crates/kanban-service/tests/create_card_with_sprint.rs
@@ -1,4 +1,6 @@
-use kanban_domain::{CreateCardOptions, DomainError, KanbanError, KanbanOperations, KanbanResult};
+use kanban_domain::{
+    CreateCardOptions, DomainError, KanbanError, KanbanOperations, KanbanResult, UndoOperations,
+};
 use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
 use uuid::Uuid;

--- a/crates/kanban-service/tests/delete_board_cascade.rs
+++ b/crates/kanban-service/tests/delete_board_cascade.rs
@@ -5,7 +5,7 @@
 
 use kanban_domain::{
     commands::{Command, MoveCard},
-    ArchivedCard, Board, Card, Column, Sprint,
+    ArchivedCard, Board, Card, Column, Sprint, UndoOperations,
 };
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;

--- a/crates/kanban-service/tests/execute_with.rs
+++ b/crates/kanban-service/tests/execute_with.rs
@@ -7,7 +7,7 @@
 
 use kanban_core::AppConfig;
 use kanban_domain::commands::{CardCommand, Command, CreateCard};
-use kanban_domain::{CreateCardOptions, KanbanOperations, Prefix};
+use kanban_domain::{CreateCardOptions, KanbanOperations, Prefix, UndoOperations};
 use kanban_service::KanbanContext;
 use std::sync::Arc;
 use tempfile::TempDir;

--- a/crates/kanban-service/tests/export_import_prefix_counters.rs
+++ b/crates/kanban-service/tests/export_import_prefix_counters.rs
@@ -9,7 +9,7 @@
 //! destination already ahead of the import must not be rolled backwards, or the
 //! collision simply happens from the other side.
 
-use kanban_domain::{CreateCardOptions, KanbanOperations, KanbanResult, Prefix};
+use kanban_domain::{CreateCardOptions, KanbanOperations, KanbanResult, Prefix, UndoOperations};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::{read_full_snapshot, AppConfig, KanbanBackend, KanbanContext};

--- a/crates/kanban-service/tests/import_merges_dependency_graph.rs
+++ b/crates/kanban-service/tests/import_merges_dependency_graph.rs
@@ -5,7 +5,9 @@
 //! edge among the destination's own cards.
 
 use kanban_core::graph::Edge;
-use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations, RelatesKind, Severity};
+use kanban_domain::{
+    CreateCardOptions, GraphOperations, KanbanOperations, RelatesKind, Severity, UndoOperations,
+};
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext};

--- a/crates/kanban-service/tests/inverse_commands.rs
+++ b/crates/kanban-service/tests/inverse_commands.rs
@@ -14,7 +14,7 @@ use kanban_domain::commands::{
 };
 use kanban_domain::{
     BoardUpdate, CardPriority, CardStatus, CardUpdate, ColumnUpdate, FieldUpdate, KanbanOperations,
-    KanbanResult, SortField, SortOrder, SprintStatus, SprintUpdate, TaskListView,
+    KanbanResult, SortField, SortOrder, SprintStatus, SprintUpdate, TaskListView, UndoOperations,
 };
 use kanban_service::{read_full_snapshot, KanbanContext};
 use std::sync::Arc;

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -2,7 +2,7 @@ use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
     BoardUpdate, Card, CardUpdate, DataStore, EntityIds, GraphOperations, Invalidation,
     KanbanOperations, KanbanResult, Model, NewBoard, NewCard, NewColumn, Prefix, RelatesKind,
-    Severity, Sprint,
+    Severity, Sprint, UndoOperations,
 };
 use kanban_service::{FetchPlan, FetchRound, KanbanContext, LoadedEntities};
 use std::collections::HashSet;

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -1,4 +1,4 @@
-use kanban_domain::{Board, CardListFilter, KanbanOperations, KanbanResult, Snapshot};
+use kanban_domain::{Board, CardListFilter, KanbanOperations, KanbanResult, Snapshot, UndoOperations};
 use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
 

--- a/crates/kanban-service/tests/sqlite_backend.rs
+++ b/crates/kanban-service/tests/sqlite_backend.rs
@@ -1,4 +1,6 @@
-use kanban_domain::{Board, CardListFilter, KanbanOperations, KanbanResult, Snapshot, UndoOperations};
+use kanban_domain::{
+    Board, CardListFilter, KanbanOperations, KanbanResult, Snapshot, UndoOperations,
+};
 use kanban_service::{AppConfig, KanbanContext};
 use tempfile::TempDir;
 

--- a/crates/kanban-service/tests/undo_invalidation.rs
+++ b/crates/kanban-service/tests/undo_invalidation.rs
@@ -1,5 +1,7 @@
 use kanban_backend_memory::InMemoryStore;
-use kanban_domain::{CardUpdate, EntityIds, Invalidation, KanbanOperations, KanbanResult};
+use kanban_domain::{
+    CardUpdate, EntityIds, Invalidation, KanbanOperations, KanbanResult, UndoOperations,
+};
 use kanban_service::KanbanContext;
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/crates/kanban-service/tests/undo_redo.rs
+++ b/crates/kanban-service/tests/undo_redo.rs
@@ -5,6 +5,7 @@ use kanban_domain::commands::{
 };
 use kanban_domain::{
     BoardUpdate, CardUpdate, EntityIds, Invalidation, KanbanOperations, KanbanResult,
+    UndoOperations,
 };
 use kanban_service::undo_stack::UndoStack;
 use kanban_service::{read_full_snapshot, write_full_snapshot, KanbanContext};

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -2,7 +2,7 @@ use super::{App, AppMode, ViewScope};
 use crate::view_strategy::UnifiedViewStrategy;
 use kanban_domain::{
     filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, Invalidation,
-    KanbanResult, LoadState, Resolved, Snapshot,
+    KanbanResult, LoadState, Resolved, Snapshot, UndoOperations,
 };
 use kanban_view::view_strategy::{ViewRefreshContext, ViewStrategy};
 use std::collections::HashMap;
@@ -233,7 +233,7 @@ impl App {
 
     /// Undo the last action
     pub fn undo(&mut self) -> KanbanResult<()> {
-        if self.ctx.undo()? {
+        if self.ctx.undo()?.is_some() {
             self.reload_model();
             self.needs_redraw = true;
         } else {
@@ -244,7 +244,7 @@ impl App {
 
     /// Redo the last undone action
     pub fn redo(&mut self) -> KanbanResult<()> {
-        if self.ctx.redo()? {
+        if self.ctx.redo()?.is_some() {
             self.reload_model();
             self.needs_redraw = true;
         } else {

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -619,6 +619,7 @@ mod tests {
     use crossterm::event::KeyCode;
     use kanban_domain::{
         BoardUpdate, CreateCardOptions, KanbanOperations, LoadState, SortOrder, TaskListView,
+        UndoOperations,
     };
 
     /// Pull the store snapshot into `app.model` and resync `app.board_list` so
@@ -732,7 +733,7 @@ mod tests {
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
 
-        assert!(app.ctx.undo().unwrap(), "undo applies");
+        assert!(app.ctx.undo().unwrap().is_some(), "undo applies");
         assert!(
             app.ctx.data_store().list_boards().unwrap().is_empty(),
             "the whole creation batch reverses in one step"
@@ -748,7 +749,7 @@ mod tests {
         let mut app = App::test_default();
         create_named_board(&mut app, "Roadmap");
 
-        assert!(app.ctx.undo().unwrap(), "undo applies");
+        assert!(app.ctx.undo().unwrap().is_some(), "undo applies");
         assert!(
             app.ctx.data_store().list_all_columns().unwrap().is_empty(),
             "the whole creation batch, including the seeded columns, reverses in one step"

--- a/crates/kanban-tui/src/tui_context.rs
+++ b/crates/kanban-tui/src/tui_context.rs
@@ -6,6 +6,7 @@ use kanban_domain::{
     CardListFilter, CardSummary, CardUpdate, Column, ColumnCreateOutcome, ColumnUpdate,
     CreateCardOptions, GraphOperations, Invalidation, KanbanOperations, MutationOperations,
     NewBoard, NewCard, NewColumn, RelatesKind, Severity, Sprint, SprintCreateOutcome, SprintUpdate,
+    UndoOperations,
 };
 use kanban_service::backend::KanbanBackend;
 use kanban_service::KanbanContext;
@@ -76,30 +77,6 @@ impl TuiContext {
     }
 
     // --- Delegation: state methods ---
-
-    pub fn undo(&mut self) -> KanbanResult<bool> {
-        let applied = self.inner.undo()?.is_some();
-        if applied && self.save_coordinator.has_save_channel() {
-            self.save_coordinator.queue_flush();
-        }
-        Ok(applied)
-    }
-
-    pub fn redo(&mut self) -> KanbanResult<bool> {
-        let applied = self.inner.redo()?.is_some();
-        if applied && self.save_coordinator.has_save_channel() {
-            self.save_coordinator.queue_flush();
-        }
-        Ok(applied)
-    }
-
-    pub fn can_undo(&self) -> bool {
-        self.inner.can_undo()
-    }
-
-    pub fn can_redo(&self) -> bool {
-        self.inner.can_redo()
-    }
 
     pub fn transfer_state_to(&self, target: &dyn KanbanBackend) -> KanbanResult<()> {
         self.inner.transfer_state_to(target)
@@ -533,6 +510,32 @@ impl MutationOperations for TuiContext {
     fn execute(&mut self, commands: Vec<Command>) -> KanbanResult<Invalidation> {
         let r = self.inner.execute(commands);
         self.with_flush(r)
+    }
+}
+
+impl UndoOperations for TuiContext {
+    fn undo(&mut self) -> KanbanResult<Option<Invalidation>> {
+        let inv = self.inner.undo()?;
+        if inv.is_some() && self.save_coordinator.has_save_channel() {
+            self.save_coordinator.queue_flush();
+        }
+        Ok(inv)
+    }
+
+    fn redo(&mut self) -> KanbanResult<Option<Invalidation>> {
+        let inv = self.inner.redo()?;
+        if inv.is_some() && self.save_coordinator.has_save_channel() {
+            self.save_coordinator.queue_flush();
+        }
+        Ok(inv)
+    }
+
+    fn can_undo(&self) -> bool {
+        self.inner.can_undo()
+    }
+
+    fn can_redo(&self) -> bool {
+        self.inner.can_redo()
     }
 }
 

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -1,7 +1,7 @@
 mod helpers;
 
 use helpers::warm_archived_card_markers;
-use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_domain::{CreateCardOptions, KanbanOperations, UndoOperations};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::App;
@@ -224,7 +224,7 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
         "card must be archived (marked) after animation completion"
     );
 
-    assert!(app.ctx.undo().unwrap(), "first undo must succeed");
+    assert!(app.ctx.undo().unwrap().is_some(), "first undo must succeed");
     app.reload_model();
     app.prepare_frame();
     warm_archived_card_markers(&mut app);

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -11,7 +11,9 @@
 //! the stack-aware base mode (correct under a modal underlay).
 
 use crossterm::event::KeyCode;
-use kanban_domain::{AnimationType, CardPriority, CreateCardOptions, KanbanOperations, UndoOperations};
+use kanban_domain::{
+    AnimationType, CardPriority, CreateCardOptions, KanbanOperations, UndoOperations,
+};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::keybindings::card_list::CardListProvider;
@@ -309,7 +311,10 @@ fn test_d_in_the_archived_cards_view_leaves_the_card_archived_after_undo() {
         !app.ctx.can_undo(),
         "`d` on an already-archived card must not push an undo entry"
     );
-    assert!(app.ctx.undo().unwrap().is_none(), "there must be nothing to undo");
+    assert!(
+        app.ctx.undo().unwrap().is_none(),
+        "there must be nothing to undo"
+    );
     app.reload_model();
     app.prepare_frame();
     assert!(

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -11,7 +11,7 @@
 //! the stack-aware base mode (correct under a modal underlay).
 
 use crossterm::event::KeyCode;
-use kanban_domain::{AnimationType, CardPriority, CreateCardOptions, KanbanOperations};
+use kanban_domain::{AnimationType, CardPriority, CreateCardOptions, KanbanOperations, UndoOperations};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
 use kanban_tui::keybindings::card_list::CardListProvider;
@@ -309,7 +309,7 @@ fn test_d_in_the_archived_cards_view_leaves_the_card_archived_after_undo() {
         !app.ctx.can_undo(),
         "`d` on an already-archived card must not push an undo entry"
     );
-    assert!(!app.ctx.undo().unwrap(), "there must be nothing to undo");
+    assert!(app.ctx.undo().unwrap().is_none(), "there must be nothing to undo");
     app.reload_model();
     app.prepare_frame();
     assert!(

--- a/crates/kanban-tui/tests/batch_completion_sync_tests.rs
+++ b/crates/kanban-tui/tests/batch_completion_sync_tests.rs
@@ -11,7 +11,7 @@
 //! 3. Single undo unit: one `undo()` reverses every chained command across every
 //!    card in the multi-select
 
-use kanban_domain::{CardStatus, ColumnUpdate, CreateCardOptions, KanbanOperations};
+use kanban_domain::{CardStatus, ColumnUpdate, CreateCardOptions, KanbanOperations, UndoOperations};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::App;
 
@@ -93,7 +93,7 @@ fn test_multi_select_toggle_completion_batches_into_one_undo_unit_with_distinct_
     );
 
     assert!(app.ctx.can_undo(), "batch should be one undo unit");
-    assert!(app.ctx.undo().unwrap(), "undo should succeed");
+    assert!(app.ctx.undo().unwrap().is_some(), "undo should succeed");
     for card in &cards {
         let restored = app.ctx.get_card(card.id).unwrap().unwrap();
         assert_eq!(
@@ -184,7 +184,7 @@ fn test_multi_select_move_right_to_completion_column_chains_status_per_card() {
     );
 
     assert!(app.ctx.can_undo());
-    assert!(app.ctx.undo().unwrap());
+    assert!(app.ctx.undo().unwrap().is_some());
     for card in &cards {
         let restored = app.ctx.get_card(card.id).unwrap().unwrap();
         assert_eq!(restored.column_id, backlog.id);

--- a/crates/kanban-tui/tests/batch_completion_sync_tests.rs
+++ b/crates/kanban-tui/tests/batch_completion_sync_tests.rs
@@ -11,7 +11,9 @@
 //! 3. Single undo unit: one `undo()` reverses every chained command across every
 //!    card in the multi-select
 
-use kanban_domain::{CardStatus, ColumnUpdate, CreateCardOptions, KanbanOperations, UndoOperations};
+use kanban_domain::{
+    CardStatus, ColumnUpdate, CreateCardOptions, KanbanOperations, UndoOperations,
+};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::App;
 

--- a/crates/kanban-tui/tests/column_default_status_tests.rs
+++ b/crates/kanban-tui/tests/column_default_status_tests.rs
@@ -1,5 +1,7 @@
 use crossterm::event::KeyCode;
-use kanban_domain::{CardStatus, ColumnUpdate, CreateCardOptions, KanbanOperations, UndoOperations};
+use kanban_domain::{
+    CardStatus, ColumnUpdate, CreateCardOptions, KanbanOperations, UndoOperations,
+};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::{AppMode, BoardFocus, DialogMode};
 use kanban_tui::App;

--- a/crates/kanban-tui/tests/column_default_status_tests.rs
+++ b/crates/kanban-tui/tests/column_default_status_tests.rs
@@ -1,5 +1,5 @@
 use crossterm::event::KeyCode;
-use kanban_domain::{CardStatus, ColumnUpdate, CreateCardOptions, KanbanOperations};
+use kanban_domain::{CardStatus, ColumnUpdate, CreateCardOptions, KanbanOperations, UndoOperations};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::{AppMode, BoardFocus, DialogMode};
 use kanban_tui::App;
@@ -288,7 +288,7 @@ fn test_column_default_status_change_is_undoable() {
     assert_eq!(column.default_status, Some(CardStatus::Blocked));
 
     assert!(app.ctx.can_undo(), "the change must ride a command");
-    assert!(app.ctx.undo().unwrap(), "undo must succeed");
+    assert!(app.ctx.undo().unwrap().is_some(), "undo must succeed");
 
     let restored = app.ctx.get_column(doing).unwrap().unwrap();
     assert_eq!(
@@ -408,7 +408,7 @@ fn test_moving_card_into_default_status_column_updates_status_in_tui() {
     );
 
     assert!(app.ctx.can_undo());
-    assert!(app.ctx.undo().unwrap());
+    assert!(app.ctx.undo().unwrap().is_some());
     let restored = app.ctx.get_card(card.id).unwrap().unwrap();
     assert_eq!(restored.column_id, todo);
     assert_eq!(restored.status, CardStatus::Todo);

--- a/crates/kanban-tui/tests/columnless_board_card_tests.rs
+++ b/crates/kanban-tui/tests/columnless_board_card_tests.rs
@@ -1,5 +1,5 @@
 use crossterm::event::KeyCode;
-use kanban_domain::{CardStatus, KanbanOperations};
+use kanban_domain::{CardStatus, KanbanOperations, UndoOperations};
 use kanban_tui::app::dialog_input::CreateCardFocus;
 use kanban_tui::app::focus::Focus;
 use kanban_tui::view_strategy::UnifiedViewStrategy;

--- a/crates/kanban-tui/tests/reload_tests.rs
+++ b/crates/kanban-tui/tests/reload_tests.rs
@@ -1,4 +1,4 @@
-use kanban_domain::KanbanOperations;
+use kanban_domain::{KanbanOperations, UndoOperations};
 use kanban_service::{AppConfig, KanbanContext, StoreManager};
 use kanban_tui::tui_context::TuiContext;
 use tempfile::TempDir;

--- a/crates/kanban-tui/tests/tui_context_sync.rs
+++ b/crates/kanban-tui/tests/tui_context_sync.rs
@@ -1,5 +1,5 @@
 use kanban_domain::{
-    CreateCardOptions, KanbanOperations, Model, MutationOperations, NoProjections,
+    CreateCardOptions, KanbanOperations, Model, MutationOperations, NoProjections, UndoOperations,
 };
 use kanban_service::{
     fetch_plan::{requestable, FetchPlan, FetchRound, LoadedEntities},
@@ -207,5 +207,71 @@ async fn test_tui_context_mutation_operations_queues_a_flush() {
     assert!(
         save_rx.try_recv().is_ok(),
         "MutationOperations::update_card_impl must queue a save flush"
+    );
+}
+
+#[test]
+fn test_tui_context_has_no_inherent_undo_forwarders() {
+    let src = include_str!("../src/tui_context.rs");
+    for name in [
+        "pub fn undo(",
+        "pub fn redo(",
+        "pub fn can_undo(",
+        "pub fn can_redo(",
+    ] {
+        assert!(
+            !src.contains(name),
+            "TuiContext must not carry a hand-written inherent forwarder for {name}; it should come from impl UndoOperations for TuiContext instead"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_tui_undo_returns_the_invalidation_and_queues_flush() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("undo.json");
+    let sm = test_store_manager();
+    let backend = sm
+        .make_backend(path.to_str().unwrap(), &AppConfig::default())
+        .await
+        .unwrap();
+    let ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let (mut tui_ctx, save_rx, _completion_rx) = TuiContext::new(ctx).unwrap();
+    let mut save_rx = save_rx.expect("json backend must provide a save channel");
+
+    let board = tui_ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let column = tui_ctx.create_column(board.id, "Col".into(), None).unwrap();
+    tui_ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    while save_rx.try_recv().is_ok() {}
+
+    let inv = UndoOperations::undo(&mut tui_ctx).unwrap();
+    assert!(inv.is_some(), "undo of a real batch must return Some");
+    assert!(
+        save_rx.try_recv().is_ok(),
+        "an applied undo must queue a save flush"
+    );
+
+    while UndoOperations::can_undo(&tui_ctx) {
+        UndoOperations::undo(&mut tui_ctx).unwrap();
+    }
+    while save_rx.try_recv().is_ok() {}
+
+    let inv = UndoOperations::undo(&mut tui_ctx).unwrap();
+    assert!(inv.is_none(), "undo on an empty stack must return None");
+    assert!(
+        save_rx.try_recv().is_err(),
+        "a no-op undo must not queue a save flush"
     );
 }

--- a/crates/kanban-tui/tests/undo_redo_tests.rs
+++ b/crates/kanban-tui/tests/undo_redo_tests.rs
@@ -1,4 +1,4 @@
-use kanban_domain::KanbanOperations;
+use kanban_domain::{KanbanOperations, UndoOperations};
 use kanban_service::{AppConfig, KanbanContext, StoreManager};
 use kanban_tui::tui_context::TuiContext;
 use tempfile::TempDir;
@@ -35,7 +35,7 @@ async fn test_undo_queues_flush_signal_to_save_coordinator() {
     // drain the post-create flush signal
     save_rx.try_recv().ok();
 
-    assert!(ctx.undo().unwrap());
+    assert!(ctx.undo().unwrap().is_some());
     save_rx
         .try_recv()
         .expect("undo should queue a flush signal to the save coordinator");
@@ -50,11 +50,11 @@ async fn test_redo_queues_flush_signal_to_save_coordinator() {
     let (mut ctx, mut save_rx, _dir) = make_ctx_with_persistence().await;
 
     ctx.create_board("Board".into(), None).unwrap();
-    assert!(ctx.undo().unwrap());
+    assert!(ctx.undo().unwrap().is_some());
     // drain setup flush signals (create + undo)
     while save_rx.try_recv().is_ok() {}
 
-    assert!(ctx.redo().unwrap());
+    assert!(ctx.redo().unwrap().is_some());
     save_rx
         .try_recv()
         .expect("redo should queue a flush signal to the save coordinator");
@@ -69,7 +69,7 @@ async fn test_redo_queues_flush_signal_to_save_coordinator() {
 async fn test_undo_when_nothing_to_undo_does_not_queue_flush_signal() {
     let (mut ctx, mut save_rx, _dir) = make_ctx_with_persistence().await;
 
-    assert!(!ctx.undo().unwrap());
+    assert!(ctx.undo().unwrap().is_none());
     assert!(
         save_rx.try_recv().is_err(),
         "failed undo should not queue a flush signal"

--- a/crates/kanban-tui/tests/wal_checkpoint_tests.rs
+++ b/crates/kanban-tui/tests/wal_checkpoint_tests.rs
@@ -1,4 +1,4 @@
-use kanban_domain::{KanbanOperations, KanbanResult};
+use kanban_domain::{KanbanOperations, KanbanResult, UndoOperations};
 use kanban_service::{AppConfig, KanbanContext, StoreManager};
 use kanban_tui::tui_context::TuiContext;
 use tempfile::TempDir;
@@ -78,7 +78,7 @@ async fn test_tui_undo_checkpoints_wal_on_sqlite_path() {
         .unwrap();
     let (mut tui_ctx, _, _) = TuiContext::new(ctx).unwrap();
     tui_ctx.create_board("B".to_string(), None).unwrap();
-    assert!(tui_ctx.undo().unwrap());
+    assert!(tui_ctx.undo().unwrap().is_some());
     tui_ctx.save().await.unwrap();
     assert_wal_empty(&path);
 }
@@ -93,8 +93,8 @@ async fn test_tui_redo_checkpoints_wal_on_sqlite_path() {
         .unwrap();
     let (mut tui_ctx, _, _) = TuiContext::new(ctx).unwrap();
     tui_ctx.create_board("B".to_string(), None).unwrap();
-    assert!(tui_ctx.undo().unwrap());
-    assert!(tui_ctx.redo().unwrap());
+    assert!(tui_ctx.undo().unwrap().is_some());
+    assert!(tui_ctx.redo().unwrap().is_some());
     tui_ctx.save().await.unwrap();
     assert_wal_empty(&path);
 }


### PR DESCRIPTION
## Summary

- Adds a four-method `UndoOperations` trait to `kanban-domain` (`undo`, `redo`, `can_undo`, `can_redo`), no default bodies, object-safe.
- `KanbanContext`, `TuiContext`, and `McpContext` implement it for real. `TuiContext::undo`/`redo` now return the full `Option<Invalidation>` instead of a bool, and still queue a save flush only when something was actually undone or redone.
- `CliContext` and the server's `Session` decline undo/redo with `KanbanError::unsupported` and report `can_undo`/`can_redo` as `false` unconditionally, so a shared session or a fresh per-process CLI context cannot silently inherit another context's undo history through `Deref`.
- The four inherent `undo`/`redo`/`can_undo`/`can_redo` forwarders are deleted from `KanbanContext`, `TuiContext`, and `McpContext` so there is exactly one surface. This forces every call site across `kanban-service`, `kanban-tui`, and `kanban-mcp` to import the trait, and the TUI call sites additionally adapt from the old bool shape to `Option<Invalidation>`.
- `kanban-service/README.md`'s undo/redo section now documents the trait surface instead of an inherent one.

## Test plan

- [x] `cargo test -p kanban-domain`, verifying trait object-safety and the method-count guard
- [x] `cargo test -p kanban-service --all-features`
- [x] `cargo test -p kanban-tui --all-features`
- [x] `cargo test -p kanban-mcp --all-features`
- [x] `cargo test -p kanban-cli --all-features`
- [x] `cargo test -p kanban-server --all-features` (the Session decline test is gated on `test-helpers` and needs `--all-features` to run)
- [x] `cargo test --all-features --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Mutation check: replaced the `Session` decline impl with pass-through delegation to the inner context; `test_session_undo_declines_with_unsupported` failed as expected, then reverted
