### PR TITLE
KAN-1570 fix(backend-http): make block_on ambient-runtime-aware

### DIFF
--- a/.changeset/kan-1570-ambient-aware-block-on.md
+++ b/.changeset/kan-1570-ambient-aware-block-on.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+backend-http: bridge block_on through block_in_place so reads work when a Tokio runtime already drives the calling thread

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -137,6 +137,13 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    #[should_panic(expected = "HttpBackend requires a multi-threaded Tokio runtime")]
+    async fn test_block_on_inside_current_thread_runtime_panics_with_flavor_message() {
+        let backend = HttpBackend::new("http://example.com").unwrap();
+        let _ = backend.block_on(async { 1 + 1 });
+    }
+
     #[test]
     fn test_http_backend_new_mints_nonnil_instance_id() -> kanban_domain::KanbanResult<()> {
         let backend = HttpBackend::new("http://example.com")?;

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -88,15 +88,29 @@ impl HttpBackend {
     }
 
     /// Bridge a synchronous DataStore/CommandStore call onto the dedicated
-    /// runtime -- never the caller's ambient one. Must not be called from a
-    /// thread already inside a Tokio runtime; doing so panics with "Cannot
-    /// start a runtime from within a runtime". An async caller reaches this
-    /// through `tokio::task::spawn_blocking`.
+    /// runtime -- never the caller's ambient one. With no ambient runtime on
+    /// the calling thread, this blocks directly. Inside a multi-thread
+    /// ambient runtime, it enters via `tokio::task::block_in_place` so the
+    /// dedicated runtime can be driven without nesting. A current_thread
+    /// ambient runtime is rejected: it has no worker to hand off to, so
+    /// `block_in_place` deadlocks or panics.
     pub(crate) fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
-        self.runtime
+        let runtime = self
+            .runtime
             .as_ref()
-            .expect("the runtime is taken only while dropping")
-            .block_on(fut)
+            .expect("the runtime is taken only while dropping");
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                debug_assert!(
+                    handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread,
+                    "HttpBackend requires a multi-threaded Tokio runtime (e.g. #[tokio::main]). \
+                     The current_thread runtime is not supported because synchronous DataStore \
+                     methods need to block on async HTTP I/O."
+                );
+                tokio::task::block_in_place(|| runtime.block_on(fut))
+            }
+            Err(_) => runtime.block_on(fut),
+        }
     }
 
     pub(crate) fn base_url(&self) -> &str {

--- a/crates/kanban-backend-http/tests/ambient_runtime.rs
+++ b/crates/kanban-backend-http/tests/ambient_runtime.rs
@@ -1,0 +1,42 @@
+use kanban_api::{CreateBoardRequest, SortFieldDto, SortOrderDto, TaskListViewDto};
+use kanban_backend_http::HttpBackend;
+use kanban_domain::DataStore;
+use kanban_server::test_helpers::TestServer;
+use uuid::Uuid;
+
+async fn seed_board(server: &TestServer, name: &str) -> Uuid {
+    let req = CreateBoardRequest {
+        id: None,
+        name: name.to_string(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: Some(SortFieldDto::Default),
+        task_sort_order: Some(SortOrderDto::Ascending),
+        sprint_duration_days: None,
+        task_list_view: Some(TaskListViewDto::Flat),
+    };
+    let resp = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    let board: kanban_api::BoardResponse = resp.json().await.unwrap();
+    board.id
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ambient_multi_thread_runtime_read_succeeds_without_spawn_blocking() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Ambient").await;
+
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+    let result = backend.get_board(board_id);
+
+    let board = result.unwrap().unwrap();
+    assert_eq!(board.id, board_id);
+
+    server.shutdown().await;
+}

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -126,12 +126,15 @@ async fn test_a_datastore_call_from_a_blocking_thread_inside_an_ambient_runtime_
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[should_panic(expected = "Cannot start a runtime from within a runtime")]
-async fn test_a_datastore_call_directly_on_a_runtime_worker_thread_panics() {
+async fn test_a_datastore_call_directly_on_a_runtime_worker_thread_returns_data() {
     let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Direct Board").await;
     let backend = HttpBackend::new(&server.base_url()).unwrap();
 
-    let _ = backend.list_boards();
+    let boards = backend.list_boards().unwrap();
+
+    assert_eq!(boards.len(), 1);
+    assert_eq!(boards[0].id, board_id);
 
     server.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- Make `HttpBackend::block_on` ambient-aware: when a Tokio runtime is already driving the calling thread, it now enters the backend's dedicated runtime through `tokio::task::block_in_place` instead of calling `Runtime::block_on` directly, which panicked with "Cannot start a runtime from within a runtime".
- With no ambient runtime, the thread keeps blocking directly as before.
- A `debug_assert!` guards against a `current_thread` ambient runtime, which has no worker to hand off to and would deadlock or panic; the message names the requirement plainly.
- This unblocks the HTTP read surface from every shipped binary (CLI, TUI, MCP), all of which run under `#[tokio::main]` (multi-thread by default).
- Updated an existing test in `remote_reads.rs` that pinned the old panic-on-ambient-runtime behavior; it now asserts the read succeeds, matching the fixed behavior.

## Test plan

- [x] `cargo test -p kanban-backend-http` green, including the new ambient-runtime test and the updated `remote_reads.rs` test
- [x] Mutation check: reverting the fix reproduces the original panic in the new pin test, confirming it is load-bearing
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --all-features --workspace` green
