### PR TITLE
KAN-1550 feat(api,server): batch card operation routes over HTTP

### DIFF
--- a/.changeset/kan-1550-batch-op-routes.md
+++ b/.changeset/kan-1550-batch-op-routes.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+add batch card operation routes for archive, move, assign-sprint and update

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -6,13 +6,14 @@
 mod v1;
 pub use v1::{
     ActivateSprintRequest, AddBlockRequest, AddRelatedRequest, ApiError, ArchivedBoardResponse,
-    ArchivedCardResponse, ArchivedFilterDto, AttachChildrenRequest, BlockEdgeDto, BoardResponse,
-    CardGraphResponse, CardPriorityDto, CardResponse, CardStatusDto, CarryOverRequest,
-    CarryOverResponse, ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest,
-    CreateCardRequest, CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType,
-    ErrorCode, Page, PageParams, Patch, PrefixResponse, RelatedEdgeDto, RelatesKindDto,
-    ReorderColumnRequest, ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest,
-    ReplaceSprintRequest, SeverityDto, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto,
-    TaskListViewDto, UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest,
-    UpdateSprintRequest,
+    ArchivedCardResponse, ArchivedFilterDto, AttachChildrenRequest, BatchArchiveRequest,
+    BatchAssignSprintRequest, BatchFailure, BatchMoveRequest, BatchOperationResponse,
+    BatchUpdateItem, BatchUpdateRequest, BlockEdgeDto, BoardResponse, CardGraphResponse,
+    CardPriorityDto, CardResponse, CardStatusDto, CarryOverRequest, CarryOverResponse,
+    ChangeEventFrame, ChangeKind, ColumnResponse, CreateBoardRequest, CreateCardRequest,
+    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType, ErrorCode, Page,
+    PageParams, Patch, PrefixResponse, RelatedEdgeDto, RelatesKindDto, ReorderColumnRequest,
+    ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest,
+    SeverityDto, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto,
+    UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
 };

--- a/crates/kanban-api/src/v1/cards/batch.rs
+++ b/crates/kanban-api/src/v1/cards/batch.rs
@@ -1,0 +1,45 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v1::Patch;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_batch_update_item_flattens_update_fields() {
+        let id = Uuid::new_v4();
+        let json = serde_json::json!({
+            "id": id,
+            "title": "T",
+            "points": 3,
+            "description": null,
+        });
+
+        let item: BatchUpdateItem = serde_json::from_value(json).unwrap();
+
+        assert_eq!(item.id, id);
+        assert_eq!(item.update.title, Some("T".to_string()));
+        assert_eq!(item.update.points, Patch::Set(3));
+        assert_eq!(item.update.description, Patch::Clear);
+        assert_eq!(item.update.due_date, Patch::NoChange);
+    }
+
+    #[test]
+    fn test_batch_operation_response_serde_round_trip() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let response = BatchOperationResponse::new(
+            vec![a],
+            vec![BatchFailure::new(b, "Card ... not found".to_string())],
+        );
+
+        let value = serde_json::to_value(&response).unwrap();
+        assert_eq!(value["succeeded"][0], a.to_string());
+        assert_eq!(value["failed"][0]["id"], b.to_string());
+        assert!(value["failed"][0]["error"].is_string());
+
+        let round_tripped: BatchOperationResponse = serde_json::from_value(value).unwrap();
+        assert_eq!(round_tripped.succeeded, response.succeeded);
+        assert_eq!(round_tripped.failed[0].id, response.failed[0].id);
+        assert_eq!(round_tripped.failed[0].error, response.failed[0].error);
+    }
+}

