### PR TITLE
KAN-702 feat(core,service,persistence-json,persistence-sqlite,backend-http): route http/https locators to HttpBackendFactory

### DIFF
--- a/.changeset/kan-702-http-locator-routing.md
+++ b/.changeset/kan-702-http-locator-routing.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Route http:// and https:// locators to a new HttpBackendFactory instead of silently misrouting them to the JSON or SQLite backend factories

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,8 @@ dependencies = [
  "kanban-backend",
  "kanban-core",
  "kanban-domain",
+ "kanban-persistence-json",
+ "kanban-persistence-sqlite",
  "kanban-server",
  "kanban-service",
  "reqwest",

--- a/crates/kanban-backend-http/Cargo.toml
+++ b/crates/kanban-backend-http/Cargo.toml
@@ -29,4 +29,6 @@ chrono.workspace = true
 [dev-dependencies]
 kanban-server = { path = "../kanban-server", features = ["test-helpers"] }
 kanban-service = { path = "../kanban-service" }
+kanban-persistence-json = { path = "../kanban-persistence-json" }
+kanban-persistence-sqlite = { path = "../kanban-persistence-sqlite" }
 tempfile.workspace = true

--- a/crates/kanban-backend-http/README.md
+++ b/crates/kanban-backend-http/README.md
@@ -32,14 +32,29 @@ impl kanban_backend::KanbanBackend for HttpBackend {
     fn as_data_store(&self) -> &dyn kanban_domain::DataStore { self }
     fn instance_id(&self) -> uuid::Uuid { self.instance_id }
 }
+
+pub struct HttpBackendFactory;
+
+impl kanban_backend::KanbanBackendFactory for HttpBackendFactory {
+    fn name(&self) -> &str { "http" }
+    fn matches_locator(&self, locator: &str, _header: &[u8]) -> bool;
+    async fn create(&self, locator: &str, config: &kanban_core::AppConfig)
+        -> kanban_domain::KanbanResult<std::sync::Arc<dyn kanban_backend::KanbanBackend>>;
+}
 ```
 
-`HttpBackend::new` normalizes a trailing slash off `base_url`, builds a
-`reqwest::Client`, and spins up a dedicated multi-thread Tokio runtime — every
-synchronous `DataStore`/`CommandStore` call bridges onto that runtime via a
-private `block_on` helper rather than assuming an ambient one, since
-`KanbanBackend`'s inherent methods are synchronous but the HTTP calls
-underneath are async.
+`HttpBackend::new` rejects a locator that does not carry an `http://` or
+`https://` scheme (`kanban_core::scheme_of`), then normalizes a trailing
+slash off `base_url`, builds a `reqwest::Client`, and spins up a dedicated
+multi-thread Tokio runtime — every synchronous `DataStore`/`CommandStore`
+call bridges onto that runtime via a private `block_on` helper rather than
+assuming an ambient one, since `KanbanBackend`'s inherent methods are
+synchronous but the HTTP calls underneath are async.
+
+`HttpBackendFactory::matches_locator` claims a locator only when its scheme is
+`http` or `https`, so it is safe to register alongside `JsonBackendFactory`
+and `SqliteBackendFactory` in any registration order — both of those decline
+a remote locator before their own content/suffix checks run.
 
 ## Position in the workspace
 
@@ -82,4 +97,11 @@ test-only and omitted from the diagram above. See the
 
 ## Related crates
 
-Used by: none yet — no crate in the workspace currently registers `HttpBackend` as a `KanbanBackendFactory`. [kanban-server](../kanban-server/README.md) depends on this crate only in reverse, as a dev-dependency (feature `test-helpers`) to spin up a real server for this crate's own integration tests.
+`HttpBackendFactory` is exported from this crate's root for an application to
+register in its own `kanban_backend::KanbanBackendRegistry`. No consumer
+registers it yet — `kanban-cli`, `kanban-tui`, and `kanban-mcp` still resolve
+every locator through their local `json`/`sqlite` registries only. Wiring an
+application to accept an `http://`/`https://` locator end to end is follow-up
+work. [kanban-server](../kanban-server/README.md) depends on this crate only
+in reverse, as a dev-dependency (feature `test-helpers`) to spin up a real
+server for this crate's own integration tests.

--- a/crates/kanban-backend-http/src/backend_factory.rs
+++ b/crates/kanban-backend-http/src/backend_factory.rs
@@ -1,0 +1,20 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_backend::KanbanBackendFactory;
+
+    #[test]
+    fn test_the_http_factory_claims_an_http_locator() {
+        assert_eq!(HttpBackendFactory.name(), "http");
+        assert!(HttpBackendFactory.matches_locator("http://127.0.0.1:3000", &[]));
+        assert!(HttpBackendFactory.matches_locator("https://example.com", &[]));
+    }
+
+    #[test]
+    fn test_the_http_factory_declines_a_local_path_and_a_foreign_scheme() {
+        assert!(!HttpBackendFactory.matches_locator("board.json", &[]));
+        assert!(!HttpBackendFactory.matches_locator("/abs/board.sqlite", &[]));
+        assert!(!HttpBackendFactory.matches_locator("C://boards", &[]));
+        assert!(!HttpBackendFactory.matches_locator("notes://draft.json", &[]));
+    }
+}

