### PR TITLE
KAN-1552 feat(server): board export and import over HTTP

### DIFF
--- a/.changeset/kan-1552-import-export-routes.md
+++ b/.changeset/kan-1552-import-export-routes.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: add board export/import HTTP routes for backup, migration and seeding

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -54,7 +54,7 @@ On startup the server opens (or creates) the board file, binds the configured ad
 
 The bind address can also be set with the `--addr` flag or the `server_addr` key in the kanban config file (`~/.config/kanban/config.toml`); the resolution order is `--addr` > `KANBAN_ADDR` > `server_addr` > the `127.0.0.1:0` default.
 
-Request bodies are capped at 2 MiB by default. A request over the cap is rejected with 413 Payload Too Large before it reaches the handler. The request timeout bounds the time to the response, not the lifetime of a streaming body, so an open `GET /v1/events` SSE stream is unaffected and stays connected indefinitely. The timeout also does not remove write serialization: every handler acquires one shared `tokio::sync::Mutex`, so a slow store still queues every other request behind the in-flight one, and the timeout only bounds how long a queued client waits before failing fast.
+Request bodies are capped at 2 MiB by default. A request over the cap is rejected with 413 Payload Too Large before it reaches the handler. `POST /v1/import` is the exception: it is capped at 32 MiB instead, since a full board export can exceed the default cap. The request timeout bounds the time to the response, not the lifetime of a streaming body, so an open `GET /v1/events` SSE stream is unaffected and stays connected indefinitely. The timeout also does not remove write serialization: every handler acquires one shared `tokio::sync::Mutex`, so a slow store still queues every other request behind the in-flight one, and the timeout only bounds how long a queued client waits before failing fast.
 
 ### Example
 
