### PR TITLE
KAN-1567 fix(backend-http): shut the owned runtime down in the background on drop

### DIFF
--- a/.changeset/kan-1567-http-backend-runtime-shutdown-background.md
+++ b/.changeset/kan-1567-http-backend-runtime-shutdown-background.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+backend-http: shut the owned runtime down in the background on drop, fixing the exit-101 abort when an http:// locator is dropped from inside an async context

--- a/crates/kanban-backend-http/README.md
+++ b/crates/kanban-backend-http/README.md
@@ -49,7 +49,9 @@ slash off `base_url`, builds a `reqwest::Client`, and spins up a dedicated
 multi-thread Tokio runtime — every synchronous `DataStore`/`CommandStore`
 call bridges onto that runtime via a private `block_on` helper rather than
 assuming an ambient one, since `KanbanBackend`'s inherent methods are
-synchronous but the HTTP calls underneath are async.
+synchronous but the HTTP calls underneath are async. That runtime is handed to
+`shutdown_background()` when the backend is dropped, so a caller that drops it
+from inside its own async context does not abort.
 
 `HttpBackendFactory::matches_locator` claims a locator only when its scheme is
 `http` or `https`, so it is safe to register alongside `JsonBackendFactory`

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -10,8 +10,19 @@ pub use backend_factory::HttpBackendFactory;
 pub struct HttpBackend {
     base_url: String,
     client: reqwest::Client,
-    runtime: tokio::runtime::Runtime,
+    runtime: Option<tokio::runtime::Runtime>,
     instance_id: uuid::Uuid,
+}
+
+/// Dropping a `tokio::runtime::Runtime` blocks the current thread, and
+/// blocking is forbidden on a thread already inside another runtime -- which
+/// is where every application drops this backend.
+impl Drop for HttpBackend {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            runtime.shutdown_background();
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -71,7 +82,7 @@ impl HttpBackend {
         Ok(Self {
             base_url,
             client,
-            runtime,
+            runtime: Some(runtime),
             instance_id: uuid::Uuid::new_v4(),
         })
     }
@@ -82,7 +93,10 @@ impl HttpBackend {
     /// start a runtime from within a runtime". An async caller reaches this
     /// through `tokio::task::spawn_blocking`.
     pub(crate) fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
-        self.runtime.block_on(fut)
+        self.runtime
+            .as_ref()
+            .expect("the runtime is taken only while dropping")
+            .block_on(fut)
     }
 
     pub(crate) fn base_url(&self) -> &str {

--- a/crates/kanban-backend-http/tests/open_probe.rs
+++ b/crates/kanban-backend-http/tests/open_probe.rs
@@ -16,12 +16,8 @@ async fn test_open_over_http_backend_against_live_server_succeeds() {
         Err(e) => panic!("expected open() to succeed against a live server, got: {e}"),
     };
 
-    tokio::task::spawn_blocking(move || {
-        drop(ctx);
-        drop(backend);
-    })
-    .await
-    .unwrap();
+    drop(ctx);
+    drop(backend);
 
     server.shutdown().await;
 }
@@ -43,7 +39,5 @@ async fn test_open_over_http_backend_against_dead_server_fails_with_transport_er
         Ok(_) => panic!("expected open() to fail against an unreachable server"),
     }
 
-    tokio::task::spawn_blocking(move || drop(backend))
-        .await
-        .unwrap();
+    drop(backend);
 }

