### PR TITLE
KAN-1559 feat(server): etag and if-none-match on single-entity GET routes

### DIFF
--- a/.changeset/kan-1559-etag-if-none-match.md
+++ b/.changeset/kan-1559-etag-if-none-match.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+kanban-server single-entity GET routes now send a strong ETag and honour If-None-Match with a bodiless 304 (board, card, column, sprint, and their flat aliases)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+# Hashing
+sha2 = "0.10"
+
 # UUID and time
 uuid = { version = "1.11", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/kanban-server/Cargo.toml
+++ b/crates/kanban-server/Cargo.toml
@@ -37,7 +37,8 @@ kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite", version = "
 kanban-service = { path = "../kanban-service", version = "^0.9" }
 prometheus = { workspace = true }
 clap = { workspace = true }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 reqwest = { workspace = true, optional = true }
 kanban-backend-memory = { path = "../kanban-backend-memory", version = "^0.9", optional = true }
 
@@ -50,4 +51,4 @@ assert_cmd = { workspace = true }
 predicates = { workspace = true }
 
 [features]
-test-helpers = ["dep:serde_json", "dep:reqwest", "dep:kanban-backend-memory"]
+test-helpers = ["dep:reqwest", "dep:kanban-backend-memory"]

--- a/crates/kanban-server/src/etag.rs
+++ b/crates/kanban-server/src/etag.rs
@@ -1,3 +1,65 @@
+use crate::error::AppError;
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use kanban_service::api::{ApiError, ErrorCode};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+const HEX: [u8; 16] = *b"0123456789abcdef";
+
+pub fn etag_for(body: &[u8]) -> String {
+    let digest = Sha256::digest(body);
+    let mut tag = String::with_capacity(34);
+    tag.push('"');
+    for byte in &digest[..16] {
+        tag.push(HEX[(byte >> 4) as usize] as char);
+        tag.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    tag.push('"');
+    tag
+}
+
+fn strong(tag: &str) -> &str {
+    tag.strip_prefix("W/").unwrap_or(tag)
+}
+
+pub fn if_none_match_matches(headers: &HeaderMap, etag: &str) -> bool {
+    let ours = strong(etag);
+    headers
+        .get_all(header::IF_NONE_MATCH)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .any(|candidate| candidate == "*" || strong(candidate) == ours)
+}
+
+fn serialization_failed() -> AppError {
+    AppError(ApiError::new(
+        ErrorCode::SerializationError,
+        "failed to serialize response",
+    ))
+}
+
+pub fn json_with_etag<T: Serialize>(headers: &HeaderMap, value: &T) -> Result<Response, AppError> {
+    let body = serde_json::to_vec(value).map_err(|_| serialization_failed())?;
+    let tag = etag_for(&body);
+    let tag_value = HeaderValue::try_from(tag).map_err(|_| serialization_failed())?;
+
+    let mut response = if if_none_match_matches(headers, tag_value.to_str().unwrap_or_default()) {
+        StatusCode::NOT_MODIFIED.into_response()
+    } else {
+        let mut response = body.into_response();
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        response
+    };
+    response.headers_mut().insert(header::ETAG, tag_value);
+    Ok(response)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-server/src/etag.rs
+++ b/crates/kanban-server/src/etag.rs
@@ -1,0 +1,64 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    #[test]
+    fn test_etag_is_quoted_thirty_two_hex_chars() {
+        let tag = etag_for(b"{}");
+        assert_eq!(tag.len(), 34);
+        assert!(tag.starts_with('"'));
+        assert!(tag.ends_with('"'));
+        assert!(tag[1..33]
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn test_same_body_same_etag_different_body_different_etag() {
+        assert_eq!(etag_for(b"{\"a\":1}"), etag_for(b"{\"a\":1}"));
+        assert_ne!(etag_for(b"{\"a\":1}"), etag_for(b"{\"a\":2}"));
+    }
+
+    #[test]
+    fn test_if_none_match_star_matches_any_etag() {
+        let mut headers = HeaderMap::new();
+        headers.insert("if-none-match", "*".parse().unwrap());
+        assert!(if_none_match_matches(&headers, "\"abc\""));
+    }
+
+    #[test]
+    fn test_if_none_match_ignores_weak_prefix() {
+        let mut headers = HeaderMap::new();
+        headers.insert("if-none-match", "W/\"abc\"".parse().unwrap());
+        assert!(if_none_match_matches(&headers, "\"abc\""));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("if-none-match", "\"abc\"".parse().unwrap());
+        assert!(if_none_match_matches(&headers, "\"abc\""));
+    }
+
+    #[test]
+    fn test_if_none_match_matches_any_tag_in_comma_list() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "if-none-match",
+            "\"zzz\", W/\"abc\" , \"yyy\"".parse().unwrap(),
+        );
+        assert!(if_none_match_matches(&headers, "\"abc\""));
+    }
+
+    #[test]
+    fn test_if_none_match_with_only_non_matching_tags_does_not_match() {
+        let mut headers = HeaderMap::new();
+        headers.insert("if-none-match", "\"zzz\", \"yyy\"".parse().unwrap());
+        assert!(!if_none_match_matches(&headers, "\"abc\""));
+    }
+
+    #[test]
+    fn test_absent_if_none_match_never_matches() {
+        let headers = HeaderMap::new();
+        assert!(!if_none_match_matches(&headers, "\"\""));
+        assert!(!if_none_match_matches(&headers, "\"abc\""));
+    }
+}

--- a/crates/kanban-server/src/lib.rs
+++ b/crates/kanban-server/src/lib.rs
@@ -7,6 +7,7 @@ pub mod app;
 pub mod capabilities;
 pub mod client_ident;
 pub mod error;
+pub mod etag;
 pub mod layers;
 pub mod model_read;
 pub mod pagination;

--- a/crates/kanban-server/src/routes/boards.rs
+++ b/crates/kanban-server/src/routes/boards.rs
@@ -1,12 +1,14 @@
 use crate::client_ident::ClientIdent;
 use crate::error::{AppError, AppJson};
+use crate::etag;
 use crate::handlers::boards::{create_board, create_or_replace_board};
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
 use crate::scope::RouteScope;
 use crate::state::AppState;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::Response;
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use kanban_domain::{Model, NoProjections};
@@ -44,10 +46,11 @@ fn board_response(session: &crate::state::Session, id: Uuid) -> Result<BoardResp
 
 async fn get_board(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(id): Path<Uuid>,
-) -> Result<Json<BoardResponse>, AppError> {
+) -> Result<Response, AppError> {
     let guard = state.lock_session().await;
-    Ok(Json(board_response(&guard, id)?))
+    etag::json_with_etag(&headers, &board_response(&guard, id)?)
 }
 
 async fn list_archived_boards(

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -1,10 +1,12 @@
 use crate::error::{AppError, AppJson};
+use crate::etag;
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
 use crate::scope::RouteScope;
 use crate::state::AppState;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::Response;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
@@ -163,8 +165,9 @@ async fn list_cards(
 
 async fn get_card(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
-) -> Result<Json<CardResponse>, AppError> {
+) -> Result<Response, AppError> {
     let scope = RouteScope::Card(id);
     let guard = state.lock_session().await;
     let mut model = Model::default();
@@ -174,7 +177,7 @@ async fn get_card(
     if card.board_id != board_id {
         return Err(AppError::from(&KanbanError::not_found("Card", id)));
     }
-    Ok(Json(CardResponse::from(card)))
+    etag::json_with_etag(&headers, &CardResponse::from(card))
 }
 
 async fn list_archived_cards(
@@ -355,15 +358,16 @@ pub fn write_router() -> Router<AppState> {
 
 async fn get_card_flat(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(id): Path<Uuid>,
-) -> Result<Json<CardResponse>, AppError> {
+) -> Result<Response, AppError> {
     let scope = RouteScope::Card(id);
     let guard = state.lock_session().await;
     let mut model = Model::default();
     guard.sync(&scope, &mut model, &mut NoProjections);
 
     let card = require_loaded_entity(model.card_by_id_state(id), "Card", id)?;
-    Ok(Json(CardResponse::from(card)))
+    etag::json_with_etag(&headers, &CardResponse::from(card))
 }
 
 async fn update_card_route_flat(

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -1,10 +1,12 @@
 use crate::error::{AppError, AppJson};
+use crate::etag;
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
 use crate::scope::RouteScope;
 use crate::state::AppState;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::Response;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use kanban_domain::{Column, Model, NoProjections};
@@ -28,8 +30,9 @@ async fn list_columns(
 
 async fn get_column(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
-) -> Result<Json<ColumnResponse>, AppError> {
+) -> Result<Response, AppError> {
     let session = state.lock_session().await;
     let scope = RouteScope::Column(id);
     let mut model = Model::default();
@@ -38,7 +41,7 @@ async fn get_column(
     if column.board_id != board_id {
         return Err(AppError::from(&KanbanError::not_found("Column", id)));
     }
-    Ok(Json(ColumnResponse::from(column)))
+    etag::json_with_etag(&headers, &ColumnResponse::from(column))
 }
 
 pub fn read_router() -> Router<AppState> {
@@ -206,14 +209,15 @@ pub fn write_router() -> Router<AppState> {
 
 async fn get_column_flat(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(id): Path<Uuid>,
-) -> Result<Json<ColumnResponse>, AppError> {
+) -> Result<Response, AppError> {
     let session = state.lock_session().await;
     let scope = RouteScope::Column(id);
     let mut model = Model::default();
     session.sync(&scope, &mut model, &mut NoProjections);
     let column = require_loaded_entity(model.column_id_status(id), "Column", id)?;
-    Ok(Json(ColumnResponse::from(column)))
+    etag::json_with_etag(&headers, &ColumnResponse::from(column))
 }
 
 async fn update_column_route_flat(

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -1,10 +1,12 @@
 use crate::error::{AppError, AppJson};
+use crate::etag;
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
 use crate::scope::RouteScope;
 use crate::state::AppState;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::Response;
 use axum::routing::{get, patch, post, put};
 use axum::{Json, Router};
 use kanban_domain::{Model, NoProjections, Sprint};
@@ -35,8 +37,9 @@ async fn list_sprints(
 
 async fn get_sprint(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
-) -> Result<Json<SprintResponse>, AppError> {
+) -> Result<Response, AppError> {
     let guard = state.lock_session().await;
     let mut model = Model::default();
     guard.sync(
@@ -52,10 +55,10 @@ async fn get_sprint(
         return Err(AppError::from(&KanbanError::not_found("Sprint", id)));
     }
     let board = require_loaded_entity(model.board_id_status(board_id), "Board", board_id)?;
-    Ok(Json(SprintResponse::new(
-        sprint,
-        sprint.get_name(board).map(str::to_string),
-    )))
+    etag::json_with_etag(
+        &headers,
+        &SprintResponse::new(sprint, sprint.get_name(board).map(str::to_string)),
+    )
 }
 
 pub fn read_router() -> Router<AppState> {
@@ -210,8 +213,9 @@ pub fn write_router() -> Router<AppState> {
 
 async fn get_sprint_flat(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(id): Path<Uuid>,
-) -> Result<Json<SprintResponse>, AppError> {
+) -> Result<Response, AppError> {
     let guard = state.lock_session().await;
     let mut model = Model::default();
     guard.sync(
@@ -236,10 +240,10 @@ async fn get_sprint_flat(
         "Board",
         sprint.board_id,
     )?;
-    Ok(Json(SprintResponse::new(
-        &sprint,
-        sprint.get_name(board).map(str::to_string),
-    )))
+    etag::json_with_etag(
+        &headers,
+        &SprintResponse::new(&sprint, sprint.get_name(board).map(str::to_string)),
+    )
 }
 
 async fn update_sprint_route_flat(

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -5,10 +5,29 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send, send_with_headers};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
+
+fn etag_of(response: &axum::response::Response) -> String {
+    response
+        .headers()
+        .get("etag")
+        .expect("etag header")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn is_quoted_32_hex(tag: &str) -> bool {
+    tag.len() == 34
+        && tag.starts_with('"')
+        && tag.ends_with('"')
+        && tag[1..33]
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_boards_empty_returns_200_empty_page() {
@@ -321,4 +340,213 @@ async fn test_patch_board_then_get_board_returns_the_updated_name_across_request
 
     let get2 = json_of(send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await).await;
     assert_eq!(get2["name"], "Renamed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_carries_etag_header() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let response = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let tag = etag_of(&response);
+    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_with_matching_if_none_match_returns_304_empty_body_with_etag() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let first = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let tag = etag_of(&first);
+
+    let second = send_with_headers(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}", board_id),
+        None,
+        &[("if-none-match", &tag)],
+    )
+    .await;
+
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    let response_tag = etag_of(&second);
+    assert_eq!(response_tag, tag);
+    let bytes = axum::body::to_bytes(second.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(bytes.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_with_stale_if_none_match_returns_200_and_body() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let response = send_with_headers(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}", board_id),
+        None,
+        &[(
+            "if-none-match",
+            "\"00000000000000000000000000000000\"",
+        )],
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let tag = etag_of(&response);
+    assert_ne!(tag, "\"00000000000000000000000000000000\"");
+    let json = json_of(response).await;
+    assert_eq!(json["name"], "Board");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_with_weak_if_none_match_returns_304_not_modified() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let first = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let tag = etag_of(&first);
+    let weak = format!("W/{tag}");
+
+    let second = send_with_headers(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}", board_id),
+        None,
+        &[("if-none-match", &weak)],
+    )
+    .await;
+
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_etag_changes_after_update() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let first = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let etag1 = etag_of(&first);
+
+    let patch_body = serde_json::json!({ "name": "Renamed" });
+    let patch_resp = send(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{}", board_id),
+        Some(&patch_body),
+    )
+    .await;
+    assert_eq!(patch_resp.status(), StatusCode::OK);
+
+    let second = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let etag2 = etag_of(&second);
+
+    assert_ne!(etag1, etag2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_archival_changes_etag() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let first = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let etag1 = etag_of(&first);
+
+    {
+        let mut ctx = state.ctx.lock().await;
+        ctx.archive_board(board_id).unwrap();
+    }
+
+    let second = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let etag2 = etag_of(&second);
+
+    assert_ne!(etag1, etag2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_board_etag_is_stable_across_repeated_gets_on_sqlite() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "To Do".to_string(), None)
+            .unwrap()
+            .id;
+        ctx.create_card(board_id, col_id, "Task".to_string(), Default::default())
+            .unwrap();
+        board_id
+    };
+
+    let first = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let etag1 = etag_of(&first);
+    let second = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let etag2 = etag_of(&second);
+    let third = send(&state, "GET", &format!("/v1/boards/{}", board_id), None).await;
+    let etag3 = etag_of(&third);
+
+    assert_eq!(etag1, etag2);
+    assert_eq!(etag2, etag3);
+
+    let fourth = send_with_headers(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}", board_id),
+        None,
+        &[("if-none-match", &etag1)],
+    )
+    .await;
+    assert_eq!(fourth.status(), StatusCode::NOT_MODIFIED);
 }

--- a/crates/kanban-server/tests/boards_read.rs
+++ b/crates/kanban-server/tests/boards_read.rs
@@ -5,7 +5,9 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send, send_with_headers};
+use kanban_server::test_helpers::{
+    json_of, make_sqlite_state, make_state, send, send_with_headers,
+};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -358,7 +360,10 @@ async fn test_get_board_carries_etag_header() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let tag = etag_of(&response);
-    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+    assert!(
+        is_quoted_32_hex(&tag),
+        "expected quoted 32-hex etag, got {tag}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -411,10 +416,7 @@ async fn test_get_board_with_stale_if_none_match_returns_200_and_body() {
         "GET",
         &format!("/v1/boards/{}", board_id),
         None,
-        &[(
-            "if-none-match",
-            "\"00000000000000000000000000000000\"",
-        )],
+        &[("if-none-match", "\"00000000000000000000000000000000\"")],
     )
     .await;
 

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -6,7 +6,9 @@
 
 use axum::http::StatusCode;
 use kanban_domain::{CardPriority, CardStatus, CardUpdate, CreateCardOptions};
-use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send, send_with_headers};
+use kanban_server::test_helpers::{
+    json_of, make_sqlite_state, make_state, send, send_with_headers,
+};
 use kanban_service::api::CardResponse;
 use kanban_service::KanbanOperations;
 use std::collections::HashSet;
@@ -1705,7 +1707,10 @@ async fn test_get_card_carries_etag_header() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let tag = etag_of(&response);
-    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+    assert!(
+        is_quoted_32_hex(&tag),
+        "expected quoted 32-hex etag, got {tag}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/cards_read.rs
+++ b/crates/kanban-server/tests/cards_read.rs
@@ -6,12 +6,31 @@
 
 use axum::http::StatusCode;
 use kanban_domain::{CardPriority, CardStatus, CardUpdate, CreateCardOptions};
-use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send, send_with_headers};
 use kanban_service::api::CardResponse;
 use kanban_service::KanbanOperations;
 use std::collections::HashSet;
 use tempfile::tempdir;
 use uuid::Uuid;
+
+fn etag_of(response: &axum::response::Response) -> String {
+    response
+        .headers()
+        .get("etag")
+        .expect("etag header")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn is_quoted_32_hex(tag: &str) -> bool {
+    tag.len() == 34
+        && tag.starts_with('"')
+        && tag.ends_with('"')
+        && tag[1..33]
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_cards_returns_all_board_cards_by_default() {
@@ -1652,4 +1671,75 @@ async fn test_list_cards_malformed_sprint_ids_returns_400() {
     )
     .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_carries_etag_header() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, card_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "To Do".to_string(), None)
+            .unwrap()
+            .id;
+        let card_id = ctx
+            .create_card(board_id, col_id, "Task".to_string(), Default::default())
+            .unwrap()
+            .id;
+        (board_id, card_id)
+    };
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/cards/{}", board_id, card_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let tag = etag_of(&response);
+    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_with_matching_if_none_match_returns_304() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, card_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "To Do".to_string(), None)
+            .unwrap()
+            .id;
+        let card_id = ctx
+            .create_card(board_id, col_id, "Task".to_string(), Default::default())
+            .unwrap()
+            .id;
+        (board_id, card_id)
+    };
+
+    let uri = format!("/v1/boards/{}/cards/{}", board_id, card_id);
+    let first = send(&state, "GET", &uri, None).await;
+    let tag = etag_of(&first);
+
+    let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
+
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(etag_of(&second), tag);
+    let bytes = axum::body::to_bytes(second.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(bytes.is_empty());
 }

--- a/crates/kanban-server/tests/columns_read.rs
+++ b/crates/kanban-server/tests/columns_read.rs
@@ -5,7 +5,9 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send, send_with_headers};
+use kanban_server::test_helpers::{
+    json_of, make_sqlite_state, make_state, send, send_with_headers,
+};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -428,7 +430,10 @@ async fn test_get_column_carries_etag_header() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let tag = etag_of(&response);
-    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+    assert!(
+        is_quoted_32_hex(&tag),
+        "expected quoted 32-hex etag, got {tag}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-server/tests/columns_read.rs
+++ b/crates/kanban-server/tests/columns_read.rs
@@ -5,10 +5,29 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send, send_with_headers};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
+
+fn etag_of(response: &axum::response::Response) -> String {
+    response
+        .headers()
+        .get("etag")
+        .expect("etag header")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn is_quoted_32_hex(tag: &str) -> bool {
+    tag.len() == 34
+        && tag.starts_with('"')
+        && tag.ends_with('"')
+        && tag[1..33]
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_columns_returns_board_columns_in_position_order() {
@@ -379,4 +398,67 @@ async fn test_list_columns_on_sqlite_serves_an_archived_boards_columns() {
     let arr = json["items"].as_array().expect("items should be an array");
     assert_eq!(arr.len(), 1);
     assert_eq!(arr[0]["name"], "Column 1");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_column_carries_etag_header() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "To Do".to_string(), None)
+            .unwrap()
+            .id;
+        (board_id, col_id)
+    };
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/columns/{}", board_id, col_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let tag = etag_of(&response);
+    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_column_with_matching_if_none_match_returns_304() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, col_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let col_id = ctx
+            .create_column(board_id, "To Do".to_string(), None)
+            .unwrap()
+            .id;
+        (board_id, col_id)
+    };
+
+    let uri = format!("/v1/boards/{}/columns/{}", board_id, col_id);
+    let first = send(&state, "GET", &uri, None).await;
+    let tag = etag_of(&first);
+
+    let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
+
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(etag_of(&second), tag);
+    let bytes = axum::body::to_bytes(second.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(bytes.is_empty());
 }

--- a/crates/kanban-server/tests/flat_routes.rs
+++ b/crates/kanban-server/tests/flat_routes.rs
@@ -409,7 +409,10 @@ async fn test_get_card_flat_carries_etag_header_and_matching_if_none_match_retur
     let first = send(&state, "GET", &uri, None).await;
     assert_eq!(first.status(), StatusCode::OK);
     let tag = etag_of(&first);
-    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+    assert!(
+        is_quoted_32_hex(&tag),
+        "expected quoted 32-hex etag, got {tag}"
+    );
 
     let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
     assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
@@ -430,7 +433,10 @@ async fn test_get_column_flat_carries_etag_header_and_matching_if_none_match_ret
     let first = send(&state, "GET", &uri, None).await;
     assert_eq!(first.status(), StatusCode::OK);
     let tag = etag_of(&first);
-    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+    assert!(
+        is_quoted_32_hex(&tag),
+        "expected quoted 32-hex etag, got {tag}"
+    );
 
     let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
     assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
@@ -451,7 +457,10 @@ async fn test_get_sprint_flat_carries_etag_header_and_matching_if_none_match_ret
     let first = send(&state, "GET", &uri, None).await;
     assert_eq!(first.status(), StatusCode::OK);
     let tag = etag_of(&first);
-    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+    assert!(
+        is_quoted_32_hex(&tag),
+        "expected quoted 32-hex etag, got {tag}"
+    );
 
     let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
     assert_eq!(second.status(), StatusCode::NOT_MODIFIED);

--- a/crates/kanban-server/tests/flat_routes.rs
+++ b/crates/kanban-server/tests/flat_routes.rs
@@ -7,10 +7,29 @@
 use axum::http::StatusCode;
 use kanban_domain::KanbanOperations;
 use kanban_server::state::AppState;
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_server::test_helpers::{json_of, make_state, send, send_with_headers};
 use serde_json::json;
 use tempfile::tempdir;
 use uuid::Uuid;
+
+fn etag_of(response: &axum::response::Response) -> String {
+    response
+        .headers()
+        .get("etag")
+        .expect("etag header")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn is_quoted_32_hex(tag: &str) -> bool {
+    tag.len() == 34
+        && tag.starts_with('"')
+        && tag.ends_with('"')
+        && tag[1..33]
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
 
 async fn seed_board_column_and_card(state: &AppState) -> (Uuid, Uuid, Uuid) {
     let mut ctx = state.ctx.lock().await;
@@ -378,4 +397,67 @@ async fn test_delete_sprint_flat_unknown_id_returns_404() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let json = json_of(response).await;
     assert_eq!(json["code"], "NOT_FOUND");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_card_flat_carries_etag_header_and_matching_if_none_match_returns_304() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, card_id) = seed_board_and_card(&state).await;
+
+    let uri = format!("/v1/cards/{card_id}");
+    let first = send(&state, "GET", &uri, None).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let tag = etag_of(&first);
+    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+
+    let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(etag_of(&second), tag);
+    let bytes = axum::body::to_bytes(second.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(bytes.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_column_flat_carries_etag_header_and_matching_if_none_match_returns_304() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, col_id) = seed_board_and_column(&state).await;
+
+    let uri = format!("/v1/columns/{col_id}");
+    let first = send(&state, "GET", &uri, None).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let tag = etag_of(&first);
+    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+
+    let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(etag_of(&second), tag);
+    let bytes = axum::body::to_bytes(second.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(bytes.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_flat_carries_etag_header_and_matching_if_none_match_returns_304() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, sprint_id) = seed_board_and_sprint(&state, "Alpha").await;
+
+    let uri = format!("/v1/sprints/{sprint_id}");
+    let first = send(&state, "GET", &uri, None).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let tag = etag_of(&first);
+    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+
+    let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(etag_of(&second), tag);
+    let bytes = axum::body::to_bytes(second.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(bytes.is_empty());
 }

--- a/crates/kanban-server/tests/sprints_read.rs
+++ b/crates/kanban-server/tests/sprints_read.rs
@@ -5,10 +5,29 @@
 //! against the router directly, with no real TCP socket.
 
 use axum::http::StatusCode;
-use kanban_server::test_helpers::{json_of, make_state, send};
+use kanban_server::test_helpers::{json_of, make_state, send, send_with_headers};
 use kanban_service::KanbanOperations;
 use tempfile::tempdir;
 use uuid::Uuid;
+
+fn etag_of(response: &axum::response::Response) -> String {
+    response
+        .headers()
+        .get("etag")
+        .expect("etag header")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn is_quoted_32_hex(tag: &str) -> bool {
+    tag.len() == 34
+        && tag.starts_with('"')
+        && tag.ends_with('"')
+        && tag[1..33]
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_sprints_returns_only_the_boards_sprints() {
@@ -248,4 +267,67 @@ async fn test_get_sprint_from_another_board_returns_404() {
         StatusCode::OK,
         "the guard must reject, not delete, the sprint"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_carries_etag_header() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, sprint_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let sprint_id = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+        (board_id, sprint_id)
+    };
+
+    let response = send(
+        &state,
+        "GET",
+        &format!("/v1/boards/{}/sprints/{}", board_id, sprint_id),
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let tag = etag_of(&response);
+    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_sprint_with_matching_if_none_match_returns_304() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (board_id, sprint_id) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let sprint_id = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Alpha".to_string()))
+            .unwrap()
+            .id;
+        (board_id, sprint_id)
+    };
+
+    let uri = format!("/v1/boards/{}/sprints/{}", board_id, sprint_id);
+    let first = send(&state, "GET", &uri, None).await;
+    let tag = etag_of(&first);
+
+    let second = send_with_headers(&state, "GET", &uri, None, &[("if-none-match", &tag)]).await;
+
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(etag_of(&second), tag);
+    let bytes = axum::body::to_bytes(second.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(bytes.is_empty());
 }

--- a/crates/kanban-server/tests/sprints_read.rs
+++ b/crates/kanban-server/tests/sprints_read.rs
@@ -297,7 +297,10 @@ async fn test_get_sprint_carries_etag_header() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let tag = etag_of(&response);
-    assert!(is_quoted_32_hex(&tag), "expected quoted 32-hex etag, got {tag}");
+    assert!(
+        is_quoted_32_hex(&tag),
+        "expected quoted 32-hex etag, got {tag}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- Added `crates/kanban-server/src/etag.rs`: `etag_for` computes a strong ETag as the first 16 bytes of a SHA-256 digest over the exact serialized JSON response body (quoted lowercase hex), `if_none_match_matches` implements RFC 9110 weak comparison for `If-None-Match` (`*`, `W/` prefix, comma-separated lists), and `json_with_etag` serializes once, tags those exact bytes, and answers a matching request with a bodiless 304 that still carries the ETag.
- Wired the seven single-entity GET handlers into `json_with_etag`: `get_board`, `get_card`, `get_card_flat`, `get_column`, `get_column_flat`, `get_sprint`, `get_sprint_flat`. Every other route (collections, `/v1/cards/{id}/graph`, the export routes, all write routes) is untouched.
- Made `serde_json` a non-optional dependency of `kanban-server` (it was previously gated behind `test-helpers`, which cannot work once production code calls `serde_json::to_vec`) and added `sha2` as a workspace dependency, used only by `kanban-server`. This also happens to fix a pre-existing latent break: `crates/kanban-server/src/routes/transfer.rs` already called `serde_json` in non-test code while the dependency was optional, so `cargo check -p kanban-server --no-default-features` failed on develop; CI never caught it because every job runs with `--all-features`.

## Test plan

- [x] New integration tests in `boards_read.rs`, `cards_read.rs`, `columns_read.rs`, `sprints_read.rs`, `flat_routes.rs` cover: ETag present and well-formed, matching `If-None-Match` returns 304 with an empty body and the ETag, a stale tag returns 200 with a fresh ETag, `W/` weak-prefix matching, ETag changes after a PATCH and after archival, and ETag stability plus 304 behaviour against a real SQLite backend.
- [x] New unit tests in `etag.rs` cover `etag_for` determinism/format and `if_none_match_matches` against `*`, weak prefixes, comma lists, non-matching tags, and an absent header.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] `cargo check -p kanban-server --no-default-features` (previously failing, now green)
