### PR TITLE
KAN-1551 feat(server): full CardListFilter parity for GET /v1/boards/{id}/cards

### DIFF
--- a/.changeset/kan-1551-card-query-parity.md
+++ b/.changeset/kan-1551-card-query-parity.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: extend GET /v1/boards/{id}/cards to the full CardListFilter (status, search, sort, hide_assigned, multi-sprint_ids)

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -14,10 +14,10 @@ use kanban_domain::{
 use kanban_service::api::ArchivedCardResponse;
 use kanban_service::api::ArchivedFilterDto;
 use kanban_service::api::CardResponse;
+use kanban_service::api::{CardStatusDto, SortFieldDto, SortOrderDto};
 use kanban_service::api::{
     ChangeKind, CreateCardRequest, EntityType, Page, PageParams, UpdateCardRequest,
 };
-use kanban_service::api::{CardStatusDto, SortFieldDto, SortOrderDto};
 use kanban_service::{CardUpdate, KanbanError, KanbanOperations};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -56,7 +56,9 @@ pub struct CardQuery {
 fn card_query_filter(q: &CardQuery, board_id: Uuid, archived: ArchivedFilter) -> CardListFilter {
     let mut sprint_ids = q.sprint_ids.clone();
     if let Some(sprint_id) = q.sprint_id {
-        sprint_ids.get_or_insert_with(HashSet::new).insert(sprint_id);
+        sprint_ids
+            .get_or_insert_with(HashSet::new)
+            .insert(sprint_id);
     }
     CardListFilter {
         board_id: if archived == ArchivedFilter::LiveOnly {
@@ -447,4 +449,131 @@ pub fn flat_write_router() -> Router<AppState> {
         )
         .route("/v1/cards/{id}/archive", post(archive_card_route))
         .route("/v1/cards/{id}/restore", post(restore_card_route))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::{CardStatus, SortField, SortOrder};
+
+    #[test]
+    fn test_card_query_filter_maps_every_field() {
+        let board_id = Uuid::new_v4();
+        let sprint_id = Uuid::new_v4();
+        let other_sprint_id = Uuid::new_v4();
+        let q = CardQuery {
+            column_id: Some(Uuid::new_v4()),
+            sprint_id: Some(sprint_id),
+            sprint_ids: Some(HashSet::from([other_sprint_id])),
+            hide_assigned: true,
+            status: Some(CardStatusDto::Done),
+            search: Some("q".to_string()),
+            sort: Some(SortFieldDto::Priority),
+            sort_order: Some(SortOrderDto::Descending),
+            archived: ArchivedFilterDto::LiveOnly,
+        };
+
+        let filter = card_query_filter(&q, board_id, ArchivedFilter::LiveOnly);
+
+        assert_eq!(filter.board_id, Some(board_id));
+        assert_eq!(filter.column_id, q.column_id);
+        assert_eq!(
+            filter.sprint_ids,
+            Some(HashSet::from([sprint_id, other_sprint_id]))
+        );
+        assert!(filter.hide_assigned);
+        assert_eq!(filter.status, Some(CardStatus::Done));
+        assert_eq!(filter.search, Some("q".to_string()));
+        assert_eq!(filter.sort, Some(SortField::Priority));
+        assert_eq!(filter.sort_order, Some(SortOrder::Descending));
+        assert_eq!(filter.archived, ArchivedFilter::LiveOnly);
+    }
+
+    #[test]
+    fn test_card_query_filter_clears_board_id_for_non_live_only() {
+        let board_id = Uuid::new_v4();
+        let q = CardQuery::default();
+
+        for archived in [ArchivedFilter::Include, ArchivedFilter::ArchivedOnly] {
+            let filter = card_query_filter(&q, board_id, archived);
+            assert_eq!(filter.board_id, None);
+        }
+
+        let filter = card_query_filter(&q, board_id, ArchivedFilter::LiveOnly);
+        assert_eq!(filter.board_id, Some(board_id));
+    }
+
+    #[test]
+    fn test_card_query_filter_unions_sprint_id_into_sprint_ids() {
+        let board_id = Uuid::new_v4();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+
+        let only_sprint_id = CardQuery {
+            sprint_id: Some(a),
+            ..Default::default()
+        };
+        assert_eq!(
+            card_query_filter(&only_sprint_id, board_id, ArchivedFilter::LiveOnly).sprint_ids,
+            Some(HashSet::from([a]))
+        );
+
+        let only_sprint_ids = CardQuery {
+            sprint_ids: Some(HashSet::from([a, b])),
+            ..Default::default()
+        };
+        assert_eq!(
+            card_query_filter(&only_sprint_ids, board_id, ArchivedFilter::LiveOnly).sprint_ids,
+            Some(HashSet::from([a, b]))
+        );
+
+        let both = CardQuery {
+            sprint_id: Some(a),
+            sprint_ids: Some(HashSet::from([b])),
+            ..Default::default()
+        };
+        assert_eq!(
+            card_query_filter(&both, board_id, ArchivedFilter::LiveOnly).sprint_ids,
+            Some(HashSet::from([a, b]))
+        );
+
+        let neither = CardQuery::default();
+        assert_eq!(
+            card_query_filter(&neither, board_id, ArchivedFilter::LiveOnly).sprint_ids,
+            None
+        );
+    }
+
+    #[test]
+    fn test_uuid_csv_parses_a_list_and_rejects_garbage() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+
+        let q: CardQuery =
+            serde_json::from_value(serde_json::json!({ "sprint_ids": format!("{a},{b}") }))
+                .unwrap();
+        assert_eq!(q.sprint_ids, Some(HashSet::from([a, b])));
+
+        let err =
+            serde_json::from_value::<CardQuery>(serde_json::json!({ "sprint_ids": "notauuid" }));
+        assert!(err.is_err());
+
+        let q: CardQuery =
+            serde_json::from_value(serde_json::json!({ "sprint_ids": format!("{a}, {b} ") }))
+                .unwrap();
+        assert_eq!(q.sprint_ids, Some(HashSet::from([a, b])));
+    }
+
+    #[test]
+    fn test_uuid_csv_empty_value_yields_no_filter() {
+        let q: CardQuery = serde_json::from_value(serde_json::json!({ "sprint_ids": "" })).unwrap();
+        assert_eq!(q.sprint_ids, None);
+
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let q: CardQuery =
+            serde_json::from_value(serde_json::json!({ "sprint_ids": format!("{a},,{b}") }))
+                .unwrap();
+        assert_eq!(q.sprint_ids, Some(HashSet::from([a, b])));
+    }
 }

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -9,7 +9,7 @@ use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
 use kanban_domain::{
-    filter_and_sort_cards, ArchivedFilter, Card, CardListFilter, Model, NoProjections,
+    filter_and_sort_cards, ArchivedFilter, Card, CardListFilter, Model, NoProjections, Sprint,
 };
 use kanban_service::api::ArchivedCardResponse;
 use kanban_service::api::ArchivedFilterDto;
@@ -17,17 +17,62 @@ use kanban_service::api::CardResponse;
 use kanban_service::api::{
     ChangeKind, CreateCardRequest, EntityType, Page, PageParams, UpdateCardRequest,
 };
+use kanban_service::api::{CardStatusDto, SortFieldDto, SortOrderDto};
 use kanban_service::{CardUpdate, KanbanError, KanbanOperations};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
-#[derive(Debug, Deserialize)]
+/// Comma-separated UUID list; blank segments are skipped, an all-blank value
+/// yields `None`.
+fn uuid_csv<'de, D>(deserializer: D) -> Result<Option<HashSet<Uuid>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    let mut ids = HashSet::new();
+    for part in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        ids.insert(Uuid::parse_str(part).map_err(serde::de::Error::custom)?);
+    }
+    Ok(if ids.is_empty() { None } else { Some(ids) })
+}
+
+#[derive(Debug, Default, Deserialize)]
 pub struct CardQuery {
     pub column_id: Option<Uuid>,
     pub sprint_id: Option<Uuid>,
+    #[serde(default, deserialize_with = "uuid_csv")]
+    pub sprint_ids: Option<HashSet<Uuid>>,
+    #[serde(default)]
+    pub hide_assigned: bool,
+    pub status: Option<CardStatusDto>,
+    pub search: Option<String>,
+    pub sort: Option<SortFieldDto>,
+    pub sort_order: Option<SortOrderDto>,
     #[serde(default)]
     pub archived: ArchivedFilterDto,
+}
+
+fn card_query_filter(q: &CardQuery, board_id: Uuid, archived: ArchivedFilter) -> CardListFilter {
+    let mut sprint_ids = q.sprint_ids.clone();
+    if let Some(sprint_id) = q.sprint_id {
+        sprint_ids.get_or_insert_with(HashSet::new).insert(sprint_id);
+    }
+    CardListFilter {
+        board_id: if archived == ArchivedFilter::LiveOnly {
+            Some(board_id)
+        } else {
+            None
+        },
+        column_id: q.column_id,
+        sprint_ids,
+        hide_assigned: q.hide_assigned,
+        status: q.status.map(Into::into),
+        search: q.search.clone(),
+        sort: q.sort.map(Into::into),
+        sort_order: q.sort_order.map(Into::into),
+        archived,
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,10 +97,12 @@ async fn list_cards(
     Query(params): Query<PageParams>,
 ) -> Result<Json<Page<CardResponse>>, AppError> {
     let archived: ArchivedFilter = q.archived.into();
+    let searching = q.search.as_deref().is_some_and(|s| !s.is_empty());
     let scope = RouteScope::BoardCards {
         board_id,
         column_id: q.column_id,
         archived,
+        search: searching,
     };
 
     let guard = state.lock_session().await;
@@ -98,18 +145,13 @@ async fn list_cards(
         }
     }
 
-    let filter = CardListFilter {
-        board_id: if archived == ArchivedFilter::LiveOnly {
-            Some(board_id)
-        } else {
-            None
-        },
-        column_id: q.column_id,
-        sprint_ids: q.sprint_id.map(|id| HashSet::from([id])),
-        archived,
-        ..Default::default()
+    let filter = card_query_filter(&q, board_id, archived);
+    let sprints: &[Sprint] = if searching {
+        require_loaded(model.board_sprints_state(board_id), "sprints of board")?
+    } else {
+        &[]
     };
-    let filtered = filter_and_sort_cards(&cards, columns, &[], Some(board), &[], &filter);
+    let filtered = filter_and_sort_cards(&cards, columns, sprints, Some(board), &[], &filter);
     let responses: Vec<CardResponse> = filtered
         .iter()
         .map(|c| CardResponse::with_archived_at(c, archived_at.get(&c.id).copied()))

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -414,6 +414,35 @@ mod tests {
     }
 
     #[test]
+    fn test_route_scope_for_board_cards_with_search_plans_the_board_sprint_tier() {
+        let board_id = Uuid::new_v4();
+        let round = RouteScope::BoardCards {
+            board_id,
+            column_id: None,
+            archived: ArchivedFilter::LiveOnly,
+            search: true,
+        }
+        .next_round(&Model::default());
+
+        assert_eq!(round.sprints_by_board, vec![board_id]);
+    }
+
+    #[test]
+    fn test_route_scope_for_board_cards_without_search_plans_no_sprint_tier() {
+        let board_id = Uuid::new_v4();
+        let round = RouteScope::BoardCards {
+            board_id,
+            column_id: None,
+            archived: ArchivedFilter::LiveOnly,
+            search: false,
+        }
+        .next_round(&Model::default());
+
+        assert!(round.sprints_by_board.is_empty());
+        assert!(!round.sprint_list);
+    }
+
+    #[test]
     fn test_route_scope_for_board_archived_cards_requests_the_board_and_its_markers() {
         let board_id = Uuid::new_v4();
         let round = RouteScope::BoardArchivedCards(board_id).next_round(&Model::default());

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -18,6 +18,9 @@ pub enum RouteScope {
         board_id: Uuid,
         column_id: Option<Uuid>,
         archived: ArchivedFilter,
+        /// Plans the board's sprint tier, which the search predicate reads
+        /// to match a card's branch name.
+        search: bool,
     },
     BoardArchivedCards(Uuid),
     BoardSprints(Uuid),
@@ -63,6 +66,7 @@ impl FetchPlan for RouteScope {
                 board_id,
                 column_id,
                 archived,
+                search,
             } => {
                 want_board(&mut round, loaded, board_id);
                 if requestable(loaded.columns_of_board(board_id)) {
@@ -95,6 +99,9 @@ impl FetchPlan for RouteScope {
                             }
                         }
                     }
+                }
+                if search && requestable(loaded.sprints_of_board(board_id)) {
+                    round.sprints_by_board.push(board_id);
                 }
             }
             RouteScope::BoardArchivedCards(board_id) => {
@@ -217,6 +224,7 @@ mod tests {
             board_id,
             column_id: None,
             archived: ArchivedFilter::LiveOnly,
+            search: false,
         }
         .next_round(&Model::default());
 
@@ -257,6 +265,7 @@ mod tests {
             board_id,
             column_id: None,
             archived: ArchivedFilter::LiveOnly,
+            search: false,
         };
         let round2 = scope.next_round(&model);
         assert_eq!(
@@ -288,6 +297,7 @@ mod tests {
             board_id,
             column_id: Some(column_id),
             archived: ArchivedFilter::LiveOnly,
+            search: false,
         }
         .next_round(&Model::default());
 
@@ -303,6 +313,7 @@ mod tests {
             board_id,
             column_id: None,
             archived: ArchivedFilter::LiveOnly,
+            search: false,
         }
         .next_round(&Model::default());
 
@@ -332,6 +343,7 @@ mod tests {
             board_id,
             column_id: None,
             archived: ArchivedFilter::Include,
+            search: false,
         };
 
         let round1 = scope.next_round(&Model::default());
@@ -387,12 +399,14 @@ mod tests {
             board_id,
             column_id: None,
             archived: ArchivedFilter::Include,
+            search: false,
         }
         .next_round(&Model::default());
         let archived_only_round = RouteScope::BoardCards {
             board_id,
             column_id: None,
             archived: ArchivedFilter::ArchivedOnly,
+            search: false,
         }
         .next_round(&Model::default());
 

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -5,10 +5,11 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_domain::{CardPriority, CardUpdate, CreateCardOptions};
+use kanban_domain::{CardPriority, CardStatus, CardUpdate, CreateCardOptions};
 use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
 use kanban_service::api::CardResponse;
 use kanban_service::KanbanOperations;
+use std::collections::HashSet;
 use tempfile::tempdir;
 use uuid::Uuid;
 
@@ -1002,4 +1003,653 @@ async fn test_list_cards_with_a_column_from_another_board_returns_an_empty_page_
             "query {query:?} should return no cards from another board's column"
         );
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_sprint_ids_csv_filters_any_of() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let sprint_a: Uuid;
+    let sprint_b: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        sprint_a = ctx.create_sprint(board_id, None, None).unwrap().id;
+        sprint_b = ctx.create_sprint(board_id, None, None).unwrap().id;
+        let sprint_c = ctx.create_sprint(board_id, None, None).unwrap().id;
+
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Card A".to_string(),
+            CreateCardOptions {
+                sprint_id: Some(sprint_a),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Card B".to_string(),
+            CreateCardOptions {
+                sprint_id: Some(sprint_b),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Card C".to_string(),
+            CreateCardOptions {
+                sprint_id: Some(sprint_c),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!(
+            "/v1/boards/{}/cards?sprint_ids={},{}",
+            board_id, sprint_a, sprint_b
+        ),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    let sprint_ids: HashSet<String> = items
+        .iter()
+        .map(|c| c["sprint_id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(items.len(), 2, "items: {items:?}");
+    assert_eq!(
+        sprint_ids,
+        HashSet::from([sprint_a.to_string(), sprint_b.to_string()])
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_sprint_id_and_sprint_ids_union() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let sprint_a: Uuid;
+    let sprint_b: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        sprint_a = ctx.create_sprint(board_id, None, None).unwrap().id;
+        sprint_b = ctx.create_sprint(board_id, None, None).unwrap().id;
+
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Card A".to_string(),
+            CreateCardOptions {
+                sprint_id: Some(sprint_a),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Card B".to_string(),
+            CreateCardOptions {
+                sprint_id: Some(sprint_b),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!(
+            "/v1/boards/{}/cards?sprint_id={}&sprint_ids={}",
+            board_id, sprint_a, sprint_b
+        ),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    let sprint_ids: HashSet<String> = items
+        .iter()
+        .map(|c| c["sprint_id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(items.len(), 2, "items: {items:?}");
+    assert_eq!(
+        sprint_ids,
+        HashSet::from([sprint_a.to_string(), sprint_b.to_string()])
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_filters_by_status() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let done_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        let _todo_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Todo Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        done_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Done Card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.update_card(
+            done_id,
+            CardUpdate {
+                status: Some(CardStatus::Done),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?status=done", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "items: {items:?}");
+    assert_eq!(items[0]["id"], done_id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_unknown_status_value_returns_400() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?status=bogus", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_search_matches_title_case_insensitive() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let needle_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        needle_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "needle in title".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.create_card(
+            board_id,
+            col_id,
+            "unrelated".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?search=NEEdle", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "items: {items:?}");
+    assert_eq!(items[0]["id"], needle_id.to_string());
+}
+
+async fn search_matches_sprint_branch_segment(sqlite: bool) {
+    let dir = tempdir().unwrap();
+    let state = if sqlite {
+        make_sqlite_state(&dir.path().join("s.sqlite")).await
+    } else {
+        make_state(&dir.path().join("s.json"))
+    };
+
+    let board_id: Uuid;
+    let card_x_id: Uuid;
+    let query: String;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        let sprint = ctx
+            .create_sprint(board_id, Some("zed".to_string()), Some("S".to_string()))
+            .unwrap();
+        query = format!(
+            "{}-{}",
+            sprint.prefix.as_deref().unwrap(),
+            sprint.sprint_number
+        );
+
+        card_x_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "card x".to_string(),
+                CreateCardOptions {
+                    sprint_id: Some(sprint.id),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+        ctx.create_card(board_id, col_id, "card y".to_string(), Default::default())
+            .unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?search={}", board_id, query),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "items: {items:?}");
+    assert_eq!(items[0]["id"], card_x_id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_search_matches_the_sprint_segment_of_the_branch_name() {
+    search_matches_sprint_branch_segment(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_search_over_a_sqlite_locator_matches_the_sprint_branch_segment() {
+    search_matches_sprint_branch_segment(true).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_hide_assigned_excludes_sprint_members() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let unassigned_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        let sprint_id = ctx.create_sprint(board_id, None, None).unwrap().id;
+        ctx.create_card(
+            board_id,
+            col_id,
+            "Assigned".to_string(),
+            CreateCardOptions {
+                sprint_id: Some(sprint_id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        unassigned_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Unassigned".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?hide_assigned=true", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "items: {items:?}");
+    assert_eq!(items[0]["id"], unassigned_id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_sort_by_priority_descending() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let low_id: Uuid;
+    let critical_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        low_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Low".to_string(),
+                CreateCardOptions {
+                    priority: Some(CardPriority::Low),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+        critical_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Critical".to_string(),
+                CreateCardOptions {
+                    priority: Some(CardPriority::Critical),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!(
+            "/v1/boards/{}/cards?sort=priority&sort_order=descending",
+            board_id
+        ),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    let ids: Vec<String> = items
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids, vec![critical_id.to_string(), low_id.to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_status_and_column_and_search_compose() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let col1_id: Uuid;
+    let target_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        col1_id = ctx
+            .create_column(board_id, "Column 1".to_string(), None)
+            .unwrap()
+            .id;
+        let col2_id = ctx
+            .create_column(board_id, "Column 2".to_string(), None)
+            .unwrap()
+            .id;
+
+        let wrong_status = ctx
+            .create_card(
+                board_id,
+                col1_id,
+                "keyword card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let wrong_search = ctx
+            .create_card(
+                board_id,
+                col1_id,
+                "unrelated card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let wrong_column = ctx
+            .create_card(
+                board_id,
+                col2_id,
+                "keyword card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        target_id = ctx
+            .create_card(
+                board_id,
+                col1_id,
+                "keyword card".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+
+        for id in [wrong_search, wrong_column, target_id] {
+            ctx.update_card(
+                id,
+                CardUpdate {
+                    status: Some(CardStatus::Done),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        }
+        let _ = wrong_status;
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!(
+            "/v1/boards/{}/cards?column_id={}&status=done&search=keyword",
+            board_id, col1_id
+        ),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "items: {items:?}");
+    assert_eq!(items[0]["id"], target_id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_archived_include_with_status_filters_dangling_column_archived_cards() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id: Uuid;
+    let todo_id: Uuid;
+    {
+        let mut ctx = state.ctx.lock().await;
+        board_id = ctx
+            .create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "Column".to_string(), None)
+            .unwrap()
+            .id;
+        todo_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Todo Archived".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        let done_id = ctx
+            .create_card(
+                board_id,
+                col_id,
+                "Done Archived".to_string(),
+                Default::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.update_card(
+            done_id,
+            CardUpdate {
+                status: Some(CardStatus::Done),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        ctx.archive_card(todo_id).unwrap();
+        ctx.archive_card(done_id).unwrap();
+        ctx.delete_column(col_id).unwrap();
+    }
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?archived=include&status=todo", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_of(response).await;
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "items: {items:?}");
+    assert_eq!(items[0]["id"], todo_id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_malformed_sprint_ids_returns_400() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Test Board".to_string(), Some("TB".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?sprint_ids=notauuid", board_id),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let valid = Uuid::new_v4();
+    let response = send(
+        &state,
+        "GET",
+        &format!(
+            "/v1/boards/{}/cards?sprint_ids={},notauuid",
+            board_id, valid
+        ),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }


### PR DESCRIPTION
## Summary

- `CardQuery` on `GET /v1/boards/{board_id}/cards` grows from 3 to all 8 `CardListFilter` axes: `status`, `search`, `sort`, `sort_order`, `hide_assigned`, and a comma-separated `sprint_ids` (unioned with the existing singular `sprint_id`), plus the existing `column_id` and `archived`.
- A new private `card_query_filter` builds a `CardListFilter` from the query and threads every request through the same `filter_and_sort_cards` engine the local backends use, replacing the previous hand-rolled filter literal.
- `RouteScope::BoardCards` gains a `search: bool` field. When the request has a non-empty `search`, the fetch plan additionally loads the board's `sprints_by_board` tier, matching `KanbanContext::filter_cards`'s `searching` rule, so the branch-name-based sprint search works over HTTP the same way it works locally. When there is no search, no sprint tier is planned, keeping the hot list path free of an extra fetch.
- A new `uuid_csv` deserializer parses the `sprint_ids` query param: comma-separated UUIDs, blank segments skipped, an all-blank value yields no filter, and a malformed id is a 400.
- An unknown `status` value now returns a 400 (axum's plain-text `Query` rejection, not the JSON error envelope; enveloping unknown-query-value errors is left as a follow-up).

## Tests

- 12 new integration tests in `crates/kanban-server/tests/cards_read.rs` covering each new filter axis individually, several composed together, the sprint-search-through-branch-name behavior on both the JSON and SQLite backends, and the two new 400 cases.
- 2 new `RouteScope` unit tests pinning that the sprint tier is planned only when searching.
- 5 new unit tests for `card_query_filter` and `uuid_csv`.
- Confirmed the sprint-search fix is load-bearing by reverting it to `&[]` and observing the two sprint-search tests fail, then restoring it.

## Scope

Confined to `crates/kanban-server/src/routes/cards.rs`, `crates/kanban-server/src/scope.rs`, and `crates/kanban-server/tests/cards_read.rs`. No change to `CardListFilter`, `filter_and_sort_cards`, `KanbanContext::filter_cards`, the flat/unscoped card routes, or the archived-cards marker route.