--- a/crates/kanban-backend-http/tests/runtime_drop.rs
+++ b/crates/kanban-backend-http/tests/runtime_drop.rs
@@ -1,0 +1,23 @@
+use kanban_backend::KanbanBackend;
+use kanban_backend_http::HttpBackend;
+use std::sync::Arc;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dropping_the_http_backend_inside_an_async_context_does_not_panic() {
+    let backend = HttpBackend::new("http://127.0.0.1:1").unwrap();
+    drop(backend);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dropping_the_last_arc_to_the_http_backend_inside_an_async_context_does_not_panic() {
+    let backend: Arc<dyn KanbanBackend> = Arc::new(HttpBackend::new("http://127.0.0.1:1").unwrap());
+    let clone = Arc::clone(&backend);
+    drop(backend);
+    drop(clone);
+}
+
+#[test]
+fn test_dropping_the_http_backend_outside_any_runtime_does_not_panic() {
+    let backend = HttpBackend::new("http://127.0.0.1:1").unwrap();
+    drop(backend);
+}

--- a/crates/kanban-cli/tests/remote_locator.rs
+++ b/crates/kanban-cli/tests/remote_locator.rs
@@ -28,6 +28,20 @@ fn test_cli_subcommand_on_a_url_locator_is_not_a_missing_file_error() {
         .stderr(predicate::str::contains("/http:/").not());
 }
 
+#[cfg(feature = "http")]
+#[test]
+fn test_cli_on_an_unreachable_url_locator_exits_with_a_transport_error_not_a_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    kanban_no_config(dir.path())
+        .args(["http://127.0.0.1:1", "board", "list"])
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("transport error"))
+        .stderr(predicate::str::contains("health probe"))
+        .stderr(predicate::str::contains("Cannot drop a runtime").not());
+}
+
 #[test]
 fn test_cli_init_on_a_url_locator_is_rejected_with_guidance() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

`HttpBackend` owned a bare `tokio::runtime::Runtime`. Dropping it blocks the current thread, and tokio forbids blocking on a thread already inside another runtime, which is exactly where every application (CLI, TUI, MCP) drops the backend today: `KanbanContext::open` drops its local `ctx` on the `?` after a failed probe, and the CLI holds no other `Arc` to the backend. The result was a panic (process exit 101) on both an unreachable-server probe failure and, more subtly, on normal process exit whenever the backend was the last `Arc` dropped from async code.

- `HttpBackend::runtime` is now `Option<tokio::runtime::Runtime>`.
- A new `impl Drop for HttpBackend` takes the runtime and calls `shutdown_background()`, which abandons worker threads without blocking, instead of the default drop glue which blocks.
- `block_on` unwraps the `Option` with an `expect`, since it is only ever taken during drop.
- The two `tokio::task::spawn_blocking(move || drop(backend))` workarounds in `crates/kanban-backend-http/tests/open_probe.rs` are gone; the tests now drop the backend directly on the test's own async thread.
- New `crates/kanban-backend-http/tests/runtime_drop.rs` pins the drop-inside-async and drop-of-the-last-Arc-inside-async cases directly.
- New CLI test in `crates/kanban-cli/tests/remote_locator.rs` proves the actual binary exits with code 1 and a transport error message on an unreachable `http://` locator, rather than accepting the panic's exit code 101 as a pass (the existing sibling test only asserted `.failure()`, which a panic also satisfies).

## Out of scope (reported, not fixed here)

- `FaultInjectingBackend::probe` in `kanban-service` does not forward to the wrapped backend (the trait default is used instead of delegating). No existing test backend has an observably different `probe`, so a red test for this would need a new ~130-line delegating wrapper or a `kanban-service` -> `kanban-backend-http` dev-dependency, which is out of scope for this fix. Worth a follow-up on KAN-1554.
- `.changeset/kan-1425-fault-injecting.md` claims every trait method delegates through `FaultInjectingBackend` including defaulted ones; `probe` is the counterexample above.
- `crates/kanban-backend-http/README.md` still says no crate in the workspace depends on `kanban-backend-http`, which became false once `HttpBackendFactory` was wired into the app registries. Already tracked as a KAN-1554 follow-up.
- The transport failure path in `kanban-cli` exits through a bare `eprintln!("Error: {e}")` in `main.rs` rather than `output::output_error`, so it skips the JSON `CliResponse` envelope every other CLI error path emits. Worth its own card.

## Test plan

- [x] `cargo test -p kanban-backend-http` green, including the new `runtime_drop.rs`
- [x] `cargo test -p kanban-cli` green, including the new unreachable-locator test
- [x] `cargo build -p kanban-cli --no-default-features --features json,sqlite` compiles (http stays optional)
- [x] `cargo test -p kanban-cli --no-default-features --features json,sqlite` green (new test correctly skipped without the `http` feature)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --all-features --workspace` green
