### PR TITLE
KAN-1548 feat(api,server): dependency-graph write routes over HTTP

### DIFF
--- a/.changeset/kan-1548-graph-write-routes.md
+++ b/.changeset/kan-1548-graph-write-routes.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+dependency-graph write routes (attach/detach children, block/unblock, relate/dissociate) over HTTP, with edge severity/kind now surfaced on the card graph response

--- a/crates/kanban-api/README.md
+++ b/crates/kanban-api/README.md
@@ -16,14 +16,15 @@ Re-exported from `src/lib.rs` (`pub use v1::{ ... }`):
 
 ```rust
 pub use v1::{
-    ActivateSprintRequest, ApiError, ArchivedFilterDto, BoardResponse, CardGraphResponse,
-    CardPriorityDto, CardResponse, CardStatusDto, CarryOverRequest, CarryOverResponse,
-    ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest, CreateCardRequest,
-    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType, ErrorCode, Page,
-    PageParams, Patch, PrefixResponse, ReorderColumnRequest, ReplaceBoardRequest,
-    ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SortFieldDto, SortOrderDto,
-    SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest, UpdateCardRequest,
-    UpdateColumnRequest, UpdateSprintRequest,
+    ActivateSprintRequest, AddBlockRequest, AddRelatedRequest, ApiError, ArchivedFilterDto,
+    AttachChildrenRequest, BlockEdgeDto, BoardResponse, CardGraphResponse, CardPriorityDto,
+    CardResponse, CardStatusDto, CarryOverRequest, CarryOverResponse, ChangeEventFrame,
+    ChangeKind, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
+    CreateSprintParts, CreateSprintRequest, EntityType, ErrorCode, Page, PageParams, Patch,
+    PrefixResponse, RelatedEdgeDto, RelatesKindDto, ReorderColumnRequest, ReplaceBoardRequest,
+    ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SeverityDto, SortFieldDto,
+    SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest,
+    UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
 };
 ```
 

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -6,12 +6,12 @@
 mod v1;
 pub use v1::{
     ActivateSprintRequest, ApiError, ArchivedBoardResponse, ArchivedCardResponse,
-    ArchivedFilterDto, BoardResponse, CardGraphResponse, CardPriorityDto, CardResponse,
-    CardStatusDto, CarryOverRequest, CarryOverResponse, ChangeEventFrame, ChangeKind,
-    ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintParts,
-    CreateSprintRequest, EntityType, ErrorCode, Page, PageParams, Patch, PrefixResponse,
-    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
-    ReplaceSprintRequest, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
-    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
-    UpdateSprintRequest,
+    ArchivedFilterDto, BlockEdgeDto, BoardResponse, CardGraphResponse, CardPriorityDto,
+    CardResponse, CardStatusDto, CarryOverRequest, CarryOverResponse, ChangeEventFrame,
+    ChangeKind, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
+    CreateSprintParts, CreateSprintRequest, EntityType, ErrorCode, Page, PageParams, Patch,
+    PrefixResponse, RelatedEdgeDto, RelatesKindDto, ReorderColumnRequest, ReplaceBoardRequest,
+    ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SeverityDto, SortFieldDto,
+    SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest,
+    UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
 };

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -5,13 +5,14 @@
 //! callers into an explicit version path.
 mod v1;
 pub use v1::{
-    ActivateSprintRequest, ApiError, ArchivedBoardResponse, ArchivedCardResponse,
-    ArchivedFilterDto, BlockEdgeDto, BoardResponse, CardGraphResponse, CardPriorityDto,
-    CardResponse, CardStatusDto, CarryOverRequest, CarryOverResponse, ChangeEventFrame,
-    ChangeKind, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
-    CreateSprintParts, CreateSprintRequest, EntityType, ErrorCode, Page, PageParams, Patch,
-    PrefixResponse, RelatedEdgeDto, RelatesKindDto, ReorderColumnRequest, ReplaceBoardRequest,
-    ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SeverityDto, SortFieldDto,
-    SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest,
-    UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
+    ActivateSprintRequest, AddBlockRequest, AddRelatedRequest, ApiError, ArchivedBoardResponse,
+    ArchivedCardResponse, ArchivedFilterDto, AttachChildrenRequest, BlockEdgeDto, BoardResponse,
+    CardGraphResponse, CardPriorityDto, CardResponse, CardStatusDto, CarryOverRequest,
+    CarryOverResponse, ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest,
+    CreateCardRequest, CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType,
+    ErrorCode, Page, PageParams, Patch, PrefixResponse, RelatedEdgeDto, RelatesKindDto,
+    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
+    ReplaceSprintRequest, SeverityDto, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
+    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
+    UpdateSprintRequest,
 };

--- a/crates/kanban-api/src/v1/enums.rs
+++ b/crates/kanban-api/src/v1/enums.rs
@@ -4,7 +4,8 @@
 //! — a renamed or added domain variant fails to compile here (the drift guard).
 
 use kanban_domain::{
-    ArchivedFilter, CardPriority, CardStatus, SortField, SortOrder, SprintStatus, TaskListView,
+    ArchivedFilter, CardPriority, CardStatus, RelatesKind, Severity, SortField, SortOrder,
+    SprintStatus, TaskListView,
 };
 use serde::{Deserialize, Serialize};
 
@@ -408,6 +409,61 @@ mod tests {
             let domain: CardStatus = dto.into();
             assert_eq!(CardStatusDto::from(domain), dto);
         }
