### PR TITLE
KAN-1557 feat(server): trace, body-limit and CORS layers on the router

### DIFF
--- a/.changeset/kan-1557-server-trace-body-limit-cors-layers.md
+++ b/.changeset/kan-1557-server-trace-body-limit-cors-layers.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+kanban-server now logs every request, caps request bodies at 2 MiB, and can serve browser clients from other origins via KANBAN_CORS_ORIGINS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,6 +3290,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
  "tower",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ dunce = "1.0"
 # HTTP server
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace", "cors"] }
+tower-http = { version = "0.6", features = ["trace", "cors", "limit"] }
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -48,9 +48,12 @@ On startup the server opens (or creates) the board file, binds the configured ad
 | `KANBAN_FILE` | `kanban.json` (in the working directory) | Storage locator, resolved through the same backend registry as the CLI/TUI/MCP server — a `.json` path uses the JSON backend, a `.sqlite`/`.db` path (or existing SQLite file) uses the SQLite backend. |
 | `KANBAN_ADDR` | `127.0.0.1:0` (ephemeral loopback) | Address the HTTP server binds, as `host:port` where host is an IP literal (`127.0.0.1`, `0.0.0.0`, `[::1]`); hostnames such as `localhost` are not resolved. Resolved with the same layered precedence as `KANBAN_FILE`: the `--addr` flag wins, then `KANBAN_ADDR`, then the `server_addr` key in the config file, then the default. Set `0.0.0.0:<port>` to accept non-loopback connections (e.g. behind a reverse proxy). |
 | `KANBAN_SHUTDOWN_GRACE_SECS` | `10` | Seconds to wait after a shutdown signal for in-flight responses to complete before remaining connections are closed. Open SSE streams never end on their own, so this is what bounds shutdown. An unparseable value falls back to the default. |
-| `RUST_LOG` | unset (⇒ `error` only) | Standard `tracing-subscriber` env filter. Set to `info` to see the startup log line; there is no per-request access logging. |
+| `RUST_LOG` | unset (⇒ `error` only) | Standard `tracing-subscriber` env filter. Set to `info` to see the startup log line. Per-request access logging comes from tower-http's TraceLayer; set `tower_http=debug` (or `debug`) to see one span per request with method, path, status and latency. |
+| `KANBAN_CORS_ORIGINS` | unset (no CORS layer, same-origin only) | Comma-separated list of allowed browser origins. Unset means no CORS headers are sent at all. A single `*` allows any origin and is intended for local development only. A list allows exactly those origins with the GET/POST/PUT/PATCH/DELETE methods and the content-type and x-kanban-client-id request headers. |
 
 The bind address can also be set with the `--addr` flag or the `server_addr` key in the kanban config file (`~/.config/kanban/config.toml`); the resolution order is `--addr` > `KANBAN_ADDR` > `server_addr` > the `127.0.0.1:0` default.
+
+Request bodies are capped at 2 MiB by default. A request over the cap is rejected with 413 Payload Too Large before it reaches the handler.
 
 ### Example
 

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -1,8 +1,11 @@
+use crate::layers::LayerConfig;
 use crate::state::AppState;
 use axum::extract::State;
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::Serialize;
+use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::trace::TraceLayer;
 
 #[derive(Serialize)]
 struct HealthResponse {
@@ -20,7 +23,16 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
 /// The single `Router` composition point. Entity route cards extend this via
 /// `.merge`/`.nest` rather than building their own `Router`.
 pub fn router(state: AppState) -> Router {
-    Router::new()
+    router_with(state, LayerConfig::default())
+}
+
+/// Like [`router`], but with an explicit [`LayerConfig`].
+///
+/// `.layer()` wraps outside-in on the LAST call, so calling body-limit then
+/// cors then trace here makes Trace the outermost layer and BodyLimit the
+/// innermost.
+pub fn router_with(state: AppState, config: LayerConfig) -> Router {
+    let router = Router::new()
         .route("/health", get(health))
         .merge(crate::routes::boards::read_router())
         .merge(crate::routes::boards::write_router())
@@ -38,6 +50,11 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::sprints::write_router())
         .merge(crate::routes::sprints::flat_read_router())
         .merge(crate::routes::sprints::flat_write_router())
-        .merge(crate::routes::events::router())
-        .with_state(state)
+        .merge(crate::routes::events::router());
+
+    let mut router = router.layer(RequestBodyLimitLayer::new(config.body_limit_bytes));
+    if let Some(cors) = config.cors.into_layer() {
+        router = router.layer(cors);
+    }
+    router.layer(TraceLayer::new_for_http()).with_state(state)
 }

