### PR TITLE
KAN-1565 fix(domain): import upserts sprints before the cards that reference them

### DIFF
--- a/.changeset/kan-1565-import-upserts-sprints-before-cards.md
+++ b/.changeset/kan-1565-import-upserts-sprints-before-cards.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: import writes sprints before cards so a sprint-bound card survives import on SQLite

--- a/crates/kanban-domain/src/commands/board_commands.rs
+++ b/crates/kanban-domain/src/commands/board_commands.rs
@@ -840,6 +840,11 @@ impl ImportEntities {
         let stamped = self.stamped_cards(&universe);
         self.merge_prefix_counters(context, &stamped, &universe)?;
         crate::ensure_prefix_rows_exist(&stamped, &context.store.list_prefixes()?)?;
+        // Sprints land before cards: `cards.sprint_id` is a foreign key on
+        // backends that enforce one.
+        for s in &self.sprints {
+            context.store.upsert_sprint(s.clone())?;
+        }
         for c in &stamped {
             context.store.upsert_card(c.clone())?;
         }
@@ -848,9 +853,6 @@ impl ImportEntities {
         }
         for ab in &self.archived_boards {
             context.store.insert_archived_board(*ab)?;
-        }
-        for s in &self.sprints {
-            context.store.upsert_sprint(s.clone())?;
         }
         if let Some(ref graph) = self.graph {
             let mut merged = context.store.get_graph()?;

--- a/crates/kanban-domain/tests/common/prefix_write_order.rs
+++ b/crates/kanban-domain/tests/common/prefix_write_order.rs
@@ -6,10 +6,11 @@ use kanban_domain::{
 use std::sync::Mutex;
 use uuid::Uuid;
 
-/// Records any card written while the namespace its prefix names has no row.
+/// Records writes made before the rows they name exist (prefix and sprint).
 pub struct PrefixWriteOrderStore {
     inner: InMemoryStore,
     unbacked_at_write: Mutex<Vec<(u32, String)>>,
+    unbacked_sprint_at_write: Mutex<Vec<Uuid>>,
     prefix_upsert_names: Mutex<Vec<String>>,
     swallow_prefix_writes: bool,
 }
@@ -19,6 +20,7 @@ impl PrefixWriteOrderStore {
         Self {
             inner: InMemoryStore::default(),
             unbacked_at_write: Mutex::new(Vec::new()),
+            unbacked_sprint_at_write: Mutex::new(Vec::new()),
             prefix_upsert_names: Mutex::new(Vec::new()),
             swallow_prefix_writes: false,
         }
@@ -28,6 +30,7 @@ impl PrefixWriteOrderStore {
         Self {
             inner: InMemoryStore::default(),
             unbacked_at_write: Mutex::new(Vec::new()),
+            unbacked_sprint_at_write: Mutex::new(Vec::new()),
             prefix_upsert_names: Mutex::new(Vec::new()),
             swallow_prefix_writes: true,
         }
@@ -35,6 +38,10 @@ impl PrefixWriteOrderStore {
 
     pub fn unbacked_at_write(&self) -> Vec<(u32, String)> {
         self.unbacked_at_write.lock().unwrap().clone()
+    }
+
+    pub fn unbacked_sprint_at_write(&self) -> Vec<Uuid> {
+        self.unbacked_sprint_at_write.lock().unwrap().clone()
     }
 
     /// The exact `Prefix::name` string passed to each `upsert_prefix` call,
@@ -131,6 +138,11 @@ impl DataStore for PrefixWriteOrderStore {
                     .lock()
                     .unwrap()
                     .push((card.card_number, card.prefix.clone()));
+            }
+        }
+        if let Some(sid) = card.sprint_id {
+            if self.inner.get_sprint(sid)?.is_none() {
+                self.unbacked_sprint_at_write.lock().unwrap().push(card.id);
             }
         }
         self.inner.upsert_card(card)

--- a/crates/kanban-domain/tests/import_sprint_ordering.rs
+++ b/crates/kanban-domain/tests/import_sprint_ordering.rs
@@ -1,0 +1,36 @@
+mod common;
+
+use common::prefix_write_order::PrefixWriteOrderStore;
+use kanban_domain::commands::board_commands::ImportEntities;
+use kanban_domain::commands::CommandContext;
+use kanban_domain::{Board, Card, Column, DataStore, Sprint};
+
+#[test]
+fn test_import_writes_the_sprint_before_the_cards_that_reference_it() {
+    let board = Board::new("B", Some("KAN"));
+    let col = Column::new(board.id, "Todo", 0);
+    let sprint = Sprint::new(board.id, 1, None, Some("KAN"));
+    let mut card = Card::new(board.id, col.id, "C", 0);
+    card.sprint_id = Some(sprint.id);
+
+    let payload = ImportEntities {
+        boards: vec![board],
+        columns: vec![col],
+        cards: vec![card.clone()],
+        sprints: vec![sprint.clone()],
+        ..Default::default()
+    };
+
+    let store = PrefixWriteOrderStore::new();
+    let context = CommandContext { store: &store };
+    payload.execute(&context).unwrap();
+
+    let violations = store.unbacked_sprint_at_write();
+    assert!(
+        violations.is_empty(),
+        "cards written while their sprint had no row: {violations:?}"
+    );
+
+    let stored = store.get_card(card.id).unwrap().unwrap();
+    assert_eq!(stored.sprint_id, Some(sprint.id));
+}

--- a/crates/kanban-server/tests/transfer.rs
+++ b/crates/kanban-server/tests/transfer.rs
@@ -254,7 +254,7 @@ async fn test_export_then_import_round_trips_the_full_graph_on_sqlite() {
     let state_a = make_sqlite_state(&dir_a.path().join("s.sqlite")).await;
     let ids = {
         let mut guard = state_a.ctx.lock().await;
-        seed_graph(&mut guard.ctx, false)
+        seed_graph(&mut guard.ctx, true)
     };
 
     let body_string = export_body(&state_a, ids.board).await;
@@ -274,9 +274,14 @@ async fn test_export_then_import_round_trips_the_full_graph_on_sqlite() {
     .await;
     let cards: Value = json_of(response).await;
     let items = cards["items"].as_array().unwrap();
-    assert!(items
+    let card1_json = items
         .iter()
-        .any(|c| c["id"].as_str().unwrap() == ids.card1.to_string()));
+        .find(|c| c["id"].as_str().unwrap() == ids.card1.to_string())
+        .expect("card1 present");
+    assert_eq!(
+        card1_json["sprint_id"].as_str().unwrap(),
+        ids.sprint.to_string()
+    );
     assert!(items
         .iter()
         .any(|c| c["id"].as_str().unwrap() == ids.card2.to_string()));

--- a/crates/kanban-service/tests/import_sprint_bound_card.rs
+++ b/crates/kanban-service/tests/import_sprint_bound_card.rs
@@ -1,0 +1,117 @@
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::{KanbanOperations, KanbanResult};
+use kanban_persistence_json::{JsonDataStore, JsonFileStore};
+use kanban_persistence_sqlite::SqliteBackend;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+async fn open_json_ctx(path: &std::path::Path) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(JsonDataStore::new(Arc::new(JsonFileStore::new(path))));
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+async fn open_sqlite_ctx(path: &std::path::Path) -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> =
+        Arc::new(SqliteBackend::open(path.to_str().unwrap()).await.unwrap());
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+async fn open_memory_ctx() -> KanbanContext {
+    let backend: Arc<dyn KanbanBackend> = Arc::new(InMemoryStore::new());
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+fn assert_sprint_bound(ctx: &KanbanContext, card_id: uuid::Uuid, sprint_id: uuid::Uuid) {
+    let card = ctx
+        .get_card(card_id)
+        .unwrap()
+        .expect("card must survive import");
+    assert_eq!(card.sprint_id, Some(sprint_id));
+    assert!(
+        ctx.get_sprint(sprint_id).unwrap().is_some(),
+        "sprint must survive import"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_bound_card_import_round_trips_on_json() -> KanbanResult<()> {
+    let dir = tempdir().unwrap();
+    let source_path = dir.path().join("source.json");
+    let dest_path = dir.path().join("dest.json");
+
+    let (card_id, sprint_id, json) = {
+        let mut ctx = open_json_ctx(&source_path).await;
+        let board = ctx.create_board("B".into(), None)?;
+        let col = ctx.create_column(board.id, "Todo".into(), None)?;
+        let card = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
+        let sprint = ctx.create_sprint(board.id, Some("S".into()), None)?;
+        ctx.assign_card_to_sprint(card.id, sprint.id)?;
+        ctx.save().await?;
+        let json = ctx.export_board(Some(board.id))?;
+        (card.id, sprint.id, json)
+    };
+
+    {
+        let mut dest = open_json_ctx(&dest_path).await;
+        dest.import_board(&json)?;
+        dest.save().await?;
+    }
+
+    let dest = open_json_ctx(&dest_path).await;
+    assert_sprint_bound(&dest, card_id, sprint_id);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_bound_card_import_round_trips_on_sqlite() -> KanbanResult<()> {
+    let dir = tempdir().unwrap();
+    let source_path = dir.path().join("source.sqlite");
+    let dest_path = dir.path().join("dest.sqlite");
+
+    let (card_id, sprint_id, json) = {
+        let mut ctx = open_sqlite_ctx(&source_path).await;
+        let board = ctx.create_board("B".into(), None)?;
+        let col = ctx.create_column(board.id, "Todo".into(), None)?;
+        let card = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
+        let sprint = ctx.create_sprint(board.id, Some("S".into()), None)?;
+        ctx.assign_card_to_sprint(card.id, sprint.id)?;
+        ctx.save().await?;
+        let json = ctx.export_board(Some(board.id))?;
+        (card.id, sprint.id, json)
+    };
+
+    {
+        let mut dest = open_sqlite_ctx(&dest_path).await;
+        dest.import_board(&json)?;
+        dest.save().await?;
+    }
+
+    let dest = open_sqlite_ctx(&dest_path).await;
+    assert_sprint_bound(&dest, card_id, sprint_id);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_bound_card_import_round_trips_in_memory() -> KanbanResult<()> {
+    let mut ctx = open_memory_ctx().await;
+    let board = ctx.create_board("B".into(), None)?;
+    let col = ctx.create_column(board.id, "Todo".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
+    let sprint = ctx.create_sprint(board.id, Some("S".into()), None)?;
+    ctx.assign_card_to_sprint(card.id, sprint.id)?;
+    let json = ctx.export_board(Some(board.id))?;
+
+    let mut dest = open_memory_ctx().await;
+    dest.import_board(&json)?;
+
+    assert_sprint_bound(&dest, card.id, sprint.id);
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Importing a snapshot whose cards carry a non-null `sprint_id` fails on SQLite with a foreign key violation (error 787). `ImportEntities::execute` wrote cards before sprints, so `cards.sprint_id -> sprints(id)` (non-deferrable, `crates/kanban-persistence-sqlite/src/schema.sql:157`) tripped on any sprint-bound card. This is reachable today via `kanban import` against a `.sqlite` board file from the CLI or TUI, independent of the server, and also via the server's `/v1/import` route.

## Fix

Move the sprint upsert loop in `ImportEntities::execute` (`crates/kanban-domain/src/commands/board_commands.rs`) to run after `ensure_prefix_rows_exist` and immediately before the card upsert loop, so sprints are always written before any card that references one.

## Tests

- `test_import_writes_the_sprint_before_the_cards_that_reference_it` (kanban-domain): red before the fix, using an extended `PrefixWriteOrderStore` that records any card written while its named sprint has no row yet.
- `test_sprint_bound_card_import_round_trips_on_sqlite` / `_on_json` / `_in_memory` (kanban-service): a three-backend export/import round trip of a sprint-bound card. Only the SQLite arm is red before the fix (it fails with a `FOREIGN KEY constraint failed` error); JSON and in-memory pass on origin/develop already and serve as parity pins.
- `test_export_then_import_round_trips_the_full_graph_on_sqlite` (kanban-server): un-narrowed by binding a sprint in the seed again (`seed_graph(_, true)`) and asserting `sprint_id` on the round-tripped card, matching its JSON sibling. Red before the fix at the `StatusCode::CREATED` assertion for `POST /v1/import`.

All three were confirmed red against the pre-fix code, then green after the reorder.

## Scope notes

- The inverse (undo) path is untouched; it deletes its own entities in its own order and import clears the undo stack anyway.
- `seed_graph`'s `bind_sprint` parameter is now `true` at both call sites in `transfer.rs`, which leaves it looking like dead flexibility. Left in place deliberately rather than removed, to keep this diff scoped to the ordering fix.
