### PR TITLE
KAN-1556 fix(server): graceful shutdown on SIGTERM and ctrl-c

### DIFF
--- a/.changeset/kan-1556-server-graceful-shutdown.md
+++ b/.changeset/kan-1556-server-graceful-shutdown.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+kanban-server exits cleanly on SIGTERM and ctrl-c, draining in-flight requests and open SSE streams within a bounded window

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -39,7 +39,7 @@ cargo install --path crates/kanban-server
 kanban-server
 ```
 
-On startup the server opens (or creates) the board file, binds the configured address (default `127.0.0.1` on an OS-assigned ephemeral port), and serves until killed. Pin a fixed host/port with the `--addr` flag, the `KANBAN_ADDR` env var, or the `server_addr` config key (see [Configuration](#configuration)). When left on the default ephemeral port, read the bound address from the startup log line (`RUST_LOG=info`) or `lsof -p <pid>`.
+On startup the server opens (or creates) the board file, binds the configured address (default `127.0.0.1` on an OS-assigned ephemeral port), and serves until it receives SIGTERM or ctrl-c (SIGINT), at which point it stops accepting connections, lets in-flight requests finish, cuts anything still open (an SSE stream never finishes on its own) after the drain window, and exits 0. Pin a fixed host/port with the `--addr` flag, the `KANBAN_ADDR` env var, or the `server_addr` config key (see [Configuration](#configuration)). When left on the default ephemeral port, read the bound address from the startup log line (`RUST_LOG=info`) or `lsof -p <pid>`.
 
 ### Configuration
 
@@ -47,6 +47,7 @@ On startup the server opens (or creates) the board file, binds the configured ad
 |---|---|---|
 | `KANBAN_FILE` | `kanban.json` (in the working directory) | Storage locator, resolved through the same backend registry as the CLI/TUI/MCP server — a `.json` path uses the JSON backend, a `.sqlite`/`.db` path (or existing SQLite file) uses the SQLite backend. |
 | `KANBAN_ADDR` | `127.0.0.1:0` (ephemeral loopback) | Address the HTTP server binds, as `host:port` where host is an IP literal (`127.0.0.1`, `0.0.0.0`, `[::1]`); hostnames such as `localhost` are not resolved. Resolved with the same layered precedence as `KANBAN_FILE`: the `--addr` flag wins, then `KANBAN_ADDR`, then the `server_addr` key in the config file, then the default. Set `0.0.0.0:<port>` to accept non-loopback connections (e.g. behind a reverse proxy). |
+| `KANBAN_SHUTDOWN_GRACE_SECS` | `10` | Seconds to wait after a shutdown signal for in-flight responses to complete before remaining connections are closed. Open SSE streams never end on their own, so this is what bounds shutdown. An unparseable value falls back to the default. |
 | `RUST_LOG` | unset (⇒ `error` only) | Standard `tracing-subscriber` env filter. Set to `info` to see the startup log line; there is no per-request access logging. |
 
 The bind address can also be set with the `--addr` flag or the `server_addr` key in the kanban config file (`~/.config/kanban/config.toml`); the resolution order is `--addr` > `KANBAN_ADDR` > `server_addr` > the `127.0.0.1:0` default.

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -71,6 +71,22 @@ async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_grace_defaults_to_ten_seconds_when_unset() {
+        assert_eq!(parse_grace(None), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_grace_parses_env_value_as_seconds() {
+        assert_eq!(parse_grace(Some("3".into())), Duration::from_secs(3));
+    }
+
+    #[test]
+    fn test_grace_falls_back_to_default_on_unparseable_value() {
+        assert_eq!(parse_grace(Some("soon".into())), Duration::from_secs(10));
+    }
 
     #[test]
     fn test_addr_defaults_to_none_without_flag_or_env() {

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -63,9 +63,67 @@ async fn run(
         )
     })?;
     let listener = tokio::net::TcpListener::bind(socket_addr).await?;
+    let shutdown_rx = install_shutdown_watch()?;
     tracing::info!(addr = %listener.local_addr()?, "kanban-server listening");
-    axum::serve(listener, app::router(state)).await?;
+
+    let mut graceful_rx = shutdown_rx.clone();
+    let mut drain_rx = shutdown_rx;
+    let serve = axum::serve(listener, app::router(state)).with_graceful_shutdown(async move {
+        let _ = graceful_rx.changed().await;
+    });
+    tokio::select! {
+        r = serve => r?,
+        _ = async {
+            let _ = drain_rx.changed().await;
+            tokio::time::sleep(drain_grace()).await;
+        } => {
+            tracing::warn!("shutdown drain window elapsed; closing remaining connections");
+        }
+    }
     Ok(())
+}
+
+const DEFAULT_SHUTDOWN_GRACE_SECS: u64 = 10;
+
+fn parse_grace(raw: Option<String>) -> std::time::Duration {
+    raw.and_then(|v| v.parse().ok())
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(|| std::time::Duration::from_secs(DEFAULT_SHUTDOWN_GRACE_SECS))
+}
+
+fn drain_grace() -> std::time::Duration {
+    parse_grace(std::env::var("KANBAN_SHUTDOWN_GRACE_SECS").ok())
+}
+
+/// Installs the shutdown signal handlers and returns a receiver that flips
+/// to `true` once one fires.
+#[cfg(unix)]
+fn install_shutdown_watch() -> std::io::Result<tokio::sync::watch::Receiver<bool>> {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut term = signal(SignalKind::terminate())?;
+    let mut int = signal(SignalKind::interrupt())?;
+    let (tx, rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        tokio::select! {
+            _ = term.recv() => {}
+            _ = int.recv() => {}
+        }
+        let _ = tx.send(true);
+    });
+    Ok(rx)
+}
+
+/// Installs the shutdown signal handlers and returns a receiver that flips
+/// to `true` once one fires.
+#[cfg(not(unix))]
+fn install_shutdown_watch() -> std::io::Result<tokio::sync::watch::Receiver<bool>> {
+    let (tx, rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        let _ = tx.send(true);
+    });
+    Ok(rx)
 }
 
 #[cfg(test)]

--- a/crates/kanban-server/tests/graceful_shutdown.rs
+++ b/crates/kanban-server/tests/graceful_shutdown.rs
@@ -1,0 +1,157 @@
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command as StdCommand, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::tempdir;
+
+fn spawn_and_wait_for_port(dir: &Path, env: &[(&str, &str)], args: &[&str]) -> (Child, u16) {
+    let bin_path = assert_cmd::cargo_bin!("kanban-server");
+
+    let mut cmd = StdCommand::new(bin_path);
+    cmd.current_dir(dir)
+        .env_remove("KANBAN_FILE")
+        .env_remove("KANBAN_ADDR")
+        .env_remove("KANBAN_CONFIG")
+        .env("NO_COLOR", "1")
+        .env("RUST_LOG", "info")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd.spawn().expect("failed to spawn kanban-server");
+    let stdout = child.stdout.take().expect("stdout must be piped");
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    if let Some(idx) = line.find("addr=") {
+                        let rest = &line[idx + "addr=".len()..];
+                        if let Some(end) = rest.find([' ', '\n']) {
+                            let addr_str = &rest[..end];
+                            if let Some(colon_idx) = addr_str.rfind(':') {
+                                if let Ok(port) = addr_str[colon_idx + 1..].parse::<u16>() {
+                                    let _ = tx.send(port);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let port = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("server did not report its bound port within 5s");
+    (child, port)
+}
+
+fn send_signal(pid: u32, sig: &str) {
+    let status = StdCommand::new("/bin/sh")
+        .arg("-c")
+        .arg(format!("kill -{sig} {pid}"))
+        .status()
+        .expect("failed to invoke kill");
+    assert!(status.success(), "kill -{sig} {pid} failed");
+}
+
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> std::process::ExitStatus {
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait failed") {
+            return status;
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "process did not exit within {:?} (waited {:?})",
+                timeout,
+                start.elapsed()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn test_sigterm_exits_zero_after_drain() {
+    let dir = tempdir().unwrap();
+    let data_file = dir.path().join("test_data.json");
+
+    let (mut child, _port) = spawn_and_wait_for_port(
+        dir.path(),
+        &[("KANBAN_SHUTDOWN_GRACE_SECS", "1")],
+        &["--addr", "127.0.0.1:0", data_file.to_str().unwrap()],
+    );
+
+    send_signal(child.id(), "TERM");
+    let status = wait_for_exit(&mut child, Duration::from_secs(5));
+    assert_eq!(status.code(), Some(0));
+}
+
+#[test]
+fn test_sigint_exits_zero_after_drain() {
+    let dir = tempdir().unwrap();
+    let data_file = dir.path().join("test_data.json");
+
+    let (mut child, _port) = spawn_and_wait_for_port(
+        dir.path(),
+        &[("KANBAN_SHUTDOWN_GRACE_SECS", "1")],
+        &["--addr", "127.0.0.1:0", data_file.to_str().unwrap()],
+    );
+
+    send_signal(child.id(), "INT");
+    let status = wait_for_exit(&mut child, Duration::from_secs(5));
+    assert_eq!(status.code(), Some(0));
+}
+
+#[test]
+fn test_sigterm_with_open_sse_connection_exits_within_grace() {
+    let dir = tempdir().unwrap();
+    let data_file = dir.path().join("test_data.json");
+
+    let (mut child, port) = spawn_and_wait_for_port(
+        dir.path(),
+        &[("KANBAN_SHUTDOWN_GRACE_SECS", "1")],
+        &["--addr", "127.0.0.1:0", data_file.to_str().unwrap()],
+    );
+
+    let mut stream =
+        TcpStream::connect(("127.0.0.1", port)).expect("failed to connect to /v1/events");
+    stream
+        .write_all(
+            b"GET /v1/events HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: text/event-stream\r\n\r\n",
+        )
+        .expect("failed to write request");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("failed to set read timeout");
+    let mut buf = [0u8; 1024];
+    let n = stream.read(&mut buf).expect("failed to read response");
+    let text = String::from_utf8_lossy(&buf[..n]);
+    assert!(
+        text.contains("200"),
+        "expected a 200 response establishing the SSE stream, got: {text}"
+    );
+
+    send_signal(child.id(), "TERM");
+    let status = wait_for_exit(&mut child, Duration::from_secs(5));
+    assert_eq!(status.code(), Some(0));
+
+    drop(stream);
+}


### PR DESCRIPTION
## Summary

- `kanban-server` now installs SIGTERM and SIGINT (ctrl-c) handlers before it starts serving, and binds the axum serve loop with `with_graceful_shutdown` so the process stops accepting new connections and lets in-flight requests finish once a signal fires.
- A `KANBAN_SHUTDOWN_GRACE_SECS` env var (default 10) bounds how long the drain waits before remaining connections, including any never-ending SSE stream on `/v1/events`, are forcibly closed. An unparseable value falls back to the default.
- On non-unix targets the same shutdown watch is driven by `tokio::signal::ctrl_c()`.
- New integration tests spawn the real binary and send real signals to prove SIGTERM and SIGINT both exit 0, and that a held-open SSE connection does not prevent shutdown within the grace window.
- README documents the new shutdown behavior and the `KANBAN_SHUTDOWN_GRACE_SECS` env var.

## Test plan

- [x] `cargo test -p kanban-server --all-features` (includes the new `graceful_shutdown` integration tests and the `parse_grace` unit tests)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] Mutation check: reverted the graceful-shutdown wiring, confirmed all three new integration tests fail (process hangs past the 5s wait), restored the fix