+    }
+
+    #[test]
+    fn test_severity_and_relates_kind_dtos_serialize_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&SeverityDto::Critical).unwrap(),
+            "\"critical\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SeverityDto::Low).unwrap(),
+            "\"low\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SeverityDto::Medium).unwrap(),
+            "\"medium\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SeverityDto::High).unwrap(),
+            "\"high\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RelatesKindDto::MentionedIn).unwrap(),
+            "\"mentioned_in\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RelatesKindDto::Duplicates).unwrap(),
+            "\"duplicates\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RelatesKindDto::General).unwrap(),
+            "\"general\""
+        );
+    }
+
+    #[test]
+    fn test_severity_and_relates_kind_dtos_round_trip_through_domain() {
+        for dto in [
+            SeverityDto::Low,
+            SeverityDto::Medium,
+            SeverityDto::High,
+            SeverityDto::Critical,
+        ] {
+            let domain: Severity = dto.into();
+            assert_eq!(SeverityDto::from(domain), dto);
+        }
+        for dto in [
+            RelatesKindDto::General,
+            RelatesKindDto::Duplicates,
+            RelatesKindDto::MentionedIn,
+        ] {
+            let domain: RelatesKind = dto.into();
+            assert_eq!(RelatesKindDto::from(domain), dto);
+        }
+        assert_eq!(SeverityDto::default(), SeverityDto::Medium);
+        assert_eq!(RelatesKindDto::default(), RelatesKindDto::General);
     }
 
     #[test]

--- a/crates/kanban-api/src/v1/enums.rs
+++ b/crates/kanban-api/src/v1/enums.rs
@@ -482,10 +482,7 @@ mod tests {
             serde_json::to_string(&SeverityDto::Critical).unwrap(),
             "\"critical\""
         );
-        assert_eq!(
-            serde_json::to_string(&SeverityDto::Low).unwrap(),
-            "\"low\""
-        );
+        assert_eq!(serde_json::to_string(&SeverityDto::Low).unwrap(), "\"low\"");
         assert_eq!(
             serde_json::to_string(&SeverityDto::Medium).unwrap(),
             "\"medium\""

--- a/crates/kanban-api/src/v1/enums.rs
+++ b/crates/kanban-api/src/v1/enums.rs
@@ -245,6 +245,71 @@ impl From<ArchivedFilter> for ArchivedFilterDto {
     }
 }
 
