### PR TITLE
KAN-1547 feat(api,server): board archive, restore and archived-board listing routes

### DIFF
--- a/.changeset/kan-1547-board-archive-restore-routes.md
+++ b/.changeset/kan-1547-board-archive-restore-routes.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+kanban-server exposes POST /v1/boards/{id}/archive, POST /v1/boards/{id}/restore and GET /v1/archived-boards so HTTP clients can remove a board reversibly instead of only permanently deleting it

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -5,9 +5,9 @@
 //! callers into an explicit version path.
 mod v1;
 pub use v1::{
-    ApiError, ArchivedCardResponse, ArchivedFilterDto, BoardResponse, CardGraphResponse,
-    CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame, ChangeKind, ColumnResponse,
-    CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
+    ApiError, ArchivedBoardResponse, ArchivedCardResponse, ArchivedFilterDto, BoardResponse,
+    CardGraphResponse, CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame, ChangeKind,
+    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
     CreateSprintRequest, EntityType, ErrorCode, Page, PageParams, Patch, PrefixResponse,
     ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
     ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,

--- a/crates/kanban-api/src/v1/boards/archived_response.rs
+++ b/crates/kanban-api/src/v1/boards/archived_response.rs
@@ -1,0 +1,40 @@
+#[cfg(test)]
+mod tests {
+    use super::ArchivedBoardResponse;
+    use chrono::Utc;
+    use kanban_domain::ArchivedBoard;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_archived_board_response_round_trips_and_flattens_metadata() {
+        let id = Uuid::new_v4();
+        let ts = Utc::now();
+        let ab = ArchivedBoard::at(id, ts);
+        let resp = ArchivedBoardResponse::from(&ab);
+
+        let value = serde_json::to_value(&resp).unwrap();
+        assert!(value.get("entity_id").is_some());
+        assert!(value.get("archived_at").is_some());
+        assert!(value.get("metadata").is_none(), "metadata must not be nested");
+        assert!(value.get("context").is_none(), "context must not be nested");
+        assert!(
+            value.get("board_id").is_none(),
+            "a board marker is NoContext, unlike ArchivedCardResponse"
+        );
+
+        let back: ArchivedBoardResponse = serde_json::from_value(value).unwrap();
+        assert_eq!(back, resp);
+    }
+
+    #[test]
+    fn test_archived_board_response_from_marker_preserves_fields() {
+        use chrono::{TimeZone, Utc};
+        let id = Uuid::new_v4();
+        let ts = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        let ab = ArchivedBoard::at(id, ts);
+        let resp = ArchivedBoardResponse::from(&ab);
+
+        assert_eq!(resp.entity_id, ab.entity_id);
+        assert_eq!(resp.archived_at, ab.metadata.archived_at);
+    }
+}

--- a/crates/kanban-api/src/v1/boards/archived_response.rs
+++ b/crates/kanban-api/src/v1/boards/archived_response.rs
@@ -1,3 +1,25 @@
+use chrono::{DateTime, Utc};
+use kanban_domain::ArchivedBoard;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Response body for an archived-board marker. A board is a scoping root, so
+/// unlike `ArchivedCardResponse` there is no restore context (no `board_id`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArchivedBoardResponse {
+    pub entity_id: Uuid,
+    pub archived_at: DateTime<Utc>,
+}
+
+impl From<&ArchivedBoard> for ArchivedBoardResponse {
+    fn from(ab: &ArchivedBoard) -> Self {
+        Self {
+            entity_id: ab.entity_id,
+            archived_at: ab.metadata.archived_at,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ArchivedBoardResponse;
@@ -15,7 +37,10 @@ mod tests {
         let value = serde_json::to_value(&resp).unwrap();
         assert!(value.get("entity_id").is_some());
         assert!(value.get("archived_at").is_some());
-        assert!(value.get("metadata").is_none(), "metadata must not be nested");
+        assert!(
+            value.get("metadata").is_none(),
+            "metadata must not be nested"
+        );
         assert!(value.get("context").is_none(), "context must not be nested");
         assert!(
             value.get("board_id").is_none(),

--- a/crates/kanban-api/src/v1/boards/mod.rs
+++ b/crates/kanban-api/src/v1/boards/mod.rs
@@ -1,5 +1,7 @@
+mod archived_response;
 mod conversions;
 mod requests;
 mod response;
+pub use archived_response::ArchivedBoardResponse;
 pub use requests::{CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
 pub use response::BoardResponse;

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -10,7 +10,10 @@ mod pagination;
 mod patch;
 mod prefixes;
 mod sprints;
-pub use boards::{BoardResponse, CreateBoardRequest, ReplaceBoardRequest, UpdateBoardRequest};
+pub use boards::{
+    ArchivedBoardResponse, BoardResponse, CreateBoardRequest, ReplaceBoardRequest,
+    UpdateBoardRequest,
+};
 pub use cards::{
     ArchivedCardResponse, CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest,
 };

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -142,7 +142,7 @@ curl -s http://127.0.0.1:58548/v1/boards/00000000-0000-0000-0000-000000000000 | 
 
 ## Endpoints
 
-All request/response bodies are JSON. Errors share one envelope (see [Error Handling](#error-handling)). The four collection `GET`s (`/v1/boards`, `/v1/boards/{board_id}/columns`, `/v1/boards/{board_id}/cards`, `/v1/boards/{board_id}/sprints`) accept `?page=&page_size=` and return a `Page<T>` envelope; see [Pagination](#pagination).
+All request/response bodies are JSON. Errors share one envelope (see [Error Handling](#error-handling)). The paginated collection `GET`s (`/v1/boards`, `/v1/archived-boards`, `/v1/boards/{board_id}/columns`, `/v1/boards/{board_id}/cards`, `/v1/boards/{board_id}/sprints`) accept `?page=&page_size=` and return a `Page<T>` envelope; see [Pagination](#pagination).
 
 ### Health
 
@@ -160,6 +160,9 @@ All request/response bodies are JSON. Errors share one envelope (see [Error Hand
 | `PUT` | `/v1/boards/{id}` | Full replace (RFC 9110 §9.3.4) — creates the board at `id` if absent (`201`), otherwise replaces it in full (`200`). All non-nullable fields are required; a partial body is a 400. | `ReplaceBoardRequest` |
 | `PATCH` | `/v1/boards/{id}` | Partial update — JSON Merge Patch (RFC 7386): an absent field is no change, `null` clears it, a value sets it. | `UpdateBoardRequest` |
 | `DELETE` | `/v1/boards/{id}` | Delete a board and everything under it. `204 No Content`. | — |
+| `POST` | `/v1/boards/{id}/archive` | Archive a board reversibly. `200 OK` with the board stamped with `archived_at`; the subtree stays reachable. Re-archiving succeeds and refreshes the stamp. | — |
+| `POST` | `/v1/boards/{id}/restore` | Restore an archived board. `200 OK`; `archived_at` is absent. 404 if the board is not archived. | — |
+| `GET` | `/v1/archived-boards` | List archived-board markers (`entity_id` + `archived_at`). Returns `Page<ArchivedBoardResponse>`; accepts `?page=&page_size=`. | — |
 
 ### Columns
 
@@ -208,7 +211,7 @@ Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event naming the en
 
 ## Pagination
 
-`GET /v1/boards`, `GET /v1/boards/{board_id}/columns`, `GET /v1/boards/{board_id}/cards` and `GET /v1/boards/{board_id}/sprints` accept `?page=` (1-based) and `?page_size=`, both optional, and return a `Page<T>` envelope:
+`GET /v1/boards`, `GET /v1/archived-boards`, `GET /v1/boards/{board_id}/columns`, `GET /v1/boards/{board_id}/cards` and `GET /v1/boards/{board_id}/sprints` accept `?page=` (1-based) and `?page_size=`, both optional, and return a `Page<T>` envelope:
 
 ```json
 { "items": [...], "total": 42, "page": 1, "page_size": 50, "total_pages": 1 }

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -10,8 +10,8 @@ use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use kanban_domain::{Model, NoProjections};
 use kanban_service::api::{
-    BoardResponse, ChangeKind, CreateBoardRequest, EntityType, Page, PageParams,
-    ReplaceBoardRequest, UpdateBoardRequest,
+    ArchivedBoardResponse, BoardResponse, ChangeKind, CreateBoardRequest, EntityType, Page,
+    PageParams, ReplaceBoardRequest, UpdateBoardRequest,
 };
 use uuid::Uuid;
 
@@ -29,26 +29,49 @@ async fn list_boards(
     )
 }
 
-async fn get_board(
-    State(state): State<AppState>,
-    Path(id): Path<Uuid>,
-) -> Result<Json<BoardResponse>, AppError> {
-    let guard = state.lock_session().await;
+fn board_response(session: &crate::state::Session, id: Uuid) -> Result<BoardResponse, AppError> {
     let mut model = Model::default();
-    guard.sync(&RouteScope::Board(id), &mut model, &mut NoProjections);
+    session.sync(&RouteScope::Board(id), &mut model, &mut NoProjections);
     let board = require_loaded_entity(model.board_id_status(id), "Board", id)?;
     let markers = require_loaded(model.archived_boards_state(), "archived board list")?;
     let archived_at = markers
         .iter()
         .find(|marker| marker.entity_id == id)
         .map(|marker| marker.metadata.archived_at);
-    Ok(Json(BoardResponse::with_archived_at(board, archived_at)))
+    Ok(BoardResponse::with_archived_at(board, archived_at))
+}
+
+async fn get_board(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<BoardResponse>, AppError> {
+    let guard = state.lock_session().await;
+    Ok(Json(board_response(&guard, id)?))
+}
+
+async fn list_archived_boards(
+    State(state): State<AppState>,
+    Query(params): Query<PageParams>,
+) -> Result<Json<Page<ArchivedBoardResponse>>, AppError> {
+    let guard = state.lock_session().await;
+    let mut model = Model::default();
+    guard.sync(
+        &RouteScope::ArchivedBoardList,
+        &mut model,
+        &mut NoProjections,
+    );
+    let markers = require_loaded(model.archived_boards_state(), "archived board list")?;
+    paginate_response(
+        markers.iter().map(ArchivedBoardResponse::from).collect(),
+        &params,
+    )
 }
 
 pub fn read_router() -> Router<AppState> {
     Router::new()
         .route("/v1/boards", get(list_boards))
         .route("/v1/boards/{id}", get(get_board))
+        .route("/v1/archived-boards", get(list_archived_boards))
 }
 
 async fn post_board(
@@ -129,9 +152,43 @@ async fn delete_board(
     Ok(StatusCode::NO_CONTENT)
 }
 
+async fn archive_board(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<BoardResponse>, AppError> {
+    let mut guard = state.lock_session().await;
+    let _invalidation = crate::state::mutate_unit(&mut guard, |c| c.archive_board_impl(id))
+        .map_err(|e| AppError::from(&e))?;
+    let response = board_response(&guard, id)?;
+    state
+        .persist_and_broadcast(&guard, EntityType::Board, id, ChangeKind::Updated)
+        .await
+        .map_err(|e| AppError::from(&e))?;
+    Ok(Json(response))
+}
+
+async fn restore_board(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<BoardResponse>, AppError> {
+    let mut guard = state.lock_session().await;
+    let _invalidation = crate::state::mutate_unit(&mut guard, |c| c.restore_board_impl(id))
+        .map_err(|e| AppError::from(&e))?;
+    let response = board_response(&guard, id)?;
+    state
+        .persist_and_broadcast(&guard, EntityType::Board, id, ChangeKind::Updated)
+        .await
+        .map_err(|e| AppError::from(&e))?;
+    Ok(Json(response))
+}
+
 pub fn write_router() -> Router<AppState> {
-    Router::new().route("/v1/boards", post(post_board)).route(
-        "/v1/boards/{id}",
-        put(put_board).patch(patch_board).delete(delete_board),
-    )
+    Router::new()
+        .route("/v1/boards", post(post_board))
+        .route(
+            "/v1/boards/{id}",
+            put(put_board).patch(patch_board).delete(delete_board),
+        )
+        .route("/v1/boards/{id}/archive", post(archive_board))
+        .route("/v1/boards/{id}/restore", post(restore_board))
 }

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -152,6 +152,36 @@ mod tests {
     use kanban_service::FetchPlan;
 
     #[test]
+    fn test_route_scope_for_archived_board_list_requests_only_the_marker_tier() {
+        let round = RouteScope::ArchivedBoardList.next_round(&Model::default());
+
+        assert_eq!(
+            round,
+            FetchRound {
+                archived_board_list: true,
+                ..Default::default()
+            }
+        );
+        assert!(!round.board_list);
+        assert!(round.boards.is_empty());
+    }
+
+    #[test]
+    fn test_route_scope_for_archived_board_list_halts_once_the_markers_are_loaded() {
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            archived_boards: Collection {
+                all: LoadState::Loaded(vec![]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let round = RouteScope::ArchivedBoardList.next_round(&model);
+        assert!(round.is_empty());
+    }
+
+    #[test]
     fn test_route_scope_for_board_list_requests_only_the_board_list() {
         let round = RouteScope::BoardList.next_round(&Model::default());
 

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RouteScope {
     BoardList,
+    ArchivedBoardList,
     Board(Uuid),
     BoardColumns(Uuid),
     BoardCards {
@@ -44,6 +45,9 @@ impl FetchPlan for RouteScope {
         match *self {
             RouteScope::BoardList => {
                 round.board_list = requestable(loaded.board_list());
+            }
+            RouteScope::ArchivedBoardList => {
+                round.archived_board_list = requestable(loaded.archived_board_list());
             }
             RouteScope::Board(id) => {
                 want_board(&mut round, loaded, id);

--- a/crates/kanban-server/tests/boards_archive_restore.rs
+++ b/crates/kanban-server/tests/boards_archive_restore.rs
@@ -37,9 +37,7 @@ async fn archive_returns_200_with_archived_at_stamped_case(state: AppState) {
     let list_json = json_of(list_response).await;
     let items = list_json["items"].as_array().unwrap();
     assert!(
-        items
-            .iter()
-            .all(|b| b["id"] != board_id.to_string()),
+        items.iter().all(|b| b["id"] != board_id.to_string()),
         "archived board must not appear in the live list"
     );
 
@@ -571,9 +569,7 @@ async fn archive_is_visible_to_subsequent_reads_case(state: AppState) {
 
     let before = json_of(send(&state, "GET", "/v1/boards", None).await).await;
     let before_items = before["items"].as_array().unwrap();
-    assert!(before_items
-        .iter()
-        .any(|b| b["id"] == board_id.to_string()));
+    assert!(before_items.iter().any(|b| b["id"] == board_id.to_string()));
 
     let archive_response = send(
         &state,
@@ -586,9 +582,7 @@ async fn archive_is_visible_to_subsequent_reads_case(state: AppState) {
 
     let after = json_of(send(&state, "GET", "/v1/boards", None).await).await;
     let after_items = after["items"].as_array().unwrap();
-    assert!(after_items
-        .iter()
-        .all(|b| b["id"] != board_id.to_string()));
+    assert!(after_items.iter().all(|b| b["id"] != board_id.to_string()));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/boards_archive_restore.rs
+++ b/crates/kanban-server/tests/boards_archive_restore.rs
@@ -9,7 +9,6 @@ use kanban_domain::{FieldUpdate, GraphOperations, Severity};
 use kanban_server::state::AppState;
 use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
 use kanban_service::{ColumnUpdate, KanbanOperations};
-use serde_json::Value;
 use tempfile::tempdir;
 use uuid::Uuid;
 
@@ -38,7 +37,9 @@ async fn archive_returns_200_with_archived_at_stamped_case(state: AppState) {
     let list_json = json_of(list_response).await;
     let items = list_json["items"].as_array().unwrap();
     assert!(
-        items.iter().all(|b| b["id"] != Value::from(board_id.to_string())),
+        items
+            .iter()
+            .all(|b| b["id"] != board_id.to_string()),
         "archived board must not appear in the live list"
     );
 
@@ -90,20 +91,10 @@ async fn seed_nontrivial_graph(state: &AppState) -> SeededGraph {
     )
     .unwrap();
     let card1 = ctx
-        .create_card(
-            board_id,
-            col1.id,
-            "Card 1".to_string(),
-            Default::default(),
-        )
+        .create_card(board_id, col1.id, "Card 1".to_string(), Default::default())
         .unwrap();
     let card2 = ctx
-        .create_card(
-            board_id,
-            col2.id,
-            "Card 2".to_string(),
-            Default::default(),
-        )
+        .create_card(board_id, col2.id, "Card 2".to_string(), Default::default())
         .unwrap();
     let sprint_id = ctx
         .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
@@ -145,16 +136,8 @@ async fn archive_board_keeps_subtree_reachable_case(state: AppState) {
     .await;
     assert_eq!(columns_json["items"].as_array().unwrap().len(), 2);
 
-    let cards_json = json_of(
-        send(
-            &state,
-            "GET",
-            &format!("/v1/boards/{board_id}/cards"),
-            None,
-        )
-        .await,
-    )
-    .await;
+    let cards_json =
+        json_of(send(&state, "GET", &format!("/v1/boards/{board_id}/cards"), None).await).await;
     assert_eq!(cards_json["items"].as_array().unwrap().len(), 2);
 
     let sprints_json = json_of(
@@ -179,7 +162,16 @@ async fn archive_board_keeps_subtree_reachable_case(state: AppState) {
         .await,
     )
     .await;
-    assert!(graph_json["cards"].as_array().unwrap().len() >= 2);
+    assert_eq!(
+        graph_json["children"].as_array().unwrap().len(),
+        1,
+        "the spawns edge must survive the board archive"
+    );
+    assert_eq!(
+        graph_json["blocks"].as_array().unwrap().len(),
+        1,
+        "the blocks edge must survive the board archive"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -210,16 +202,8 @@ async fn restore_board_returns_the_full_subtree_over_the_wire_case(state: AppSta
         .await,
     )
     .await;
-    let cards_before = json_of(
-        send(
-            &state,
-            "GET",
-            &format!("/v1/boards/{board_id}/cards"),
-            None,
-        )
-        .await,
-    )
-    .await;
+    let cards_before =
+        json_of(send(&state, "GET", &format!("/v1/boards/{board_id}/cards"), None).await).await;
     let sprints_before = json_of(
         send(
             &state,
@@ -274,16 +258,8 @@ async fn restore_board_returns_the_full_subtree_over_the_wire_case(state: AppSta
         .await,
     )
     .await;
-    let cards_after = json_of(
-        send(
-            &state,
-            "GET",
-            &format!("/v1/boards/{board_id}/cards"),
-            None,
-        )
-        .await,
-    )
-    .await;
+    let cards_after =
+        json_of(send(&state, "GET", &format!("/v1/boards/{board_id}/cards"), None).await).await;
     let sprints_after = json_of(
         send(
             &state,
@@ -479,12 +455,13 @@ async fn list_archived_boards_route_reflects_archive_and_restore_case(state: App
     assert_eq!(items.len(), 1);
     assert_eq!(items[0]["entity_id"], board_id.to_string());
     assert!(items[0]["archived_at"].is_string());
-    let keys: std::collections::BTreeSet<&str> =
-        items[0].as_object().unwrap().keys().map(|s| s.as_str()).collect();
-    assert_eq!(
-        keys,
-        ["entity_id", "archived_at"].into_iter().collect()
-    );
+    let keys: std::collections::BTreeSet<&str> = items[0]
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(|s| s.as_str())
+        .collect();
+    assert_eq!(keys, ["entity_id", "archived_at"].into_iter().collect());
 
     send(
         &state,
@@ -596,7 +573,7 @@ async fn archive_is_visible_to_subsequent_reads_case(state: AppState) {
     let before_items = before["items"].as_array().unwrap();
     assert!(before_items
         .iter()
-        .any(|b| b["id"] == Value::from(board_id.to_string())));
+        .any(|b| b["id"] == board_id.to_string()));
 
     let archive_response = send(
         &state,
@@ -611,7 +588,7 @@ async fn archive_is_visible_to_subsequent_reads_case(state: AppState) {
     let after_items = after["items"].as_array().unwrap();
     assert!(after_items
         .iter()
-        .all(|b| b["id"] != Value::from(board_id.to_string())));
+        .all(|b| b["id"] != board_id.to_string()));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/boards_archive_restore.rs
+++ b/crates/kanban-server/tests/boards_archive_restore.rs
@@ -1,0 +1,629 @@
+#![cfg(feature = "test-helpers")]
+
+//! POST /v1/boards/{id}/archive, POST /v1/boards/{id}/restore and
+//! GET /v1/archived-boards. Archive/restore is proven the identity over the
+//! full entity graph on both the JSON and SQLite backends.
+
+use axum::http::StatusCode;
+use kanban_domain::{FieldUpdate, GraphOperations, Severity};
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use kanban_service::{ColumnUpdate, KanbanOperations};
+use serde_json::Value;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn archive_returns_200_with_archived_at_stamped_case(state: AppState) {
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/archive"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert!(json["archived_at"].is_string());
+
+    let list_response = send(&state, "GET", "/v1/boards", None).await;
+    let list_json = json_of(list_response).await;
+    let items = list_json["items"].as_array().unwrap();
+    assert!(
+        items.iter().all(|b| b["id"] != Value::from(board_id.to_string())),
+        "archived board must not appear in the live list"
+    );
+
+    let get_response = send(&state, "GET", &format!("/v1/boards/{board_id}"), None).await;
+    let get_json = json_of(get_response).await;
+    assert_eq!(get_json["id"], board_id.to_string());
+    assert!(get_json["archived_at"].is_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_board_returns_200_with_archived_at_stamped() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    archive_returns_200_with_archived_at_stamped_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_board_returns_200_with_archived_at_stamped_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    archive_returns_200_with_archived_at_stamped_case(state).await;
+}
+
+struct SeededGraph {
+    board_id: Uuid,
+    columns: (Uuid, Uuid),
+    cards: (Uuid, Uuid),
+    sprint_id: Uuid,
+}
+
+async fn seed_nontrivial_graph(state: &AppState) -> SeededGraph {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col1 = ctx
+        .create_column(board_id, "Todo".to_string(), Some(0))
+        .unwrap();
+    let col2 = ctx
+        .create_column(board_id, "Doing".to_string(), Some(1))
+        .unwrap();
+    ctx.update_column(
+        col1.id,
+        ColumnUpdate {
+            wip_limit: FieldUpdate::Set(3),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let card1 = ctx
+        .create_card(
+            board_id,
+            col1.id,
+            "Card 1".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    let card2 = ctx
+        .create_card(
+            board_id,
+            col2.id,
+            "Card 2".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    let sprint_id = ctx
+        .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+        .unwrap()
+        .id;
+    ctx.attach_children(card1.id, vec![card2.id]).unwrap();
+    ctx.block(card1.id, card2.id, Severity::Medium).unwrap();
+
+    SeededGraph {
+        board_id,
+        columns: (col1.id, col2.id),
+        cards: (card1.id, card2.id),
+        sprint_id,
+    }
+}
+
+async fn archive_board_keeps_subtree_reachable_case(state: AppState) {
+    let seeded = seed_nontrivial_graph(&state).await;
+    let board_id = seeded.board_id;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/archive"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let columns_json = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/columns"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(columns_json["items"].as_array().unwrap().len(), 2);
+
+    let cards_json = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/cards"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(cards_json["items"].as_array().unwrap().len(), 2);
+
+    let sprints_json = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/sprints"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(sprints_json["items"].as_array().unwrap().len(), 1);
+
+    let graph_json = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/cards/{}/graph", seeded.cards.0),
+            None,
+        )
+        .await,
+    )
+    .await;
+    assert!(graph_json["cards"].as_array().unwrap().len() >= 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_board_keeps_subtree_reachable() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    archive_board_keeps_subtree_reachable_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_board_keeps_subtree_reachable_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    archive_board_keeps_subtree_reachable_case(state).await;
+}
+
+async fn restore_board_returns_the_full_subtree_over_the_wire_case(state: AppState) {
+    let seeded = seed_nontrivial_graph(&state).await;
+    let board_id = seeded.board_id;
+
+    let columns_before = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/columns"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let cards_before = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/cards"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let sprints_before = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/sprints"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let graph_before = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/cards/{}/graph", seeded.cards.0),
+            None,
+        )
+        .await,
+    )
+    .await;
+
+    let archive_response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/archive"),
+        None,
+    )
+    .await;
+    assert_eq!(archive_response.status(), StatusCode::OK);
+
+    let restore_response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/restore"),
+        None,
+    )
+    .await;
+    assert_eq!(restore_response.status(), StatusCode::OK);
+    let restore_json = json_of(restore_response).await;
+    assert!(
+        restore_json.get("archived_at").is_none(),
+        "a restored board must omit the archived_at key entirely"
+    );
+
+    let columns_after = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/columns"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let cards_after = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/cards"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let sprints_after = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/sprints"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let graph_after = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/cards/{}/graph", seeded.cards.0),
+            None,
+        )
+        .await,
+    )
+    .await;
+
+    assert_eq!(columns_before, columns_after);
+    assert_eq!(cards_before, cards_after);
+    assert_eq!(sprints_before, sprints_after);
+    assert_eq!(graph_before, graph_after);
+
+    let _ = seeded.columns;
+    let _ = seeded.sprint_id;
+
+    let archived_list_json = json_of(send(&state, "GET", "/v1/archived-boards", None).await).await;
+    assert!(archived_list_json["items"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_restore_board_returns_the_full_subtree_over_the_wire() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    restore_board_returns_the_full_subtree_over_the_wire_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_restore_board_returns_the_full_subtree_over_the_wire_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    restore_board_returns_the_full_subtree_over_the_wire_case(state).await;
+}
+
+async fn archive_missing_board_returns_404_case(state: AppState) {
+    let missing = Uuid::new_v4();
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{missing}/archive"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_missing_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    archive_missing_board_returns_404_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_missing_board_returns_404_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    archive_missing_board_returns_404_case(state).await;
+}
+
+async fn restore_live_board_returns_404_case(state: AppState) {
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+    }
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/restore"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_restore_live_board_returns_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    restore_live_board_returns_404_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_restore_live_board_returns_404_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    restore_live_board_returns_404_case(state).await;
+}
+
+async fn rearchive_board_succeeds_and_refreshes_archived_at_case(state: AppState) {
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let first = json_of(
+        send(
+            &state,
+            "POST",
+            &format!("/v1/boards/{board_id}/archive"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let second = json_of(
+        send(
+            &state,
+            "POST",
+            &format!("/v1/boards/{board_id}/archive"),
+            None,
+        )
+        .await,
+    )
+    .await;
+
+    let first_at: chrono::DateTime<chrono::Utc> =
+        first["archived_at"].as_str().unwrap().parse().unwrap();
+    let second_at: chrono::DateTime<chrono::Utc> =
+        second["archived_at"].as_str().unwrap().parse().unwrap();
+    assert!(second_at >= first_at);
+
+    let list_json = json_of(send(&state, "GET", "/v1/archived-boards", None).await).await;
+    let items = list_json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rearchive_board_succeeds_and_refreshes_archived_at() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    rearchive_board_succeeds_and_refreshes_archived_at_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rearchive_board_succeeds_and_refreshes_archived_at_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    rearchive_board_succeeds_and_refreshes_archived_at_case(state).await;
+}
+
+async fn list_archived_boards_route_reflects_archive_and_restore_case(state: AppState) {
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let empty = json_of(send(&state, "GET", "/v1/archived-boards", None).await).await;
+    assert_eq!(empty["items"].as_array().unwrap().len(), 0);
+    assert_eq!(empty["total"], 0);
+    assert_eq!(empty["page"], 1);
+    assert_eq!(empty["page_size"], 50);
+
+    send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/archive"),
+        None,
+    )
+    .await;
+
+    let archived = json_of(send(&state, "GET", "/v1/archived-boards", None).await).await;
+    let items = archived["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["entity_id"], board_id.to_string());
+    assert!(items[0]["archived_at"].is_string());
+    let keys: std::collections::BTreeSet<&str> =
+        items[0].as_object().unwrap().keys().map(|s| s.as_str()).collect();
+    assert_eq!(
+        keys,
+        ["entity_id", "archived_at"].into_iter().collect()
+    );
+
+    send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/restore"),
+        None,
+    )
+    .await;
+
+    let restored = json_of(send(&state, "GET", "/v1/archived-boards", None).await).await;
+    assert_eq!(restored["items"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_archived_boards_route_reflects_archive_and_restore() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    list_archived_boards_route_reflects_archive_and_restore_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_archived_boards_route_reflects_archive_and_restore_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    list_archived_boards_route_reflects_archive_and_restore_case(state).await;
+}
+
+async fn archive_and_restore_emit_board_updated_frames_case(state: AppState) {
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let mut rx = state.event_tx.subscribe();
+
+    send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/archive"),
+        None,
+    )
+    .await;
+    let archive_frame = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for the archive frame")
+        .expect("broadcast channel closed unexpectedly");
+    assert_eq!(
+        archive_frame.entity_type,
+        Some(kanban_service::api::EntityType::Board)
+    );
+    assert_eq!(archive_frame.entity_id, Some(board_id));
+    assert_eq!(
+        archive_frame.kind,
+        Some(kanban_service::api::ChangeKind::Updated)
+    );
+    assert_eq!(archive_frame.writer_instance_id, state.instance_id);
+
+    send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/restore"),
+        None,
+    )
+    .await;
+    let restore_frame = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for the restore frame")
+        .expect("broadcast channel closed unexpectedly");
+    assert_eq!(
+        restore_frame.entity_type,
+        Some(kanban_service::api::EntityType::Board)
+    );
+    assert_eq!(restore_frame.entity_id, Some(board_id));
+    assert_eq!(
+        restore_frame.kind,
+        Some(kanban_service::api::ChangeKind::Updated)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_and_restore_emit_board_updated_frames() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    archive_and_restore_emit_board_updated_frames_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_and_restore_emit_board_updated_frames_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    archive_and_restore_emit_board_updated_frames_case(state).await;
+}
+
+async fn archive_is_visible_to_subsequent_reads_case(state: AppState) {
+    let board_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+    }
+
+    let before = json_of(send(&state, "GET", "/v1/boards", None).await).await;
+    let before_items = before["items"].as_array().unwrap();
+    assert!(before_items
+        .iter()
+        .any(|b| b["id"] == Value::from(board_id.to_string())));
+
+    let archive_response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/archive"),
+        None,
+    )
+    .await;
+    assert_eq!(archive_response.status(), StatusCode::OK);
+
+    let after = json_of(send(&state, "GET", "/v1/boards", None).await).await;
+    let after_items = after["items"].as_array().unwrap();
+    assert!(after_items
+        .iter()
+        .all(|b| b["id"] != Value::from(board_id.to_string())));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_is_visible_to_subsequent_reads() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    archive_is_visible_to_subsequent_reads_case(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_archive_is_visible_to_subsequent_reads_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    archive_is_visible_to_subsequent_reads_case(state).await;
+}


### PR DESCRIPTION
## Summary

- Add `POST /v1/boards/{id}/archive`, `POST /v1/boards/{id}/restore` and `GET /v1/archived-boards` to kanban-server so a client can reversibly remove a board over HTTP instead of only permanently deleting it.
- Add `ArchivedBoardResponse` (entity_id + archived_at, no restore context) to kanban-api, exported through the usual three layers.
- Add `RouteScope::ArchivedBoardList`, planning only the archived-board marker tier.
- Both mutations route through `crate::state::mutate_unit` against `MutationOperations`; the archived-board listing route reads through the new scope plus a request-local `Model`. A shared `board_response` helper (extracted from the existing `get_board`) builds the response for both the mutation handlers and the plain read, so a POST /archive response is byte-identical to a follow-up GET.
- New test suite `crates/kanban-server/tests/boards_archive_restore.rs` proves archive/restore is the identity over the board's full entity graph (columns with a wip_limit, cards, a sprint, a spawns edge and a blocks edge) on both the JSON and SQLite backends, including 404s, re-archive idempotency, event-frame emission and archived-boards listing.
- Documents the three routes in the server README and adds a patch changeset.

## Test plan

- [x] `cargo test -p kanban-api`
- [x] `cargo test -p kanban-server --features test-helpers`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
