### PR TITLE
KAN-1563 feat(server): request timeout layer, with the SSE-survival question answered

### DIFF
--- a/.changeset/kan-1563-request-timeout-layer.md
+++ b/.changeset/kan-1563-request-timeout-layer.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+kanban-server now answers 408 Request Timeout for requests that exceed KANBAN_REQUEST_TIMEOUT_SECS (default 30s, 0 to disable); open SSE streams on /v1/events are unaffected.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,6 +3292,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ dunce = "1.0"
 # HTTP server
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace", "cors", "limit"] }
+tower-http = { version = "0.6", features = ["trace", "cors", "limit", "timeout"] }
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -50,10 +50,11 @@ On startup the server opens (or creates) the board file, binds the configured ad
 | `KANBAN_SHUTDOWN_GRACE_SECS` | `10` | Seconds to wait after a shutdown signal for in-flight responses to complete before remaining connections are closed. Open SSE streams never end on their own, so this is what bounds shutdown. An unparseable value falls back to the default. |
 | `RUST_LOG` | unset (⇒ `error` only) | Standard `tracing-subscriber` env filter. Set to `info` to see the startup log line. Per-request access logging comes from tower-http's TraceLayer; set `tower_http=debug` (or `debug`) to see one span per request with method, path, status and latency. |
 | `KANBAN_CORS_ORIGINS` | unset (no CORS layer, same-origin only) | Comma-separated list of allowed browser origins. Unset means no CORS headers are sent at all. A single `*` allows any origin and is intended for local development only. A list allows exactly those origins with the GET/POST/PUT/PATCH/DELETE methods and the content-type and x-kanban-client-id request headers. |
+| `KANBAN_REQUEST_TIMEOUT_SECS` | `30` | Seconds a single request may take before the server answers 408 Request Timeout. `0` disables the timeout entirely. An unparseable value falls back to the default. |
 
 The bind address can also be set with the `--addr` flag or the `server_addr` key in the kanban config file (`~/.config/kanban/config.toml`); the resolution order is `--addr` > `KANBAN_ADDR` > `server_addr` > the `127.0.0.1:0` default.
 
-Request bodies are capped at 2 MiB by default. A request over the cap is rejected with 413 Payload Too Large before it reaches the handler.
+Request bodies are capped at 2 MiB by default. A request over the cap is rejected with 413 Payload Too Large before it reaches the handler. The request timeout bounds the time to the response, not the lifetime of a streaming body, so an open `GET /v1/events` SSE stream is unaffected and stays connected indefinitely. The timeout also does not remove write serialization: every handler acquires one shared `tokio::sync::Mutex`, so a slow store still queues every other request behind the in-flight one, and the timeout only bounds how long a queued client waits before failing fast.
 
 ### Example
 

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -1,10 +1,12 @@
 use crate::layers::LayerConfig;
 use crate::state::AppState;
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::Serialize;
 use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
 #[derive(Serialize)]
