### PR TITLE
KAN-1545 feat(domain,server,cli,mcp,tui): capability manifest and per-app wiring guards

### DIFF
--- a/.changeset/kan-1545-capability-manifest-guards.md
+++ b/.changeset/kan-1545-capability-manifest-guards.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+add a capability manifest guard proving every KanbanOperations/GraphOperations/UndoOperations method is wired or explicitly declined in each application

--- a/crates/kanban-cli/src/capabilities.rs
+++ b/crates/kanban-cli/src/capabilities.rs
@@ -1,0 +1,10 @@
+pub const DECLINED_CAPABILITIES: &[(&str, &str)] = &[
+    (
+        "undo",
+        "undo: the CLI opens a fresh context per invocation, so the per-process undo history is always empty",
+    ),
+    (
+        "redo",
+        "redo: the CLI opens a fresh context per invocation, so the per-process undo history is always empty",
+    ),
+];

--- a/crates/kanban-cli/src/lib.rs
+++ b/crates/kanban-cli/src/lib.rs
@@ -6,6 +6,7 @@
 //! `main.rs`, owning the entrypoint while reusing all CLI plumbing.
 
 pub(crate) mod app;
+pub mod capabilities;
 pub(crate) mod cli;
 pub(crate) mod context;
 pub(crate) mod error;

--- a/crates/kanban-cli/tests/capability_guard.rs
+++ b/crates/kanban-cli/tests/capability_guard.rs
@@ -1,0 +1,38 @@
+use kanban_cli::capabilities::DECLINED_CAPABILITIES;
+use kanban_domain::{capability_violations, CAPABILITY_MANIFEST};
+
+const SOURCES: &[&str] = &[
+    include_str!("../src/cli.rs"),
+    include_str!("../src/app.rs"),
+    include_str!("../src/handlers/board.rs"),
+    include_str!("../src/handlers/card.rs"),
+    include_str!("../src/handlers/column.rs"),
+    include_str!("../src/handlers/export.rs"),
+    include_str!("../src/handlers/migrate.rs"),
+    include_str!("../src/handlers/relation.rs"),
+    include_str!("../src/handlers/sprint.rs"),
+];
+
+#[test]
+fn test_every_capability_is_routed_or_declined() {
+    let violations = capability_violations(CAPABILITY_MANIFEST, SOURCES, DECLINED_CAPABILITIES);
+    assert!(
+        violations.is_empty(),
+        "cli capability wiring gaps: {violations:#?}"
+    );
+
+    for src in SOURCES {
+        let stripped = kanban_domain::capabilities::strip_test_modules(src);
+        assert!(
+            !stripped.contains("#[test]"),
+            "stripped source still contains #[test]; the block-scoped stripper missed a cfg(test) module"
+        );
+    }
+}
+
+#[test]
+fn test_unknown_capability_is_reported() {
+    let violations = capability_violations(&["frobnicate_card"], SOURCES, DECLINED_CAPABILITIES);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("frobnicate_card"));
+}

