### PR TITLE
KAN-1558 feat(service,server): stamp mutations and SSE frames with the client identity

### DIFF
--- a/.changeset/kan-1558-client-identity-core.md
+++ b/.changeset/kan-1558-client-identity-core.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+the server stamps mutations and SSE events with the X-Kanban-Client-Id header on board writes and board import

--- a/crates/kanban-api/src/v1/events.rs
+++ b/crates/kanban-api/src/v1/events.rs
@@ -41,7 +41,9 @@ impl ChangeKind {
 }
 
 /// SSE frame emitted by kanban-server on every successful mutation.
-/// Clients filter by `writer_instance_id` to ignore their own writes.
+/// A client suppresses its own echoes by skipping frames whose `issued_by`
+/// equals the UUID it sends in `X-Kanban-Client-Id`; a client that sends no
+/// header instead falls back to filtering on `writer_instance_id`.
 ///
 /// `entity_type`/`entity_id`/`kind` are `None` when the emitter cannot name
 /// what changed (an external process wrote the file). Otherwise they name the

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -141,6 +141,14 @@ curl -s http://127.0.0.1:58548/v1/boards/00000000-0000-0000-0000-000000000000 | 
 }
 ```
 
+### Client identity
+
+Send `X-Kanban-Client-Id: <uuid>` on a write request to attribute it to that client. The server stamps the value onto the audit log entry the write produces and onto the `ChangeEventFrame` broadcast on `/v1/events`, so a client can filter its own writes back out of the SSE stream by comparing `issued_by` to the UUID it sent, instead of relying on `writer_instance_id`.
+
+The header is a client-generated UUID, stable for the client's lifetime; omit it and the write is recorded and broadcast with a nil `issued_by`. A value that does not parse as a UUID is rejected with `422 VALIDATION_FAILED` before the request reaches the store. The identity is unauthenticated: any client can send any UUID, so it identifies provenance for echo suppression and auditing, not authorization.
+
+Today only the board write routes (`POST`/`PUT`/`PATCH`/`DELETE /v1/boards*`, `POST /v1/boards/{id}/archive`, `POST /v1/boards/{id}/restore`) and `POST /v1/import` honour the header. Every other write route still records and broadcasts a nil `issued_by`.
+
 ## Endpoints
 
 All request/response bodies are JSON. Errors share one envelope (see [Error Handling](#error-handling)). The paginated collection `GET`s (`/v1/boards`, `/v1/archived-boards`, `/v1/boards/{board_id}/columns`, `/v1/boards/{board_id}/cards`, `/v1/boards/{board_id}/sprints`) accept `?page=&page_size=` and return a `Page<T>` envelope; see [Pagination](#pagination).
@@ -230,7 +238,7 @@ The remaining card routes (get/create/replace/update/delete, and the flat `/v1/c
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/v1/events` | Server-Sent Events stream of `ChangeEventFrame`s, one per successful mutation (or per detected external write). Each frame carries `entity_type`/`entity_id`/`kind`, all absent when the emitter cannot name what changed. |
+| `GET` | `/v1/events` | Server-Sent Events stream of `ChangeEventFrame`s, one per successful mutation (or per detected external write). Each frame carries `entity_type`/`entity_id`/`kind`, all absent when the emitter cannot name what changed, and `issued_by` (see [Client identity](#client-identity)) for per-client echo suppression. |
 
 Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event naming the entity it touched and, per the persistence layer's normal save path, durably writes to the configured store before responding.
 

--- a/crates/kanban-server/src/client_ident.rs
+++ b/crates/kanban-server/src/client_ident.rs
@@ -1,0 +1,62 @@
+#[cfg(test)]
+mod tests {
+    use crate::client_ident::{ClientIdent, CLIENT_ID_HEADER};
+    use axum::extract::FromRequestParts;
+    use axum::http::{HeaderValue, Request};
+    use kanban_core::ClientId;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn test_absent_header_yields_nil_client_id() {
+        let mut parts = Request::builder()
+            .uri("/")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = ClientIdent::from_request_parts(&mut parts, &()).await;
+        assert_eq!(result.unwrap().0, ClientId::nil());
+    }
+
+    #[tokio::test]
+    async fn test_valid_uuid_header_yields_that_client_id() {
+        let uuid = Uuid::new_v4();
+        let mut parts = Request::builder()
+            .uri("/")
+            .header(CLIENT_ID_HEADER, uuid.to_string())
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = ClientIdent::from_request_parts(&mut parts, &()).await;
+        assert_eq!(result.unwrap().0, ClientId::from(uuid));
+    }
+
+    #[tokio::test]
+    async fn test_malformed_header_returns_422() {
+        let mut parts = Request::builder()
+            .uri("/")
+            .header(CLIENT_ID_HEADER, "not-a-uuid")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = ClientIdent::from_request_parts(&mut parts, &()).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.0.code, kanban_service::api::ErrorCode::ValidationFailed);
+        use axum::response::IntoResponse;
+        assert_eq!(err.into_response().status(), 422);
+    }
+
+    #[tokio::test]
+    async fn test_non_utf8_header_returns_422() {
+        let mut parts = Request::builder().uri("/").body(()).unwrap().into_parts().0;
+        parts.headers.insert(
+            CLIENT_ID_HEADER,
+            HeaderValue::from_bytes(&[0xff]).unwrap(),
+        );
+        let result = ClientIdent::from_request_parts(&mut parts, &()).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.into_response().status(), 422);
+    }
+}

--- a/crates/kanban-server/src/client_ident.rs
+++ b/crates/kanban-server/src/client_ident.rs
@@ -1,8 +1,45 @@
+use crate::error::AppError;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use kanban_core::ClientId;
+use kanban_service::api::{ApiError, ErrorCode};
+use uuid::Uuid;
+
+pub const CLIENT_ID_HEADER: &str = "x-kanban-client-id";
+
+/// Unauthenticated, client-supplied identity carried on `X-Kanban-Client-Id`.
+/// Absent header resolves to [`ClientId::nil`]; a malformed value rejects
+/// with a 422 rather than defaulting.
+#[derive(Debug)]
+pub struct ClientIdent(pub ClientId);
+
+impl<S: Send + Sync> FromRequestParts<S> for ClientIdent {
+    type Rejection = AppError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        match parts.headers.get(CLIENT_ID_HEADER) {
+            None => Ok(ClientIdent(ClientId::nil())),
+            Some(value) => value
+                .to_str()
+                .ok()
+                .and_then(|s| Uuid::parse_str(s).ok())
+                .map(|uuid| ClientIdent(ClientId::from(uuid)))
+                .ok_or_else(|| {
+                    AppError(ApiError::new(
+                        ErrorCode::ValidationFailed,
+                        format!("{CLIENT_ID_HEADER} must be a UUID"),
+                    ))
+                }),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::client_ident::{ClientIdent, CLIENT_ID_HEADER};
     use axum::extract::FromRequestParts;
     use axum::http::{HeaderValue, Request};
+    use axum::response::IntoResponse;
     use kanban_core::ClientId;
     use uuid::Uuid;
 
@@ -15,7 +52,10 @@ mod tests {
             .into_parts()
             .0;
         let result = ClientIdent::from_request_parts(&mut parts, &()).await;
-        assert_eq!(result.unwrap().0, ClientId::nil());
+        match result {
+            Ok(ClientIdent(id)) => assert_eq!(id, ClientId::nil()),
+            Err(_) => panic!("expected Ok"),
+        }
     }
 
     #[tokio::test]
@@ -29,7 +69,10 @@ mod tests {
             .into_parts()
             .0;
         let result = ClientIdent::from_request_parts(&mut parts, &()).await;
-        assert_eq!(result.unwrap().0, ClientId::from(uuid));
+        match result {
+            Ok(ClientIdent(id)) => assert_eq!(id, ClientId::from(uuid)),
+            Err(_) => panic!("expected Ok"),
+        }
     }
 
     #[tokio::test]
@@ -44,7 +87,6 @@ mod tests {
         let result = ClientIdent::from_request_parts(&mut parts, &()).await;
         let err = result.unwrap_err();
         assert_eq!(err.0.code, kanban_service::api::ErrorCode::ValidationFailed);
-        use axum::response::IntoResponse;
         assert_eq!(err.into_response().status(), 422);
     }
 

--- a/crates/kanban-server/src/client_ident.rs
+++ b/crates/kanban-server/src/client_ident.rs
@@ -45,12 +45,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_absent_header_yields_nil_client_id() {
-        let mut parts = Request::builder()
-            .uri("/")
-            .body(())
-            .unwrap()
-            .into_parts()
-            .0;
+        let mut parts = Request::builder().uri("/").body(()).unwrap().into_parts().0;
         let result = ClientIdent::from_request_parts(&mut parts, &()).await;
         match result {
             Ok(ClientIdent(id)) => assert_eq!(id, ClientId::nil()),
@@ -93,10 +88,9 @@ mod tests {
     #[tokio::test]
     async fn test_non_utf8_header_returns_422() {
         let mut parts = Request::builder().uri("/").body(()).unwrap().into_parts().0;
-        parts.headers.insert(
-            CLIENT_ID_HEADER,
-            HeaderValue::from_bytes(&[0xff]).unwrap(),
-        );
+        parts
+            .headers
+            .insert(CLIENT_ID_HEADER, HeaderValue::from_bytes(&[0xff]).unwrap());
         let result = ClientIdent::from_request_parts(&mut parts, &()).await;
         let err = result.unwrap_err();
         assert_eq!(err.into_response().status(), 422);

--- a/crates/kanban-server/src/layers.rs
+++ b/crates/kanban-server/src/layers.rs
@@ -61,7 +61,7 @@ impl CorsPolicy {
                     ])
                     .allow_headers([
                         header::CONTENT_TYPE,
-                        HeaderName::from_static("x-kanban-client-id"),
+                        HeaderName::from_static(crate::client_ident::CLIENT_ID_HEADER),
                     ]),
             ),
         }

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod app;
 pub mod capabilities;
+pub mod client_ident;
 pub mod error;
 pub mod layers;
 pub mod model_read;

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -1,3 +1,4 @@
+use crate::client_ident::ClientIdent;
 use crate::error::{AppError, AppJson};
 use crate::handlers::boards::{create_board, create_or_replace_board};
 use crate::model_read::{require_loaded, require_loaded_entity};
@@ -76,10 +77,11 @@ pub fn read_router() -> Router<AppState> {
 
 async fn post_board(
     State(state): State<AppState>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<CreateBoardRequest>,
 ) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
     let resp = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let resp = create_board(&mut ctx, req).map_err(AppError::from)?;
         state
             .persist_and_broadcast(&ctx, EntityType::Board, resp.id, ChangeKind::Created)
@@ -93,10 +95,11 @@ async fn post_board(
 async fn put_board(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<ReplaceBoardRequest>,
 ) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
     let (resp, created) = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let (resp, created) = create_or_replace_board(&mut ctx, id, req).map_err(AppError::from)?;
         state
             .persist_and_broadcast(
@@ -120,10 +123,11 @@ async fn put_board(
 async fn patch_board(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<UpdateBoardRequest>,
 ) -> Result<Json<BoardResponse>, AppError> {
     let board = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let (board, _invalidation) =
             crate::state::mutate(&mut ctx, |c| c.update_board_impl(id, req.into()))
                 .map_err(|e| AppError::from(&e))?;
@@ -139,9 +143,10 @@ async fn patch_board(
 async fn delete_board(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let _invalidation = crate::state::mutate_unit(&mut ctx, |c| c.delete_board_impl(id))
             .map_err(|e| AppError::from(&e))?;
         state
@@ -155,8 +160,9 @@ async fn delete_board(
 async fn archive_board(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<Json<BoardResponse>, AppError> {
-    let mut guard = state.lock_session().await;
+    let mut guard = state.lock_for_write(client).await;
     let _invalidation = crate::state::mutate_unit(&mut guard, |c| c.archive_board_impl(id))
         .map_err(|e| AppError::from(&e))?;
     let response = board_response(&guard, id)?;
@@ -170,8 +176,9 @@ async fn archive_board(
 async fn restore_board(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<Json<BoardResponse>, AppError> {
-    let mut guard = state.lock_session().await;
+    let mut guard = state.lock_for_write(client).await;
     let _invalidation = crate::state::mutate_unit(&mut guard, |c| c.restore_board_impl(id))
         .map_err(|e| AppError::from(&e))?;
     let response = board_response(&guard, id)?;

--- a/crates/kanban-server/src/routes/cards_batch.rs
+++ b/crates/kanban-server/src/routes/cards_batch.rs
@@ -29,7 +29,7 @@ async fn run_detailed(
     let result = op(&mut ctx);
     ctx.save().await.map_err(|e| AppError::from(&e))?;
     for id in &result.succeeded {
-        state.broadcast_change(EntityType::Card, *id, ChangeKind::Updated);
+        state.broadcast_change(ctx.issued_by(), EntityType::Card, *id, ChangeKind::Updated);
     }
     Ok(to_wire(&result))
 }
@@ -81,7 +81,7 @@ async fn batch_update_route(
         .map_err(|e| AppError::from(&e))?;
     ctx.save().await.map_err(|e| AppError::from(&e))?;
     for id in &ids {
-        state.broadcast_change(EntityType::Card, *id, ChangeKind::Updated);
+        state.broadcast_change(ctx.issued_by(), EntityType::Card, *id, ChangeKind::Updated);
     }
     Ok(Json(BatchOperationResponse::new(ids, vec![])))
 }

--- a/crates/kanban-server/src/routes/transfer.rs
+++ b/crates/kanban-server/src/routes/transfer.rs
@@ -1,3 +1,4 @@
+use crate::client_ident::ClientIdent;
 use crate::error::AppError;
 use crate::state::AppState;
 use axum::extract::{Path, State};
@@ -38,6 +39,7 @@ pub fn read_router() -> Router<AppState> {
 
 async fn import_route(
     State(state): State<AppState>,
+    ClientIdent(client): ClientIdent,
     body: String,
 ) -> Result<(StatusCode, Json<BoardResponse>), AppError> {
     serde_json::from_str::<Snapshot>(&body).map_err(|e| {
@@ -47,7 +49,7 @@ async fn import_route(
         ))
     })?;
 
-    let mut guard = state.lock_session().await;
+    let mut guard = state.lock_for_write(client).await;
     let board = guard.import_board(&body).map_err(|e| AppError::from(&e))?;
     state
         .persist_and_broadcast(&guard, EntityType::Board, board.id, ChangeKind::Created)

--- a/crates/kanban-server/src/state.rs
+++ b/crates/kanban-server/src/state.rs
@@ -72,8 +72,19 @@ impl AppState {
         self.ctx.lock().await
     }
 
+    /// Like [`lock_session`][Self::lock_session], but stamps the context with
+    /// `client` for the lifetime of the returned guard. The identity resets
+    /// to nil when the guard drops, so it never survives past the request
+    /// that set it.
+    pub async fn lock_for_write(&self, client: ClientId) -> WriteSession<'_> {
+        let mut guard = self.lock_session().await;
+        guard.ctx.set_issued_by(client);
+        WriteSession { guard }
+    }
+
     fn emit(
         &self,
+        issued_by: ClientId,
         entity_type: Option<EntityType>,
         entity_id: Option<Uuid>,
         kind: Option<ChangeKind>,
@@ -81,7 +92,7 @@ impl AppState {
         let _ = self.event_tx.send(ChangeEventFrame::for_entity(
             self.instance_id,
             Uuid::new_v4(),
-            ClientId::nil(),
+            issued_by,
             entity_type,
             entity_id,
             kind,
@@ -93,15 +104,21 @@ impl AppState {
     /// call after the context lock guard has been dropped. A missing
     /// subscriber (no SSE consumer connected yet) is not an error, hence the
     /// discarded result.
-    pub fn broadcast_change(&self, entity_type: EntityType, entity_id: Uuid, kind: ChangeKind) {
-        self.emit(Some(entity_type), Some(entity_id), Some(kind));
+    pub fn broadcast_change(
+        &self,
+        issued_by: ClientId,
+        entity_type: EntityType,
+        entity_id: Uuid,
+        kind: ChangeKind,
+    ) {
+        self.emit(issued_by, Some(entity_type), Some(entity_id), Some(kind));
     }
 
     /// Broadcast a change event whose origin is outside this process (an
     /// external writer changed the file), so the specific entity touched is
     /// unknowable.
     pub fn broadcast_unscoped_change(&self) {
-        self.emit(None, None, None);
+        self.emit(ClientId::nil(), None, None, None);
     }
 
     /// Durably persist any pending changes, then broadcast that `entity_id`
@@ -122,8 +139,37 @@ impl AppState {
         kind: ChangeKind,
     ) -> KanbanResult<()> {
         ctx.save().await?;
-        self.broadcast_change(entity_type, entity_id, kind);
+        self.broadcast_change(ctx.issued_by(), entity_type, entity_id, kind);
         Ok(())
+    }
+}
+
+/// A [`Session`] lock scoped to one client's write request. Deref/DerefMut
+/// forward to `Session` exactly like `lock_session`'s guard; dropping this
+/// guard resets `KanbanContext::issued_by` to nil so the identity cannot
+/// leak into a later request that acquires the lock without going through
+/// `lock_for_write`.
+pub struct WriteSession<'a> {
+    guard: MutexGuard<'a, Session>,
+}
+
+impl std::ops::Deref for WriteSession<'_> {
+    type Target = Session;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl std::ops::DerefMut for WriteSession<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
+impl Drop for WriteSession<'_> {
+    fn drop(&mut self) {
+        self.guard.ctx.set_issued_by(ClientId::nil());
     }
 }
 

--- a/crates/kanban-server/src/test_helpers.rs
+++ b/crates/kanban-server/src/test_helpers.rs
@@ -58,6 +58,31 @@ pub async fn send(state: &AppState, method: &str, uri: &str, body: Option<&Value
         .unwrap()
 }
 
+/// Like [`send`], but with extra request headers.
+pub async fn send_with_headers(
+    state: &AppState,
+    method: &str,
+    uri: &str,
+    body: Option<&Value>,
+    headers: &[(&str, &str)],
+) -> Response {
+    let mut builder = Request::builder().method(method).uri(uri);
+    let body = match body {
+        Some(v) => {
+            builder = builder.header("content-type", "application/json");
+            Body::from(serde_json::to_string(v).unwrap())
+        }
+        None => Body::empty(),
+    };
+    for (k, v) in headers {
+        builder = builder.header(*k, *v);
+    }
+    app::router(state.clone())
+        .oneshot(builder.body(body).unwrap())
+        .await
+        .unwrap()
+}
+
 pub async fn json_of(response: Response) -> Value {
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await

--- a/crates/kanban-server/tests/boards_write.rs
+++ b/crates/kanban-server/tests/boards_write.rs
@@ -7,7 +7,7 @@
 use axum::http::StatusCode;
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_server::state::AppState;
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_server::test_helpers::{json_of, make_state, send, send_with_headers};
 use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
 use serde_json::json;
 use std::sync::Arc;
@@ -494,4 +494,27 @@ async fn test_put_board_rejects_a_legacy_singular_completion_column_id_key() {
         message.contains("completion_column_id"),
         "the error must name the key sent: {body}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_malformed_client_id_header_returns_422() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        "/v1/boards",
+        Some(&json!({"name": "B", "card_prefix": "KAN"})),
+        &[("x-kanban-client-id", "not-a-uuid")],
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "VALIDATION_FAILED");
+
+    let response = send(&state, "GET", "/v1/boards", None).await;
+    let body = json_of(response).await;
+    assert_eq!(body["total"], 0);
 }

--- a/crates/kanban-server/tests/events_entity_identity.rs
+++ b/crates/kanban-server/tests/events_entity_identity.rs
@@ -1,9 +1,10 @@
 #![cfg(feature = "test-helpers")]
 
 use axum::http::StatusCode;
+use kanban_core::ClientId;
 use kanban_domain::KanbanOperations;
 use kanban_server::state::AppState;
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_server::test_helpers::{json_of, make_state, send, send_with_headers, TestServer};
 use kanban_service::api::{ChangeEventFrame, ChangeKind, EntityType};
 use serde_json::json;
 use std::time::Duration;
@@ -37,13 +38,14 @@ async fn test_broadcast_change_includes_entity_identity() {
     let mut rx = state.event_tx.subscribe();
 
     let id = Uuid::new_v4();
-    state.broadcast_change(EntityType::Board, id, ChangeKind::Updated);
+    state.broadcast_change(ClientId::nil(), EntityType::Board, id, ChangeKind::Updated);
 
     let frame = rx.try_recv().unwrap();
     assert_eq!(frame.entity_type, Some(EntityType::Board));
     assert_eq!(frame.entity_id, Some(id));
     assert_eq!(frame.kind, Some(ChangeKind::Updated));
     assert_eq!(frame.writer_instance_id, state.instance_id);
+    assert_eq!(frame.issued_by, ClientId::nil());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -371,4 +373,118 @@ async fn test_flat_routes_broadcast_their_own_entity_identity() {
     assert_eq!(frame.entity_type, Some(EntityType::Column));
     assert_eq!(frame.entity_id, Some(column_id));
     assert_eq!(frame.kind, Some(ChangeKind::Deleted));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mutation_frame_carries_header_client_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let mut rx = state.event_tx.subscribe();
+    let client = Uuid::new_v4();
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        "/v1/boards",
+        Some(&json!({"name": "Board", "card_prefix": "KAN"})),
+        &[("x-kanban-client-id", &client.to_string())],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.issued_by, ClientId::from(client));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_client_identity_does_not_leak_between_requests() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let mut rx = state.event_tx.subscribe();
+    let client = Uuid::new_v4();
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        "/v1/boards",
+        Some(&json!({"name": "Board A", "card_prefix": "AAA"})),
+        &[("x-kanban-client-id", &client.to_string())],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.issued_by, ClientId::from(client));
+
+    let response = send(
+        &state,
+        "POST",
+        "/v1/boards",
+        Some(&json!({"name": "Board B", "card_prefix": "BBB"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let frame = next_frame(&mut rx).await;
+    assert_eq!(frame.issued_by, ClientId::nil());
+}
+
+async fn read_one_sse_frame(response: &mut reqwest::Response) -> serde_json::Value {
+    let mut buf = Vec::new();
+    loop {
+        let chunk = response
+            .chunk()
+            .await
+            .unwrap()
+            .expect("stream ended before a full SSE frame arrived");
+        buf.extend_from_slice(&chunk);
+        let text = String::from_utf8_lossy(&buf);
+        if let Some(idx) = text.find("\n\n") {
+            let frame_text = text[..idx].to_string();
+            let data_line = frame_text
+                .lines()
+                .find(|l| l.starts_with("data:"))
+                .expect("frame must have a data: line");
+            return serde_json::from_str(data_line.trim_start_matches("data:").trim()).unwrap();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_two_clients_frames_carry_distinct_ids() {
+    let server = TestServer::start().await;
+    let client_a = Uuid::new_v4();
+    let client_b = Uuid::new_v4();
+
+    let mut events_response = server
+        .client()
+        .get(format!("{}/v1/events", server.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .header("x-kanban-client-id", client_a.to_string())
+        .json(&json!({"name": "Board A", "card_prefix": "AAA"}))
+        .send()
+        .await
+        .unwrap();
+    let frame_a = read_one_sse_frame(&mut events_response).await;
+
+    server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .header("x-kanban-client-id", client_b.to_string())
+        .json(&json!({"name": "Board B", "card_prefix": "BBB"}))
+        .send()
+        .await
+        .unwrap();
+    let frame_b = read_one_sse_frame(&mut events_response).await;
+
+    assert_eq!(frame_a["issued_by"], client_a.to_string());
+    assert_eq!(frame_b["issued_by"], client_b.to_string());
+    assert_ne!(frame_a["issued_by"], frame_b["issued_by"]);
+
+    drop(events_response);
+    server.shutdown().await;
 }

--- a/crates/kanban-server/tests/events_entity_identity.rs
+++ b/crates/kanban-server/tests/events_entity_identity.rs
@@ -400,6 +400,7 @@ async fn test_mutation_frame_carries_header_client_id() {
 async fn test_client_identity_does_not_leak_between_requests() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, column_id) = seed_board_and_column(&state).await;
     let mut rx = state.event_tx.subscribe();
     let client = Uuid::new_v4();
 
@@ -415,11 +416,14 @@ async fn test_client_identity_does_not_leak_between_requests() {
     let frame = next_frame(&mut rx).await;
     assert_eq!(frame.issued_by, ClientId::from(client));
 
+    // The second write goes through cards.rs's still-raw `state.ctx.lock()`
+    // seam, so this pins that `lock_for_write`'s identity does not survive
+    // past its own guard into a request that never acquires it.
     let response = send(
         &state,
         "POST",
-        "/v1/boards",
-        Some(&json!({"name": "Board B", "card_prefix": "BBB"})),
+        &format!("/v1/columns/{column_id}/cards"),
+        Some(&json!({"title": "Task 1"})),
     )
     .await;
     assert_eq!(response.status(), StatusCode::CREATED);

--- a/crates/kanban-service/src/context/core.rs
+++ b/crates/kanban-service/src/context/core.rs
@@ -1,7 +1,7 @@
 use super::KanbanContext;
 use crate::backend::KanbanBackend;
 use crate::fetch_plan::{FetchPlan, LoadedEntities};
-use kanban_core::{AppConfig, AppType};
+use kanban_core::{AppConfig, AppType, ClientId};
 use kanban_domain::{
     ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, Invalidation, KanbanResult,
     Resolved, Sprint,
@@ -22,6 +22,7 @@ impl KanbanContext {
             conflict_pending: false,
             session_id: Uuid::new_v4(),
             app_type: AppType::Unknown,
+            issued_by: ClientId::nil(),
         }
     }
 
@@ -29,6 +30,14 @@ impl KanbanContext {
     pub fn with_app_type(mut self, app_type: AppType) -> Self {
         self.app_type = app_type;
         self
+    }
+
+    pub fn set_issued_by(&mut self, id: ClientId) {
+        self.issued_by = id;
+    }
+
+    pub fn issued_by(&self) -> ClientId {
+        self.issued_by
     }
 
     /// The session ID, stable for this context's lifetime. Each surface

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -68,6 +68,8 @@ pub struct KanbanContext {
     pub(super) session_id: Uuid,
     /// Which application surface owns this context. Default: Unknown.
     pub(super) app_type: AppType,
+    /// Identity of the client that issued the in-flight request; nil unless a caller sets it.
+    pub(super) issued_by: kanban_core::ClientId,
 }
 
 // The `KanbanOperations` trait impl must live in a single block (Rust forbids

--- a/crates/kanban-service/src/context/sprints.rs
+++ b/crates/kanban-service/src/context/sprints.rs
@@ -1,6 +1,6 @@
 use super::KanbanContext;
 use crate::backend::KanbanBackend;
-use kanban_core::{ClientId, KANBAN_VERSION};
+use kanban_core::KANBAN_VERSION;
 use kanban_domain::commands::{Command, SprintCommand};
 use kanban_domain::export::{AllBoardsExport, BoardImporter};
 use kanban_domain::{
@@ -460,7 +460,7 @@ impl KanbanContext {
             let batch = kanban_domain::CommandBatch {
                 commands: cmds.clone(),
                 correlation_id: Uuid::new_v4(),
-                issued_by: ClientId::nil(),
+                issued_by: self.issued_by,
                 timestamp: chrono::Utc::now(),
                 app_type: self.app_type,
                 app_version: KANBAN_VERSION.to_string(),

--- a/crates/kanban-service/src/context/undo.rs
+++ b/crates/kanban-service/src/context/undo.rs
@@ -1,5 +1,5 @@
 use super::KanbanContext;
-use kanban_core::{ClientId, KANBAN_VERSION};
+use kanban_core::KANBAN_VERSION;
 use kanban_domain::commands::{Command, CommandContext};
 use kanban_domain::{
     invalidation_from_inverse, DataStore, Invalidation, KanbanError, KanbanResult, UndoOperations,
@@ -74,8 +74,7 @@ impl KanbanContext {
             let batch = kanban_domain::CommandBatch {
                 commands: built.clone(),
                 correlation_id: Uuid::new_v4(),
-                // nil locally; the HTTP layer assigns the real client identity (KAN-751)
-                issued_by: ClientId::nil(),
+                issued_by: self.issued_by,
                 timestamp: chrono::Utc::now(),
                 app_type: self.app_type,
                 app_version: KANBAN_VERSION.to_string(),

--- a/crates/kanban-service/tests/client_identity.rs
+++ b/crates/kanban-service/tests/client_identity.rs
@@ -1,0 +1,73 @@
+//! `KanbanContext::issued_by` stamps every recorded `CommandBatch` with the
+//! identity of the client that requested the mutation.
+
+use kanban_backend_memory::InMemoryStore;
+use kanban_core::{AppConfig, ClientId};
+use kanban_domain::{KanbanOperations, KanbanResult};
+use kanban_service::KanbanContext;
+use std::sync::Arc;
+
+async fn make_ctx() -> KanbanContext {
+    KanbanContext::open(Arc::new(InMemoryStore::new()), AppConfig::default())
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_open_deferred_defaults_issued_by_to_nil() {
+    let ctx = KanbanContext::open_deferred(Arc::new(InMemoryStore::new()), AppConfig::default());
+    assert_eq!(ctx.issued_by(), ClientId::nil());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_stamps_context_issued_by_on_batch() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let backend = ctx.backend();
+    let baseline = backend.batch_count()?;
+
+    let id = ClientId::new();
+    ctx.set_issued_by(id);
+    ctx.create_board_impl("B".into(), None)?;
+
+    let batches = backend.load_batches(baseline, baseline + 1)?;
+    assert_eq!(batches[0].issued_by, id);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_import_board_stamps_context_issued_by_on_batch() -> KanbanResult<()> {
+    let mut a = make_ctx().await;
+    let board = a.create_board("Source".to_string(), Some("SRC".to_string()))?;
+    a.create_column(board.id, "To Do".to_string(), None)?;
+    let json = a.export_board(Some(board.id))?;
+
+    let mut b = make_ctx().await;
+    let backend = b.backend();
+    let baseline = backend.batch_count()?;
+
+    let id = ClientId::new();
+    b.set_issued_by(id);
+    b.import_board_impl(&json)?;
+
+    let batches = backend.load_batches(baseline, baseline + 1)?;
+    assert_eq!(batches[0].issued_by, id);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_issued_by_applies_to_subsequent_batches_only() -> KanbanResult<()> {
+    let mut ctx = make_ctx().await;
+    let backend = ctx.backend();
+    let baseline = backend.batch_count()?;
+
+    ctx.create_board_impl("Before".into(), None)?;
+
+    let id = ClientId::new();
+    ctx.set_issued_by(id);
+    ctx.create_board_impl("After".into(), None)?;
+
+    let batches = backend.load_batches(baseline, baseline + 2)?;
+    assert_eq!(batches[0].issued_by, ClientId::nil());
+    assert_eq!(batches[1].issued_by, id);
+    Ok(())
+}

--- a/crates/kanban-service/tests/client_identity.rs
+++ b/crates/kanban-service/tests/client_identity.rs
@@ -27,7 +27,7 @@ async fn test_execute_stamps_context_issued_by_on_batch() -> KanbanResult<()> {
 
     let id = ClientId::new();
     ctx.set_issued_by(id);
-    ctx.create_board_impl("B".into(), None)?;
+    let _ = ctx.create_board_impl("B".into(), None)?;
 
     let batches = backend.load_batches(baseline, baseline + 1)?;
     assert_eq!(batches[0].issued_by, id);
@@ -47,7 +47,7 @@ async fn test_import_board_stamps_context_issued_by_on_batch() -> KanbanResult<(
 
     let id = ClientId::new();
     b.set_issued_by(id);
-    b.import_board_impl(&json)?;
+    let _ = b.import_board_impl(&json)?;
 
     let batches = backend.load_batches(baseline, baseline + 1)?;
     assert_eq!(batches[0].issued_by, id);
@@ -60,11 +60,11 @@ async fn test_set_issued_by_applies_to_subsequent_batches_only() -> KanbanResult
     let backend = ctx.backend();
     let baseline = backend.batch_count()?;
 
-    ctx.create_board_impl("Before".into(), None)?;
+    let _ = ctx.create_board_impl("Before".into(), None)?;
 
     let id = ClientId::new();
     ctx.set_issued_by(id);
-    ctx.create_board_impl("After".into(), None)?;
+    let _ = ctx.create_board_impl("After".into(), None)?;
 
     let batches = backend.load_batches(baseline, baseline + 2)?;
     assert_eq!(batches[0].issued_by, ClientId::nil());


### PR DESCRIPTION
## Summary

- `KanbanContext` gains an `issued_by: ClientId` field with `set_issued_by`/`issued_by` accessors, defaulting to nil. Every recorded `CommandBatch` (both `execute_with_extra` and `import_board_impl`) now stamps this value instead of hardcoding nil.
- Added a `ClientIdent` axum extractor for the `X-Kanban-Client-Id` header: absent resolves to nil, malformed returns 422 `VALIDATION_FAILED`.
- Added `AppState::lock_for_write(client)`, a thin wrapper over the existing `lock_session()` seam that stamps the context with the client identity for the lifetime of the returned guard and resets it to nil on drop, so the identity never survives past the request that set it.
- `AppState::broadcast_change`/`emit` now take an `issued_by: ClientId` parameter, threaded from `ctx.issued_by()` in `persist_and_broadcast` so the SSE frame and the recorded batch carry the same value for the same mutation.
- All six board write routes (`POST`/`PUT`/`PATCH`/`DELETE /v1/boards*`, archive, restore) and `POST /v1/import` now acquire the lock through `lock_for_write` and extract `ClientIdent`. Every other write route (cards, columns, sprints, graph, lifecycle) is unchanged and continues to record/broadcast nil; that sweep is tracked separately.
- Documented the header contract on `ChangeEventFrame` and in the server README, including which routes honour it today.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] Mutation-tested the `WriteSession` Drop reset and the `KanbanContext::issued_by` stamping by deliberately breaking each and confirming the corresponding test fails, then restoring