@@ -29,8 +31,8 @@ pub fn router(state: AppState) -> Router {
 /// Like [`router`], but with an explicit [`LayerConfig`].
 ///
 /// `.layer()` wraps outside-in on the LAST call, so calling body-limit then
-/// cors then trace here makes Trace the outermost layer and BodyLimit the
-/// innermost.
+/// timeout then cors then trace here makes Trace the outermost layer and
+/// BodyLimit the innermost.
 pub fn router_with(state: AppState, config: LayerConfig) -> Router {
     let router = Router::new()
         .route("/health", get(health))
@@ -55,6 +57,12 @@ pub fn router_with(state: AppState, config: LayerConfig) -> Router {
         .merge(crate::routes::events::router());
 
     let mut router = router.layer(RequestBodyLimitLayer::new(config.body_limit_bytes));
+    if let Some(timeout) = config.timeout {
+        router = router.layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            timeout,
+        ));
+    }
     if let Some(cors) = config.cors.into_layer() {
         router = router.layer(cors);
     }

--- a/crates/kanban-server/src/layers.rs
+++ b/crates/kanban-server/src/layers.rs
@@ -1,4 +1,5 @@
 use axum::http::{header, HeaderName, HeaderValue, Method};
+use std::time::Duration;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 /// Cross-origin policy for browser clients. `Disabled` sends no CORS headers
@@ -68,11 +69,14 @@ impl CorsPolicy {
 }
 
 pub const DEFAULT_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024;
+pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
 
 #[derive(Debug, Clone)]
 pub struct LayerConfig {
     pub body_limit_bytes: usize,
     pub cors: CorsPolicy,
+    /// `None` applies no timeout layer at all.
+    pub timeout: Option<Duration>,
 }
 
 impl Default for LayerConfig {
@@ -80,7 +84,18 @@ impl Default for LayerConfig {
         Self {
             body_limit_bytes: DEFAULT_BODY_LIMIT_BYTES,
             cors: CorsPolicy::Disabled,
+            timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
         }
+    }
+}
+
+/// Parses `KANBAN_REQUEST_TIMEOUT_SECS`. `0` disables the timeout; an unset
+/// or unparseable value falls back to [`DEFAULT_REQUEST_TIMEOUT_SECS`].
+pub fn parse_request_timeout(raw: Option<&str>) -> Option<Duration> {
+    match raw.and_then(|v| v.parse::<u64>().ok()) {
+        Some(0) => None,
+        Some(secs) => Some(Duration::from_secs(secs)),
+        None => Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
     }
 }
 
@@ -88,6 +103,9 @@ impl LayerConfig {
     pub fn from_env() -> Self {
         Self {
             cors: CorsPolicy::parse(std::env::var("KANBAN_CORS_ORIGINS").ok().as_deref()),
+            timeout: parse_request_timeout(
+                std::env::var("KANBAN_REQUEST_TIMEOUT_SECS").ok().as_deref(),
+            ),
             ..Self::default()
         }
     }

--- a/crates/kanban-server/src/layers.rs
+++ b/crates/kanban-server/src/layers.rs
@@ -96,6 +96,44 @@ impl LayerConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_default_layer_config_request_timeout_is_thirty_seconds() {
+        assert_eq!(
+            LayerConfig::default().timeout,
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn test_request_timeout_secs_unset_yields_the_default() {
+        assert_eq!(
+            parse_request_timeout(None),
+            Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS))
+        );
+    }
+
+    #[test]
+    fn test_request_timeout_secs_parses_as_whole_seconds() {
+        assert_eq!(
+            parse_request_timeout(Some("5")),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    #[test]
+    fn test_request_timeout_secs_zero_disables_the_timeout() {
+        assert_eq!(parse_request_timeout(Some("0")), None);
+    }
+
+    #[test]
+    fn test_request_timeout_secs_unparseable_falls_back_to_the_default() {
+        assert_eq!(
+            parse_request_timeout(Some("soon")),
+            Some(Duration::from_secs(30))
+        );
+    }
 
     #[test]
     fn test_cors_origins_star_yields_permissive_policy() {

--- a/crates/kanban-server/src/test_helpers.rs
+++ b/crates/kanban-server/src/test_helpers.rs
@@ -78,13 +78,25 @@ impl TestServer {
     /// are valid the moment start() returns -- no race with a test hitting
     /// the port before bind completes).
     pub async fn start() -> Self {
-        Self::start_with(|_| {}).await
+        Self::start_full(|_| {}, crate::layers::LayerConfig::default()).await
     }
 
     /// Like [`Self::start`], but runs `seed` against the fresh `KanbanContext`
     /// before the router starts serving, so a test can put the context in a
     /// state (e.g. an archived card) that no HTTP write route can reach.
     pub async fn start_with(seed: impl FnOnce(&mut KanbanContext)) -> Self {
+        Self::start_full(seed, crate::layers::LayerConfig::default()).await
+    }
+
+    /// Like [`Self::start`], but with an explicit [`crate::layers::LayerConfig`].
+    pub async fn start_with_layers(config: crate::layers::LayerConfig) -> Self {
+        Self::start_full(|_| {}, config).await
+    }
+
+    async fn start_full(
+        seed: impl FnOnce(&mut KanbanContext),
+        config: crate::layers::LayerConfig,
+    ) -> Self {
         let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
         let mut ctx = KanbanContext::open(backend, AppConfig::default())
             .await
@@ -96,7 +108,7 @@ impl TestServer {
         let addr = listener.local_addr().unwrap();
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let router = app::router(state);
+        let router = app::router_with(state, config);
         let handle = tokio::spawn(async move {
             axum::serve(listener, router)
                 .with_graceful_shutdown(async {

--- a/crates/kanban-server/tests/layers_timeout.rs
+++ b/crates/kanban-server/tests/layers_timeout.rs
@@ -1,0 +1,153 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use kanban_server::app;
+use kanban_server::layers::LayerConfig;
+use kanban_server::test_helpers::{make_state, TestServer};
+use std::time::{Duration, Instant};
+use tempfile::tempdir;
+use tower::ServiceExt;
+
+async fn read_one_sse_frame(response: &mut reqwest::Response) -> serde_json::Value {
+    let mut buf = Vec::new();
+    loop {
+        let chunk = response
+            .chunk()
+            .await
+            .unwrap()
+            .expect("stream ended before a full SSE frame arrived");
+        buf.extend_from_slice(&chunk);
+        let text = String::from_utf8_lossy(&buf);
+        if let Some(idx) = text.find("\n\n") {
+            let frame_text = text[..idx].to_string();
+            let data_line = frame_text
+                .lines()
+                .find(|l| l.starts_with("data:"))
+                .expect("frame must have a data: line");
+            return serde_json::from_str(data_line.trim_start_matches("data:").trim()).unwrap();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_request_queued_behind_the_session_lock_returns_408() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let guard = state.lock_session().await;
+
+    let router = app::router_with(
+        state.clone(),
+        LayerConfig {
+            timeout: Some(Duration::from_millis(100)),
+            ..Default::default()
+        },
+    );
+
+    let started = Instant::now();
+    let request = Request::builder()
+        .method("GET")
+        .uri("/v1/boards")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+    assert!(started.elapsed() < Duration::from_secs(2));
+
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fast_request_under_the_timeout_still_succeeds() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let router = app::router_with(
+        state,
+        LayerConfig {
+            timeout: Some(Duration::from_secs(5)),
+            ..Default::default()
+        },
+    );
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/v1/boards")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_timeout_disabled_leaves_a_queued_request_pending() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let guard = state.lock_session().await;
+
+    let router = app::router_with(
+        state.clone(),
+        LayerConfig {
+            timeout: None,
+            ..Default::default()
+        },
+    );
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/v1/boards")
+        .body(Body::empty())
+        .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_millis(300), router.oneshot(request)).await;
+
+    assert!(result.is_err());
+
+    drop(guard);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sse_stream_survives_past_the_timeout_window() {
+    let server = TestServer::start_with_layers(LayerConfig {
+        timeout: Some(Duration::from_millis(300)),
+        ..Default::default()
+    })
+    .await;
+
+    let mut events_response = server
+        .client()
+        .get(format!("{}/v1/events", server.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        events_response.headers().get("content-type").unwrap(),
+        "text/event-stream"
+    );
+
+    tokio::time::sleep(Duration::from_millis(900)).await;
+
+    let board_response = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .json(&serde_json::json!({"name": "Late Board", "card_prefix": "LB"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(board_response.status(), StatusCode::CREATED);
+
+    let frame = tokio::time::timeout(
+        Duration::from_secs(5),
+        read_one_sse_frame(&mut events_response),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(frame["entity_type"], "board");
+    assert_eq!(frame["kind"], "created");
+
+    drop(events_response);
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Adds the request TimeoutLayer half of KAN-1557 to kanban-server:

- `LayerConfig.timeout: Option<Duration>` (default `Some(30s)`), applied in `app::router_with` via `TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, timeout)`.
- `KANBAN_REQUEST_TIMEOUT_SECS` env knob (`parse_request_timeout`): unset or unparseable falls back to 30s, `0` disables the layer entirely (`None`).
- `TestServer::start_with_layers` for tests that need a real socket with a non-default `LayerConfig`.
- README documents the new env var and clarifies the timeout's boundaries: it does not bound a streaming SSE body, and it does not remove the shared-mutex write serialization, only the wait behind it.

## Empirical answer

The card's open question was whether a global TimeoutLayer would also cut an open `/v1/events` SSE stream, forcing a per-merged-router fallback instead. It does not. Read from tower-http 0.6.11 source: `timeout::service::ResponseFuture` races `sleep` only against the inner response future, and on timeout returns `Response::new(B::default())` with the configured status code, never touching the response body. Body-level bounding is a separate type, `ResponseBodyTimeoutLayer`, which is not used here. Since `Sse::new(..)` resolves its `Response` immediately and the stream lives entirely in the body, the global layer is safe and the per-router fallback is not needed. Pinned by `test_sse_stream_survives_past_the_timeout_window`, a real-socket test (not oneshot) that keeps a stream open past 3x the configured timeout window and confirms it still delivers a fresh frame.

`TimeoutLayer::new` is deprecated as of tower-http 0.6.7 and fails `clippy -D warnings` on the locked 0.6.11; `with_status_code` is used instead, making the 408 decision explicit at the call site.

## Testing

- 4 new integration tests in `crates/kanban-server/tests/layers_timeout.rs`: a stalled request behind the session mutex returns 408 within the window, a fast request still succeeds, `timeout: None` leaves a queued request pending indefinitely, and the SSE stream survives past the window.
- 5 new unit tests in `crates/kanban-server/src/layers.rs` pinning the default, the env parsing (unset, whole seconds, `0` disables, unparseable falls back).
- `cargo test -p kanban-server --features test-helpers` and `cargo test --all-features --workspace` both green.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check` both clean.

## Out of scope

`README.md`'s "per-request logging is not [configurable]" line predates KAN-1557's TraceLayer and is already stale; left untouched, belongs to that card.