--- a/crates/kanban-domain/src/capabilities.rs
+++ b/crates/kanban-domain/src/capabilities.rs
@@ -1,3 +1,74 @@
+pub const CAPABILITY_MANIFEST: &[&str] = &[];
+
+fn strip_test_modules(src: &str) -> String {
+    let mut kept = Vec::new();
+    let mut skipping = false;
+    for line in src.lines() {
+        if skipping {
+            if line == "}" {
+                skipping = false;
+            }
+            continue;
+        }
+        if line.trim() == "#[cfg(test)]" {
+            skipping = true;
+            continue;
+        }
+        kept.push(line);
+    }
+    kept.join("\n")
+}
+
+fn contains_capability(src: &str, name: &str) -> bool {
+    let bytes = src.as_bytes();
+    for pattern in [format!("{name}("), format!("{name}_impl(")] {
+        let plen = pattern.len();
+        if plen > bytes.len() {
+            continue;
+        }
+        for start in 0..=bytes.len() - plen {
+            if &bytes[start..start + plen] == pattern.as_bytes() {
+                let boundary_ok = start == 0 || !(bytes[start - 1] as char).is_ascii_alphanumeric();
+                if boundary_ok {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn capability_violations(
+    manifest: &[&str],
+    wiring_sources: &[&str],
+    declined: &[(&str, &str)],
+) -> Vec<String> {
+    let stripped: Vec<String> = wiring_sources
+        .iter()
+        .map(|s| strip_test_modules(s))
+        .collect();
+    let mut violations = Vec::new();
+    for &name in manifest {
+        let wired = stripped.iter().any(|s| contains_capability(s, name));
+        let decline = declined.iter().find(|(n, _)| *n == name);
+        match (wired, decline) {
+            (true, Some(_)) => {
+                violations.push(format!(
+                    "{name}: declined but wired; remove the stale decline"
+                ));
+            }
+            (false, Some((_, reason))) if reason.trim().is_empty() => {
+                violations.push(format!("{name}: declined with an empty reason; state why"));
+            }
+            (false, None) => {
+                violations.push(format!("{name}: not wired in any source and not declined"));
+            }
+            _ => {}
+        }
+    }
+    violations
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,18 +141,14 @@ mod tests {
 
     #[test]
     fn test_declined_entry_with_empty_reason_is_reported() {
-        let violations =
-            capability_violations(&["undo"], &["fn nothing() {}"], &[("undo", "")]);
+        let violations = capability_violations(&["undo"], &["fn nothing() {}"], &[("undo", "")]);
         assert!(violations.iter().any(|v| v.contains("undo")));
     }
 
     #[test]
     fn test_declined_but_wired_entry_is_reported() {
-        let violations = capability_violations(
-            &["undo"],
-            &["c.undo()"],
-            &[("undo", "sessions are shared")],
-        );
+        let violations =
+            capability_violations(&["undo"], &["c.undo()"], &[("undo", "sessions are shared")]);
         assert!(violations.iter().any(|v| v.contains("undo")));
     }
 }

--- a/crates/kanban-domain/src/capabilities.rs
+++ b/crates/kanban-domain/src/capabilities.rs
@@ -1,0 +1,87 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_production_wiring_after_a_mid_file_cfg_test_module_is_still_seen() {
+        let src = "fn a() {}\n\n#[cfg(test)]\nmod t {\n    #[test]\n    fn x() { create_board(); }\n}\n\nfn wired() { archive_board(); }\n";
+        let violations = capability_violations(&["archive_board", "create_board"], &[src], &[]);
+        assert!(violations.iter().any(|v| v.contains("create_board")));
+        assert!(!violations.iter().any(|v| v.contains("archive_board")));
+    }
+
+    #[test]
+    fn test_wiring_inside_trailing_cfg_test_module_is_ignored() {
+        let src = "fn r() {}\n\n#[cfg(test)]\nmod t {\n    fn x() { delete_card(); }\n}\n";
+        let violations = capability_violations(&["delete_card"], &[src], &[]);
+        assert!(violations.iter().any(|v| v.contains("delete_card")));
+    }
+
+    #[test]
+    fn test_unwired_manifest_entry_is_reported() {
+        let violations = capability_violations(&["archive_board"], &["fn nothing() {}"], &[]);
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].contains("archive_board"));
+    }
+
+    #[test]
+    fn test_wired_entry_with_bare_call_passes() {
+        let violations = capability_violations(&["update_board"], &["c.update_board(id, u)"], &[]);
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_wired_entry_with_impl_suffix_passes() {
+        let violations = capability_violations(
+            &["update_board"],
+            &["mutate(|c| c.update_board_impl(id, u))"],
+            &[],
+        );
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_wired_entry_behind_an_underscore_prefix_passes() {
+        let violations = capability_violations(&["undo"], &["pub async fn tool_undo(&self)"], &[]);
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_entry_name_does_not_match_pluralized_sibling() {
+        let violations = capability_violations(&["update_card"], &["c.update_cards(v)"], &[]);
+        assert!(violations.iter().any(|v| v.contains("update_card")));
+    }
+
+    #[test]
+    fn test_entry_name_does_not_match_longer_identifier_prefix() {
+        let violations = capability_violations(&["block"], &["c.unblock(a, b)"], &[]);
+        assert!(violations.iter().any(|v| v.contains("block")));
+    }
+
+    #[test]
+    fn test_declined_entry_with_reason_passes() {
+        let violations = capability_violations(
+            &["undo"],
+            &["fn nothing() {}"],
+            &[("undo", "sessions are shared across clients")],
+        );
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_declined_entry_with_empty_reason_is_reported() {
+        let violations =
+            capability_violations(&["undo"], &["fn nothing() {}"], &[("undo", "")]);
+        assert!(violations.iter().any(|v| v.contains("undo")));
+    }
+
+    #[test]
+    fn test_declined_but_wired_entry_is_reported() {
+        let violations = capability_violations(
+            &["undo"],
+            &["c.undo()"],
+            &[("undo", "sessions are shared")],
+        );
+        assert!(violations.iter().any(|v| v.contains("undo")));
+    }
+}

--- a/crates/kanban-domain/src/capabilities.rs
+++ b/crates/kanban-domain/src/capabilities.rs
@@ -1,6 +1,29 @@
-pub const CAPABILITY_MANIFEST: &[&str] = &[];
+pub const CAPABILITY_MANIFEST: &[&str] = &[
+    "create_board",
+    "list_boards",
+    "get_board",
+    "update_board",
+    "delete_board",
+    "create_card",
+    "list_cards",
+    "get_card",
+    "update_card",
+    "delete_card",
+    "list_columns",
+    "get_column",
+    "update_column",
+    "delete_column",
+    "reorder_column",
+    "create_sprint",
+    "list_sprints",
+    "get_sprint",
+    "update_sprint",
+    "delete_sprint",
+    "undo",
+    "redo",
+];
 
-fn strip_test_modules(src: &str) -> String {
+pub fn strip_test_modules(src: &str) -> String {
     let mut kept = Vec::new();
     let mut skipping = false;
     for line in src.lines() {

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -5,6 +5,7 @@ pub mod archived_board;
 pub mod archived_card;
 pub mod board;
 pub mod board_factory;
+pub mod capabilities;
 pub mod card;
 pub mod card_factory;
 pub mod card_lifecycle;

--- a/crates/kanban-domain/src/lib.rs
+++ b/crates/kanban-domain/src/lib.rs
@@ -56,6 +56,7 @@ pub use board::{
     DEFAULT_BOARD_SORT_LIVE,
 };
 pub use board_factory::{BoardRecord, NewBoard};
+pub use capabilities::{capability_violations, CAPABILITY_MANIFEST};
 pub use card::{
     AnimationType, Card, CardId, CardPriority, CardStatus, CardSummary, CardUpdate,
     CreateCardOptions,

--- a/crates/kanban-mcp/tests/capability_guard.rs
+++ b/crates/kanban-mcp/tests/capability_guard.rs
@@ -1,0 +1,37 @@
+use kanban_domain::{capability_violations, CAPABILITY_MANIFEST};
+
+const SOURCES: &[&str] = &[
+    include_str!("../src/tools/board.rs"),
+    include_str!("../src/tools/card_batch.rs"),
+    include_str!("../src/tools/card_crud.rs"),
+    include_str!("../src/tools/card_relations.rs"),
+    include_str!("../src/tools/column.rs"),
+    include_str!("../src/tools/sprint.rs"),
+    include_str!("../src/tools/transfer.rs"),
+];
+
+const DECLINED: &[(&str, &str)] = &[];
+
+#[test]
+fn test_every_capability_is_routed_or_declined() {
+    let violations = capability_violations(CAPABILITY_MANIFEST, SOURCES, DECLINED);
+    assert!(
+        violations.is_empty(),
+        "mcp capability wiring gaps: {violations:#?}"
+    );
+
+    for src in SOURCES {
+        let stripped = kanban_domain::capabilities::strip_test_modules(src);
+        assert!(
+            !stripped.contains("#[test]"),
+            "stripped source still contains #[test]; the block-scoped stripper missed a cfg(test) module"
+        );
+    }
+}
+
+#[test]
+fn test_unknown_capability_is_reported() {
+    let violations = capability_violations(&["frobnicate_card"], SOURCES, DECLINED);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("frobnicate_card"));
+}

--- a/crates/kanban-server/src/capabilities.rs
+++ b/crates/kanban-server/src/capabilities.rs
@@ -1,0 +1,4 @@
+pub const DECLINED_CAPABILITIES: &[(&str, &str)] = &[
+    ("undo", "sessions are shared across clients"),
+    ("redo", "sessions are shared across clients"),
+];

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -4,6 +4,7 @@
 //! cards extend it rather than building their own.
 
 pub mod app;
+pub mod capabilities;
 pub mod error;
 pub mod model_read;
 pub mod pagination;

--- a/crates/kanban-server/tests/capability_guard.rs
+++ b/crates/kanban-server/tests/capability_guard.rs
@@ -1,0 +1,40 @@
+use kanban_domain::{capability_violations, CAPABILITY_MANIFEST};
+use kanban_server::capabilities::DECLINED_CAPABILITIES;
+
+const SOURCES: &[&str] = &[
+    include_str!("../src/app.rs"),
+    include_str!("../src/routes/boards.rs"),
+    include_str!("../src/routes/cards.rs"),
+    include_str!("../src/routes/columns.rs"),
+    include_str!("../src/routes/sprints.rs"),
+    include_str!("../src/routes/graph.rs"),
+    include_str!("../src/routes/prefixes.rs"),
+    include_str!("../src/handlers/boards.rs"),
+    include_str!("../src/handlers/cards.rs"),
+    include_str!("../src/handlers/columns.rs"),
+    include_str!("../src/handlers/sprints.rs"),
+];
+
+#[test]
+fn test_every_capability_is_routed_or_declined() {
+    let violations = capability_violations(CAPABILITY_MANIFEST, SOURCES, DECLINED_CAPABILITIES);
+    assert!(
+        violations.is_empty(),
+        "server capability wiring gaps: {violations:#?}"
+    );
+
+    for src in SOURCES {
+        let stripped = kanban_domain::capabilities::strip_test_modules(src);
+        assert!(
+            !stripped.contains("#[test]"),
+            "stripped source still contains #[test]; the block-scoped stripper missed a cfg(test) module"
+        );
+    }
+}
+
+#[test]
+fn test_unknown_capability_is_reported() {
+    let violations = capability_violations(&["frobnicate_card"], SOURCES, DECLINED_CAPABILITIES);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("frobnicate_card"));
+}

--- a/crates/kanban-tui/tests/capability_guard.rs
+++ b/crates/kanban-tui/tests/capability_guard.rs
@@ -1,0 +1,29 @@
+use kanban_domain::{capability_violations, CAPABILITY_MANIFEST};
+
+const SOURCES: &[&str] = &[include_str!("../src/tui_context.rs")];
+
+const DECLINED: &[(&str, &str)] = &[];
+
+#[test]
+fn test_every_capability_is_routed_or_declined() {
+    let violations = capability_violations(CAPABILITY_MANIFEST, SOURCES, DECLINED);
+    assert!(
+        violations.is_empty(),
+        "TuiContext's trait impls are the TUI's narrow waist; impl presence does not prove a keybinding reaches it: {violations:#?}"
+    );
+
+    for src in SOURCES {
+        let stripped = kanban_domain::capabilities::strip_test_modules(src);
+        assert!(
+            !stripped.contains("#[test]"),
+            "stripped source still contains #[test]; the block-scoped stripper missed a cfg(test) module"
+        );
+    }
+}
+
+#[test]
+fn test_unknown_capability_is_reported() {
+    let violations = capability_violations(&["frobnicate_card"], SOURCES, DECLINED);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("frobnicate_card"));
+}


### PR DESCRIPTION
## What

Adds `CAPABILITY_MANIFEST` and a pure `capability_violations` checker to `kanban-domain`, plus one `capability_guard.rs` integration test per application (server, CLI, MCP, TUI) that asserts every manifest entry is either present in that app's wiring source or listed in that app's `DECLINED_CAPABILITIES` with a reason.

No capability is wired by this PR. The manifest is seeded empirically to exactly the 22 entries that pass in all four apps today; the 39 excluded candidates are enumerated below so Epic B cards can re-add them alongside their routes.

## Checker

`kanban_domain::capability_violations(manifest, wiring_sources, declined)` strips each source's `#[cfg(test)]` modules block-scoped (a naive cut-at-first-occurrence is unsound: `crates/kanban-cli/src/cli.rs` has a mid-file `#[cfg(test)] mod sort_key_tests` at line 411 of 675, with real clap definitions resuming at line 428), then checks each manifest entry for a `name(` or `name_impl(` occurrence with a non-alphanumeric left boundary (so `tool_undo(` counts for `undo` but `unblock(` does not count for `block`).

## Measured gaps (full 61-candidate manifest, against origin/develop 67d91b02)

**Server (37 unwired):**
```
list_boards_filtered, archive_board, restore_board, list_archived_boards,
find_cards_by_identifier, list_all_cards, list_all_columns, list_all_sprints,
move_card, archive_card, restore_card, list_archived_cards_by_board,
assign_card_to_sprint, unassign_card_from_sprint, get_card_branch_name,
get_card_git_checkout, archive_cards, move_cards, update_cards,
assign_cards_to_sprint, carry_over_sprint_cards, activate_sprint,
complete_sprint, cancel_sprint, export_board, import_board, attach_children,
detach_children, list_children_of, list_parents_of, block, unblock,
list_blocked_by, list_blockers_of, relate, dissociate, list_related_to
```

**CLI (17 unwired):**
```
create_column, list_all_cards, list_all_columns, list_all_sprints,
list_archived_cards, list_archived_cards_by_board, archive_cards, move_cards,
update_cards, assign_cards_to_sprint, block, unblock, list_blocked_by,
list_blockers_of, relate, dissociate, list_related_to
```

**MCP (15 unwired):**
```
list_all_cards, list_all_columns, list_all_sprints, list_archived_cards,
list_archived_cards_by_board, update_cards, list_children_of, list_parents_of,
block, unblock, list_blocked_by, list_blockers_of, relate, dissociate,
list_related_to
```

**TUI (0 unwired).**

## frobnicate_card probe (mandatory red-provability proof)

Adding `frobnicate_card` to the manifest and running all four guards, each fails naming exactly that entry:

- server: `frobnicate_card: not wired in any source and not declined`
- cli: `frobnicate_card: not wired in any source and not declined`
- mcp: `frobnicate_card: not wired in any source and not declined`
- tui: `frobnicate_card: not wired in any source and not declined`

Reverted before commit; this scenario is pinned permanently by `test_unknown_capability_is_reported` in each guard file.

## The 39 excluded candidates, by cause

**(a) Server route pending - an Epic B (KAN-1540) card re-adds these when it wires the route:**

- `archive_card`, `restore_card` - KAN-1546 (card archive/restore over HTTP)
- `archive_board`, `restore_board`, `list_archived_boards` - KAN-1547 (board archive/restore/list over HTTP)
- `activate_sprint`, `complete_sprint`, `cancel_sprint`, `carry_over_sprint_cards` - KAN-1549 (sprint lifecycle routes)
- `export_board`, `import_board` - KAN-1552 (board export/import over HTTP)
- `list_boards_filtered`, `find_cards_by_identifier`, `move_card`, `assign_card_to_sprint`, `unassign_card_from_sprint`, `get_card_branch_name`, `get_card_git_checkout` - no dedicated Epic B card currently scopes these; none of KAN-1546 through KAN-1552's titles/descriptions name them. Flagging as a gap in Epic B's card set rather than guessing an owner.

**(b) Unwired in three or more apps - needs a routing decision, not just a route:**

```
attach_children, detach_children, list_children_of, list_parents_of, block,
unblock, list_blocked_by, list_blockers_of, relate, dissociate,
list_related_to, list_all_cards, list_all_columns, list_all_sprints,
update_cards, list_archived_cards, list_archived_cards_by_board
```

The graph-relation entries are the server's Epic B graph-writes card (KAN-1548) plus matching MCP/CLI work; the `list_all_*`/`update_cards`/`list_archived_cards*` entries have no owning card and are unscoped MCP/CLI/server work.

**(c) Wired but not matched - the two-form (`name(` / `name_impl(`) rule misses a longer seam method name the app already uses:**

- `create_column` - CLI wires it via `ctx.create_column_with_default_status(` (`crates/kanban-cli/src/handlers/column.rs:29`)
- `archive_cards`, `move_cards`, `assign_cards_to_sprint` - CLI wires them via `ctx.archive_cards_detailed(` etc. (`crates/kanban-cli/src/handlers/card.rs:189,211,233`)

Widening the match rule to catch these was considered and rejected: it buys exactly one extra seed entry (23 vs 22) while introducing false positives elsewhere (e.g. `get_card` would be satisfied by `get_card_branch_name(`). Recorded as a deferred follow-up on KAN-1545 instead (see below).

## Deferred follow-ups (checklist on KAN-1545)

- [ ] The checker's two-form match (`name(` / `name_impl(`) misses capabilities wired under longer seam method names (`create_column_with_default_status`, `archive_cards_detailed`), so four already-shipped CLI capabilities cannot enter the manifest under their short names. No manifest change proposed here; needs its own design pass if it becomes a recurring source of false negatives.
- [ ] `list_boards_filtered`, `find_cards_by_identifier`, `move_card`, `assign_card_to_sprint`, `unassign_card_from_sprint`, `get_card_branch_name`, `get_card_git_checkout` have no owning Epic B card in the current KAN-1540 children (KAN-1546..1552); needs a card or an explicit addition to an existing one before the server side of Epic B is considered complete.

## Files

- `crates/kanban-domain/src/capabilities.rs` (new): `CAPABILITY_MANIFEST`, `capability_violations`, `strip_test_modules`
- `crates/kanban-server/src/capabilities.rs`, `crates/kanban-cli/src/capabilities.rs` (new): `DECLINED_CAPABILITIES` for `undo`/`redo`, reasons copied verbatim from each app's `UndoOperations` impl
- `crates/{kanban-server,kanban-cli,kanban-mcp,kanban-tui}/tests/capability_guard.rs` (new): the four per-app guards

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`

All three green.