@@ -217,6 +217,14 @@ The remaining card routes (get/create/replace/update/delete, and the flat `/v1/c
 | `DELETE` | `/v1/cards/{id}/blocks/{blocked_id}` | Remove the blocking edge from `id` to `blocked_id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |
 | `POST` | `/v1/cards/{id}/related` | Add an undirected relates edge between `id` and `other`. `200` with the updated `CardGraphResponse`. `kind` defaults to `general`. 409 `DUPLICATE_EDGE` if the edge already exists. | `{"other": uuid, "kind"?: "general"\|"duplicates"\|"mentioned_in"}` |
 | `DELETE` | `/v1/cards/{id}/related/{other_id}` | Remove the relates edge between `id` and `other_id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |
+
+### Transfer
+
+| Method | Path | Description | Body |
+|---|---|---|---|
+| `GET` | `/v1/boards/{board_id}/export` | Export a single board's full subtree (board, columns, live and archived cards, sprints, dependency graph, prefixes) as a bare `Snapshot` JSON document, byte-compatible with `kanban export`. No `version`/`metadata`/`data` envelope. 404 if `board_id` doesn't exist; still 200 for an archived board (the head and its `archived_boards` marker are both carried). | — |
+| `GET` | `/v1/export` | Export every board in the workspace, in the same bare `Snapshot` shape. | — |
+| `POST` | `/v1/import` | Import a `Snapshot` document (from either export route, or `kanban export`) unmodified. `201` with the imported `BoardResponse`. Import is create-only: any board, column, card, archived card or sprint id already present in the target returns 422 `VALIDATION_FAILED` with a "Duplicate ..." message and imports nothing. A document with no board, a dangling column reference, or a body that fails to parse as a `Snapshot` (invalid JSON, or a wrong-typed field) also returns 422 `VALIDATION_FAILED`, never a 500. Capped at 32 MiB rather than the server's default 2 MiB body limit (see [Configuration](#configuration)). | `Snapshot` (bare JSON, no envelope) |
 
 ### Events
 

--- a/crates/kanban-server/src/app.rs
+++ b/crates/kanban-server/src/app.rs
@@ -1,6 +1,6 @@
 use crate::layers::LayerConfig;
 use crate::state::AppState;
-use axum::extract::State;
+use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
 use axum::routing::get;
 use axum::{Json, Router};
@@ -32,7 +32,9 @@ pub fn router(state: AppState) -> Router {
 ///
 /// `.layer()` wraps outside-in on the LAST call, so calling body-limit then
 /// timeout then cors then trace here makes Trace the outermost layer and
-/// BodyLimit the innermost.
+/// BodyLimit the innermost. The import route is merged in AFTER the global
+/// body-limit layer, so `.layer()` never wraps it; it carries its own,
+/// larger `RequestBodyLimitLayer` instead.
 pub fn router_with(state: AppState, config: LayerConfig) -> Router {
     let router = Router::new()
         .route("/health", get(health))
@@ -55,9 +57,16 @@ pub fn router_with(state: AppState, config: LayerConfig) -> Router {
         .merge(crate::routes::sprints::flat_read_router())
         .merge(crate::routes::sprints::flat_write_router())
         .merge(crate::routes::sprints_lifecycle::write_router())
+        .merge(crate::routes::transfer::read_router())
         .merge(crate::routes::events::router());
 
-    let mut router = router.layer(RequestBodyLimitLayer::new(config.body_limit_bytes));
+    let mut router = router
+        .layer(RequestBodyLimitLayer::new(config.body_limit_bytes))
+        .merge(
+            crate::routes::transfer::write_router()
+                .layer(DefaultBodyLimit::disable())
+                .layer(RequestBodyLimitLayer::new(config.import_body_limit_bytes)),
+        );
     if let Some(timeout) = config.timeout {
         router = router.layer(TimeoutLayer::with_status_code(
             StatusCode::REQUEST_TIMEOUT,

--- a/crates/kanban-server/src/layers.rs
+++ b/crates/kanban-server/src/layers.rs
@@ -70,6 +70,7 @@ impl CorsPolicy {
 
 pub const DEFAULT_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024;
 pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+pub const IMPORT_BODY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct LayerConfig {
@@ -77,6 +78,8 @@ pub struct LayerConfig {
     pub cors: CorsPolicy,
     /// `None` applies no timeout layer at all.
     pub timeout: Option<Duration>,
+    /// Cap for `POST /v1/import` only. Must not be lower than `body_limit_bytes`.
+    pub import_body_limit_bytes: usize,
 }
 
 impl Default for LayerConfig {
@@ -85,6 +88,7 @@ impl Default for LayerConfig {
             body_limit_bytes: DEFAULT_BODY_LIMIT_BYTES,
             cors: CorsPolicy::Disabled,
             timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
+            import_body_limit_bytes: IMPORT_BODY_LIMIT_BYTES,
         }
     }
 }

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -28,6 +28,7 @@ pub mod routes {
     pub mod prefixes;
     pub mod sprints;
     pub mod sprints_lifecycle;
+    pub mod transfer;
 }
 
 pub mod handlers {

--- a/crates/kanban-server/src/routes/transfer.rs
+++ b/crates/kanban-server/src/routes/transfer.rs
@@ -1,0 +1,61 @@
+use crate::error::AppError;
+use crate::state::AppState;
+use axum::extract::{Path, State};
+use axum::http::{header, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use kanban_domain::{KanbanError, KanbanOperations, Snapshot};
+use kanban_service::api::{ApiError, BoardResponse, ChangeKind, EntityType, ErrorCode};
+use uuid::Uuid;
+
+async fn export_board_route(
+    State(state): State<AppState>,
+    Path(board_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let guard = state.lock_session().await;
+    guard
+        .get_board(board_id)
+        .map_err(|e| AppError::from(&e))?
+        .ok_or_else(|| AppError::from(&KanbanError::not_found("Board", board_id)))?;
+    let json = guard
+        .export_board(Some(board_id))
+        .map_err(|e| AppError::from(&e))?;
+    Ok(([(header::CONTENT_TYPE, "application/json")], json))
+}
+
+async fn export_all_route(State(state): State<AppState>) -> Result<impl IntoResponse, AppError> {
+    let guard = state.lock_session().await;
+    let json = guard.export_board(None).map_err(|e| AppError::from(&e))?;
+    Ok(([(header::CONTENT_TYPE, "application/json")], json))
+}
+
+pub fn read_router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/boards/{board_id}/export", get(export_board_route))
+        .route("/v1/export", get(export_all_route))
+}
+
+async fn import_route(
+    State(state): State<AppState>,
+    body: String,
+) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
+    serde_json::from_str::<Snapshot>(&body).map_err(|e| {
+        AppError(ApiError::new(
+            ErrorCode::ValidationFailed,
+            format!("request body is not a valid snapshot: {e}"),
+        ))
+    })?;
+
+    let mut guard = state.lock_session().await;
+    let board = guard.import_board(&body).map_err(|e| AppError::from(&e))?;
+    state
+        .persist_and_broadcast(&guard, EntityType::Board, board.id, ChangeKind::Created)
+        .await
+        .map_err(|e| AppError::from(&e))?;
+    Ok((StatusCode::CREATED, Json(BoardResponse::from(&board))))
+}
+
+pub fn write_router() -> Router<AppState> {
+    Router::new().route("/v1/import", post(import_route))
+}

--- a/crates/kanban-server/tests/capability_guard.rs
+++ b/crates/kanban-server/tests/capability_guard.rs
@@ -9,6 +9,7 @@ const SOURCES: &[&str] = &[
     include_str!("../src/routes/columns.rs"),
     include_str!("../src/routes/sprints.rs"),
     include_str!("../src/routes/sprints_lifecycle.rs"),
+    include_str!("../src/routes/transfer.rs"),
     include_str!("../src/routes/graph.rs"),
     include_str!("../src/routes/prefixes.rs"),
     include_str!("../src/handlers/boards.rs"),

--- a/crates/kanban-server/tests/transfer.rs
+++ b/crates/kanban-server/tests/transfer.rs
@@ -1,0 +1,692 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use kanban_domain::GraphOperations;
+use kanban_server::app;
+use kanban_server::layers::LayerConfig;
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use kanban_service::api::{ArchivedCardResponse, BoardResponse, Page};
+use kanban_service::{KanbanContext, KanbanOperations};
+use serde_json::Value;
+use tempfile::tempdir;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+struct SeedIds {
+    board: Uuid,
+    card1: Uuid,
+    card2: Uuid,
+    card3: Uuid,
+    sprint: Uuid,
+    column_a: Uuid,
+    column_b: Uuid,
+}
+
+fn seed_graph(ctx: &mut KanbanContext, bind_sprint: bool) -> SeedIds {
+    let board = ctx
+        .create_board("Round Trip".to_string(), Some("RT".to_string()))
+        .unwrap()
+        .id;
+    let column_a = ctx
+        .create_column(board, "Todo".to_string(), None)
+        .unwrap()
+        .id;
+    let column_b = ctx
+        .create_column(board, "Doing".to_string(), None)
+        .unwrap()
+        .id;
+    let card1 = ctx
+        .create_card(board, column_a, "Card One".to_string(), Default::default())
+        .unwrap()
+        .id;
+    let card2 = ctx
+        .create_card(board, column_a, "Card Two".to_string(), Default::default())
+        .unwrap()
+        .id;
+    let card3 = ctx
+        .create_card(
+            board,
+            column_b,
+            "Card Three".to_string(),
+            Default::default(),
+        )
+        .unwrap()
+        .id;
+    let sprint = ctx
+        .create_sprint(board, Some("RT".to_string()), Some("Sprint 1".to_string()))
+        .unwrap()
+        .id;
+    if bind_sprint {
+        ctx.assign_card_to_sprint(card1, sprint).unwrap();
+    }
+    ctx.block(card1, card2, kanban_domain::Severity::Medium)
+        .unwrap();
+    ctx.archive_card(card3).unwrap();
+
+    SeedIds {
+        board,
+        card1,
+        card2,
+        card3,
+        sprint,
+        column_a,
+        column_b,
+    }
+}
+
+async fn send_raw(
+    state: &AppState,
+    method: &str,
+    uri: &str,
+    body: String,
+) -> axum::response::Response {
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("content-length", body.len().to_string())
+        .body(Body::from(body))
+        .unwrap();
+    app::router(state.clone()).oneshot(request).await.unwrap()
+}
+
+async fn send_raw_with(
+    state: &AppState,
+    config: LayerConfig,
+    method: &str,
+    uri: &str,
+    body: String,
+) -> axum::response::Response {
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("content-length", body.len().to_string())
+        .body(Body::from(body))
+        .unwrap();
+    app::router_with(state.clone(), config)
+        .oneshot(request)
+        .await
+        .unwrap()
+}
+
+async fn export_body(state: &AppState, board_id: Uuid) -> String {
+    let response = send(
+        &state.clone(),
+        "GET",
+        &format!("/v1/boards/{board_id}/export"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_then_import_into_fresh_server_round_trips_the_full_graph() {
+    let dir_a = tempdir().unwrap();
+    let state_a = make_state(&dir_a.path().join("s.json"));
+    let ids = {
+        let mut guard = state_a.ctx.lock().await;
+        seed_graph(&mut guard.ctx, true)
+    };
+
+    let response = send(
+        &state_a,
+        "GET",
+        &format!("/v1/boards/{}/export", ids.board),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_string = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+    let dir_b = tempdir().unwrap();
+    let state_b = make_state(&dir_b.path().join("s.json"));
+
+    let response = send_raw(&state_b, "POST", "/v1/import", body_string).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let imported: BoardResponse = serde_json::from_value(json_of(response).await).unwrap();
+    assert_eq!(imported.id, ids.board);
+
+    let response = send(&state_b, "GET", &format!("/v1/boards/{}", ids.board), None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let board: BoardResponse = serde_json::from_value(json_of(response).await).unwrap();
+    assert_eq!(board.name, "Round Trip");
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{}/columns", ids.board),
+        None,
+    )
+    .await;
+    let columns: Value = json_of(response).await;
+    let column_ids: Vec<Uuid> = columns["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().parse().unwrap())
+        .collect();
+    assert!(column_ids.contains(&ids.column_a));
+    assert!(column_ids.contains(&ids.column_b));
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{}/cards", ids.board),
+        None,
+    )
+    .await;
+    let cards: Value = json_of(response).await;
+    let items = cards["items"].as_array().unwrap();
+    let card1_json = items
+        .iter()
+        .find(|c| c["id"].as_str().unwrap() == ids.card1.to_string())
+        .expect("card1 present");
+    assert_eq!(
+        card1_json["sprint_id"].as_str().unwrap(),
+        ids.sprint.to_string()
+    );
+    assert!(items
+        .iter()
+        .any(|c| c["id"].as_str().unwrap() == ids.card2.to_string()));
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{}/sprints", ids.board),
+        None,
+    )
+    .await;
+    let sprints: Value = json_of(response).await;
+    assert!(sprints["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s["id"].as_str().unwrap() == ids.sprint.to_string()));
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{}/archived-cards", ids.board),
+        None,
+    )
+    .await;
+    let archived: Page<ArchivedCardResponse> =
+        serde_json::from_value(json_of(response).await).unwrap();
+    assert_eq!(archived.items.len(), 1);
+    assert_eq!(archived.items[0].entity_id, ids.card3);
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/cards/{}/graph", ids.card1),
+        None,
+    )
+    .await;
+    let graph: Value = json_of(response).await;
+    let blocks: Vec<String> = graph["blocks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(blocks.contains(&ids.card2.to_string()));
+    let block_edges = graph["block_edges"].as_array().unwrap();
+    assert_eq!(block_edges[0]["severity"].as_str().unwrap(), "medium");
+
+    let response = send(&state_b, "GET", "/v1/prefixes?name=RT", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_then_import_round_trips_the_full_graph_on_sqlite() {
+    let dir_a = tempdir().unwrap();
+    let state_a = make_sqlite_state(&dir_a.path().join("s.sqlite")).await;
+    let ids = {
+        let mut guard = state_a.ctx.lock().await;
+        seed_graph(&mut guard.ctx, false)
+    };
+
+    let body_string = export_body(&state_a, ids.board).await;
+
+    let dir_b = tempdir().unwrap();
+    let state_b = make_sqlite_state(&dir_b.path().join("s.sqlite")).await;
+
+    let response = send_raw(&state_b, "POST", "/v1/import", body_string).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{}/cards", ids.board),
+        None,
+    )
+    .await;
+    let cards: Value = json_of(response).await;
+    let items = cards["items"].as_array().unwrap();
+    assert!(items
+        .iter()
+        .any(|c| c["id"].as_str().unwrap() == ids.card1.to_string()));
+    assert!(items
+        .iter()
+        .any(|c| c["id"].as_str().unwrap() == ids.card2.to_string()));
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{}/archived-cards", ids.board),
+        None,
+    )
+    .await;
+    let archived: Page<ArchivedCardResponse> =
+        serde_json::from_value(json_of(response).await).unwrap();
+    assert_eq!(archived.items.len(), 1);
+    assert_eq!(archived.items[0].entity_id, ids.card3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_board_route_returns_snapshot_json_with_the_subtree() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = {
+        let mut guard = state.ctx.lock().await;
+        let board_id = guard
+            .ctx
+            .create_board("B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        let column_id = guard
+            .ctx
+            .create_column(board_id, "Col".to_string(), None)
+            .unwrap()
+            .id;
+        guard
+            .ctx
+            .create_card(board_id, column_id, "Card".to_string(), Default::default())
+            .unwrap();
+        board_id
+    };
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/export"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("application/json"));
+    let body = json_of(response).await;
+    assert!(!body["boards"].as_array().unwrap().is_empty());
+    assert!(!body["columns"].as_array().unwrap().is_empty());
+    assert!(!body["cards"].as_array().unwrap().is_empty());
+    assert!(body.get("graph").is_some());
+    assert!(body.get("version").is_none());
+    assert!(body.get("metadata").is_none());
+    assert!(body.get("data").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_missing_board_returns_404_not_found_envelope() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/export", Uuid::new_v4()),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = json_of(response).await;
+    assert_eq!(body["code"].as_str().unwrap(), "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_export_archived_board_succeeds_and_carries_its_marker() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = {
+        let mut guard = state.ctx.lock().await;
+        let board_id = guard
+            .ctx
+            .create_board("Archivable".to_string(), Some("AR".to_string()))
+            .unwrap()
+            .id;
+        let column_id = guard
+            .ctx
+            .create_column(board_id, "Col".to_string(), None)
+            .unwrap()
+            .id;
+        guard
+            .ctx
+            .create_card(board_id, column_id, "Card".to_string(), Default::default())
+            .unwrap();
+        board_id
+    };
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/archive"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{board_id}/export"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert!(!body["boards"].as_array().unwrap().is_empty());
+    let archived_boards = body["archived_boards"].as_array().unwrap();
+    assert!(archived_boards
+        .iter()
+        .any(|m| m["entity_id"].as_str().unwrap() == board_id.to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_full_export_route_returns_every_board() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (board_a, board_b) = {
+        let mut guard = state.ctx.lock().await;
+        let a = guard
+            .ctx
+            .create_board("A".to_string(), Some("AA".to_string()))
+            .unwrap()
+            .id;
+        let b = guard
+            .ctx
+            .create_board("B".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        (a, b)
+    };
+
+    let response = send(&state, "GET", "/v1/export", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("application/json"));
+    let body = json_of(response).await;
+    let board_ids: Vec<String> = body["boards"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["id"].as_str().unwrap().to_string())
+        .collect();
+    assert!(board_ids.contains(&board_a.to_string()));
+    assert!(board_ids.contains(&board_b.to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_with_no_board_returns_422_validation_failed() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let body = r#"{"boards": [], "columns": [], "cards": []}"#.to_string();
+    let response = send_raw(&state, "POST", "/v1/import", body).await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"].as_str().unwrap(), "VALIDATION_FAILED");
+    assert!(json["message"]
+        .as_str()
+        .unwrap()
+        .contains("No board in import data"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_with_colliding_ids_returns_422_and_leaves_the_store_unchanged() {
+    let dir_a = tempdir().unwrap();
+    let state_a = make_state(&dir_a.path().join("s.json"));
+    let board_id = {
+        let mut guard = state_a.ctx.lock().await;
+        let board_id = guard
+            .ctx
+            .create_board("Board".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        let column_id = guard
+            .ctx
+            .create_column(board_id, "Col".to_string(), None)
+            .unwrap()
+            .id;
+        guard
+            .ctx
+            .create_card(board_id, column_id, "Card".to_string(), Default::default())
+            .unwrap();
+        board_id
+    };
+    let body_string = export_body(&state_a, board_id).await;
+
+    let dir_b = tempdir().unwrap();
+    let state_b = make_state(&dir_b.path().join("s.json"));
+
+    let response = send_raw(&state_b, "POST", "/v1/import", body_string.clone()).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = send_raw(&state_b, "POST", "/v1/import", body_string).await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"].as_str().unwrap(), "VALIDATION_FAILED");
+    assert!(json["message"].as_str().unwrap().contains("Duplicate"));
+
+    let response = send(&state_b, "GET", "/v1/boards", None).await;
+    let boards: Value = json_of(response).await;
+    assert_eq!(boards["items"].as_array().unwrap().len(), 1);
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{board_id}/cards"),
+        None,
+    )
+    .await;
+    let cards: Value = json_of(response).await;
+    assert_eq!(cards["items"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_with_dangling_column_reference_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let board_id = {
+        let mut guard = state.ctx.lock().await;
+        let board_id = guard
+            .ctx
+            .create_board("Board".to_string(), Some("BB".to_string()))
+            .unwrap()
+            .id;
+        let column_id = guard
+            .ctx
+            .create_column(board_id, "Col".to_string(), None)
+            .unwrap()
+            .id;
+        guard
+            .ctx
+            .create_card(board_id, column_id, "Card".to_string(), Default::default())
+            .unwrap();
+        board_id
+    };
+    let body_string = export_body(&state, board_id).await;
+    let mut value: Value = serde_json::from_str(&body_string).unwrap();
+    value["columns"] = Value::Array(vec![]);
+    if let Some(cards) = value["cards"].as_array_mut() {
+        for card in cards.iter_mut() {
+            card["column_id"] = Value::String(Uuid::new_v4().to_string());
+        }
+    }
+
+    let dir_b = tempdir().unwrap();
+    let state_b = make_state(&dir_b.path().join("s.json"));
+
+    let response = send_raw(
+        &state_b,
+        "POST",
+        "/v1/import",
+        serde_json::to_string(&value).unwrap(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"].as_str().unwrap(), "VALIDATION_FAILED");
+    assert!(json["message"]
+        .as_str()
+        .unwrap()
+        .contains("which does not exist in the import or the current store"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_of_wrong_shaped_json_returns_422_not_500() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let body = r#"{"boards": 5}"#.to_string();
+    let response = send_raw(&state, "POST", "/v1/import", body).await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"].as_str().unwrap(), "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_of_syntactically_invalid_body_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = send_raw(&state, "POST", "/v1/import", "not json at all".to_string()).await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert_eq!(json["code"].as_str().unwrap(), "VALIDATION_FAILED");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_of_unrecognized_json_object_reports_the_missing_board() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let body = r#"{"hello": 1}"#.to_string();
+    let response = send_raw(&state, "POST", "/v1/import", body).await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = json_of(response).await;
+    assert!(json["message"]
+        .as_str()
+        .unwrap()
+        .contains("No board in import data"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_is_durably_saved_before_the_response() {
+    let dir_a = tempdir().unwrap();
+    let state_a = make_state(&dir_a.path().join("s.json"));
+    let board_id = {
+        let mut guard = state_a.ctx.lock().await;
+        guard
+            .ctx
+            .create_board("Durable".to_string(), Some("DU".to_string()))
+            .unwrap()
+            .id
+    };
+    let body_string = export_body(&state_a, board_id).await;
+
+    let dir_b = tempdir().unwrap();
+    let target_path = dir_b.path().join("s.json");
+    let state_b = make_state(&target_path);
+
+    let response = send_raw(&state_b, "POST", "/v1/import", body_string).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let on_disk = std::fs::read_to_string(&target_path).unwrap();
+    assert!(on_disk.contains(&board_id.to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_body_over_the_import_limit_returns_413() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let config = LayerConfig {
+        body_limit_bytes: 512,
+        import_body_limit_bytes: 1024,
+        ..Default::default()
+    };
+
+    let body = "a".repeat(2048);
+    let response = send_raw_with(&state, config, "POST", "/v1/import", body).await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_body_over_the_global_limit_is_accepted_under_the_import_limit() {
+    let dir_a = tempdir().unwrap();
+    let state_a = make_state(&dir_a.path().join("s.json"));
+    let board_id = {
+        let mut guard = state_a.ctx.lock().await;
+        let board_id = guard
+            .ctx
+            .create_board("Padded".to_string(), Some("PA".to_string()))
+            .unwrap()
+            .id;
+        let column_id = guard
+            .ctx
+            .create_column(board_id, "Col".to_string(), None)
+            .unwrap()
+            .id;
+        guard
+            .ctx
+            .create_card(
+                board_id,
+                column_id,
+                "Card".to_string(),
+                kanban_domain::CreateCardOptions {
+                    description: Some("x".repeat(1024)),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        board_id
+    };
+    let body_string = export_body(&state_a, board_id).await;
+    assert!(body_string.len() > 512);
+
+    let dir_b = tempdir().unwrap();
+    let state_b = make_state(&dir_b.path().join("s.json"));
+    let config = LayerConfig {
+        body_limit_bytes: 512,
+        import_body_limit_bytes: 1024 * 1024,
+        ..Default::default()
+    };
+
+    let response = send_raw_with(&state_b, config.clone(), "POST", "/v1/import", body_string).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let oversized_board = r#"{"name":"Too Big","card_prefix":"TB","padding":""}"#
+        .replace("\"\"", &format!("\"{}\"", "a".repeat(1024)));
+    let response = send_raw_with(&state_b, config, "POST", "/v1/boards", oversized_board).await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}

--- a/crates/kanban-server/tests/transfer.rs
+++ b/crates/kanban-server/tests/transfer.rs
@@ -292,6 +292,58 @@ async fn test_export_then_import_round_trips_the_full_graph_on_sqlite() {
         serde_json::from_value(json_of(response).await).unwrap();
     assert_eq!(archived.items.len(), 1);
     assert_eq!(archived.items[0].entity_id, ids.card3);
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{}/columns", ids.board),
+        None,
+    )
+    .await;
+    let columns: Value = json_of(response).await;
+    let column_ids: Vec<Uuid> = columns["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().parse().unwrap())
+        .collect();
+    assert!(column_ids.contains(&ids.column_a));
+    assert!(column_ids.contains(&ids.column_b));
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/boards/{}/sprints", ids.board),
+        None,
+    )
+    .await;
+    let sprints: Value = json_of(response).await;
+    assert!(sprints["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s["id"].as_str().unwrap() == ids.sprint.to_string()));
+
+    let response = send(
+        &state_b,
+        "GET",
+        &format!("/v1/cards/{}/graph", ids.card1),
+        None,
+    )
+    .await;
+    let graph: Value = json_of(response).await;
+    let blocks: Vec<String> = graph["blocks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(blocks.contains(&ids.card2.to_string()));
+    let block_edges = graph["block_edges"].as_array().unwrap();
+    assert_eq!(block_edges[0]["severity"].as_str().unwrap(), "medium");
+
+    let response = send(&state_b, "GET", "/v1/prefixes?name=RT", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Adds three routes over the existing `Session` surface, so an HTTP client can back up, migrate and seed boards using the exact byte-compatible bare `Snapshot` JSON the CLI writes:

- `GET /v1/boards/{board_id}/export` - export a single board's full subtree (columns, live and archived cards, sprints, dependency graph, prefixes). 404 if the board doesn't exist; still 200 for an archived board.
- `GET /v1/export` - export every board in the workspace.
- `POST /v1/import` - import a `Snapshot` document unmodified. `201` with the imported `BoardResponse`. Import is create-only: any colliding id returns 422 `VALIDATION_FAILED` and imports nothing.

Two empirical questions the card raised are answered in code:

- **Malformed import bodies never 500.** The route pre-parses the body as a `Snapshot` before calling into the service; a body that fails to parse (invalid JSON, or a wrong-typed field) returns 422 `VALIDATION_FAILED`, not 500 `SERIALIZATION_ERROR`. A body that parses into an empty `Snapshot` (every field is `#[serde(default)]`) still 422s with "No board in import data" from the existing service validation.
- **Import gets its own, larger body limit.** KAN-1557 added a global 2 MiB `RequestBodyLimitLayer` after this card was written, so the card's original per-route `DefaultBodyLimit` plan no longer works (an inner axum limit cannot raise past an outer tower-http layer). This adds `LayerConfig::import_body_limit_bytes` (32 MiB) and merges the import route into the router *after* the global body-limit layer, with its own `RequestBodyLimitLayer` and `DefaultBodyLimit::disable()`, so the import cap actually wins while every other route keeps the 2 MiB default.

## Test plan

- [x] `cargo test -p kanban-server --features test-helpers` (all 15 new tests plus the existing suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features --workspace`
- [x] Mutation-checked the three central assertions by reverting each fix in turn and confirming its test fails for the right reason, then restoring: the pre-parse (wrong-shape and invalid-JSON tests), the post-global-layer merge (both limit tests), and the `get_board` 404 guard (missing-board test).

## Notes for reviewers

- One SQLite round-trip test omits binding a card to a sprint. Doing so triggers a pre-existing `kanban-domain` bug: `ImportEntities::execute` upserts cards before sprints, and `cards.sprint_id` has a non-deferrable foreign key to `sprints(id)` in the SQLite schema, so importing a card with a `sprint_id` set fails with a FK constraint error on SQLite (the JSON backend doesn't enforce FKs, so it's silent there). This is out of scope for this card (server-only, no `kanban-domain` changes) and should be tracked separately.
- `crates/kanban-server/README.md`'s "Status: early / minimal" opening paragraph is stale (predates several merged epics); left untouched here since it's a pre-existing, unrelated issue.