--- a/crates/kanban-server/src/layers.rs
+++ b/crates/kanban-server/src/layers.rs
@@ -1,0 +1,128 @@
+use axum::http::{header, HeaderName, HeaderValue, Method};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+/// Cross-origin policy for browser clients. `Disabled` sends no CORS headers
+/// at all; `Permissive` allows any origin (`*`); `Origins` echoes back only
+/// the listed origins.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum CorsPolicy {
+    #[default]
+    Disabled,
+    Permissive,
+    Origins(Vec<HeaderValue>),
+}
+
+impl CorsPolicy {
+    /// Parses a comma-separated `KANBAN_CORS_ORIGINS` value. Any entry equal
+    /// to `*`, anywhere in the list, collapses the whole policy to
+    /// `Permissive` rather than being passed through to `AllowOrigin::list`,
+    /// which panics on a wildcard entry.
+    pub fn parse(raw: Option<&str>) -> Self {
+        let Some(raw) = raw else {
+            return Self::Disabled;
+        };
+
+        let entries: Vec<&str> = raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if entries.contains(&"*") {
+            return Self::Permissive;
+        }
+
+        let origins: Vec<HeaderValue> = entries
+            .iter()
+            .filter_map(|s| HeaderValue::from_str(s).ok())
+            .collect();
+
+        if origins.is_empty() {
+            Self::Disabled
+        } else {
+            Self::Origins(origins)
+        }
+    }
+
+    pub fn into_layer(self) -> Option<CorsLayer> {
+        match self {
+            Self::Disabled => None,
+            Self::Permissive => Some(CorsLayer::permissive()),
+            Self::Origins(origins) => Some(
+                CorsLayer::new()
+                    .allow_origin(AllowOrigin::list(origins))
+                    .allow_methods([
+                        Method::GET,
+                        Method::POST,
+                        Method::PUT,
+                        Method::PATCH,
+                        Method::DELETE,
+                    ])
+                    .allow_headers([
+                        header::CONTENT_TYPE,
+                        HeaderName::from_static("x-kanban-client-id"),
+                    ]),
+            ),
+        }
+    }
+}
+
+pub const DEFAULT_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct LayerConfig {
+    pub body_limit_bytes: usize,
+    pub cors: CorsPolicy,
+}
+
+impl Default for LayerConfig {
+    fn default() -> Self {
+        Self {
+            body_limit_bytes: DEFAULT_BODY_LIMIT_BYTES,
+            cors: CorsPolicy::Disabled,
+        }
+    }
+}
+
+impl LayerConfig {
+    pub fn from_env() -> Self {
+        Self {
+            cors: CorsPolicy::parse(std::env::var("KANBAN_CORS_ORIGINS").ok().as_deref()),
+            ..Self::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cors_origins_star_yields_permissive_policy() {
+        assert_eq!(CorsPolicy::parse(Some("*")), CorsPolicy::Permissive);
+    }
+
+    #[test]
+    fn test_cors_origins_csv_yields_exact_origin_list() {
+        assert_eq!(
+            CorsPolicy::parse(Some("http://localhost:5173, https://app.example.com")),
+            CorsPolicy::Origins(vec![
+                HeaderValue::from_static("http://localhost:5173"),
+                HeaderValue::from_static("https://app.example.com"),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_cors_origins_csv_containing_star_yields_permissive_policy() {
+        assert_eq!(
+            CorsPolicy::parse(Some("*,http://localhost:5173")),
+            CorsPolicy::Permissive
+        );
+    }
+
+    #[test]
+    fn test_cors_origins_none_yields_disabled_policy() {
+        assert_eq!(CorsPolicy::parse(None), CorsPolicy::Disabled);
+    }
+}

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod app;
 pub mod error;
+pub mod layers;
 pub mod model_read;
 pub mod pagination;
 pub mod scope;

--- a/crates/kanban-server/src/main.rs
+++ b/crates/kanban-server/src/main.rs
@@ -68,7 +68,11 @@ async fn run(
 
     let mut graceful_rx = shutdown_rx.clone();
     let mut drain_rx = shutdown_rx;
-    let serve = axum::serve(listener, app::router(state)).with_graceful_shutdown(async move {
+    let serve = axum::serve(
+        listener,
+        app::router_with(state, kanban_server::layers::LayerConfig::from_env()),
+    )
+    .with_graceful_shutdown(async move {
         let _ = graceful_rx.changed().await;
     });
     tokio::select! {

--- a/crates/kanban-server/tests/layers.rs
+++ b/crates/kanban-server/tests/layers.rs
@@ -1,0 +1,155 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::body::Body;
+use axum::http::{HeaderValue, Request, StatusCode};
+use kanban_server::app;
+use kanban_server::layers::{CorsPolicy, LayerConfig};
+use kanban_server::test_helpers::make_state;
+use tempfile::tempdir;
+use tower::ServiceExt;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_oversized_body_returns_413() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let router = app::router_with(
+        state,
+        LayerConfig {
+            body_limit_bytes: 1024,
+            ..Default::default()
+        },
+    );
+
+    let body = vec![b'a'; 2048];
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/boards")
+        .header("content-type", "application/json")
+        .header("content-length", "2048")
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_body_under_limit_still_accepted() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let router = app::router_with(
+        state,
+        LayerConfig {
+            body_limit_bytes: 1024,
+            ..Default::default()
+        },
+    );
+
+    let payload = br#"{"name":"B","card_prefix":"KAN"}"#;
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/boards")
+        .header("content-type", "application/json")
+        .header("content-length", payload.len().to_string())
+        .body(Body::from(payload.to_vec()))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_default_config_emits_no_cors_headers() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let router = app::router_with(state, LayerConfig::default());
+
+    let request = Request::builder()
+        .method("OPTIONS")
+        .uri("/v1/boards")
+        .header("origin", "http://localhost:5173")
+        .header("access-control-request-method", "POST")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert!(!response
+        .headers()
+        .contains_key("access-control-allow-origin"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cors_permissive_preflight_returns_wildcard_origin() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let router = app::router_with(
+        state,
+        LayerConfig {
+            cors: CorsPolicy::Permissive,
+            ..Default::default()
+        },
+    );
+
+    let request = Request::builder()
+        .method("OPTIONS")
+        .uri("/v1/boards")
+        .header("origin", "http://localhost:5173")
+        .header("access-control-request-method", "POST")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.headers().get("access-control-allow-origin"),
+        Some(&HeaderValue::from_static("*"))
+    );
+    assert!(response
+        .headers()
+        .contains_key("access-control-allow-methods"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cors_allowed_origin_preflight_echoes_origin() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let router = app::router_with(
+        state,
+        LayerConfig {
+            cors: CorsPolicy::Origins(vec![HeaderValue::from_static("http://localhost:5173")]),
+            ..Default::default()
+        },
+    );
+
+    let request = Request::builder()
+        .method("OPTIONS")
+        .uri("/v1/boards")
+        .header("origin", "http://localhost:5173")
+        .header("access-control-request-method", "POST")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.headers().get("access-control-allow-origin"),
+        Some(&HeaderValue::from_static("http://localhost:5173"))
+    );
+    let allow_methods = response
+        .headers()
+        .get("access-control-allow-methods")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(allow_methods.contains("POST"));
+    let allow_headers = response
+        .headers()
+        .get("access-control-allow-headers")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(allow_headers.contains("content-type"));
+}

--- a/crates/kanban-server/tests/layers_trace.rs
+++ b/crates/kanban-server/tests/layers_trace.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::body::Body;
+use axum::http::Request;
+use kanban_server::app;
+use kanban_server::test_helpers::make_state;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+use tower::ServiceExt;
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct CaptureMakeWriter(Arc<Mutex<Vec<u8>>>);
+
+impl<'a> MakeWriter<'a> for CaptureMakeWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter(self.0.clone())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trace_layer_emits_tower_http_request_events() {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_writer(CaptureMakeWriter(buffer.clone()))
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let router = app::router(state);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert!(response.status().is_success());
+
+    let captured = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+    assert!(!captured.is_empty());
+    assert!(captured.contains("tower_http::trace"));
+}


### PR DESCRIPTION
Applies the three mechanical tower-http layers to kanban-server's single router composition point (`app::router_with`).

## Changes

- New `LayerConfig` + `CorsPolicy` pair in `crates/kanban-server/src/layers.rs`.
- `app::router_with(state, config)` composes `TraceLayer` (outermost, per-request access logging), then an opt-in `CorsLayer` (from `CorsPolicy`), then `RequestBodyLimitLayer` (innermost, 2 MiB default cap, returns 413 on oversize when the request carries a `content-length` header).
- `app::router(state)` stays as the default-config entry point used by every existing test helper, so `test_helpers.rs` is unchanged.
- `main.rs` now serves via `app::router_with(state, LayerConfig::from_env())`, reading `KANBAN_CORS_ORIGINS` (comma-separated origins, or `*` for permissive) at startup.
- `CorsPolicy::parse` collapses any CSV containing a `*` entry to `Permissive` rather than passing it to `AllowOrigin::list`, which panics on a wildcard entry.
- `tower-http`'s `limit` feature added to the workspace dependency (`trace` and `cors` were already enabled).
- README documents the `KANBAN_CORS_ORIGINS` knob, the 2 MiB body cap, and the TraceLayer-based access logging.
- Changeset added.

## Out of scope

`TimeoutLayer` is not included here; KAN-1563 owns it, including the SSE-survival question, and will add a `timeout` field to `LayerConfig` plus the `timeout` cargo feature.

## Coordination notes

- When the import/export routes land, they must apply their own larger `RequestBodyLimitLayer` on their specific route rather than inheriting this 2 MiB default, and their card should name the limit explicitly.
- KAN-1563 will extend `LayerConfig` with a `timeout` field; every test in this PR constructs `LayerConfig` with `..Default::default()` so that addition should not require touching these tests.

## Testing

- `cargo test -p kanban-server --all-features` (new `tests/layers.rs`, `tests/layers_trace.rs`, and the `CorsPolicy` unit tests in `src/layers.rs`, plus the full existing suite, all green)
- `cargo test --all-features --workspace` green
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- Mutation check: reverting the body-limit layer application made `test_oversized_body_returns_413` fail with 422 instead of 413, confirming the test actually exercises the fix.
