### PR TITLE
KAN-1568 fix(backend,backend-http,service,cli): migrate offers only local-file backends

### DIFF
--- a/.changeset/kan-1568-migrate-offers-only-store-capable-backends.md
+++ b/.changeset/kan-1568-migrate-offers-only-store-capable-backends.md
@@ -1,0 +1,10 @@
+---
+bump: minor
+---
+
+`kanban migrate` no longer offers `http` as a target backend, since a remote
+backend cannot be migrated to. `kanban-backend` adds `KanbanBackendFactory::is_remote`
+(defaulted to false) and `KanbanBackendRegistry::local_names`; `kanban-backend-http`
+declares itself remote; `kanban-service` adds `StoreManager::local_backend_names`;
+`kanban-cli` builds the migrate command's possible values from it, so clap now
+rejects `http` as an invalid value instead of failing deep inside the backend.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,7 @@ layer:
    (`DataStore + CommandStore` plus lifecycle methods `flush()`/`reload()`/
    `needs_flush()`/`needs_save_worker()`) and a
    `kanban_backend::KanbanBackendFactory` (`name()`, `matches_locator()`,
-   `create()`). Model this on
+   `is_remote()`, `create()`). Model this on
    `crates/kanban-persistence-json/src/backend_factory.rs`'s
    `JsonBackendFactory`, which wraps a `PersistenceStore` in a `JsonDataStore`
    and is only ~25 lines.

--- a/crates/kanban-backend-http/README.md
+++ b/crates/kanban-backend-http/README.md
@@ -38,6 +38,7 @@ pub struct HttpBackendFactory;
 impl kanban_backend::KanbanBackendFactory for HttpBackendFactory {
     fn name(&self) -> &str { "http" }
     fn matches_locator(&self, locator: &str, _header: &[u8]) -> bool;
+    fn is_remote(&self) -> bool { true }
     async fn create(&self, locator: &str, config: &kanban_core::AppConfig)
         -> kanban_domain::KanbanResult<std::sync::Arc<dyn kanban_backend::KanbanBackend>>;
 }

--- a/crates/kanban-backend-http/src/backend_factory.rs
+++ b/crates/kanban-backend-http/src/backend_factory.rs
@@ -44,4 +44,9 @@ mod tests {
         assert!(!HttpBackendFactory.matches_locator("C://boards", &[]));
         assert!(!HttpBackendFactory.matches_locator("notes://draft.json", &[]));
     }
+
+    #[test]
+    fn test_the_http_factory_declares_itself_remote() {
+        assert!(HttpBackendFactory.is_remote());
+    }
 }

--- a/crates/kanban-backend-http/src/backend_factory.rs
+++ b/crates/kanban-backend-http/src/backend_factory.rs
@@ -16,6 +16,10 @@ impl KanbanBackendFactory for HttpBackendFactory {
         matches!(kanban_core::scheme_of(locator), Some("http" | "https"))
     }
 
+    fn is_remote(&self) -> bool {
+        true
+    }
+
     async fn create(
         &self,
         locator: &str,

--- a/crates/kanban-backend/README.md
+++ b/crates/kanban-backend/README.md
@@ -64,6 +64,7 @@ its main loop).
 pub trait KanbanBackendFactory: Send + Sync {
     fn name(&self) -> &str;
     fn matches_locator(&self, _locator: &str, _header: &[u8]) -> bool { false }
+    fn is_remote(&self) -> bool { false }
     async fn create(&self, locator: &str, config: &AppConfig) -> KanbanResult<Arc<dyn KanbanBackend>>;
 }
 
@@ -75,6 +76,7 @@ impl KanbanBackendRegistry {
     pub fn register(&mut self, factory: Box<dyn KanbanBackendFactory>);
     pub fn is_empty(&self) -> bool;
     pub fn names(&self) -> Vec<&str>;
+    pub fn local_names(&self) -> Vec<&str>;
     pub fn for_name(&self, name: &str) -> Option<&dyn KanbanBackendFactory>;
     pub fn for_locator(&self, locator: &str) -> Option<&dyn KanbanBackendFactory>;
 }