+/// Wire mirror of [`kanban_domain::Severity`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SeverityDto {
+    Low,
+    #[default]
+    Medium,
+    High,
+    Critical,
+}
+
+impl From<SeverityDto> for Severity {
+    fn from(value: SeverityDto) -> Self {
+        match value {
+            SeverityDto::Low => Self::Low,
+            SeverityDto::Medium => Self::Medium,
+            SeverityDto::High => Self::High,
+            SeverityDto::Critical => Self::Critical,
+        }
+    }
+}
+
+impl From<Severity> for SeverityDto {
+    fn from(value: Severity) -> Self {
+        match value {
+            Severity::Low => Self::Low,
+            Severity::Medium => Self::Medium,
+            Severity::High => Self::High,
+            Severity::Critical => Self::Critical,
+        }
+    }
+}
+
+/// Wire mirror of [`kanban_domain::RelatesKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum RelatesKindDto {
+    #[default]
+    General,
+    Duplicates,
+    MentionedIn,
+}
+
+impl From<RelatesKindDto> for RelatesKind {
+    fn from(value: RelatesKindDto) -> Self {
+        match value {
+            RelatesKindDto::General => Self::General,
+            RelatesKindDto::Duplicates => Self::Duplicates,
+            RelatesKindDto::MentionedIn => Self::MentionedIn,
+        }
+    }
+}
+
+impl From<RelatesKind> for RelatesKindDto {
+    fn from(value: RelatesKind) -> Self {
+        match value {
+            RelatesKind::General => Self::General,
+            RelatesKind::Duplicates => Self::Duplicates,
+            RelatesKind::MentionedIn => Self::MentionedIn,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-api/src/v1/graph/mod.rs
+++ b/crates/kanban-api/src/v1/graph/mod.rs
@@ -1,3 +1,5 @@
+mod requests;
 mod response;
 
+pub use requests::{AddBlockRequest, AddRelatedRequest, AttachChildrenRequest};
 pub use response::{BlockEdgeDto, CardGraphResponse, RelatedEdgeDto};

--- a/crates/kanban-api/src/v1/graph/mod.rs
+++ b/crates/kanban-api/src/v1/graph/mod.rs
@@ -1,3 +1,3 @@
 mod response;
 
-pub use response::CardGraphResponse;
+pub use response::{BlockEdgeDto, CardGraphResponse, RelatedEdgeDto};

--- a/crates/kanban-api/src/v1/graph/requests.rs
+++ b/crates/kanban-api/src/v1/graph/requests.rs
@@ -1,0 +1,51 @@
+use crate::v1::enums::{RelatesKindDto, SeverityDto};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct AttachChildrenRequest {
+    pub children: Vec<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct AddBlockRequest {
+    pub blocked: Uuid,
+    #[serde(default)]
+    pub severity: SeverityDto,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct AddRelatedRequest {
+    pub other: Uuid,
+    #[serde(default)]
+    pub kind: RelatesKindDto,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_attach_children_request_requires_children_field() {
+        let err =
+            serde_json::from_value::<AttachChildrenRequest>(serde_json::json!({})).unwrap_err();
+        assert!(err.to_string().contains("children"));
+    }
+
+    #[test]
+    fn test_add_block_request_defaults_severity_to_medium() {
+        let req: AddBlockRequest =
+            serde_json::from_value(serde_json::json!({"blocked": Uuid::nil()})).unwrap();
+        assert_eq!(req.severity, SeverityDto::Medium);
+    }
+
+    #[test]
+    fn test_add_related_request_defaults_kind_to_general() {
+        let req: AddRelatedRequest =
+            serde_json::from_value(serde_json::json!({"other": Uuid::nil()})).unwrap();
+        assert_eq!(req.kind, RelatesKindDto::General);
+    }
+}

--- a/crates/kanban-api/src/v1/graph/response.rs
+++ b/crates/kanban-api/src/v1/graph/response.rs
@@ -252,7 +252,9 @@ mod tests {
             [edge.source, edge.target].into_iter().collect();
         assert_eq!(
             endpoints,
-            [subject, other].into_iter().collect::<std::collections::HashSet<Uuid>>()
+            [subject, other]
+                .into_iter()
+                .collect::<std::collections::HashSet<Uuid>>()
         );
         assert_eq!(edge.kind, crate::v1::enums::RelatesKindDto::Duplicates);
     }

--- a/crates/kanban-api/src/v1/graph/response.rs
+++ b/crates/kanban-api/src/v1/graph/response.rs
@@ -114,6 +114,10 @@ mod tests {
 
     #[test]
     fn test_card_graph_response_serde_round_trip() {
+        let blocker = Uuid::new_v4();
+        let blocked = Uuid::new_v4();
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
         let response = CardGraphResponse {
             card_id: Uuid::new_v4(),
             parents: vec![Uuid::new_v4()],
@@ -121,6 +125,16 @@ mod tests {
             blocked_by: vec![Uuid::new_v4()],
             blocks: vec![Uuid::new_v4()],
             related: vec![Uuid::new_v4()],
+            block_edges: vec![BlockEdgeDto {
+                blocker,
+                blocked,
+                severity: crate::v1::enums::SeverityDto::Critical,
+            }],
+            related_edges: vec![RelatedEdgeDto {
+                source,
+                target,
+                kind: crate::v1::enums::RelatesKindDto::Duplicates,
+            }],
         };
 
         let value = serde_json::to_value(&response).unwrap();
@@ -132,17 +146,105 @@ mod tests {
             "blocked_by",
             "blocks",
             "related",
+            "block_edges",
+            "related_edges",
         ] {
             assert!(obj.get(key).is_some(), "missing key {key}");
         }
         assert_eq!(
             obj.len(),
-            6,
+            8,
             "unexpected keys: {:?}",
             obj.keys().collect::<Vec<_>>()
         );
 
         let round_tripped: CardGraphResponse = serde_json::from_value(value).unwrap();
         assert_eq!(round_tripped, response);
+    }
+
+    #[test]
+    fn test_card_graph_response_block_edges_carry_severity() {
+        let blocker = Uuid::new_v4();
+        let subject = Uuid::new_v4();
+
+        let mut g = DependencyGraph::new();
+        g.set_block_with_severity(blocker, subject, Severity::Critical)
+            .unwrap();
+
+        let r = CardGraphResponse::from_graph(subject, &g);
+        assert_eq!(
+            r.block_edges,
+            vec![BlockEdgeDto {
+                blocker,
+                blocked: subject,
+                severity: crate::v1::enums::SeverityDto::Critical,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_card_graph_response_related_edges_carry_kind() {
+        let subject = Uuid::new_v4();
+        let other = Uuid::new_v4();
+
+        let mut g = DependencyGraph::new();
+        g.relate_with_kind(subject, other, RelatesKind::Duplicates)
+            .unwrap();
+
+        let r = CardGraphResponse::from_graph(subject, &g);
+        assert_eq!(r.related_edges.len(), 1);
+        let edge = &r.related_edges[0];
+        let endpoints: std::collections::HashSet<Uuid> =
+            [edge.source, edge.target].into_iter().collect();
+        assert_eq!(
+            endpoints,
+            [subject, other].into_iter().collect::<std::collections::HashSet<Uuid>>()
+        );
+        assert_eq!(edge.kind, crate::v1::enums::RelatesKindDto::Duplicates);
+    }
+
+    #[test]
+    fn test_card_graph_response_new_edge_fields_exclude_archived_and_foreign_edges() {
+        let subject = Uuid::new_v4();
+        let archived_blocker = Uuid::new_v4();
+        let archived_rel = Uuid::new_v4();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let incident_blocker = Uuid::new_v4();
+
+        let mut g = DependencyGraph::new();
+        g.add_archived_blocks(archived_blocker, subject, Severity::High)
+            .unwrap();
+        g.add_archived_relates(subject, archived_rel, RelatesKind::Duplicates)
+            .unwrap();
+        g.set_block_with_severity(a, b, Severity::Low).unwrap();
+        g.relate_with_kind(a, b, RelatesKind::General).unwrap();
+
+        let r = CardGraphResponse::from_graph(subject, &g);
+        assert!(r.block_edges.is_empty());
+        assert!(r.related_edges.is_empty());
+
+        g.set_block_with_severity(incident_blocker, subject, Severity::Medium)
+            .unwrap();
+        let r = CardGraphResponse::from_graph(subject, &g);
+        assert_eq!(r.block_edges.len(), 1);
+        assert_eq!(r.block_edges[0].blocker, incident_blocker);
+    }
+
+    #[test]
+    fn test_card_graph_response_deserializes_payload_without_edge_fields() {
+        let card_id = Uuid::new_v4();
+        let value = serde_json::json!({
+            "card_id": card_id,
+            "parents": [],
+            "children": [],
+            "blocked_by": [],
+            "blocks": [],
+            "related": [],
+        });
+
+        let response: CardGraphResponse = serde_json::from_value(value).unwrap();
+        assert!(response.block_edges.is_empty());
+        assert!(response.related_edges.is_empty());
     }
 }

--- a/crates/kanban-api/src/v1/graph/response.rs
+++ b/crates/kanban-api/src/v1/graph/response.rs
@@ -1,12 +1,34 @@
+use crate::v1::enums::{RelatesKindDto, SeverityDto};
 use kanban_domain::DependencyGraph;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+/// A blocking edge incident to the requested card, carrying its severity.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BlockEdgeDto {
+    pub blocker: Uuid,
+    pub blocked: Uuid,
+    pub severity: SeverityDto,
+}
+
+/// An undirected relates edge incident to the requested card, carrying its
+/// kind. `source`/`target` preserve whichever orientation created the edge;
+/// callers that only care about the other endpoint should compare against
+/// both.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RelatedEdgeDto {
+    pub source: Uuid,
+    pub target: Uuid,
+    pub kind: RelatesKindDto,
+}
 
 /// A card's dependency edges, scoped to that card and split by direction.
 /// `parents`/`children` are the Spawns edges that spawned it / that it
 /// spawned; `blocked_by`/`blocks` are the Blocks edges pointing into it /
 /// out of it; `related` is its undirected Relates neighbors. Only active
-/// edges are reported; archived edges are excluded.
+/// edges are reported; archived edges are excluded. `block_edges` and
+/// `related_edges` carry the same active-only, incident-only scoping as the
+/// id arrays, plus each edge's metadata.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CardGraphResponse {
     pub card_id: Uuid,
@@ -15,10 +37,40 @@ pub struct CardGraphResponse {
     pub blocked_by: Vec<Uuid>,
     pub blocks: Vec<Uuid>,
     pub related: Vec<Uuid>,
+    #[serde(default)]
+    pub block_edges: Vec<BlockEdgeDto>,
+    #[serde(default)]
+    pub related_edges: Vec<RelatedEdgeDto>,
 }
 
 impl CardGraphResponse {
     pub fn from_graph(card_id: Uuid, graph: &DependencyGraph) -> Self {
+        let block_edges = graph
+            .blocks_edges()
+            .iter()
+            .filter(|e| {
+                e.base.archived_at.is_none()
+                    && (e.base.source == card_id || e.base.target == card_id)
+            })
+            .map(|e| BlockEdgeDto {
+                blocker: e.base.source,
+                blocked: e.base.target,
+                severity: e.severity.into(),
+            })
+            .collect();
+        let related_edges = graph
+            .relates_edges()
+            .iter()
+            .filter(|e| {
+                e.base.archived_at.is_none()
+                    && (e.base.source == card_id || e.base.target == card_id)
+            })
+            .map(|e| RelatedEdgeDto {
+                source: e.base.source,
+                target: e.base.target,
+                kind: e.kind.into(),
+            })
+            .collect();
         Self {
             card_id,
             parents: graph.parents(card_id),
@@ -26,6 +78,8 @@ impl CardGraphResponse {
             blocked_by: graph.blockers(card_id),
             blocks: graph.blocked(card_id),
             related: graph.related(card_id),
+            block_edges,
+            related_edges,
         }
     }
 }

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -27,7 +27,10 @@ pub use enums::{
 };
 pub use error::{ApiError, ErrorCode};
 pub use events::{ChangeEventFrame, ChangeKind, EntityType};
-pub use graph::{BlockEdgeDto, CardGraphResponse, RelatedEdgeDto};
+pub use graph::{
+    AddBlockRequest, AddRelatedRequest, AttachChildrenRequest, BlockEdgeDto, CardGraphResponse,
+    RelatedEdgeDto,
+};
 pub use pagination::{Page, PageParams};
 pub use patch::Patch;
 pub use prefixes::PrefixResponse;

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -22,12 +22,12 @@ pub use columns::{
     UpdateColumnRequest,
 };
 pub use enums::{
-    ArchivedFilterDto, CardPriorityDto, CardStatusDto, SortFieldDto, SortOrderDto, SprintStatusDto,
-    TaskListViewDto,
+    ArchivedFilterDto, CardPriorityDto, CardStatusDto, RelatesKindDto, SeverityDto, SortFieldDto,
+    SortOrderDto, SprintStatusDto, TaskListViewDto,
 };
 pub use error::{ApiError, ErrorCode};
 pub use events::{ChangeEventFrame, ChangeKind, EntityType};
-pub use graph::CardGraphResponse;
+pub use graph::{BlockEdgeDto, CardGraphResponse, RelatedEdgeDto};
 pub use pagination::{Page, PageParams};
 pub use patch::Patch;
 pub use prefixes::PrefixResponse;

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -205,7 +205,13 @@ The remaining card routes (get/create/replace/update/delete, and the flat `/v1/c
 
 | Method | Path | Description | Body |
 |---|---|---|---|
-| `GET` | `/v1/cards/{id}/graph` | The card's dependency edges, scoped to that card: parents/children (spawns), blocked_by/blocks and related. Only active edges; archived edges are omitted. 404s if the card does not exist, rather than returning empty arrays. | — |
+| `GET` | `/v1/cards/{id}/graph` | The card's dependency edges, scoped to that card: parents/children (spawns), blocked_by/blocks and related, plus `block_edges`/`related_edges` carrying each edge's severity/kind. Only active edges; archived edges are omitted. 404s if the card does not exist, rather than returning empty arrays. | — |
+| `POST` | `/v1/cards/{id}/children` | Attach cards as spawned children of `id`. `200` with the updated `CardGraphResponse`. 404 if `id` or any child is unknown; 409 `CYCLE_DETECTED` if the edge would create a cycle. | `{"children": [uuid, ...]}` |
+| `DELETE` | `/v1/cards/{id}/children/{child_id}` | Detach `child_id` as a spawned child of `id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |
+| `POST` | `/v1/cards/{id}/blocks` | Add a blocking edge from `id` to `blocked`. `200` with the updated `CardGraphResponse`. `severity` defaults to `medium`. 422 `SELF_REFERENCE` if `blocked == id`; 409 `DUPLICATE_EDGE` if the edge already exists. | `{"blocked": uuid, "severity"?: "low"\|"medium"\|"high"\|"critical"}` |
+| `DELETE` | `/v1/cards/{id}/blocks/{blocked_id}` | Remove the blocking edge from `id` to `blocked_id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |
+| `POST` | `/v1/cards/{id}/related` | Add an undirected relates edge between `id` and `other`. `200` with the updated `CardGraphResponse`. `kind` defaults to `general`. 409 `DUPLICATE_EDGE` if the edge already exists. | `{"other": uuid, "kind"?: "general"\|"duplicates"\|"mentioned_in"}` |
+| `DELETE` | `/v1/cards/{id}/related/{other_id}` | Remove the relates edge between `id` and `other_id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |
 
 ### Events
 

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -45,6 +45,7 @@ pub fn router_with(state: AppState, config: LayerConfig) -> Router {
         .merge(crate::routes::columns::flat_read_router())
         .merge(crate::routes::columns::flat_write_router())
         .merge(crate::routes::graph::read_router())
+        .merge(crate::routes::graph::write_router())
         .merge(crate::routes::prefixes::read_router())
         .merge(crate::routes::sprints::read_router())
         .merge(crate::routes::sprints::write_router())

--- a/crates/kanban-server/src/routes/graph.rs
+++ b/crates/kanban-server/src/routes/graph.rs
@@ -1,12 +1,17 @@
-use crate::error::AppError;
+use crate::error::{AppError, AppJson};
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::scope::RouteScope;
 use crate::state::AppState;
 use axum::extract::{Path, State};
-use axum::routing::get;
+use axum::http::StatusCode;
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use kanban_domain::{Model, NoProjections};
-use kanban_service::api::CardGraphResponse;
+use kanban_service::api::{
+    AddBlockRequest, AddRelatedRequest, AttachChildrenRequest, CardGraphResponse, ChangeKind,
+    EntityType,
+};
+use kanban_service::KanbanContext;
 use uuid::Uuid;
 
 async fn get_card_graph(
@@ -23,4 +28,142 @@ async fn get_card_graph(
 
 pub fn read_router() -> Router<AppState> {
     Router::new().route("/v1/cards/{id}/graph", get(get_card_graph))
+}
+
+fn graph_mutation_response(
+    ctx: &KanbanContext,
+    id: Uuid,
+) -> Result<Json<CardGraphResponse>, AppError> {
+    let mut model = Model::default();
+    ctx.sync(&RouteScope::CardGraph(id), &mut model, &mut NoProjections);
+    require_loaded_entity(model.card_id_status(id), "Card", id)?;
+    let graph = require_loaded(model.graph_state().as_ref(), "card graph")?;
+    Ok(Json(CardGraphResponse::from_graph(id, graph)))
+}
+
+async fn attach_children_route(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    AppJson(req): AppJson<AttachChildrenRequest>,
+) -> Result<Json<CardGraphResponse>, AppError> {
+    let body = {
+        let mut ctx = state.ctx.lock().await;
+        let _ = crate::state::mutate_unit(&mut ctx, |c| c.attach_children_impl(id, req.children))
+            .map_err(|e| AppError::from(&e))?;
+        let body = graph_mutation_response(&ctx.ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        body
+    };
+    Ok(body)
+}
+
+async fn detach_child_route(
+    State(state): State<AppState>,
+    Path((id, child_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        let _ = crate::state::mutate_unit(&mut ctx, |c| c.detach_children_impl(id, vec![child_id]))
+            .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn add_block_route(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    AppJson(req): AppJson<AddBlockRequest>,
+) -> Result<Json<CardGraphResponse>, AppError> {
+    let body = {
+        let mut ctx = state.ctx.lock().await;
+        let _ = crate::state::mutate_unit(&mut ctx, |c| {
+            c.block_impl(id, req.blocked, req.severity.into())
+        })
+        .map_err(|e| AppError::from(&e))?;
+        let body = graph_mutation_response(&ctx.ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        body
+    };
+    Ok(body)
+}
+
+async fn remove_block_route(
+    State(state): State<AppState>,
+    Path((id, blocked_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        let _ = crate::state::mutate_unit(&mut ctx, |c| c.unblock_impl(id, blocked_id))
+            .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn add_related_route(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    AppJson(req): AppJson<AddRelatedRequest>,
+) -> Result<Json<CardGraphResponse>, AppError> {
+    let body = {
+        let mut ctx = state.ctx.lock().await;
+        let _ =
+            crate::state::mutate_unit(&mut ctx, |c| c.relate_impl(id, req.other, req.kind.into()))
+                .map_err(|e| AppError::from(&e))?;
+        let body = graph_mutation_response(&ctx.ctx, id)?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+        body
+    };
+    Ok(body)
+}
+
+async fn remove_related_route(
+    State(state): State<AppState>,
+    Path((id, other_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, AppError> {
+    {
+        let mut ctx = state.ctx.lock().await;
+        let _ = crate::state::mutate_unit(&mut ctx, |c| c.dissociate_impl(id, other_id))
+            .map_err(|e| AppError::from(&e))?;
+        state
+            .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
+            .await
+            .map_err(|e| AppError::from(&e))?;
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub fn write_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/cards/{id}/children", post(attach_children_route))
+        .route(
+            "/v1/cards/{id}/children/{child_id}",
+            delete(detach_child_route),
+        )
+        .route("/v1/cards/{id}/blocks", post(add_block_route))
+        .route(
+            "/v1/cards/{id}/blocks/{blocked_id}",
+            delete(remove_block_route),
+        )
+        .route("/v1/cards/{id}/related", post(add_related_route))
+        .route(
+            "/v1/cards/{id}/related/{other_id}",
+            delete(remove_related_route),
+        )
 }

--- a/crates/kanban-server/tests/graph_read.rs
+++ b/crates/kanban-server/tests/graph_read.rs
@@ -168,6 +168,8 @@ async fn test_get_card_graph_existing_card_with_no_edges_returns_200_empty_array
             "blocked_by": [],
             "blocks": [],
             "related": [],
+            "block_edges": [],
+            "related_edges": [],
         })
     );
 }

--- a/crates/kanban-server/tests/graph_write.rs
+++ b/crates/kanban-server/tests/graph_write.rs
@@ -285,7 +285,13 @@ async fn test_dissociate_returns_204_and_removes_the_relates_edge(state: AppStat
     )
     .await;
 
-    let response = send(&state, "DELETE", &format!("/v1/cards/{b}/related/{a}"), None).await;
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{b}/related/{a}"),
+        None,
+    )
+    .await;
     assert_eq!(response.status(), 204);
 
     for id in [a, b] {

--- a/crates/kanban-server/tests/graph_write.rs
+++ b/crates/kanban-server/tests/graph_write.rs
@@ -1,0 +1,584 @@
+#![cfg(feature = "test-helpers")]
+
+//! POST/DELETE dependency-graph write routes under /v1/cards/{id}/{children,blocks,related}.
+
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use kanban_service::KanbanOperations;
+use serde_json::json;
+use std::time::Duration;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn seed_cards(state: &AppState, n: usize) -> Vec<Uuid> {
+    let mut ctx = state.ctx.lock().await;
+    let board = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap();
+    let column = ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    (0..n)
+        .map(|i| {
+            ctx.create_card(board.id, column.id, format!("Card {i}"), Default::default())
+                .unwrap()
+                .id
+        })
+        .collect()
+}
+
+async fn test_attach_children_returns_the_updated_graph_json(state: AppState) {
+    let cards = seed_cards(&state, 3).await;
+    let (parent, c1, c2) = (cards[0], cards[1], cards[2]);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{parent}/children"),
+        Some(&json!({"children": [c1, c2]})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+    let body = json_of(response).await;
+    let children: Vec<Uuid> = serde_json::from_value(body["children"].clone()).unwrap();
+    assert!(children.contains(&c1) && children.contains(&c2));
+
+    let response = send(&state, "GET", &format!("/v1/cards/{parent}/graph"), None).await;
+    let body = json_of(response).await;
+    let children: Vec<Uuid> = serde_json::from_value(body["children"].clone()).unwrap();
+    assert!(children.contains(&c1) && children.contains(&c2));
+
+    let response = send(&state, "GET", &format!("/v1/cards/{c1}/graph"), None).await;
+    let body = json_of(response).await;
+    let parents: Vec<Uuid> = serde_json::from_value(body["parents"].clone()).unwrap();
+    assert_eq!(parents, vec![parent]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_attach_children_returns_the_updated_graph_json_backend() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_attach_children_returns_the_updated_graph_json(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_attach_children_returns_the_updated_graph_sqlite_backend() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_attach_children_returns_the_updated_graph_json(state).await;
+}
+
+async fn test_block_write_then_read_round_trips_severity_over_the_wire(state: AppState) {
+    let cards = seed_cards(&state, 2).await;
+    let (blocker, blocked) = (cards[0], cards[1]);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{blocker}/blocks"),
+        Some(&json!({"blocked": blocked, "severity": "critical"})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+    let body = json_of(response).await;
+    assert_eq!(
+        body["block_edges"],
+        json!([{"blocker": blocker, "blocked": blocked, "severity": "critical"}])
+    );
+
+    let response = send(&state, "GET", &format!("/v1/cards/{blocked}/graph"), None).await;
+    assert_eq!(response.status(), 200);
+    let body = json_of(response).await;
+    let blocked_by: Vec<Uuid> = serde_json::from_value(body["blocked_by"].clone()).unwrap();
+    assert_eq!(blocked_by, vec![blocker]);
+    assert_eq!(
+        body["block_edges"],
+        json!([{"blocker": blocker, "blocked": blocked, "severity": "critical"}])
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_write_then_read_round_trips_severity_over_the_wire_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_block_write_then_read_round_trips_severity_over_the_wire(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_write_then_read_round_trips_severity_over_the_wire_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_block_write_then_read_round_trips_severity_over_the_wire(state).await;
+}
+
+async fn test_related_write_round_trips_kind(state: AppState) {
+    let cards = seed_cards(&state, 2).await;
+    let (a, b) = (cards[0], cards[1]);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{a}/related"),
+        Some(&json!({"other": b, "kind": "duplicates"})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+
+    for id in [a, b] {
+        let response = send(&state, "GET", &format!("/v1/cards/{id}/graph"), None).await;
+        let body = json_of(response).await;
+        let related_edges = body["related_edges"].as_array().unwrap();
+        assert_eq!(related_edges.len(), 1);
+        let edge = &related_edges[0];
+        let source = Uuid::parse_str(edge["source"].as_str().unwrap()).unwrap();
+        let target = Uuid::parse_str(edge["target"].as_str().unwrap()).unwrap();
+        let endpoints: std::collections::HashSet<Uuid> = [source, target].into_iter().collect();
+        assert_eq!(endpoints, [a, b].into_iter().collect());
+        assert_eq!(edge["kind"], "duplicates");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_related_write_round_trips_kind_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_related_write_round_trips_kind(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_related_write_round_trips_kind_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_related_write_round_trips_kind(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_related_write_defaults_kind_to_general_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let cards = seed_cards(&state, 2).await;
+    let (a, b) = (cards[0], cards[1]);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{a}/related"),
+        Some(&json!({"other": b})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+    let body = json_of(response).await;
+    assert_eq!(body["related_edges"][0]["kind"], "general");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_write_defaults_severity_to_medium_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let cards = seed_cards(&state, 2).await;
+    let (blocker, blocked) = (cards[0], cards[1]);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{blocker}/blocks"),
+        Some(&json!({"blocked": blocked})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+    let body = json_of(response).await;
+    assert_eq!(body["block_edges"][0]["severity"], "medium");
+}
+
+async fn test_detach_child_returns_204_and_removes_the_spawns_edge(state: AppState) {
+    let cards = seed_cards(&state, 2).await;
+    let (parent, child) = (cards[0], cards[1]);
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{parent}/children"),
+        Some(&json!({"children": [child]})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{parent}/children/{child}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), 204);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(body.is_empty());
+
+    let response = send(&state, "GET", &format!("/v1/cards/{parent}/graph"), None).await;
+    let body = json_of(response).await;
+    assert_eq!(body["children"], json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_detach_child_returns_204_and_removes_the_spawns_edge_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_detach_child_returns_204_and_removes_the_spawns_edge(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_detach_child_returns_204_and_removes_the_spawns_edge_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_detach_child_returns_204_and_removes_the_spawns_edge(state).await;
+}
+
+async fn test_unblock_returns_204_and_removes_the_blocks_edge(state: AppState) {
+    let cards = seed_cards(&state, 2).await;
+    let (blocker, blocked) = (cards[0], cards[1]);
+    send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{blocker}/blocks"),
+        Some(&json!({"blocked": blocked})),
+    )
+    .await;
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{blocker}/blocks/{blocked}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), 204);
+
+    let response = send(&state, "GET", &format!("/v1/cards/{blocked}/graph"), None).await;
+    let body = json_of(response).await;
+    assert_eq!(body["blocked_by"], json!([]));
+    assert_eq!(body["block_edges"], json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unblock_returns_204_and_removes_the_blocks_edge_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_unblock_returns_204_and_removes_the_blocks_edge(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unblock_returns_204_and_removes_the_blocks_edge_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_unblock_returns_204_and_removes_the_blocks_edge(state).await;
+}
+
+async fn test_dissociate_returns_204_and_removes_the_relates_edge(state: AppState) {
+    let cards = seed_cards(&state, 2).await;
+    let (a, b) = (cards[0], cards[1]);
+    send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{a}/related"),
+        Some(&json!({"other": b})),
+    )
+    .await;
+
+    let response = send(&state, "DELETE", &format!("/v1/cards/{b}/related/{a}"), None).await;
+    assert_eq!(response.status(), 204);
+
+    for id in [a, b] {
+        let response = send(&state, "GET", &format!("/v1/cards/{id}/graph"), None).await;
+        let body = json_of(response).await;
+        assert_eq!(body["related"], json!([]));
+        assert_eq!(body["related_edges"], json!([]));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dissociate_returns_204_and_removes_the_relates_edge_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_dissociate_returns_204_and_removes_the_relates_edge(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dissociate_returns_204_and_removes_the_relates_edge_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_dissociate_returns_204_and_removes_the_relates_edge(state).await;
+}
+
+async fn test_spawns_cycle_returns_409_cycle_detected(state: AppState) {
+    let cards = seed_cards(&state, 2).await;
+    let (a, b) = (cards[0], cards[1]);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{a}/children"),
+        Some(&json!({"children": [b]})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{b}/children"),
+        Some(&json!({"children": [a]})),
+    )
+    .await;
+    assert_eq!(response.status(), 409);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "CYCLE_DETECTED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_spawns_cycle_returns_409_cycle_detected_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_spawns_cycle_returns_409_cycle_detected(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_spawns_cycle_returns_409_cycle_detected_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_spawns_cycle_returns_409_cycle_detected(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_self_block_returns_422_self_reference_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let cards = seed_cards(&state, 1).await;
+    let id = cards[0];
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{id}/blocks"),
+        Some(&json!({"blocked": id})),
+    )
+    .await;
+    assert_eq!(response.status(), 422);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "SELF_REFERENCE");
+}
+
+async fn test_duplicate_block_returns_409_duplicate_edge(state: AppState) {
+    let cards = seed_cards(&state, 2).await;
+    let (blocker, blocked) = (cards[0], cards[1]);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{blocker}/blocks"),
+        Some(&json!({"blocked": blocked})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{blocker}/blocks"),
+        Some(&json!({"blocked": blocked})),
+    )
+    .await;
+    assert_eq!(response.status(), 409);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "DUPLICATE_EDGE");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_duplicate_block_returns_409_duplicate_edge_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_duplicate_block_returns_409_duplicate_edge(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_duplicate_block_returns_409_duplicate_edge_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_duplicate_block_returns_409_duplicate_edge(state).await;
+}
+
+async fn test_remove_missing_edge_returns_404_edge_not_found(state: AppState) {
+    let cards = seed_cards(&state, 2).await;
+    let (a, b) = (cards[0], cards[1]);
+
+    let response = send(&state, "DELETE", &format!("/v1/cards/{a}/blocks/{b}"), None).await;
+    assert_eq!(response.status(), 404);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "EDGE_NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_remove_missing_edge_returns_404_edge_not_found_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_remove_missing_edge_returns_404_edge_not_found(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_remove_missing_edge_returns_404_edge_not_found_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_remove_missing_edge_returns_404_edge_not_found(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graph_write_on_unknown_card_returns_404_not_found_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let cards = seed_cards(&state, 1).await;
+    let real = cards[0];
+    let unknown = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{unknown}/children"),
+        Some(&json!({"children": [real]})),
+    )
+    .await;
+    assert_eq!(response.status(), 404);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "NOT_FOUND");
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{real}/children"),
+        Some(&json!({"children": [unknown]})),
+    )
+    .await;
+    assert_eq!(response.status(), 404);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "NOT_FOUND");
+}
+
+async fn test_attach_empty_children_pins_observed_behavior(state: AppState) {
+    let cards = seed_cards(&state, 1).await;
+    let id = cards[0];
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{id}/children"),
+        Some(&json!({"children": []})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+    let body = json_of(response).await;
+    assert_eq!(body["children"], json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_attach_empty_children_pins_observed_behavior_json() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    test_attach_empty_children_pins_observed_behavior(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_attach_empty_children_pins_observed_behavior_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    test_attach_empty_children_pins_observed_behavior(state).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graph_writes_emit_card_updated_frames() {
+    use kanban_service::api::{ChangeKind, EntityType};
+
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let cards = seed_cards(&state, 6).await;
+
+    let mut rx = state.event_tx.subscribe();
+
+    async fn next_frame(
+        rx: &mut tokio::sync::broadcast::Receiver<kanban_service::api::ChangeEventFrame>,
+    ) -> kanban_service::api::ChangeEventFrame {
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timed out waiting for a change event frame")
+            .expect("broadcast channel closed unexpectedly")
+    }
+
+    let (c0, c1, c2, c3, c4, c5) = (cards[0], cards[1], cards[2], cards[3], cards[4], cards[5]);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{c0}/children"),
+        Some(&json!({"children": [c1]})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_type, Some(EntityType::Card));
+    assert_eq!(frame.entity_id, Some(c0));
+    assert_eq!(frame.kind, Some(ChangeKind::Updated));
+    assert_eq!(frame.writer_instance_id, state.instance_id);
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{c2}/blocks"),
+        Some(&json!({"blocked": c3})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_id, Some(c2));
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/cards/{c4}/related"),
+        Some(&json!({"other": c5})),
+    )
+    .await;
+    assert_eq!(response.status(), 200);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_id, Some(c4));
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{c0}/children/{c1}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), 204);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_id, Some(c0));
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{c2}/blocks/{c3}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), 204);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_id, Some(c2));
+
+    let response = send(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{c4}/related/{c5}"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), 204);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.entity_id, Some(c4));
+}


### PR DESCRIPTION
## Summary

Adds the six missing dependency-graph write routes to `kanban-server`, POST/DELETE under `/v1/cards/{id}/{children|blocks|related}`, and extends `CardGraphResponse` with edge metadata so severity and relates-kind survive a write-then-read round trip over HTTP.

- `POST /v1/cards/{id}/children` (attach spawned children), `DELETE .../children/{child_id}` (detach)
- `POST /v1/cards/{id}/blocks` (block, with optional `severity`, default `medium`), `DELETE .../blocks/{blocked_id}` (unblock)
- `POST /v1/cards/{id}/related` (relate, with optional `kind`, default `general`), `DELETE .../related/{other_id}` (dissociate)
- Every write goes through `crate::state::mutate_unit` against the `MutationOperations` graph signatures, then `persist_and_broadcast` (Card/Updated). POST responses are built from a fresh post-mutation `RouteScope::CardGraph` sync; DELETE returns 204.
- `CardGraphResponse` gains `block_edges: Vec<BlockEdgeDto>` and `related_edges: Vec<RelatedEdgeDto>`, both `#[serde(default)]` so older 6-key payloads still deserialize. New `SeverityDto`/`RelatesKindDto` wire mirrors in `kanban-api`, exhaustive both directions, exported through `kanban_service::api::*`.
- Error mapping is exercised end to end: cycle -> 409 `CYCLE_DETECTED`, self-reference -> 422 `SELF_REFERENCE`, duplicate edge -> 409 `DUPLICATE_EDGE`, missing edge -> 404 `EDGE_NOT_FOUND`, unknown card (path or body) -> 404 `NOT_FOUND`.
- Attaching an empty `children` array is a pinned no-op: 200 with the unchanged graph (still durably saved and broadcast, since the underlying command batch is empty but still executes a transaction).
- README updates for both crates documenting the new routes and exports.

## Test plan

- [x] `cargo test -p kanban-api`: DTO unit tests (snake_case wire, exhaustive domain round trips, archived/foreign edge exclusion, backward-compatible deserialization)
- [x] `cargo test -p kanban-server --features test-helpers --test graph_write`: 25 integration tests across both JSON and SQLite backends, covering every write route, every error path (by status *and* body code), and severity/kind round-tripping over HTTP
- [x] `cargo test -p kanban-server --features test-helpers --test graph_read`: existing GET route, updated for the new response fields
- [x] `cargo test -p kanban-server --features test-helpers --test capability_guard`: unaffected, still green
- [x] Mutation check: severity mapping deliberately broken (mapped to `Medium` unconditionally), confirmed `test_block_write_then_read_round_trips_severity_over_the_wire_json` fails, then restored and re-verified green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace` (full suite, all crates green)
