### PR TITLE
KAN-1564 feat(server): thread client identity through the remaining write routes

### DIFF
--- a/.changeset/kan-1564-client-identity-sweep.md
+++ b/.changeset/kan-1564-client-identity-sweep.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+every card, column and sprint write route now honours the client identity header

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -147,7 +147,7 @@ Send `X-Kanban-Client-Id: <uuid>` on a write request to attribute it to that cli
 
 The header is a client-generated UUID, stable for the client's lifetime; omit it and the write is recorded and broadcast with a nil `issued_by`. A value that does not parse as a UUID is rejected with `422 VALIDATION_FAILED` before the request reaches the store. The identity is unauthenticated: any client can send any UUID, so it identifies provenance for echo suppression and auditing, not authorization.
 
-Today only the board write routes (`POST`/`PUT`/`PATCH`/`DELETE /v1/boards*`, `POST /v1/boards/{id}/archive`, `POST /v1/boards/{id}/restore`) and `POST /v1/import` honour the header. Every other write route still records and broadcasts a nil `issued_by`.
+Every write route honours the header. Frames whose origin is an external file writer detected by the watcher carry a nil `issued_by`, since no client issued them.
 
 ## Endpoints
 

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -1,3 +1,4 @@
+use crate::client_ident::ClientIdent;
 use crate::error::{AppError, AppJson};
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
@@ -265,10 +266,11 @@ fn require_card_in_board(
 async fn create_card_route(
     State(state): State<AppState>,
     Path(column_id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<CreateCardRequest>,
 ) -> Result<(StatusCode, Json<CardResponse>), AppError> {
     let (resp, created) = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let result = crate::handlers::cards::create_card(&mut ctx, column_id, req)
             .map_err(AppError::from)?;
         state
@@ -288,10 +290,11 @@ async fn create_card_route(
 async fn put_card_route(
     State(state): State<AppState>,
     Path((column_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<CreateCardRequest>,
 ) -> Result<(StatusCode, Json<CardResponse>), AppError> {
     let (resp, created) = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let result = crate::handlers::cards::create_or_replace_card(&mut ctx, column_id, id, req)
             .map_err(AppError::from)?;
         state
@@ -311,11 +314,12 @@ async fn put_card_route(
 async fn update_card_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<UpdateCardRequest>,
 ) -> Result<Json<CardResponse>, AppError> {
     let updates = CardUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
     let card = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_card_in_board(&ctx, board_id, id)?;
         let card = do_update_card(&mut ctx, id, updates)?;
         state
@@ -330,9 +334,10 @@ async fn update_card_route(
 async fn delete_card_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_card_in_board(&ctx, board_id, id)?;
         do_delete_card(&mut ctx, id)?;
         state
@@ -369,11 +374,12 @@ async fn get_card_flat(
 async fn update_card_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<UpdateCardRequest>,
 ) -> Result<Json<CardResponse>, AppError> {
     let updates = CardUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
     let card = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let card = do_update_card(&mut ctx, id, updates)?;
         state
             .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)
@@ -387,9 +393,10 @@ async fn update_card_route_flat(
 async fn delete_card_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         do_delete_card(&mut ctx, id)?;
         state
             .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Deleted)
@@ -402,9 +409,10 @@ async fn delete_card_route_flat(
 async fn archive_card_route(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<Json<CardResponse>, AppError> {
     let (card, archived_at) = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         do_archive_card(&mut ctx, id)?;
         let card = ctx
             .get_card(id)
@@ -424,9 +432,10 @@ async fn restore_card_route(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
     Query(q): Query<RestoreCardQuery>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<Json<CardResponse>, AppError> {
     let card = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let card = do_restore_card(&mut ctx, id, q.column_id)?;
         state
             .persist_and_broadcast(&ctx, EntityType::Card, id, ChangeKind::Updated)

--- a/crates/kanban-server/src/routes/cards_batch.rs
+++ b/crates/kanban-server/src/routes/cards_batch.rs
@@ -1,8 +1,10 @@
+use crate::client_ident::ClientIdent;
 use crate::error::{AppError, AppJson};
 use crate::state::{AppState, Session};
 use axum::extract::State;
 use axum::routing::post;
 use axum::{Json, Router};
+use kanban_core::ClientId;
 use kanban_service::api::{
     BatchArchiveRequest, BatchAssignSprintRequest, BatchFailure, BatchMoveRequest,
     BatchOperationResponse, BatchUpdateRequest, ChangeKind, EntityType,
@@ -23,9 +25,10 @@ fn to_wire(result: &BatchOperationResult) -> BatchOperationResponse {
 
 async fn run_detailed(
     state: &AppState,
+    client: ClientId,
     op: impl FnOnce(&mut Session) -> BatchOperationResult,
 ) -> Result<BatchOperationResponse, AppError> {
-    let mut ctx = state.ctx.lock().await;
+    let mut ctx = state.lock_for_write(client).await;
     let result = op(&mut ctx);
     ctx.save().await.map_err(|e| AppError::from(&e))?;
     for id in &result.succeeded {
@@ -36,28 +39,34 @@ async fn run_detailed(
 
 async fn batch_archive_route(
     State(state): State<AppState>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<BatchArchiveRequest>,
 ) -> Result<Json<BatchOperationResponse>, AppError> {
     Ok(Json(
-        run_detailed(&state, |c| c.archive_cards_detailed(req.ids).0).await?,
+        run_detailed(&state, client, |c| c.archive_cards_detailed(req.ids).0).await?,
     ))
 }
 
 async fn batch_move_route(
     State(state): State<AppState>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<BatchMoveRequest>,
 ) -> Result<Json<BatchOperationResponse>, AppError> {
     Ok(Json(
-        run_detailed(&state, |c| c.move_cards_detailed(req.ids, req.column_id).0).await?,
+        run_detailed(&state, client, |c| {
+            c.move_cards_detailed(req.ids, req.column_id).0
+        })
+        .await?,
     ))
 }
 
 async fn batch_assign_sprint_route(
     State(state): State<AppState>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<BatchAssignSprintRequest>,
 ) -> Result<Json<BatchOperationResponse>, AppError> {
     Ok(Json(
-        run_detailed(&state, |c| {
+        run_detailed(&state, client, |c| {
             c.assign_cards_to_sprint_detailed(req.ids, req.sprint_id).0
         })
         .await?,
@@ -66,6 +75,7 @@ async fn batch_assign_sprint_route(
 
 async fn batch_update_route(
     State(state): State<AppState>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<BatchUpdateRequest>,
 ) -> Result<Json<BatchOperationResponse>, AppError> {
     let ids: Vec<Uuid> = req.updates.iter().map(|i| i.id).collect();
@@ -76,7 +86,7 @@ async fn batch_update_route(
         .collect::<Result<_, _>>()
         .map_err(|e| AppError::from(&e))?;
 
-    let mut ctx = state.ctx.lock().await;
+    let mut ctx = state.lock_for_write(client).await;
     let (_count, _inv) = crate::state::mutate(&mut ctx, |c| c.update_cards_impl(pairs))
         .map_err(|e| AppError::from(&e))?;
     ctx.save().await.map_err(|e| AppError::from(&e))?;

--- a/crates/kanban-server/src/routes/columns.rs
+++ b/crates/kanban-server/src/routes/columns.rs
@@ -1,3 +1,4 @@
+use crate::client_ident::ClientIdent;
 use crate::error::{AppError, AppJson};
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
@@ -89,10 +90,11 @@ fn require_column_in_board(
 async fn create_column_route(
     State(state): State<AppState>,
     Path(board_id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::CreateColumnRequest>,
 ) -> Result<(StatusCode, Json<ColumnResponse>), AppError> {
     let (resp, created) = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let result = crate::handlers::columns::create_column(&mut ctx, board_id, req)
             .map_err(AppError::from)?;
         state
@@ -112,10 +114,11 @@ async fn create_column_route(
 async fn put_column_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::ReplaceColumnRequest>,
 ) -> Result<(StatusCode, Json<ColumnResponse>), AppError> {
     let (resp, created) = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let result =
             crate::handlers::columns::create_or_replace_column(&mut ctx, board_id, id, req)
                 .map_err(AppError::from)?;
@@ -136,11 +139,12 @@ async fn put_column_route(
 async fn update_column_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
     let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
     let col = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_column_in_board(&ctx, board_id, id)?;
         let col = do_update_column(&mut ctx, id, updates)?;
         state
@@ -155,9 +159,10 @@ async fn update_column_route(
 async fn delete_column_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_column_in_board(&ctx, board_id, id)?;
         do_delete_column(&mut ctx, id)?;
         state
@@ -171,11 +176,12 @@ async fn delete_column_route(
 async fn reorder_column_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::ReorderColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
     let position = req.validated_position().map_err(|e| AppError::from(&e))?;
     let col = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_column_in_board(&ctx, board_id, id)?;
         let (col, _invalidation) =
             crate::state::mutate(&mut ctx, |c| c.reorder_column_impl(id, position))
@@ -219,11 +225,12 @@ async fn get_column_flat(
 async fn update_column_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::UpdateColumnRequest>,
 ) -> Result<Json<ColumnResponse>, AppError> {
     let updates = ColumnUpdate::try_from(req).map_err(|e| AppError::from(&e))?;
     let col = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let col = do_update_column(&mut ctx, id, updates)?;
         state
             .persist_and_broadcast(&ctx, EntityType::Column, id, ChangeKind::Updated)
@@ -237,9 +244,10 @@ async fn update_column_route_flat(
 async fn delete_column_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         do_delete_column(&mut ctx, id)?;
         state
             .persist_and_broadcast(&ctx, EntityType::Column, id, ChangeKind::Deleted)

--- a/crates/kanban-server/src/routes/graph.rs
+++ b/crates/kanban-server/src/routes/graph.rs
@@ -1,3 +1,4 @@
+use crate::client_ident::ClientIdent;
 use crate::error::{AppError, AppJson};
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::scope::RouteScope;
@@ -44,10 +45,11 @@ fn graph_mutation_response(
 async fn attach_children_route(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<AttachChildrenRequest>,
 ) -> Result<Json<CardGraphResponse>, AppError> {
     let body = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let _ = crate::state::mutate_unit(&mut ctx, |c| c.attach_children_impl(id, req.children))
             .map_err(|e| AppError::from(&e))?;
         let body = graph_mutation_response(&ctx.ctx, id)?;
@@ -63,9 +65,10 @@ async fn attach_children_route(
 async fn detach_child_route(
     State(state): State<AppState>,
     Path((id, child_id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let _ = crate::state::mutate_unit(&mut ctx, |c| c.detach_children_impl(id, vec![child_id]))
             .map_err(|e| AppError::from(&e))?;
         state
@@ -79,10 +82,11 @@ async fn detach_child_route(
 async fn add_block_route(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<AddBlockRequest>,
 ) -> Result<Json<CardGraphResponse>, AppError> {
     let body = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let _ = crate::state::mutate_unit(&mut ctx, |c| {
             c.block_impl(id, req.blocked, req.severity.into())
         })
@@ -100,9 +104,10 @@ async fn add_block_route(
 async fn remove_block_route(
     State(state): State<AppState>,
     Path((id, blocked_id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let _ = crate::state::mutate_unit(&mut ctx, |c| c.unblock_impl(id, blocked_id))
             .map_err(|e| AppError::from(&e))?;
         state
@@ -116,10 +121,11 @@ async fn remove_block_route(
 async fn add_related_route(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<AddRelatedRequest>,
 ) -> Result<Json<CardGraphResponse>, AppError> {
     let body = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let _ =
             crate::state::mutate_unit(&mut ctx, |c| c.relate_impl(id, req.other, req.kind.into()))
                 .map_err(|e| AppError::from(&e))?;
@@ -136,9 +142,10 @@ async fn add_related_route(
 async fn remove_related_route(
     State(state): State<AppState>,
     Path((id, other_id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let _ = crate::state::mutate_unit(&mut ctx, |c| c.dissociate_impl(id, other_id))
             .map_err(|e| AppError::from(&e))?;
         state

--- a/crates/kanban-server/src/routes/sprints.rs
+++ b/crates/kanban-server/src/routes/sprints.rs
@@ -1,3 +1,4 @@
+use crate::client_ident::ClientIdent;
 use crate::error::{AppError, AppJson};
 use crate::model_read::{require_loaded, require_loaded_entity};
 use crate::pagination::paginate_response;
@@ -117,10 +118,11 @@ pub(crate) fn respond(
 async fn create_sprint_route(
     State(state): State<AppState>,
     Path(board_id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::CreateSprintRequest>,
 ) -> Result<(StatusCode, Json<SprintResponse>), AppError> {
     let (resp, created) = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let result = crate::handlers::sprints::create_sprint(&mut ctx, board_id, req)
             .map_err(AppError::from)?;
         state
@@ -140,10 +142,11 @@ async fn create_sprint_route(
 async fn put_sprint_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::ReplaceSprintRequest>,
 ) -> Result<(StatusCode, Json<SprintResponse>), AppError> {
     let (resp, created) = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         let result =
             crate::handlers::sprints::create_or_replace_sprint(&mut ctx, board_id, id, req)
                 .map_err(AppError::from)?;
@@ -164,11 +167,12 @@ async fn put_sprint_route(
 async fn update_sprint_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::UpdateSprintRequest>,
 ) -> Result<Json<SprintResponse>, AppError> {
     let updates = SprintUpdate::from(req);
     let body = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_sprint_in_board(&ctx, board_id, id)?;
         let sprint = do_update_sprint(&mut ctx, id, updates)?;
         let body = respond(&ctx, &sprint)?;
@@ -184,9 +188,10 @@ async fn update_sprint_route(
 async fn delete_sprint_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_sprint_in_board(&ctx, board_id, id)?;
         do_delete_sprint(&mut ctx, id)?;
         state
@@ -245,11 +250,12 @@ async fn get_sprint_flat(
 async fn update_sprint_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<kanban_service::api::UpdateSprintRequest>,
 ) -> Result<Json<SprintResponse>, AppError> {
     let updates = SprintUpdate::from(req);
     let body = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         do_get_sprint(&ctx, id)?;
         let sprint = do_update_sprint(&mut ctx, id, updates)?;
         let body = respond(&ctx, &sprint)?;
@@ -265,9 +271,10 @@ async fn update_sprint_route_flat(
 async fn delete_sprint_route_flat(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<StatusCode, AppError> {
     {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         do_get_sprint(&ctx, id)?;
         do_delete_sprint(&mut ctx, id)?;
         state

--- a/crates/kanban-server/src/routes/sprints_lifecycle.rs
+++ b/crates/kanban-server/src/routes/sprints_lifecycle.rs
@@ -1,3 +1,4 @@
+use crate::client_ident::ClientIdent;
 use crate::error::{AppError, AppJson};
 use crate::routes::sprints::{require_sprint_in_board, respond};
 use crate::state::AppState;
@@ -11,13 +12,14 @@ use uuid::Uuid;
 async fn activate_sprint_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<ActivateSprintRequest>,
 ) -> Result<Json<SprintResponse>, AppError> {
     let duration_days = req
         .validated_duration_days()
         .map_err(|e| AppError::from(&e))?;
     let body = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_sprint_in_board(&ctx, board_id, id)?;
         let (sprint, _invalidation) =
             crate::state::mutate(&mut ctx, |c| c.activate_sprint_impl(id, duration_days))
@@ -35,9 +37,10 @@ async fn activate_sprint_route(
 async fn complete_sprint_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<Json<SprintResponse>, AppError> {
     let body = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_sprint_in_board(&ctx, board_id, id)?;
         let (sprint, _invalidation) =
             crate::state::mutate(&mut ctx, |c| c.complete_sprint_impl(id))
@@ -55,9 +58,10 @@ async fn complete_sprint_route(
 async fn cancel_sprint_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
 ) -> Result<Json<SprintResponse>, AppError> {
     let body = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_sprint_in_board(&ctx, board_id, id)?;
         let (sprint, _invalidation) = crate::state::mutate(&mut ctx, |c| c.cancel_sprint_impl(id))
             .map_err(|e| AppError::from(&e))?;
@@ -74,10 +78,11 @@ async fn cancel_sprint_route(
 async fn carry_over_sprint_route(
     State(state): State<AppState>,
     Path((board_id, id)): Path<(Uuid, Uuid)>,
+    ClientIdent(client): ClientIdent,
     AppJson(req): AppJson<CarryOverRequest>,
 ) -> Result<Json<CarryOverResponse>, AppError> {
     let moved = {
-        let mut ctx = state.ctx.lock().await;
+        let mut ctx = state.lock_for_write(client).await;
         require_sprint_in_board(&ctx, board_id, id)?;
         require_sprint_in_board(&ctx, board_id, req.to_sprint_id)?;
         let (moved, _invalidation) = crate::state::mutate(&mut ctx, |c| {

--- a/crates/kanban-server/tests/events_client_identity.rs
+++ b/crates/kanban-server/tests/events_client_identity.rs
@@ -298,7 +298,7 @@ async fn test_graph_write_routes_stamp_the_header_client_id() {
         &state,
         "POST",
         &format!("/v1/cards/{a}/related"),
-        Some(&json!({"other": b, "kind": "duplicate"})),
+        Some(&json!({"other": b, "kind": "duplicates"})),
         &headers,
     )
     .await;
@@ -352,7 +352,7 @@ async fn test_column_write_routes_stamp_the_header_client_id() {
         &state,
         "PUT",
         &format!("/v1/boards/{board_id}/columns/{new_id}"),
-        Some(&json!({"name": "Doing"})),
+        Some(&json!({"name": "Doing", "position": 1})),
         &headers,
     )
     .await;

--- a/crates/kanban-server/tests/events_client_identity.rs
+++ b/crates/kanban-server/tests/events_client_identity.rs
@@ -33,7 +33,11 @@ async fn seed_board_and_column(state: &AppState) -> (Uuid, Uuid) {
     (board_id, col.id)
 }
 
-async fn card_write_routes(state: &AppState, client: Uuid, mut rx: broadcast::Receiver<ChangeEventFrame>) {
+async fn card_write_routes(
+    state: &AppState,
+    client: Uuid,
+    mut rx: broadcast::Receiver<ChangeEventFrame>,
+) {
     let headers = [("x-kanban-client-id", client.to_string())];
     let headers: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
 

--- a/crates/kanban-server/tests/events_client_identity.rs
+++ b/crates/kanban-server/tests/events_client_identity.rs
@@ -1,0 +1,629 @@
+#![cfg(feature = "test-helpers")]
+
+use axum::http::StatusCode;
+use kanban_core::ClientId;
+use kanban_domain::{CardStatus, CardUpdate, CreateCardOptions, KanbanOperations};
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{
+    json_of, make_sqlite_state, make_state, send, send_with_headers,
+};
+use kanban_service::api::ChangeEventFrame;
+use serde_json::json;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+async fn next_frame(rx: &mut broadcast::Receiver<ChangeEventFrame>) -> ChangeEventFrame {
+    tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for a change event frame")
+        .expect("broadcast channel closed unexpectedly")
+}
+
+async fn seed_board_and_column(state: &AppState) -> (Uuid, Uuid) {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap()
+        .id;
+    let col = ctx
+        .create_column(board_id, "To Do".to_string(), None)
+        .unwrap();
+    (board_id, col.id)
+}
+
+async fn card_write_routes(state: &AppState, client: Uuid, mut rx: broadcast::Receiver<ChangeEventFrame>) {
+    let headers = [("x-kanban-client-id", client.to_string())];
+    let headers: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+    let (board_id, column_id) = seed_board_and_column(state).await;
+
+    let response = send_with_headers(
+        state,
+        "POST",
+        &format!("/v1/columns/{column_id}/cards"),
+        Some(&json!({"title": "Task 1"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_of(response).await;
+    let card_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let new_id = Uuid::new_v4();
+    let response = send_with_headers(
+        state,
+        "PUT",
+        &format!("/v1/columns/{column_id}/cards/{new_id}"),
+        Some(&json!({"title": "Task 2"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/cards/{card_id}"),
+        Some(&json!({"title": "Renamed"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        state,
+        "PATCH",
+        &format!("/v1/cards/{card_id}"),
+        Some(&json!({"title": "Renamed again"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        state,
+        "POST",
+        &format!("/v1/cards/{card_id}/archive"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        state,
+        "POST",
+        &format!("/v1/cards/{card_id}/restore?column_id={column_id}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        state,
+        "DELETE",
+        &format!("/v1/cards/{card_id}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/cards/{new_id}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_card_write_routes_stamp_the_header_client_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let rx = state.event_tx.subscribe();
+    let client = Uuid::new_v4();
+    card_write_routes(&state, client, rx).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_card_write_routes_stamp_the_header_client_id_sqlite_backend() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+    let rx = state.event_tx.subscribe();
+    let client = Uuid::new_v4();
+    card_write_routes(&state, client, rx).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_card_batch_routes_stamp_the_header_client_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let client = Uuid::new_v4();
+    let headers = [("x-kanban-client-id", client.to_string())];
+    let headers: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+    let (board_id, column_id) = seed_board_and_column(&state).await;
+    let (sprint_id, card_a, card_b) = {
+        let mut ctx = state.ctx.lock().await;
+        let sprint_id = ctx.create_sprint(board_id, None, None).unwrap().id;
+        let card_a = ctx
+            .create_card(board_id, column_id, "A".to_string(), Default::default())
+            .unwrap()
+            .id;
+        let card_b = ctx
+            .create_card(board_id, column_id, "B".to_string(), Default::default())
+            .unwrap()
+            .id;
+        (sprint_id, card_a, card_b)
+    };
+
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        "/v1/cards/batch/update",
+        Some(&json!({"updates": [{"id": card_a, "title": "A2"}]})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        "/v1/cards/batch/move",
+        Some(&json!({"ids": [card_a, card_b], "column_id": column_id})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        "/v1/cards/batch/assign-sprint",
+        Some(&json!({"ids": [card_a, card_b], "sprint_id": sprint_id})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        "/v1/cards/batch/archive",
+        Some(&json!({"ids": [card_a, card_b]})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_graph_write_routes_stamp_the_header_client_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let client = Uuid::new_v4();
+    let headers = [("x-kanban-client-id", client.to_string())];
+    let headers: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+    let (board_id, column_id) = seed_board_and_column(&state).await;
+    let (a, b, c) = {
+        let mut ctx = state.ctx.lock().await;
+        let a = ctx
+            .create_card(board_id, column_id, "A".to_string(), Default::default())
+            .unwrap()
+            .id;
+        let b = ctx
+            .create_card(board_id, column_id, "B".to_string(), Default::default())
+            .unwrap()
+            .id;
+        let c = ctx
+            .create_card(board_id, column_id, "C".to_string(), Default::default())
+            .unwrap()
+            .id;
+        (a, b, c)
+    };
+
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/cards/{a}/children"),
+        Some(&json!({"children": [b]})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{a}/children/{b}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/cards/{a}/blocks"),
+        Some(&json!({"blocked": c, "severity": "critical"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{a}/blocks/{c}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/cards/{a}/related"),
+        Some(&json!({"other": b, "kind": "duplicate"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "DELETE",
+        &format!("/v1/cards/{a}/related/{b}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_column_write_routes_stamp_the_header_client_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let client = Uuid::new_v4();
+    let headers = [("x-kanban-client-id", client.to_string())];
+    let headers: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns"),
+        Some(&json!({"name": "To Do"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_of(response).await;
+    let column_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let new_id = Uuid::new_v4();
+    let response = send_with_headers(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/columns/{new_id}"),
+        Some(&json!({"name": "Doing"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/columns/{column_id}"),
+        Some(&json!({"name": "Renamed"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/columns/{column_id}/reorder"),
+        Some(&json!({"position": 0})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "PATCH",
+        &format!("/v1/columns/{column_id}"),
+        Some(&json!({"name": "Renamed flat"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "DELETE",
+        &format!("/v1/columns/{column_id}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/columns/{new_id}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_write_routes_stamp_the_header_client_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let client = Uuid::new_v4();
+    let headers = [("x-kanban-client-id", client.to_string())];
+    let headers: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+    let board_id = {
+        let mut ctx = state.ctx.lock().await;
+        ctx.create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id
+    };
+
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints"),
+        Some(&json!({"name": "Sprint 1"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_of(response).await;
+    let sprint_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let new_id = Uuid::new_v4();
+    let response = send_with_headers(
+        &state,
+        "PUT",
+        &format!("/v1/boards/{board_id}/sprints/{new_id}"),
+        Some(&json!({"name": "Sprint 2"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "PATCH",
+        &format!("/v1/boards/{board_id}/sprints/{sprint_id}"),
+        Some(&json!({"name": "Renamed"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "PATCH",
+        &format!("/v1/sprints/{sprint_id}"),
+        Some(&json!({"name": "Renamed flat"})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "DELETE",
+        &format!("/v1/sprints/{sprint_id}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "DELETE",
+        &format!("/v1/boards/{board_id}/sprints/{new_id}"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sprint_lifecycle_routes_stamp_the_header_client_id() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let client = Uuid::new_v4();
+    let headers = [("x-kanban-client-id", client.to_string())];
+    let headers: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+    let (board_id, column_id, sprint1, sprint2) = {
+        let mut ctx = state.ctx.lock().await;
+        let board_id = ctx
+            .create_board("Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let column_id = ctx
+            .create_column(board_id, "Todo".to_string(), None)
+            .unwrap()
+            .id;
+        let sprint1 = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("One".to_string()))
+            .unwrap()
+            .id;
+        let sprint2 = ctx
+            .create_sprint(board_id, Some("SPR".to_string()), Some("Two".to_string()))
+            .unwrap()
+            .id;
+        let done = ctx
+            .create_card(
+                board_id,
+                column_id,
+                "Done card".to_string(),
+                CreateCardOptions {
+                    sprint_id: Some(sprint1),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .id;
+        ctx.update_card(
+            done,
+            CardUpdate {
+                status: Some(CardStatus::Done),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        (board_id, column_id, sprint1, sprint2)
+    };
+    let _ = column_id;
+
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/activate"),
+        Some(&json!({"duration_days": 7})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/complete"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint1}/carry-over"),
+        Some(&json!({"to_sprint_id": sprint2})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint2}/activate"),
+        Some(&json!({"duration_days": 7})),
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+
+    let response = send_with_headers(
+        &state,
+        "POST",
+        &format!("/v1/boards/{board_id}/sprints/{sprint2}/cancel"),
+        None,
+        &headers,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::from(client));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_writes_without_the_header_emit_nil_issued_by() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let (_board_id, column_id) = seed_board_and_column(&state).await;
+    let mut rx = state.event_tx.subscribe();
+
+    let response = send(
+        &state,
+        "POST",
+        &format!("/v1/columns/{column_id}/cards"),
+        Some(&json!({"title": "Task 1"})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    assert_eq!(next_frame(&mut rx).await.issued_by, ClientId::nil());
+}

--- a/crates/kanban-server/tests/events_entity_identity.rs
+++ b/crates/kanban-server/tests/events_entity_identity.rs
@@ -416,9 +416,8 @@ async fn test_client_identity_does_not_leak_between_requests() {
     let frame = next_frame(&mut rx).await;
     assert_eq!(frame.issued_by, ClientId::from(client));
 
-    // The second write goes through cards.rs's still-raw `state.ctx.lock()`
-    // seam, so this pins that `lock_for_write`'s identity does not survive
-    // past its own guard into a request that never acquires it.
+    // The second write sends no header, so it acquires lock_for_write with a
+    // nil client id; no earlier request's identity survives into it.
     let response = send(
         &state,
         "POST",

--- a/crates/kanban-server/tests/write_lock_guard.rs
+++ b/crates/kanban-server/tests/write_lock_guard.rs
@@ -1,0 +1,31 @@
+const RAW_LOCK: &str = "state.ctx.lock()";
+
+const ROUTE_MODULES: &[(&str, &str)] = &[
+    ("boards", include_str!("../src/routes/boards.rs")),
+    ("cards", include_str!("../src/routes/cards.rs")),
+    ("cards_batch", include_str!("../src/routes/cards_batch.rs")),
+    ("columns", include_str!("../src/routes/columns.rs")),
+    ("events", include_str!("../src/routes/events.rs")),
+    ("graph", include_str!("../src/routes/graph.rs")),
+    ("prefixes", include_str!("../src/routes/prefixes.rs")),
+    ("sprints", include_str!("../src/routes/sprints.rs")),
+    (
+        "sprints_lifecycle",
+        include_str!("../src/routes/sprints_lifecycle.rs"),
+    ),
+    ("transfer", include_str!("../src/routes/transfer.rs")),
+];
+
+#[test]
+fn test_no_route_module_acquires_the_raw_context_lock() {
+    let offenders: Vec<&str> = ROUTE_MODULES
+        .iter()
+        .filter(|(_, src)| src.contains(RAW_LOCK))
+        .map(|(name, _)| *name)
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "route modules still acquire the raw context lock instead of state.lock_for_write(client): {offenders:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Finishes the client identity wire sweep that KAN-1558 started. Every remaining write handler in the card, column and sprint route families now takes a `ClientIdent` extractor and acquires the session through `state.lock_for_write(client)` instead of the raw `state.ctx.lock()`, so the SSE frame and the recorded command batch carry the caller's identity instead of a nil UUID.

- `routes/cards.rs`: all eight write handlers, including the flat and archive/restore variants
- `routes/cards_batch.rs`: `run_detailed` (shared by archive/move/assign-sprint) and `batch_update_route`
- `routes/columns.rs`: all seven write handlers, including the flat variants and reorder
- `routes/graph.rs`: all six children/blocks/related write handlers
- `routes/sprints.rs`: all six write handlers, including the flat variants
- `routes/sprints_lifecycle.rs`: activate, complete, cancel and carry-over

`routes/cards_batch.rs`, `routes/graph.rs` and `routes/sprints_lifecycle.rs` are in scope even though they hold the card and sprint route families under different filenames; no other card owns them and the batch/graph/lifecycle handlers were the last routes still recording a nil `issued_by`.

Also adds:
- `tests/write_lock_guard.rs`: a source guard asserting no `routes/*.rs` module contains the raw `state.ctx.lock()` call, so a future handler can't regress silently
- `tests/events_client_identity.rs`: per-family tests driving every write route with the `X-Kanban-Client-Id` header and asserting the SSE frame's `issued_by` matches, plus a backward-compat pin that an absent header still yields a nil id
- README update: the client identity section no longer claims only board routes and import honour the header
- Patch changeset

No `kanban-service` changes; both nil sites from KAN-1558's follow-up were already fixed on develop.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] Mutation check: reverted one handler's `lock_for_write` back to the raw lock, confirmed the corresponding identity test failed, restored the fix