--- a/crates/kanban-backend/src/factory.rs
+++ b/crates/kanban-backend/src/factory.rs
@@ -22,6 +22,12 @@ pub trait KanbanBackendFactory: Send + Sync {
         false
     }
 
+    /// True when this factory's locators address a remote server rather than a
+    /// file on this machine. Default: local.
+    fn is_remote(&self) -> bool {
+        false
+    }
+
     async fn create(
         &self,
         locator: &str,
@@ -51,6 +57,16 @@ impl KanbanBackendRegistry {
 
     pub fn names(&self) -> Vec<&str> {
         self.factories.iter().map(|f| f.name()).collect()
+    }
+
+    /// Names of the registered factories that are not remote, in registration
+    /// order.
+    pub fn local_names(&self) -> Vec<&str> {
+        self.factories
+            .iter()
+            .filter(|f| !f.is_remote())
+            .map(|f| f.name())
+            .collect()
     }
 
     /// First registration wins when two factories claim the same name.

--- a/crates/kanban-backend/tests/backend_factory.rs
+++ b/crates/kanban-backend/tests/backend_factory.rs
@@ -205,3 +205,42 @@ async fn test_registry_dispatches_locator_and_config_to_the_matching_factory() {
 
     assert!(err.to_string().contains("/tmp/board.json"));
 }
+
+#[test]
+fn test_a_factory_is_local_by_default() {
+    assert!(!StubFactory { name: "file" }.is_remote());
+}
+
+#[test]
+fn test_registry_local_names_excludes_remote_factories() {
+    struct RemoteStub;
+
+    #[async_trait::async_trait]
+    impl KanbanBackendFactory for RemoteStub {
+        fn name(&self) -> &str {
+            "remote"
+        }
+
+        fn is_remote(&self) -> bool {
+            true
+        }
+
+        async fn create(
+            &self,
+            locator: &str,
+            _config: &AppConfig,
+        ) -> KanbanResult<Arc<dyn KanbanBackend>> {
+            Err(KanbanError::validation(format!(
+                "remote factory reached with {locator}"
+            )))
+        }
+    }
+
+    let mut registry = KanbanBackendRegistry::new();
+    registry.register(stub("file"));
+    registry.register(Box::new(RemoteStub));
+    registry.register(stub("memory"));
+
+    assert_eq!(registry.names(), vec!["file", "remote", "memory"]);
+    assert_eq!(registry.local_names(), vec!["file", "memory"]);
+}

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -83,7 +83,7 @@ where
     T: Into<std::ffi::OsString> + Clone,
 {
     let backend_names: Vec<String> = store_manager
-        .backend_names()
+        .local_backend_names()
         .into_iter()
         .map(str::to_owned)
         .collect();

--- a/crates/kanban-cli/tests/migrate.rs
+++ b/crates/kanban-cli/tests/migrate.rs
@@ -667,3 +667,56 @@ async fn test_migrate_rejects_unknown_backend() {
         "stderr: {stderr}"
     );
 }
+
+#[test]
+fn test_migrate_help_lists_only_store_backends() {
+    use assert_cmd::cargo_bin_cmd;
+
+    let output = cargo_bin_cmd!("kanban")
+        .args(["migrate", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let backend_line = stdout
+        .lines()
+        .find(|line| line.contains("possible values"))
+        .unwrap_or_else(|| panic!("no possible-values line in stdout: {stdout}"));
+
+    assert!(
+        backend_line.contains("possible values: sqlite, json"),
+        "backend_line: {backend_line}"
+    );
+    assert!(
+        !backend_line.contains("http"),
+        "backend_line: {backend_line}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_to_http_rejected_as_invalid_value() {
+    use assert_cmd::cargo_bin_cmd;
+
+    let dir = TempDir::new().unwrap();
+    let src_path = dir.path().join("source.json");
+
+    create_populated_json_context(&src_path).await;
+
+    let output = cargo_bin_cmd!("kanban")
+        .args([
+            "migrate",
+            src_path.to_str().unwrap(),
+            "http",
+            "--output",
+            dir.path().join("dest.http").to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid value 'http'"), "stderr: {stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Migrating"), "stdout: {stdout}");
+}

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -43,6 +43,12 @@ impl StoreManager {
         self.backends.names()
     }
 
+    /// Names of the registered backend factories that address local files, in
+    /// registration order. This is the set `migrate_store` can write to.
+    pub fn local_backend_names(&self) -> Vec<&str> {
+        self.backends.local_names()
+    }
+
     /// Returns `true` if `locator` points to a SQLite database — either
     /// because `detect_backend` recognised it as `"sqlite"`, or because the
     /// file extension matches one of the conventional SQLite extensions.

--- a/crates/kanban-service/src/store_manager.rs
+++ b/crates/kanban-service/src/store_manager.rs
@@ -770,4 +770,45 @@ mod tests {
             assert_eq!(sm.detect_backend("whatever.db"), Some("json".to_string()));
         }
     }
+
+    struct RemoteStub;
+
+    #[async_trait::async_trait]
+    impl kanban_backend::KanbanBackendFactory for RemoteStub {
+        fn name(&self) -> &str {
+            "remote"
+        }
+
+        fn is_remote(&self) -> bool {
+            true
+        }
+
+        async fn create(
+            &self,
+            locator: &str,
+            _config: &AppConfig,
+        ) -> Result<Arc<dyn crate::backend::KanbanBackend>, KanbanError> {
+            Err(KanbanError::validation(format!(
+                "remote factory reached with {locator}"
+            )))
+        }
+    }
+
+    #[test]
+    fn test_local_backend_names_excludes_a_remote_factory() {
+        let mut registry = StoreRegistry::new();
+        registry.register(Box::new(kanban_persistence_json::JsonStoreFactory));
+        let mut backends = kanban_backend::KanbanBackendRegistry::new();
+        #[cfg(feature = "sqlite")]
+        backends.register(Box::new(kanban_persistence_sqlite::SqliteBackendFactory));
+        backends.register(Box::new(kanban_persistence_json::JsonBackendFactory));
+        backends.register(Box::new(RemoteStub));
+        let sm = StoreManager::new(registry, backends);
+
+        assert!(sm.backend_names().contains(&"remote"));
+        assert!(!sm.local_backend_names().contains(&"remote"));
+        assert!(sm.local_backend_names().contains(&"json"));
+        #[cfg(feature = "sqlite")]
+        assert!(sm.local_backend_names().contains(&"sqlite"));
+    }
 }


### PR DESCRIPTION
## Summary

- `kanban migrate --help` now lists only local-file backends (`sqlite`, `json`); `http` is no longer an accepted target
- `KanbanBackendFactory` gains a defaulted `is_remote()` method (default false), plus `KanbanBackendRegistry::local_names()` which filters out remote factories
- `HttpBackendFactory` overrides `is_remote()` to return true
- `StoreManager` exposes `local_backend_names()`, delegating to the filtered registry; `backend_names()` is unchanged
- `parse_cli` now builds migrate's possible-values list from `local_backend_names()`, so clap rejects `http` with an invalid-value error (exit code 2) before any store work runs, instead of failing deep inside `HttpBackend::new`

## Test plan

- New tests: `test_a_factory_is_local_by_default`, `test_registry_local_names_excludes_remote_factories` (kanban-backend), `test_the_http_factory_declares_itself_remote` (kanban-backend-http), `test_local_backend_names_excludes_a_remote_factory` (kanban-service), `test_migrate_help_lists_only_store_backends`, `test_migrate_to_http_rejected_as_invalid_value` (kanban-cli)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`