--- a/crates/kanban-backend-http/src/backend_factory.rs
+++ b/crates/kanban-backend-http/src/backend_factory.rs
@@ -1,3 +1,30 @@
+use crate::HttpBackend;
+use kanban_backend::{KanbanBackend, KanbanBackendFactory};
+use kanban_core::AppConfig;
+use kanban_domain::KanbanResult;
+use std::sync::Arc;
+
+pub struct HttpBackendFactory;
+
+#[async_trait::async_trait]
+impl KanbanBackendFactory for HttpBackendFactory {
+    fn name(&self) -> &str {
+        "http"
+    }
+
+    fn matches_locator(&self, locator: &str, _header: &[u8]) -> bool {
+        matches!(kanban_core::scheme_of(locator), Some("http" | "https"))
+    }
+
+    async fn create(
+        &self,
+        locator: &str,
+        _config: &AppConfig,
+    ) -> KanbanResult<Arc<dyn KanbanBackend>> {
+        Ok(Arc::new(HttpBackend::new(locator)?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -5,6 +5,8 @@ mod data_store;
 mod http;
 mod remote_writes;
 
+pub use backend_factory::HttpBackendFactory;
+
 pub struct HttpBackend {
     base_url: String,
     client: reqwest::Client,
@@ -49,6 +51,11 @@ impl kanban_backend::KanbanBackend for HttpBackend {
 
 impl HttpBackend {
     pub fn new(base_url: &str) -> kanban_domain::KanbanResult<Self> {
+        if !matches!(kanban_core::scheme_of(base_url), Some("http" | "https")) {
+            return Err(kanban_domain::KanbanError::validation(format!(
+                "HttpBackend requires an http:// or https:// URL, got '{base_url}'"
+            )));
+        }
         let base_url = base_url.trim_end_matches('/').to_string();
         let client = reqwest::Client::builder().build().map_err(|e| {
             kanban_domain::KanbanError::Internal(format!("failed to build http client: {e}"))
@@ -189,8 +196,10 @@ mod tests {
     #[test]
     fn test_http_backend_new_rejects_a_locator_without_a_scheme() {
         let result = HttpBackend::new("boards.json");
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
+        let Err(err) = result else {
+            panic!("expected an error for a schemeless locator");
+        };
+        let err = err.to_string();
         assert!(err.contains("boards.json"), "Got: {err}");
         assert!(err.contains("http"), "Got: {err}");
     }

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -1,3 +1,4 @@
+mod backend_factory;
 mod command_store;
 mod conversions;
 mod data_store;
@@ -183,6 +184,21 @@ mod tests {
              mutations with no transaction around them"
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_http_backend_new_rejects_a_locator_without_a_scheme() {
+        let result = HttpBackend::new("boards.json");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("boards.json"), "Got: {err}");
+        assert!(err.contains("http"), "Got: {err}");
+    }
+
+    #[test]
+    fn test_http_backend_new_rejects_a_non_http_scheme() {
+        assert!(HttpBackend::new("ftp://example.com").is_err());
+        assert!(HttpBackend::new("notes://draft.json").is_err());
     }
 
     #[test]

--- a/crates/kanban-backend-http/tests/locator_routing.rs
+++ b/crates/kanban-backend-http/tests/locator_routing.rs
@@ -1,0 +1,45 @@
+use kanban_backend::KanbanBackendRegistry;
+use kanban_backend_http::HttpBackendFactory;
+use kanban_persistence_json::JsonBackendFactory;
+use kanban_persistence_sqlite::SqliteBackendFactory;
+
+fn registry() -> KanbanBackendRegistry {
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(Box::new(SqliteBackendFactory));
+    registry.register(Box::new(JsonBackendFactory));
+    registry.register(Box::new(HttpBackendFactory));
+    registry
+}
+
+#[test]
+fn test_the_registry_selects_the_http_backend_for_a_url() {
+    let registry = registry();
+    let factory = registry.for_locator("http://127.0.0.1:3000").unwrap();
+    assert_eq!(factory.name(), "http");
+}
+
+#[test]
+fn test_the_registry_selects_the_http_backend_for_a_url_ending_in_db() {
+    let registry = registry();
+    let factory = registry
+        .for_locator("http://127.0.0.1:3000/board.db")
+        .unwrap();
+    assert_eq!(factory.name(), "http");
+}
+
+#[test]
+fn test_the_registry_still_selects_json_and_sqlite_for_local_paths() {
+    let registry = registry();
+    let dir = tempfile::tempdir().unwrap();
+
+    let json_path = dir.path().join("board.json");
+    std::fs::write(&json_path, b"{\"boards\":[]}").unwrap();
+    let json_factory = registry.for_locator(json_path.to_str().unwrap()).unwrap();
+    assert_eq!(json_factory.name(), "json");
+
+    let sqlite_path = dir.path().join("nonexistent.sqlite");
+    let sqlite_factory = registry
+        .for_locator(sqlite_path.to_str().unwrap())
+        .unwrap();
+    assert_eq!(sqlite_factory.name(), "sqlite");
+}

--- a/crates/kanban-backend-http/tests/locator_routing.rs
+++ b/crates/kanban-backend-http/tests/locator_routing.rs
@@ -38,8 +38,6 @@ fn test_the_registry_still_selects_json_and_sqlite_for_local_paths() {
     assert_eq!(json_factory.name(), "json");
 
     let sqlite_path = dir.path().join("nonexistent.sqlite");
-    let sqlite_factory = registry
-        .for_locator(sqlite_path.to_str().unwrap())
-        .unwrap();
+    let sqlite_factory = registry.for_locator(sqlite_path.to_str().unwrap()).unwrap();
     assert_eq!(sqlite_factory.name(), "sqlite");
 }

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod graph;
 pub mod health;
 pub mod input;
+pub mod locator;
 pub mod logging;
 pub mod paginated_list;
 pub mod selection;
@@ -29,6 +30,7 @@ pub use graph::{
 };
 pub use health::{HealthChecker, HealthStatus};
 pub use input::InputState;
+pub use locator::{is_remote_locator, scheme_of};
 pub use logging::{LogEntry, Loggable};
 pub use paginated_list::{
     resolve_page_params, PaginatedList, DEFAULT_PAGE, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,

--- a/crates/kanban-core/src/locator.rs
+++ b/crates/kanban-core/src/locator.rs
@@ -1,3 +1,27 @@
+/// The URL scheme of `locator`, when it has one. `None` for every filesystem
+/// path, including a Windows drive letter and a relative path whose first
+/// component happens to contain `://`.
+pub fn scheme_of(locator: &str) -> Option<&str> {
+    let (scheme, _) = locator.split_once("://")?;
+    if scheme.len() < 2 {
+        return None;
+    }
+    let mut chars = scheme.chars();
+    if !chars.next()?.is_ascii_alphabetic() {
+        return None;
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
+        return None;
+    }
+    Some(scheme)
+}
+
+/// True when the locator carries a URL scheme and must therefore never be
+/// treated as a filesystem path.
+pub fn is_remote_locator(locator: &str) -> bool {
+    scheme_of(locator).is_some()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kanban-core/src/locator.rs
+++ b/crates/kanban-core/src/locator.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_an_http_locator_reports_its_scheme() {
+        assert_eq!(scheme_of("http://127.0.0.1:3000"), Some("http"));
+        assert_eq!(scheme_of("https://example.com/boards"), Some("https"));
+        assert!(is_remote_locator("http://127.0.0.1:3000"));
+        assert!(is_remote_locator("https://example.com/boards"));
+    }
+
+    #[test]
+    fn test_a_non_http_scheme_is_still_remote() {
+        assert!(is_remote_locator("notes://draft.json"));
+        assert_eq!(scheme_of("s3+v4://bucket/key"), Some("s3+v4"));
+    }
+
+    #[test]
+    fn test_a_path_segment_containing_the_scheme_marker_is_not_remote() {
+        assert!(!is_remote_locator("data/a://b.json"));
+        assert!(!is_remote_locator("/abs/dir/x://y.json"));
+    }
+
+    #[test]
+    fn test_a_single_letter_scheme_is_not_remote() {
+        assert!(!is_remote_locator("C://boards"));
+        assert!(!is_remote_locator("c://boards"));
+    }
+
+    #[test]
+    fn test_a_scheme_with_a_leading_digit_is_not_remote() {
+        assert!(!is_remote_locator("2fast://x"));
+        assert!(!is_remote_locator("ht tp://x"));
+    }
+
+    #[test]
+    fn test_a_plain_relative_path_has_no_scheme() {
+        assert!(scheme_of("kanban.json").is_none());
+        assert!(scheme_of("/home/u/boards.sqlite").is_none());
+        assert!(scheme_of("").is_none());
+    }
+}

--- a/crates/kanban-persistence-json/src/backend_factory.rs
+++ b/crates/kanban-persistence-json/src/backend_factory.rs
@@ -13,7 +13,10 @@ impl KanbanBackendFactory for JsonBackendFactory {
         "json"
     }
 
-    fn matches_locator(&self, _locator: &str, header: &[u8]) -> bool {
+    fn matches_locator(&self, locator: &str, header: &[u8]) -> bool {
+        if kanban_core::is_remote_locator(locator) {
+            return false;
+        }
         let trimmed = header.iter().find(|b| !b.is_ascii_whitespace());
         header.is_empty() || matches!(trimmed, Some(b'{') | Some(b'['))
     }

--- a/crates/kanban-persistence-json/tests/backend_factory.rs
+++ b/crates/kanban-persistence-json/tests/backend_factory.rs
@@ -36,7 +36,7 @@ async fn test_json_factory_creates_backend_without_touching_disk() {
 }
 
 #[test]
-fn test_json_backend_factory_matches_locator_as_catch_all() {
+fn test_json_backend_factory_matches_any_local_locator() {
     assert!(JsonBackendFactory.matches_locator("board.json", b"{\"boards\":[]}"));
     assert!(JsonBackendFactory.matches_locator("board.txt", b"[1,2,3]"));
     assert!(JsonBackendFactory.matches_locator("board.json", b"   {\"boards\":[]}"));

--- a/crates/kanban-persistence-json/tests/backend_factory.rs
+++ b/crates/kanban-persistence-json/tests/backend_factory.rs
@@ -42,3 +42,10 @@ fn test_json_backend_factory_matches_locator_as_catch_all() {
     assert!(JsonBackendFactory.matches_locator("board.json", b"   {\"boards\":[]}"));
     assert!(JsonBackendFactory.matches_locator("/nonexistent/board.json", &[]));
 }
+
+#[test]
+fn test_json_factory_declines_a_remote_locator() {
+    assert!(!JsonBackendFactory.matches_locator("http://127.0.0.1:3000", &[]));
+    assert!(!JsonBackendFactory.matches_locator("https://example.com/boards", &[]));
+    assert!(!JsonBackendFactory.matches_locator("notes://draft.json", &[]));
+}

--- a/crates/kanban-persistence-sqlite/src/backend_factory.rs
+++ b/crates/kanban-persistence-sqlite/src/backend_factory.rs
@@ -13,6 +13,9 @@ impl KanbanBackendFactory for SqliteBackendFactory {
     }
 
     fn matches_locator(&self, locator: &str, header: &[u8]) -> bool {
+        if kanban_core::is_remote_locator(locator) {
+            return false;
+        }
         header.starts_with(b"SQLite format 3\0")
             || (header.is_empty()
                 && (locator.ends_with(".sqlite")

--- a/crates/kanban-persistence-sqlite/tests/backend_factory.rs
+++ b/crates/kanban-persistence-sqlite/tests/backend_factory.rs
@@ -47,3 +47,9 @@ fn test_sqlite_backend_factory_matches_locator_by_extension_for_new_file() {
     assert!(SqliteBackendFactory.matches_locator("/nonexistent/board.db", &[]));
     assert!(!SqliteBackendFactory.matches_locator("/nonexistent/board.json", &[]));
 }
+
+#[test]
+fn test_sqlite_factory_declines_a_remote_locator_ending_in_a_db_suffix() {
+    assert!(!SqliteBackendFactory.matches_locator("http://127.0.0.1:3000/board.db", &[]));
+    assert!(!SqliteBackendFactory.matches_locator("https://host/board.sqlite3", &[]));
+}

--- a/crates/kanban-service/src/config.rs
+++ b/crates/kanban-service/src/config.rs
@@ -833,6 +833,33 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_storage_location_passes_a_remote_locator_through() {
+        let config = AppConfig {
+            storage_location: Some("http://127.0.0.1:3000".into()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_storage_location(&config), "http://127.0.0.1:3000");
+    }
+
+    #[test]
+    fn test_validate_accepts_a_remote_storage_location() {
+        let config = AppConfig {
+            storage_location: Some("http://127.0.0.1:3000".into()),
+            ..Default::default()
+        };
+        validate(&config).unwrap();
+    }
+
+    #[test]
+    fn test_validate_accepts_a_remote_storage_location_containing_a_dotdot_segment() {
+        let config = AppConfig {
+            storage_location: Some("http://example.com/a/../b".into()),
+            ..Default::default()
+        };
+        validate(&config).unwrap();
+    }
+
+    #[test]
     fn test_validate_storage_location_none_is_valid() {
         let config = AppConfig {
             storage_location: None,

--- a/crates/kanban-service/src/config.rs
+++ b/crates/kanban-service/src/config.rs
@@ -135,6 +135,9 @@ pub fn effective_configuration_location(config: &AppConfig) -> String {
 /// This function performs the cwd join for callers that need a filesystem path.
 pub fn resolve_storage_location(config: &AppConfig) -> String {
     let raw = config.effective_storage_location();
+    if kanban_core::is_remote_locator(&raw) {
+        return raw;
+    }
     let path = Path::new(&raw);
     if path.is_absolute() {
         raw
@@ -154,6 +157,9 @@ pub fn resolve_server_addr(config: &AppConfig) -> String {
 pub fn validate(config: &AppConfig) -> CoreResult<()> {
     config.validate_values()?;
     if let Some(ref v) = config.storage_location {
+        if kanban_core::is_remote_locator(v) {
+            return Ok(());
+        }
         if std::path::Path::new(v)
             .components()
             .any(|c| c == std::path::Component::ParentDir)

--- a/crates/kanban-service/src/path.rs
+++ b/crates/kanban-service/src/path.rs
@@ -17,12 +17,18 @@ use std::path::{Path, PathBuf};
 /// This function prevents callers from accidentally (or maliciously) opening files
 /// outside the working directory. Path traversal attempts such as `../../secret.json`
 /// return `Err` with a message containing "Path traversal not allowed".
+///
+/// A locator carrying a URL scheme (`kanban_core::is_remote_locator`) is returned
+/// unchanged and is not validated as a path.
 pub fn validate_path(path: &Path) -> KanbanResult<PathBuf> {
     let cwd = std::env::current_dir().map_err(|e| KanbanError::from(std::io::Error::other(e)))?;
     validate_path_with_cwd(path, &cwd)
 }
 
 fn validate_path_with_cwd(path: &Path, cwd: &Path) -> KanbanResult<PathBuf> {
+    if path.to_str().is_some_and(kanban_core::is_remote_locator) {
+        return Ok(path.to_path_buf());
+    }
     if path.is_absolute() {
         Ok(dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
     } else {

--- a/crates/kanban-service/src/path.rs
+++ b/crates/kanban-service/src/path.rs
@@ -115,6 +115,22 @@ mod tests {
     }
 
     #[test]
+    fn test_a_remote_locator_is_not_cwd_joined() {
+        let dir = TempDir::new().unwrap();
+        let result =
+            validate_path_with_cwd(Path::new("http://127.0.0.1:3000"), dir.path()).unwrap();
+        assert_eq!(result, PathBuf::from("http://127.0.0.1:3000"));
+        assert!(result.to_string_lossy().contains("://"));
+    }
+
+    #[test]
+    fn test_a_remote_locator_passes_through_the_public_entry_point() -> KanbanResult<()> {
+        let result = validate_path(Path::new("https://example.com/boards"))?;
+        assert_eq!(result, PathBuf::from("https://example.com/boards"));
+        Ok(())
+    }
+
+    #[test]
     fn test_validate_path_absolute_existing_file_returns_non_unc() -> KanbanResult<()> {
         let dir = TempDir::new().unwrap();
         let cwd = dunce::canonicalize(dir.path()).unwrap();


### PR DESCRIPTION
## Summary

An `http://`/`https://` locator today gets cwd-joined into a bogus filesystem path (`<cwd>/http:/host:port`) and, if the guard even lets it through, is silently claimed by the JSON catch-all factory or the SQLite `.db`-suffix factory. This PR makes a scheme'd locator survive the shared path helpers intact and routes it to a new `HttpBackendFactory` through the existing `KanbanBackendRegistry`.

- `kanban-core` gains `locator::{scheme_of, is_remote_locator}`, exported from the crate root. The predicate answers "does this locator carry a URL scheme", not "is this HTTP" - it is deliberately provider-agnostic.
- `kanban-service::path::{validate_path, validate_path_with_cwd}` and `config::resolve_storage_location` return a remote locator byte-identical to the input instead of cwd-joining it.
- `kanban-service::config::validate` accepts a remote `storage_location`, checked ahead of both the `..`-component scan and the parent-directory existence check, while continuing to reject a local path with a missing parent.
- `JsonBackendFactory` and `SqliteBackendFactory` both decline any remote locator before running their existing content/suffix checks, closing the trap where a URL was silently claimed by either backend.
- `kanban-backend-http` gains `HttpBackendFactory`, which claims only `http`/`https` locators, and `HttpBackend::new` now rejects a schemeless or non-http/https locator up front.

## Out of scope

This ships dispatch only. No consumer (`kanban-cli`, `kanban-tui`, `kanban-mcp`) registers `HttpBackendFactory` yet, so a URL still does not work end to end from any application entry point; that is tracked as follow-up work. No test in this PR reads board data over HTTP.

## Test plan

- [x] Red tests committed separately, confirmed failing to compile before the implementation (`kanban_core::locator` and `HttpBackendFactory` did not exist)
- [x] `cargo test --all-features --workspace` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation check: reverting `is_remote_locator` to always return `false` fails the registry-selection tests as expected; reverted
- [x] `git diff --name-only origin/develop...HEAD` touches no file under `kanban-cli`, `kanban-tui`, or `kanban-mcp`