--- a/crates/kanban-api/src/v1/cards/batch.rs
+++ b/crates/kanban-api/src/v1/cards/batch.rs
@@ -1,3 +1,68 @@
+use super::requests::UpdateCardRequest;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct BatchArchiveRequest {
+    pub ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct BatchMoveRequest {
+    pub ids: Vec<Uuid>,
+    pub column_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct BatchAssignSprintRequest {
+    pub ids: Vec<Uuid>,
+    pub sprint_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchUpdateItem {
+    pub id: Uuid,
+    #[serde(flatten)]
+    pub update: UpdateCardRequest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchUpdateRequest {
+    pub updates: Vec<BatchUpdateItem>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchFailure {
+    pub id: Uuid,
+    pub error: String,
+}
+
+impl BatchFailure {
+    pub fn new(id: Uuid, error: impl Into<String>) -> Self {
+        Self {
+            id,
+            error: error.into(),
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchOperationResponse {
+    pub succeeded: Vec<Uuid>,
+    pub failed: Vec<BatchFailure>,
+}
+
+impl BatchOperationResponse {
+    pub fn new(succeeded: Vec<Uuid>, failed: Vec<BatchFailure>) -> Self {
+        Self { succeeded, failed }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-api/src/v1/cards/mod.rs
+++ b/crates/kanban-api/src/v1/cards/mod.rs
@@ -1,7 +1,12 @@
 mod archived_response;
+mod batch;
 mod conversions;
 mod requests;
 mod response;
 pub use archived_response::ArchivedCardResponse;
+pub use batch::{
+    BatchArchiveRequest, BatchAssignSprintRequest, BatchFailure, BatchMoveRequest,
+    BatchOperationResponse, BatchUpdateItem, BatchUpdateRequest,
+};
 pub use requests::{CreateCardRequest, ReplaceCardRequest, UpdateCardRequest};
 pub use response::CardResponse;

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -15,7 +15,9 @@ pub use boards::{
     UpdateBoardRequest,
 };
 pub use cards::{
-    ArchivedCardResponse, CardResponse, CreateCardRequest, ReplaceCardRequest, UpdateCardRequest,
+    ArchivedCardResponse, BatchArchiveRequest, BatchAssignSprintRequest, BatchFailure,
+    BatchMoveRequest, BatchOperationResponse, BatchUpdateItem, BatchUpdateRequest, CardResponse,
+    CreateCardRequest, ReplaceCardRequest, UpdateCardRequest,
 };
 pub use columns::{
     ColumnResponse, CreateColumnRequest, ReorderColumnRequest, ReplaceColumnRequest,

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -198,6 +198,10 @@ Column writes (create/update/delete) aren't implemented yet.
 | `GET` | `/v1/boards/{board_id}/cards` | List a board's cards. 404s if `board_id` doesn't exist (does not collapse into an empty list). Supports `?column_id=`, `?sprint_id=` and `?archived=` filters alongside pagination. Returns `Page<CardResponse>`; accepts `?page=&page_size=`. | — |
 | `POST` | `/v1/cards/{id}/archive` | Archive a card. `200` with `CardResponse` (`archived_at` set). 404 if the card is unknown or already archived. | — |
 | `POST` | `/v1/cards/{id}/restore` | Restore an archived card. `200` with the live `CardResponse` (no `archived_at`). Accepts `?column_id=` to redirect it to a different column; otherwise it stays in its current column. 404 if the card is not archived, or if `column_id` names an unknown column. | — |
+| `POST` | `/v1/cards/batch/archive` | Archive up to N cards. `200` with `BatchOperationResponse`: each id lands in `succeeded` or `failed` (with an error message) independently; an unknown id never fails the whole request. | `BatchArchiveRequest` (`{"ids": [uuid, ...]}`) |
+| `POST` | `/v1/cards/batch/move` | Move up to N cards into `column_id`. `200` with `BatchOperationResponse`. If moving would violate the target column's WIP limit, every id in the request fails with no card moved. | `BatchMoveRequest` (`{"ids": [uuid, ...], "column_id": uuid}`) |
+| `POST` | `/v1/cards/batch/assign-sprint` | Assign up to N cards to `sprint_id`. `200` with `BatchOperationResponse`. An unknown sprint id fails every card id. | `BatchAssignSprintRequest` (`{"ids": [uuid, ...], "sprint_id": uuid}`) |
+| `POST` | `/v1/cards/batch/update` | Apply a per-card `UpdateCardRequest`-shaped patch to each id, all-or-nothing. `200` with `BatchOperationResponse` (`failed` always empty) on full success; an unknown id or any other execution error is an ordinary `ApiError` envelope and no card is modified. | `BatchUpdateRequest` (`{"updates": [{"id": uuid, ...UpdateCardRequest fields}, ...]}`) |
 
 The remaining card routes (get/create/replace/update/delete, and the flat `/v1/cards/{id}` aliases) exist but aren't documented in this table yet.
 

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -40,6 +40,7 @@ pub fn router_with(state: AppState, config: LayerConfig) -> Router {
         .merge(crate::routes::cards::write_router())
         .merge(crate::routes::cards::flat_read_router())
         .merge(crate::routes::cards::flat_write_router())
+        .merge(crate::routes::cards_batch::write_router())
         .merge(crate::routes::columns::read_router())
         .merge(crate::routes::columns::write_router())
         .merge(crate::routes::columns::flat_read_router())

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -21,6 +21,7 @@ pub mod test_helpers;
 pub mod routes {
     pub mod boards;
     pub mod cards;
+    pub mod cards_batch;
     pub mod columns;
     pub mod events;
     pub mod graph;

--- a/crates/kanban-server/src/routes/cards_batch.rs
+++ b/crates/kanban-server/src/routes/cards_batch.rs
@@ -1,0 +1,101 @@
+use crate::error::{AppError, AppJson};
+use crate::state::{AppState, Session};
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use kanban_service::api::{
+    BatchArchiveRequest, BatchAssignSprintRequest, BatchFailure, BatchMoveRequest,
+    BatchOperationResponse, BatchUpdateRequest, ChangeKind, EntityType,
+};
+use kanban_service::{BatchOperationResult, CardUpdate};
+use uuid::Uuid;
+
+fn to_wire(result: &BatchOperationResult) -> BatchOperationResponse {
+    BatchOperationResponse::new(
+        result.succeeded.clone(),
+        result
+            .failed
+            .iter()
+            .map(|f| BatchFailure::new(f.id, f.error.clone()))
+            .collect(),
+    )
+}
+
+async fn run_detailed(
+    state: &AppState,
+    op: impl FnOnce(&mut Session) -> BatchOperationResult,
+) -> Result<BatchOperationResponse, AppError> {
+    let mut ctx = state.ctx.lock().await;
+    let result = op(&mut ctx);
+    ctx.save().await.map_err(|e| AppError::from(&e))?;
+    for id in &result.succeeded {
+        state.broadcast_change(EntityType::Card, *id, ChangeKind::Updated);
+    }
+    Ok(to_wire(&result))
+}
+
+async fn batch_archive_route(
+    State(state): State<AppState>,
+    AppJson(req): AppJson<BatchArchiveRequest>,
+) -> Result<Json<BatchOperationResponse>, AppError> {
+    Ok(Json(
+        run_detailed(&state, |c| c.archive_cards_detailed(req.ids).0).await?,
+    ))
+}
+
+async fn batch_move_route(
+    State(state): State<AppState>,
+    AppJson(req): AppJson<BatchMoveRequest>,
+) -> Result<Json<BatchOperationResponse>, AppError> {
+    Ok(Json(
+        run_detailed(&state, |c| c.move_cards_detailed(req.ids, req.column_id).0).await?,
+    ))
+}
+
+async fn batch_assign_sprint_route(
+    State(state): State<AppState>,
+    AppJson(req): AppJson<BatchAssignSprintRequest>,
+) -> Result<Json<BatchOperationResponse>, AppError> {
+    Ok(Json(
+        run_detailed(&state, |c| {
+            c.assign_cards_to_sprint_detailed(req.ids, req.sprint_id).0
+        })
+        .await?,
+    ))
+}
+
+async fn batch_update_route(
+    State(state): State<AppState>,
+    AppJson(req): AppJson<BatchUpdateRequest>,
+) -> Result<Json<BatchOperationResponse>, AppError> {
+    let ids: Vec<Uuid> = req.updates.iter().map(|i| i.id).collect();
+    let pairs: Vec<(Uuid, CardUpdate)> = req
+        .updates
+        .into_iter()
+        .map(|i| CardUpdate::try_from(i.update).map(|u| (i.id, u)))
+        .collect::<Result<_, _>>()
+        .map_err(|e| AppError::from(&e))?;
+
+    let mut ctx = state.ctx.lock().await;
+    let (_count, _inv) = crate::state::mutate(&mut ctx, |c| c.update_cards_impl(pairs))
+        .map_err(|e| AppError::from(&e))?;
+    ctx.save().await.map_err(|e| AppError::from(&e))?;
+    for id in &ids {
+        state.broadcast_change(EntityType::Card, *id, ChangeKind::Updated);
+    }
+    Ok(Json(BatchOperationResponse::new(ids, vec![])))
+}
+
+/// Invalid ids are rejected individually; the remaining ids are applied in a
+/// single transaction, so on any execution error no card is modified and
+/// every id is reported failed.
+pub fn write_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/cards/batch/archive", post(batch_archive_route))
+        .route("/v1/cards/batch/move", post(batch_move_route))
+        .route(
+            "/v1/cards/batch/assign-sprint",
+            post(batch_assign_sprint_route),
+        )
+        .route("/v1/cards/batch/update", post(batch_update_route))
+}

--- a/crates/kanban-server/tests/capability_guard.rs
+++ b/crates/kanban-server/tests/capability_guard.rs
@@ -5,6 +5,7 @@ const SOURCES: &[&str] = &[
     include_str!("../src/app.rs"),
     include_str!("../src/routes/boards.rs"),
     include_str!("../src/routes/cards.rs"),
+    include_str!("../src/routes/cards_batch.rs"),
     include_str!("../src/routes/columns.rs"),
     include_str!("../src/routes/sprints.rs"),
     include_str!("../src/routes/sprints_lifecycle.rs"),

--- a/crates/kanban-server/tests/cards_batch.rs
+++ b/crates/kanban-server/tests/cards_batch.rs
@@ -1,0 +1,485 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::http::StatusCode;
+use kanban_domain::{ColumnUpdate, FieldUpdate, KanbanOperations};
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use serde_json::json;
+use std::time::Duration;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn seed_two_cards(state: &AppState) -> (Uuid, Uuid, Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col_id = ctx
+        .create_column(board_id, "To Do".to_string(), None)
+        .unwrap()
+        .id;
+    let c1 = ctx
+        .create_card(board_id, col_id, "One".to_string(), Default::default())
+        .unwrap()
+        .id;
+    let c2 = ctx
+        .create_card(board_id, col_id, "Two".to_string(), Default::default())
+        .unwrap()
+        .id;
+    (board_id, col_id, c1, c2)
+}
+
+async fn scenario_batch_archive_reports_per_id_success_and_failure(state: AppState) {
+    let (board_id, _col_id, c1, c2) = seed_two_cards(&state).await;
+    let missing = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/archive",
+        Some(&json!({ "ids": [c1, c2, missing] })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    let succeeded: Vec<String> = body["succeeded"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        succeeded
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>(),
+        [c1.to_string(), c2.to_string()].into_iter().collect()
+    );
+    let failed = body["failed"].as_array().unwrap();
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed[0]["id"], missing.to_string());
+    assert!(failed[0]["error"].as_str().unwrap().contains("not found"));
+
+    let archived_resp = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/archived-cards", board_id),
+        None,
+    )
+    .await;
+    let archived = json_of(archived_resp).await;
+    let ids: Vec<String> = archived["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["entity_id"].as_str().unwrap().to_string())
+        .collect();
+    assert!(ids.contains(&c1.to_string()));
+    assert!(ids.contains(&c2.to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_archive_route_reports_per_id_success_and_failure_json() {
+    let dir = tempdir().unwrap();
+    scenario_batch_archive_reports_per_id_success_and_failure(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_archive_route_reports_per_id_success_and_failure_sqlite() {
+    let dir = tempdir().unwrap();
+    scenario_batch_archive_reports_per_id_success_and_failure(
+        make_sqlite_state(&dir.path().join("s.sqlite")).await,
+    )
+    .await;
+}
+
+async fn scenario_batch_archive_path_not_captured_by_flat_card_id_route(state: AppState) {
+    let (_board_id, _col_id, c1, c2) = seed_two_cards(&state).await;
+
+    let batch_response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/archive",
+        Some(&json!({ "ids": [c1] })),
+    )
+    .await;
+    assert_eq!(batch_response.status(), StatusCode::OK);
+
+    let flat_response = send(&state, "POST", &format!("/v1/cards/{}/archive", c2), None).await;
+    assert_eq!(flat_response.status(), StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_archive_path_is_not_captured_by_the_flat_card_id_route() {
+    let dir = tempdir().unwrap();
+    scenario_batch_archive_path_not_captured_by_flat_card_id_route(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+async fn scenario_batch_archive_route_with_empty_ids_returns_empty_result(state: AppState) {
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/archive",
+        Some(&json!({ "ids": [] })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["succeeded"].as_array().unwrap().len(), 0);
+    assert_eq!(body["failed"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_archive_route_with_empty_ids_returns_empty_result() {
+    let dir = tempdir().unwrap();
+    scenario_batch_archive_route_with_empty_ids_returns_empty_result(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+async fn scenario_batch_move_route_moves_valid_ids_into_target_column(state: AppState) {
+    let (board_id, col_a, c1, c2) = seed_two_cards(&state).await;
+    let mut ctx = state.ctx.lock().await;
+    let col_b = ctx
+        .create_column(board_id, "Doing".to_string(), None)
+        .unwrap()
+        .id;
+    drop(ctx);
+    let _ = col_a;
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/move",
+        Some(&json!({ "ids": [c1, c2], "column_id": col_b })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["succeeded"].as_array().unwrap().len(), 2);
+    assert_eq!(body["failed"].as_array().unwrap().len(), 0);
+
+    for id in [c1, c2] {
+        let card_resp = send(&state, "GET", &format!("/v1/cards/{}", id), None).await;
+        let card = json_of(card_resp).await;
+        assert_eq!(card["column_id"], col_b.to_string());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_move_route_moves_valid_ids_into_target_column() {
+    let dir = tempdir().unwrap();
+    scenario_batch_move_route_moves_valid_ids_into_target_column(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+async fn scenario_batch_move_route_wip_violation_fails_every_id_and_changes_nothing(
+    state: AppState,
+) {
+    let (board_id, col_a, c1, c2) = seed_two_cards(&state).await;
+    let mut ctx = state.ctx.lock().await;
+    let col_b = ctx
+        .create_column(board_id, "Doing".to_string(), None)
+        .unwrap()
+        .id;
+    ctx.update_column(
+        col_b,
+        ColumnUpdate {
+            wip_limit: FieldUpdate::Set(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    drop(ctx);
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/move",
+        Some(&json!({ "ids": [c1, c2], "column_id": col_b })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["succeeded"].as_array().unwrap().len(), 0);
+    let failed = body["failed"].as_array().unwrap();
+    assert_eq!(failed.len(), 2);
+    for f in failed {
+        assert!(f["error"].as_str().unwrap().to_lowercase().contains("wip"));
+    }
+
+    for id in [c1, c2] {
+        let card_resp = send(&state, "GET", &format!("/v1/cards/{}", id), None).await;
+        let card = json_of(card_resp).await;
+        assert_eq!(card["column_id"], col_a.to_string());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_move_route_wip_violation_fails_every_id_and_changes_nothing_json() {
+    let dir = tempdir().unwrap();
+    scenario_batch_move_route_wip_violation_fails_every_id_and_changes_nothing(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_move_route_wip_violation_fails_every_id_and_changes_nothing_sqlite() {
+    let dir = tempdir().unwrap();
+    scenario_batch_move_route_wip_violation_fails_every_id_and_changes_nothing(
+        make_sqlite_state(&dir.path().join("s.sqlite")).await,
+    )
+    .await;
+}
+
+async fn scenario_batch_assign_sprint_route_missing_sprint_fails_every_id(state: AppState) {
+    let (_board_id, _col_id, c1, c2) = seed_two_cards(&state).await;
+    let missing_sprint = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/assign-sprint",
+        Some(&json!({ "ids": [c1, c2], "sprint_id": missing_sprint })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["succeeded"].as_array().unwrap().len(), 0);
+    let failed = body["failed"].as_array().unwrap();
+    assert_eq!(failed.len(), 2);
+    for f in failed {
+        assert!(f["error"]
+            .as_str()
+            .unwrap()
+            .to_lowercase()
+            .contains("not found"));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_assign_sprint_route_missing_sprint_fails_every_id() {
+    let dir = tempdir().unwrap();
+    scenario_batch_assign_sprint_route_missing_sprint_fails_every_id(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+async fn scenario_batch_assign_sprint_route_assigns_and_is_visible_via_sprint_filter(
+    state: AppState,
+) {
+    let (board_id, _col_id, c1, c2) = seed_two_cards(&state).await;
+    let mut ctx = state.ctx.lock().await;
+    let sprint_id = ctx
+        .create_sprint(board_id, None, Some("Sprint 1".to_string()))
+        .unwrap()
+        .id;
+    drop(ctx);
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/assign-sprint",
+        Some(&json!({ "ids": [c1, c2], "sprint_id": sprint_id })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["succeeded"].as_array().unwrap().len(), 2);
+    assert_eq!(body["failed"].as_array().unwrap().len(), 0);
+
+    let list_resp = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards?sprint_id={}", board_id, sprint_id),
+        None,
+    )
+    .await;
+    let page = json_of(list_resp).await;
+    let ids: std::collections::HashSet<String> = page["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids, [c1.to_string(), c2.to_string()].into_iter().collect());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_assign_sprint_route_assigns_and_is_visible_via_sprint_filter() {
+    let dir = tempdir().unwrap();
+    scenario_batch_assign_sprint_route_assigns_and_is_visible_via_sprint_filter(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+async fn scenario_batch_update_route_applies_all_updates_atomically(state: AppState) {
+    let (_board_id, _col_id, c1, c2) = seed_two_cards(&state).await;
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/update",
+        Some(&json!({
+            "updates": [
+                { "id": c1, "title": "One Renamed" },
+                { "id": c2, "priority": "high" }
+            ]
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    let succeeded: Vec<String> = body["succeeded"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(succeeded, vec![c1.to_string(), c2.to_string()]);
+    assert_eq!(body["failed"].as_array().unwrap().len(), 0);
+
+    let card1 = json_of(send(&state, "GET", &format!("/v1/cards/{}", c1), None).await).await;
+    assert_eq!(card1["title"], "One Renamed");
+    let card2 = json_of(send(&state, "GET", &format!("/v1/cards/{}", c2), None).await).await;
+    assert_eq!(card2["priority"], "high");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_update_route_applies_all_updates_atomically() {
+    let dir = tempdir().unwrap();
+    scenario_batch_update_route_applies_all_updates_atomically(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+async fn scenario_batch_update_route_unknown_id_returns_404_and_applies_nothing(state: AppState) {
+    let (_board_id, _col_id, c1, _c2) = seed_two_cards(&state).await;
+    let missing = Uuid::new_v4();
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/update",
+        Some(&json!({
+            "updates": [
+                { "id": c1, "title": "Changed" },
+                { "id": missing, "title": "X" }
+            ]
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "NOT_FOUND");
+
+    let card1 = json_of(send(&state, "GET", &format!("/v1/cards/{}", c1), None).await).await;
+    assert_eq!(card1["title"], "One");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_update_route_unknown_id_returns_404_envelope_and_applies_nothing_json() {
+    let dir = tempdir().unwrap();
+    scenario_batch_update_route_unknown_id_returns_404_and_applies_nothing(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_update_route_unknown_id_returns_404_envelope_and_applies_nothing_sqlite() {
+    let dir = tempdir().unwrap();
+    scenario_batch_update_route_unknown_id_returns_404_and_applies_nothing(
+        make_sqlite_state(&dir.path().join("s.sqlite")).await,
+    )
+    .await;
+}
+
+async fn scenario_batch_route_rejects_malformed_body_with_validation_envelope(state: AppState) {
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/archive",
+        Some(&json!({ "ids": "not-an-array" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_route_rejects_malformed_body_with_validation_envelope() {
+    let dir = tempdir().unwrap();
+    scenario_batch_route_rejects_malformed_body_with_validation_envelope(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}
+
+async fn scenario_batch_archive_emits_one_change_frame_per_succeeded_card(state: AppState) {
+    let (_board_id, _col_id, c1, c2) = seed_two_cards(&state).await;
+    let missing = Uuid::new_v4();
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/cards/batch/archive",
+        Some(&json!({ "ids": [c1, c2, missing] })),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut seen = std::collections::HashSet::new();
+    for _ in 0..2 {
+        let frame = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timed out waiting for a change event frame")
+            .expect("broadcast channel closed unexpectedly");
+        assert_eq!(
+            frame.entity_type.unwrap(),
+            kanban_service::api::EntityType::Card
+        );
+        assert_eq!(
+            frame.kind.unwrap(),
+            kanban_service::api::ChangeKind::Updated
+        );
+        seen.insert(frame.entity_id.unwrap());
+    }
+    assert_eq!(seen, std::collections::HashSet::from([c1, c2]));
+
+    let extra = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+    assert!(extra.is_err(), "expected no extra frame, got one");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_archive_emits_one_change_frame_per_succeeded_card() {
+    let dir = tempdir().unwrap();
+    scenario_batch_archive_emits_one_change_frame_per_succeeded_card(make_state(
+        &dir.path().join("s.json"),
+    ))
+    .await;
+}


### PR DESCRIPTION
Adds four `POST` batch-card endpoints under `/v1/cards/batch/` so an HTTP client can archive, move, assign-sprint, or update up to N cards in one request instead of N round trips.

## Changes

- `kanban-api`: new `v1::cards::batch` module with `BatchArchiveRequest`, `BatchMoveRequest`, `BatchAssignSprintRequest`, `BatchUpdateItem`/`BatchUpdateRequest`, and the shared `BatchFailure`/`BatchOperationResponse` wire types (both `#[non_exhaustive]` with `new()` constructors).
- `kanban-server`: new `routes/cards_batch.rs` wiring four routes:
  - `POST /v1/cards/batch/archive`
  - `POST /v1/cards/batch/move`
  - `POST /v1/cards/batch/assign-sprint`

  Each of these returns `200` with a `BatchOperationResponse` reporting every id as succeeded or failed independently (an unknown id, or a WIP-limit violation on move, never fails the whole request).
  - `POST /v1/cards/batch/update`

  All-or-nothing: any invalid id or execution error returns an ordinary `ApiError` envelope and leaves every card untouched.
- Save happens once per request, inside the session lock, before broadcasting one change event per succeeded id.
- README route table extended to document all four endpoints.
- `capability_guard` test's source list extended to cover the new route file.

## Test plan

- 14 new integration tests in `crates/kanban-server/tests/cards_batch.rs`, covering per-id success/failure reporting, empty-ids, WIP-limit atomic rollback, sprint-assignment visibility, all-or-nothing update semantics, malformed-body validation, change-event broadcast, and route-priority against the existing flat `/v1/cards/{id}/archive` route. The WIP-rollback and update-rollback scenarios run against both the JSON and SQLite backends.
- 2 new unit tests in `kanban-api` pinning the `#[serde(flatten)]` behavior over a `Patch`-bearing struct and the response wire round trip.
- `cargo test --all-features --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --all -- --check` all pass.

## Notes for reviewers

- The three per-id handlers (archive/move/assign-sprint) call the corresponding `KanbanContext::*_detailed` method directly on the session guard rather than through the `crate::state::mutate` seam, because those methods are inherent on `KanbanContext` and are not part of `MutationOperations`. The update route does go through `mutate`, since `update_cards_impl` is on that trait.
- `update_cards_detailed` (a `BatchOperationResult`-shaped variant of update, matching the other three routes) does not exist yet; the update route stays all-or-nothing as a deliberate scope boundary for this PR.
