### PR TITLE
KAN-1549 feat(server): sprint activate, complete, cancel and carry-over routes

### DIFF
--- a/.changeset/kan-1549-sprint-lifecycle-routes.md
+++ b/.changeset/kan-1549-sprint-lifecycle-routes.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+kanban-server exposes POST routes to activate, complete, cancel and carry over sprints

--- a/crates/kanban-api/README.md
+++ b/crates/kanban-api/README.md
@@ -16,10 +16,11 @@ Re-exported from `src/lib.rs` (`pub use v1::{ ... }`):
 
 ```rust
 pub use v1::{
-    ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
-    CardStatusDto, ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest,
-    CreateCardRequest, CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType,
-    ErrorCode, Page, PageParams, Patch, PrefixResponse, ReorderColumnRequest, ReplaceBoardRequest,
+    ActivateSprintRequest, ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse,
+    CardPriorityDto, CardResponse, CardStatusDto, CarryOverRequest, CarryOverResponse,
+    ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest, CreateCardRequest,
+    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType, ErrorCode, Page,
+    PageParams, Patch, PrefixResponse, ReorderColumnRequest, ReplaceBoardRequest,
     ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto,
     SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest,
     UpdateColumnRequest, UpdateSprintRequest,

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -5,8 +5,9 @@
 //! callers into an explicit version path.
 mod v1;
 pub use v1::{
-    ApiError, ArchivedBoardResponse, ArchivedCardResponse, ArchivedFilterDto, BoardResponse,
-    CardGraphResponse, CardPriorityDto, CardResponse, CardStatusDto, ChangeEventFrame, ChangeKind,
+    ActivateSprintRequest, ApiError, ArchivedBoardResponse, ArchivedCardResponse,
+    ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
+    CardStatusDto, CarryOverRequest, CarryOverResponse, ChangeEventFrame, ChangeKind,
     ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
     CreateSprintRequest, EntityType, ErrorCode, Page, PageParams, Patch, PrefixResponse,
     ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -32,6 +32,6 @@ pub use pagination::{Page, PageParams};
 pub use patch::Patch;
 pub use prefixes::PrefixResponse;
 pub use sprints::{
-    CreateSprintParts, CreateSprintRequest, ReplaceSprintRequest, SprintResponse,
-    UpdateSprintRequest,
+    ActivateSprintRequest, CarryOverRequest, CarryOverResponse, CreateSprintParts,
+    CreateSprintRequest, ReplaceSprintRequest, SprintResponse, UpdateSprintRequest,
 };

--- a/crates/kanban-api/src/v1/sprints/conversions.rs
+++ b/crates/kanban-api/src/v1/sprints/conversions.rs
@@ -10,8 +10,10 @@
 //! board. The DTO→domain seam therefore stops at [`CreateSprintParts`]; slice D
 //! mints `sprint_number` + `name_index` and assembles the final `NewSprint`.
 
-use super::requests::{CreateSprintRequest, ReplaceSprintRequest, UpdateSprintRequest};
-use kanban_domain::{FieldUpdate, SprintUpdate};
+use super::requests::{
+    ActivateSprintRequest, CreateSprintRequest, ReplaceSprintRequest, UpdateSprintRequest,
+};
+use kanban_domain::{FieldUpdate, KanbanError, KanbanResult, SprintUpdate};
 use uuid::Uuid;
 
 /// Intermediate split of a [`CreateSprintRequest`]: identity (optional client
@@ -92,6 +94,19 @@ fn option_to_field_update<T>(value: Option<T>) -> FieldUpdate<T> {
     }
 }
 
+impl ActivateSprintRequest {
+    pub fn validated_duration_days(&self) -> KanbanResult<Option<i32>> {
+        if let Some(d) = self.duration_days {
+            if !(0..=36_500).contains(&d) {
+                return Err(KanbanError::validation(format!(
+                    "sprint duration_days must be between 0 and 36500, got {d}"
+                )));
+            }
+        }
+        Ok(self.duration_days)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::super::Patch;
@@ -167,5 +182,34 @@ mod tests {
         // enforces the absence of those tokens; adding a `NewSprint`/
         // `SprintUpdate`/`Sprint` field then breaks the corresponding arm at
         // compile time.
+    }
+
+    #[test]
+    fn test_activate_request_validated_duration_rejects_negative_and_out_of_range() {
+        let req = ActivateSprintRequest {
+            duration_days: Some(-1),
+        };
+        assert!(req.validated_duration_days().is_err());
+
+        let req = ActivateSprintRequest {
+            duration_days: Some(36_501),
+        };
+        assert!(req.validated_duration_days().is_err());
+    }
+
+    #[test]
+    fn test_activate_request_validated_duration_accepts_none_and_in_range() {
+        let req = ActivateSprintRequest { duration_days: None };
+        assert_eq!(req.validated_duration_days().unwrap(), None);
+
+        let req = ActivateSprintRequest {
+            duration_days: Some(7),
+        };
+        assert_eq!(req.validated_duration_days().unwrap(), Some(7));
+
+        let req = ActivateSprintRequest {
+            duration_days: Some(0),
+        };
+        assert_eq!(req.validated_duration_days().unwrap(), Some(0));
     }
 }

--- a/crates/kanban-api/src/v1/sprints/conversions.rs
+++ b/crates/kanban-api/src/v1/sprints/conversions.rs
@@ -199,7 +199,9 @@ mod tests {
 
     #[test]
     fn test_activate_request_validated_duration_accepts_none_and_in_range() {
-        let req = ActivateSprintRequest { duration_days: None };
+        let req = ActivateSprintRequest {
+            duration_days: None,
+        };
         assert_eq!(req.validated_duration_days().unwrap(), None);
 
         let req = ActivateSprintRequest {

--- a/crates/kanban-api/src/v1/sprints/mod.rs
+++ b/crates/kanban-api/src/v1/sprints/mod.rs
@@ -2,5 +2,8 @@ mod conversions;
 mod requests;
 mod response;
 pub use conversions::CreateSprintParts;
-pub use requests::{CreateSprintRequest, ReplaceSprintRequest, UpdateSprintRequest};
-pub use response::SprintResponse;
+pub use requests::{
+    ActivateSprintRequest, CarryOverRequest, CreateSprintRequest, ReplaceSprintRequest,
+    UpdateSprintRequest,
+};
+pub use response::{CarryOverResponse, SprintResponse};

--- a/crates/kanban-api/src/v1/sprints/requests.rs
+++ b/crates/kanban-api/src/v1/sprints/requests.rs
@@ -63,6 +63,23 @@ pub struct ReplaceSprintRequest {
     pub card_prefix: Option<String>,
 }
 
+/// Request body for `POST /v1/boards/:board_id/sprints/:id/activate`.
+/// `duration_days` is optional; the service applies its own default when
+/// absent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct ActivateSprintRequest {
+    #[serde(default)]
+    pub duration_days: Option<i32>,
+}
+
+/// Request body for `POST /v1/boards/:board_id/sprints/:id/carry-over`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct CarryOverRequest {
+    pub to_sprint_id: Uuid,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,5 +170,28 @@ mod tests {
         assert_eq!(back.name, Some("Fresh".to_string()));
         assert_eq!(back.prefix, Some("SPR".to_string()));
         assert_eq!(back.card_prefix, None);
+    }
+
+    #[test]
+    fn test_activate_sprint_request_empty_object_defaults_duration_none() {
+        let req: ActivateSprintRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(req.duration_days, None);
+
+        let req = ActivateSprintRequest {
+            duration_days: Some(7),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: ActivateSprintRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.duration_days, Some(7));
+    }
+
+    #[test]
+    fn test_carry_over_request_requires_to_sprint_id() {
+        assert!(serde_json::from_str::<CarryOverRequest>("{}").is_err());
+
+        let id = Uuid::new_v4();
+        let json = format!(r#"{{"to_sprint_id":"{id}"}}"#);
+        let req: CarryOverRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req.to_sprint_id, id);
     }
 }

--- a/crates/kanban-api/src/v1/sprints/response.rs
+++ b/crates/kanban-api/src/v1/sprints/response.rs
@@ -60,6 +60,12 @@ impl SprintResponse {
     }
 }
 
+/// Response body for `POST /v1/boards/:board_id/sprints/:id/carry-over`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CarryOverResponse {
+    pub moved: usize,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,5 +131,14 @@ mod tests {
         let sprint = Sprint::new(Uuid::new_v4(), 2, None, None::<String>);
         let resp = SprintResponse::new(&sprint, None);
         assert_eq!(resp.name, None);
+    }
+
+    #[test]
+    fn test_carry_over_response_round_trips_moved_field() {
+        let resp = CarryOverResponse { moved: 3 };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json, serde_json::json!({"moved": 3}));
+        let back: CarryOverResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(back, resp);
     }
 }

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -183,6 +183,10 @@ Column writes (create/update/delete) aren't implemented yet.
 | `PUT` | `/v1/boards/{board_id}/sprints/{id}` | Full replace (RFC 9110 §9.3.4) — creates the sprint at `id` if absent (`201`), otherwise replaces it in full (`200`). 404s if `id` belongs to a different board. | `ReplaceSprintRequest` |
 | `PATCH` | `/v1/boards/{board_id}/sprints/{id}` | Partial update — JSON Merge Patch (RFC 7386). 404s if the sprint belongs to a different board. | `UpdateSprintRequest` |
 | `DELETE` | `/v1/boards/{board_id}/sprints/{id}` | Delete a sprint. `204 No Content`. 404s if the sprint belongs to a different board. | — |
+| `POST` | `/v1/boards/{board_id}/sprints/{id}/activate` | Activate a sprint, setting `start_date` to now and `end_date` to `start_date + duration_days`. `duration_days` defaults to 14 when omitted; values outside `0..=36500` are a `422`. Re-activating an already-active sprint resets both dates. 404s if the sprint belongs to a different board. | `ActivateSprintRequest` |
+| `POST` | `/v1/boards/{board_id}/sprints/{id}/complete` | Mark a sprint completed. 404s if the sprint belongs to a different board. | — |
+| `POST` | `/v1/boards/{board_id}/sprints/{id}/cancel` | Mark a sprint cancelled. 404s if the sprint belongs to a different board. | — |
+| `POST` | `/v1/boards/{board_id}/sprints/{id}/carry-over` | Move every uncompleted card from this sprint to `to_sprint_id`. `422` unless this sprint is completed or cancelled and `to_sprint_id` is in planning. 404s if either sprint belongs to a different board. Returns `CarryOverResponse` with the moved count. | `CarryOverRequest` |
 | `GET` | `/v1/sprints/{id}` | Flat alias for the board-scoped `GET`. | — |
 | `PATCH` | `/v1/sprints/{id}` | Flat alias for the board-scoped `PATCH`. | `UpdateSprintRequest` |
 | `DELETE` | `/v1/sprints/{id}` | Flat alias for the board-scoped `DELETE`. | — |

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -50,6 +50,7 @@ pub fn router_with(state: AppState, config: LayerConfig) -> Router {
         .merge(crate::routes::sprints::write_router())
         .merge(crate::routes::sprints::flat_read_router())
         .merge(crate::routes::sprints::flat_write_router())
+        .merge(crate::routes::sprints_lifecycle::write_router())
         .merge(crate::routes::events::router());
 
     let mut router = router.layer(RequestBodyLimitLayer::new(config.body_limit_bytes));

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -26,6 +26,7 @@ pub mod routes {
     pub mod graph;
     pub mod prefixes;
     pub mod sprints;
+    pub mod sprints_lifecycle;
 }
 
 pub mod handlers {

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -94,7 +94,7 @@ fn do_delete_sprint(ctx: &mut crate::state::Session, id: Uuid) -> Result<(), App
         .map_err(|e| AppError::from(&e))
 }
 
-fn require_sprint_in_board(
+pub(crate) fn require_sprint_in_board(
     ctx: &crate::state::Session,
     board_id: Uuid,
     id: Uuid,
@@ -106,7 +106,10 @@ fn require_sprint_in_board(
     Ok(())
 }
 
-fn respond(ctx: &crate::state::Session, sprint: &Sprint) -> Result<SprintResponse, AppError> {
+pub(crate) fn respond(
+    ctx: &crate::state::Session,
+    sprint: &Sprint,
+) -> Result<SprintResponse, AppError> {
     let name = resolve_sprint_name(ctx, sprint).map_err(|e| AppError::from(&e))?;
     Ok(SprintResponse::new(sprint, name))
 }

--- a/crates/kanban-server/src/routes/sprints_lifecycle.rs
+++ b/crates/kanban-server/src/routes/sprints_lifecycle.rs
@@ -13,7 +13,9 @@ async fn activate_sprint_route(
     Path((board_id, id)): Path<(Uuid, Uuid)>,
     AppJson(req): AppJson<ActivateSprintRequest>,
 ) -> Result<Json<SprintResponse>, AppError> {
-    let duration_days = req.validated_duration_days().map_err(|e| AppError::from(&e))?;
+    let duration_days = req
+        .validated_duration_days()
+        .map_err(|e| AppError::from(&e))?;
     let body = {
         let mut ctx = state.ctx.lock().await;
         require_sprint_in_board(&ctx, board_id, id)?;
@@ -37,8 +39,9 @@ async fn complete_sprint_route(
     let body = {
         let mut ctx = state.ctx.lock().await;
         require_sprint_in_board(&ctx, board_id, id)?;
-        let (sprint, _invalidation) = crate::state::mutate(&mut ctx, |c| c.complete_sprint_impl(id))
-            .map_err(|e| AppError::from(&e))?;
+        let (sprint, _invalidation) =
+            crate::state::mutate(&mut ctx, |c| c.complete_sprint_impl(id))
+                .map_err(|e| AppError::from(&e))?;
         let body = respond(&ctx, &sprint)?;
         state
             .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Updated)

--- a/crates/kanban-server/src/routes/sprints_lifecycle.rs
+++ b/crates/kanban-server/src/routes/sprints_lifecycle.rs
@@ -1,0 +1,111 @@
+use crate::error::{AppError, AppJson};
+use crate::routes::sprints::{require_sprint_in_board, respond};
+use crate::state::AppState;
+use axum::extract::{Path, State};
+use axum::routing::post;
+use axum::{Json, Router};
+use kanban_service::api::{ActivateSprintRequest, CarryOverRequest, CarryOverResponse};
+use kanban_service::api::{ChangeKind, EntityType, SprintResponse};
+use uuid::Uuid;
+
+async fn activate_sprint_route(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+    AppJson(req): AppJson<ActivateSprintRequest>,
+) -> Result<Json<SprintResponse>, AppError> {
+    let duration_days = req.validated_duration_days().map_err(|e| AppError::from(&e))?;
+    let body = {
+        let mut ctx = state.ctx.lock().await;
+        require_sprint_in_board(&ctx, board_id, id)?;
+        let (sprint, _invalidation) =
+            crate::state::mutate(&mut ctx, |c| c.activate_sprint_impl(id, duration_days))
+                .map_err(|e| AppError::from(&e))?;
+        let body = respond(&ctx, &sprint)?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        body
+    };
+    Ok(Json(body))
+}
+
+async fn complete_sprint_route(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<SprintResponse>, AppError> {
+    let body = {
+        let mut ctx = state.ctx.lock().await;
+        require_sprint_in_board(&ctx, board_id, id)?;
+        let (sprint, _invalidation) = crate::state::mutate(&mut ctx, |c| c.complete_sprint_impl(id))
+            .map_err(|e| AppError::from(&e))?;
+        let body = respond(&ctx, &sprint)?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        body
+    };
+    Ok(Json(body))
+}
+
+async fn cancel_sprint_route(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<SprintResponse>, AppError> {
+    let body = {
+        let mut ctx = state.ctx.lock().await;
+        require_sprint_in_board(&ctx, board_id, id)?;
+        let (sprint, _invalidation) = crate::state::mutate(&mut ctx, |c| c.cancel_sprint_impl(id))
+            .map_err(|e| AppError::from(&e))?;
+        let body = respond(&ctx, &sprint)?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        body
+    };
+    Ok(Json(body))
+}
+
+async fn carry_over_sprint_route(
+    State(state): State<AppState>,
+    Path((board_id, id)): Path<(Uuid, Uuid)>,
+    AppJson(req): AppJson<CarryOverRequest>,
+) -> Result<Json<CarryOverResponse>, AppError> {
+    let moved = {
+        let mut ctx = state.ctx.lock().await;
+        require_sprint_in_board(&ctx, board_id, id)?;
+        require_sprint_in_board(&ctx, board_id, req.to_sprint_id)?;
+        let (moved, _invalidation) = crate::state::mutate(&mut ctx, |c| {
+            c.carry_over_sprint_cards_impl(id, req.to_sprint_id)
+        })
+        .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Sprint, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        moved
+    };
+    Ok(Json(CarryOverResponse { moved }))
+}
+
+pub fn write_router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/v1/boards/{board_id}/sprints/{id}/activate",
+            post(activate_sprint_route),
+        )
+        .route(
+            "/v1/boards/{board_id}/sprints/{id}/complete",
+            post(complete_sprint_route),
+        )
+        .route(
+            "/v1/boards/{board_id}/sprints/{id}/cancel",
+            post(cancel_sprint_route),
+        )
+        .route(
+            "/v1/boards/{board_id}/sprints/{id}/carry-over",
+            post(carry_over_sprint_route),
+        )
+}

--- a/crates/kanban-server/tests/capability_guard.rs
+++ b/crates/kanban-server/tests/capability_guard.rs
@@ -7,6 +7,7 @@ const SOURCES: &[&str] = &[
     include_str!("../src/routes/cards.rs"),
     include_str!("../src/routes/columns.rs"),
     include_str!("../src/routes/sprints.rs"),
+    include_str!("../src/routes/sprints_lifecycle.rs"),
     include_str!("../src/routes/graph.rs"),
     include_str!("../src/routes/prefixes.rs"),
     include_str!("../src/handlers/boards.rs"),

--- a/crates/kanban-server/tests/sprints_lifecycle.rs
+++ b/crates/kanban-server/tests/sprints_lifecycle.rs
@@ -1,0 +1,589 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use kanban_domain::{CardStatus, CardUpdate, CreateCardOptions, KanbanOperations};
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use serde_json::json;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn seed_board_and_sprint(state: &AppState, name: &str) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let sprint = ctx
+        .create_sprint(board_id, Some("SPR".to_string()), Some(name.to_string()))
+        .unwrap();
+    (board_id, sprint.id)
+}
+
+async fn seed_board_column_and_two_sprints(state: &AppState) -> (Uuid, Uuid, Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let column_id = ctx
+        .create_column(board_id, "Todo".to_string(), None)
+        .unwrap()
+        .id;
+    let sprint1 = ctx
+        .create_sprint(board_id, Some("SPR".to_string()), Some("One".to_string()))
+        .unwrap()
+        .id;
+    let sprint2 = ctx
+        .create_sprint(board_id, Some("SPR".to_string()), Some("Two".to_string()))
+        .unwrap()
+        .id;
+    (board_id, column_id, sprint1, sprint2)
+}
+
+fn parse_date(v: &serde_json::Value) -> DateTime<Utc> {
+    v.as_str()
+        .unwrap_or_else(|| panic!("expected a date string, got {v}"))
+        .parse()
+        .unwrap_or_else(|e| panic!("failed to parse date {v}: {e}"))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_activate_sprint_route_sets_status_active_and_dates() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}/activate"),
+        Some(&json!({"duration_days": 7})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["status"], "active");
+    let start = parse_date(&json["start_date"]);
+    let end = parse_date(&json["end_date"]);
+    assert_eq!((end - start).num_days(), 7);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_activate_sprint_route_with_empty_body_defaults_to_14_days() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}/activate"),
+        Some(&json!({})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let start = parse_date(&json["start_date"]);
+    let end = parse_date(&json["end_date"]);
+    assert_eq!((end - start).num_days(), 14);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_complete_sprint_route_sets_status_completed() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}/complete"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["status"], "completed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cancel_sprint_route_sets_status_cancelled() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}/cancel"),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    assert_eq!(json["status"], "cancelled");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_activate_already_active_sprint_succeeds_and_resets_dates() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let first = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}/activate"),
+        Some(&json!({"duration_days": 7})),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let first_json = json_of(first).await;
+    let first_start = parse_date(&first_json["start_date"]);
+
+    let second = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}/activate"),
+        Some(&json!({"duration_days": 7})),
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::OK);
+    let second_json = json_of(second).await;
+    let second_start = parse_date(&second_json["start_date"]);
+
+    assert!(second_start >= first_start);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_activate_sprint_route_with_negative_duration_returns_422_validation_failed() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}/activate"),
+        Some(&json!({"duration_days": -1})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lifecycle_routes_on_sprint_of_other_board_return_404_not_found() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_a, sprint_a) = seed_board_and_sprint(&state, "Alpha").await;
+    let board_b = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Other".to_string(), Some("OTH".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_column(board_id, "Todo".to_string(), None)
+            .unwrap();
+        board_id
+    };
+
+    for path in ["activate", "complete", "cancel"] {
+        let response = send(
+            &state,
+            "POST",
+            &format!("/v1/boards/{board_b}/sprints/{sprint_a}/{path}"),
+            Some(&json!({})),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "path {path} expected 404"
+        );
+        let json = json_of(response).await;
+        assert_eq!(json["code"], "NOT_FOUND", "path {path}");
+    }
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_b}/sprints/{sprint_a}/carry-over"),
+        Some(&json!({"to_sprint_id": Uuid::new_v4()})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_activate_missing_sprint_returns_404_not_found_code() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{}/activate", Uuid::new_v4()),
+        Some(&json!({})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_carry_over_moves_uncompleted_cards_to_planning_sprint() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, column_id, sprint1, sprint2) = seed_board_column_and_two_sprints(&state).await;
+
+    let (todo_card_id, done_card_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let todo = ctx
+            .create_card(
+                board_id,
+                column_id,
+                "Todo card".to_string(),
+                CreateCardOptions {
+                    sprint_id: Some(sprint1),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+        let done = ctx
+            .create_card(
+                board_id,
+                column_id,
+                "Done card".to_string(),
+                CreateCardOptions {
+                    sprint_id: Some(sprint1),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+        ctx.update_card(
+            done,
+            CardUpdate {
+                status: Some(CardStatus::Done),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        (todo, done)
+    };
+
+    let complete = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/complete"),
+        None,
+    )
+    .await;
+    assert_eq!(complete.status(), StatusCode::OK);
+
+    let carry_over = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/carry-over"),
+        Some(&json!({"to_sprint_id": sprint2})),
+    )
+    .await;
+    assert_eq!(carry_over.status(), StatusCode::OK);
+    let body = json_of(carry_over).await;
+    assert_eq!(body["moved"], 1);
+
+    let to_sprint2 = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/cards?sprint_id={sprint2}"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let ids: Vec<String> = to_sprint2["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids, vec![todo_card_id.to_string()]);
+
+    let still_in_sprint1 = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/cards?sprint_id={sprint1}"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let ids: Vec<String> = still_in_sprint1["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids, vec![done_card_id.to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_carry_over_moves_uncompleted_cards_to_planning_sprint_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("s.sqlite")).await;
+    let (board_id, column_id, sprint1, sprint2) = seed_board_column_and_two_sprints(&state).await;
+
+    let (todo_card_id, done_card_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let todo = ctx
+            .create_card(
+                board_id,
+                column_id,
+                "Todo card".to_string(),
+                CreateCardOptions {
+                    sprint_id: Some(sprint1),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+        let done = ctx
+            .create_card(
+                board_id,
+                column_id,
+                "Done card".to_string(),
+                CreateCardOptions {
+                    sprint_id: Some(sprint1),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+        ctx.update_card(
+            done,
+            CardUpdate {
+                status: Some(CardStatus::Done),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        (todo, done)
+    };
+
+    let complete = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/complete"),
+        None,
+    )
+    .await;
+    assert_eq!(complete.status(), StatusCode::OK);
+
+    let carry_over = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/carry-over"),
+        Some(&json!({"to_sprint_id": sprint2})),
+    )
+    .await;
+    assert_eq!(carry_over.status(), StatusCode::OK);
+    let body = json_of(carry_over).await;
+    assert_eq!(body["moved"], 1);
+
+    let to_sprint2 = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/cards?sprint_id={sprint2}"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let ids: Vec<String> = to_sprint2["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids, vec![todo_card_id.to_string()]);
+
+    let still_in_sprint1 = json_of(
+        send(
+            &state,
+            "GET",
+            &format!("/v1/boards/{board_id}/cards?sprint_id={sprint1}"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    let ids: Vec<String> = still_in_sprint1["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids, vec![done_card_id.to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_carry_over_from_planning_sprint_returns_422_validation_failed() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, _column_id, sprint1, sprint2) = seed_board_column_and_two_sprints(&state).await;
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/carry-over"),
+        Some(&json!({"to_sprint_id": sprint2})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_carry_over_to_non_planning_sprint_returns_422_validation_failed() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_id, _column_id, sprint1, sprint2) = seed_board_column_and_two_sprints(&state).await;
+
+    let complete = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/complete"),
+        None,
+    )
+    .await;
+    assert_eq!(complete.status(), StatusCode::OK);
+
+    let activate_target = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint2}/activate"),
+        Some(&json!({})),
+    )
+    .await;
+    assert_eq!(activate_target.status(), StatusCode::OK);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/carry-over"),
+        Some(&json!({"to_sprint_id": sprint2})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_carry_over_to_sprint_of_other_board_returns_404_not_found() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_a, sprint_a) = seed_board_and_sprint(&state, "Alpha").await;
+    let sprint_b = {
+        let mut ctx = state.ctx.lock().await;
+        let board_b = ctx
+            .create_board("Other".to_string(), Some("OTH".to_string()))
+            .unwrap()
+            .id;
+        ctx.create_sprint(board_b, Some("SPR".to_string()), Some("Other".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let complete = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_a}/sprints/{sprint_a}/complete"),
+        None,
+    )
+    .await;
+    assert_eq!(complete.status(), StatusCode::OK);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_a}/sprints/{sprint_a}/carry-over"),
+        Some(&json!({"to_sprint_id": sprint_b})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = json_of(response).await;
+    assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_after_lifecycle_write_reads_fresh_status_and_resolved_name() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let created = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints"),
+        Some(&json!({"name": "Alpha", "prefix": "SPR"})),
+    )
+    .await;
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let created_json = json_of(created).await;
+    let sprint_id = created_json["id"].as_str().unwrap().to_string();
+
+    let activate = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}/activate"),
+        Some(&json!({})),
+    )
+    .await;
+    assert_eq!(activate.status(), StatusCode::OK);
+
+    let get = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(get.status(), StatusCode::OK);
+    let json = json_of(get).await;
+    assert_eq!(json["status"], "active");
+    assert_eq!(json["name"], "Alpha");
+}
+

--- a/crates/kanban-server/tests/sprints_lifecycle.rs
+++ b/crates/kanban-server/tests/sprints_lifecycle.rs
@@ -586,4 +586,3 @@ async fn test_get_sprint_after_lifecycle_write_reads_fresh_status_and_resolved_n
     assert_eq!(json["status"], "active");
     assert_eq!(json["name"], "Alpha");
 }
-

--- a/crates/kanban-server/tests/sprints_lifecycle.rs
+++ b/crates/kanban-server/tests/sprints_lifecycle.rs
@@ -157,8 +157,17 @@ async fn test_activate_already_active_sprint_succeeds_and_resets_dates() {
     assert_eq!(second.status(), StatusCode::OK);
     let second_json = json_of(second).await;
     let second_start = parse_date(&second_json["start_date"]);
+    let first_end = parse_date(&first_json["end_date"]);
+    let second_end = parse_date(&second_json["end_date"]);
 
-    assert!(second_start >= first_start);
+    assert!(
+        second_start > first_start,
+        "re-activating must reset start_date: {first_start} -> {second_start}"
+    );
+    assert!(
+        second_end > first_end,
+        "re-activating must reset end_date: {first_end} -> {second_end}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- Adds four POST subresource-verb routes under `/v1/boards/{board_id}/sprints/{id}/`: `activate`, `complete`, `cancel`, `carry-over`, wired via a new `kanban-server` route module `routes::sprints_lifecycle`.
- Adds three kanban-api wire DTOs the routes need: `ActivateSprintRequest`, `CarryOverRequest`, `CarryOverResponse`, plus `ActivateSprintRequest::validated_duration_days()` which rejects a negative or absurdly large `duration_days` before it reaches the service (guards an integer-overflow panic in the underlying `duration_days as u32` cast).
- Every mutation goes through the existing `crate::state::mutate` seam onto the already-declared `MutationOperations` methods (`activate_sprint_impl`, `complete_sprint_impl`, `cancel_sprint_impl`, `carry_over_sprint_cards_impl`), followed by `persist_and_broadcast`, matching the pattern used by the existing column reorder route.
- No state-machine guard is added (matches the existing CLI/MCP behavior): activating an already-active sprint succeeds and resets its dates.
- `require_sprint_in_board` and `respond` in `routes/sprints.rs` are now `pub(crate)` so the new sibling module can reuse the same 404-scoping and response-projection logic rather than duplicating it.
- Registers `routes/sprints_lifecycle.rs` in the capability-guard test's source list so the wiring guard covers the new file.

## Test plan

- [x] `cargo test -p kanban-server --features test-helpers --test sprints_lifecycle`: 14 new tests covering status transitions, default/explicit duration, re-activation, negative-duration 422, cross-board 404 scoping for all four routes, carry-over on both JSON and SQLite backends, carry-over validation failures (source not completed, target not planning), carry-over target-sprint cross-board 404, and a post-write read returning the fresh status.
- [x] `cargo test -p kanban-api --all-features`: new DTO/serde/validation unit tests.
- [x] `cargo test --all-features --workspace` green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `git diff --name-only origin/develop` touches only `kanban-api` and `kanban-server` (plus the changeset); no `kanban-service`/`kanban-domain` change.
