### PR TITLE
KAN-1578 feat(api,server): relocate the client-id header constant and add the reverse patch conversion

### DIFF
--- a/.changeset/kan-1578-client-id-constant-and-patch-conv.md
+++ b/.changeset/kan-1578-client-id-constant-and-patch-conv.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+api, server: the client-id header name now lives in kanban-api (re-exported from kanban-server's old path) and Patch gains the reverse FieldUpdate conversion, so the HTTP client and the server share one constant and one bidirectional patch mapping

--- a/crates/kanban-api/README.md
+++ b/crates/kanban-api/README.md
@@ -19,9 +19,10 @@ pub use v1::{
     ActivateSprintRequest, AddBlockRequest, AddRelatedRequest, ApiError, ArchivedFilterDto,
     AttachChildrenRequest, BlockEdgeDto, BoardResponse, CardGraphResponse, CardPriorityDto,
     CardResponse, CardStatusDto, CarryOverRequest, CarryOverResponse, ChangeEventFrame,
-    ChangeKind, ColumnResponse, CreateBoardRequest, CreateCardRequest, CreateColumnRequest,
-    CreateSprintParts, CreateSprintRequest, EntityType, ErrorCode, Page, PageParams, Patch,
-    PrefixResponse, RelatedEdgeDto, RelatesKindDto, ReorderColumnRequest, ReplaceBoardRequest,
+    ChangeKind, CLIENT_ID_HEADER, ColumnResponse, CreateBoardRequest, CreateCardRequest,
+    CreateColumnRequest, CreateSprintParts, CreateSprintRequest, EntityType, ErrorCode, Page,
+    PageParams, Patch, PrefixResponse, RelatedEdgeDto, RelatesKindDto, ReorderColumnRequest,
+    ReplaceBoardRequest,
     ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest, SeverityDto, SortFieldDto,
     SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto, UpdateBoardRequest,
     UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
@@ -32,6 +33,7 @@ pub use v1::{
 - `Create*Request` / `Replace*Request` / `Update*Request` are the write-side DTOs for `POST` / `PUT` / `PATCH` respectively — `Update*Request` follows JSON Merge Patch (RFC 7386) semantics via `Patch<T>`.
 - `ApiError` / `ErrorCode` are the shared error envelope every non-2xx response uses.
 - `ChangeEventFrame` is the payload broadcast on `kanban-server`'s internal change-event channel; `entity_type`/`entity_id`/`kind` (`EntityType`, `ChangeKind`) name the entity a mutation touched and how, all absent when the emitter cannot know (an external process wrote the file directly).
+- `CLIENT_ID_HEADER` is the wire name of the client-identity request header, shared so the server's extractor and HTTP clients cannot drift.
 
 The optional `schemars` feature (`dep:schemars`, `features = ["uuid1"]`) derives `schemars::JsonSchema` on these DTOs so `kanban-mcp` can use them directly as `Parameters<T>` for its tool handlers (rmcp requires a JSON Schema).
 

--- a/crates/kanban-api/src/lib.rs
+++ b/crates/kanban-api/src/lib.rs
@@ -16,4 +16,5 @@ pub use v1::{
     ReplaceBoardRequest, ReplaceCardRequest, ReplaceColumnRequest, ReplaceSprintRequest,
     SeverityDto, SortFieldDto, SortOrderDto, SprintResponse, SprintStatusDto, TaskListViewDto,
     UpdateBoardRequest, UpdateCardRequest, UpdateColumnRequest, UpdateSprintRequest,
+    CLIENT_ID_HEADER,
 };

--- a/crates/kanban-api/src/v1/client_id.rs
+++ b/crates/kanban-api/src/v1/client_id.rs
@@ -1,3 +1,8 @@
+/// Wire name of the unauthenticated, client-supplied identity header.
+/// Lowercase, so it is usable with `http::HeaderName::from_static`. Shared by
+/// the server's extractor and HTTP clients so the two cannot drift.
+pub const CLIENT_ID_HEADER: &str = "x-kanban-client-id";
+
 #[cfg(test)]
 mod tests {
     use super::CLIENT_ID_HEADER;

--- a/crates/kanban-api/src/v1/client_id.rs
+++ b/crates/kanban-api/src/v1/client_id.rs
@@ -1,0 +1,9 @@
+#[cfg(test)]
+mod tests {
+    use super::CLIENT_ID_HEADER;
+
+    #[test]
+    fn test_client_id_header_is_the_lowercase_wire_name() {
+        assert_eq!(CLIENT_ID_HEADER, "x-kanban-client-id");
+    }
+}

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -20,6 +20,7 @@ pub use cards::{
     BatchMoveRequest, BatchOperationResponse, BatchUpdateItem, BatchUpdateRequest, CardResponse,
     CreateCardRequest, ReplaceCardRequest, UpdateCardRequest,
 };
+pub use client_id::CLIENT_ID_HEADER;
 pub use columns::{
     ColumnResponse, CreateColumnRequest, ReorderColumnRequest, ReplaceColumnRequest,
     UpdateColumnRequest,

--- a/crates/kanban-api/src/v1/mod.rs
+++ b/crates/kanban-api/src/v1/mod.rs
@@ -1,5 +1,6 @@
 mod boards;
 mod cards;
+mod client_id;
 mod columns;
 mod enums;
 mod error;

--- a/crates/kanban-api/src/v1/patch.rs
+++ b/crates/kanban-api/src/v1/patch.rs
@@ -39,6 +39,16 @@ impl<T> From<Patch<T>> for FieldUpdate<T> {
     }
 }
 
+impl<T> From<FieldUpdate<T>> for Patch<T> {
+    fn from(update: FieldUpdate<T>) -> Self {
+        match update {
+            FieldUpdate::NoChange => Patch::NoChange,
+            FieldUpdate::Clear => Patch::Clear,
+            FieldUpdate::Set(value) => Patch::Set(value),
+        }
+    }
+}
+
 // Only ever called for a *present* field (absent is handled by `#[serde(default)]`),
 // so `null` maps to `Clear` and any value maps to `Set`.
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for Patch<T> {

--- a/crates/kanban-api/src/v1/patch.rs
+++ b/crates/kanban-api/src/v1/patch.rs
@@ -138,4 +138,30 @@ mod tests {
     fn test_default_is_no_change() {
         assert_eq!(Patch::<String>::default(), Patch::NoChange);
     }
+
+    #[test]
+    fn test_from_field_update_maps_all_three_states() {
+        assert_eq!(
+            Patch::<String>::from(FieldUpdate::NoChange),
+            Patch::NoChange
+        );
+        assert_eq!(Patch::<String>::from(FieldUpdate::Clear), Patch::Clear);
+        assert_eq!(
+            Patch::from(FieldUpdate::Set("v".to_string())),
+            Patch::Set("v".to_string())
+        );
+    }
+
+    #[test]
+    fn test_field_update_round_trips_through_patch() {
+        for original in [
+            FieldUpdate::NoChange,
+            FieldUpdate::Clear,
+            FieldUpdate::Set("v".to_string()),
+        ] {
+            let patch = Patch::from(original.clone());
+            let round_tripped = FieldUpdate::from(patch);
+            assert_eq!(round_tripped, original);
+        }
+    }
 }

--- a/crates/kanban-server/src/client_ident.rs
+++ b/crates/kanban-server/src/client_ident.rs
@@ -5,7 +5,7 @@ use kanban_core::ClientId;
 use kanban_service::api::{ApiError, ErrorCode};
 use uuid::Uuid;
 
-pub const CLIENT_ID_HEADER: &str = "x-kanban-client-id";
+pub use kanban_service::api::CLIENT_ID_HEADER;
 
 /// Unauthenticated, client-supplied identity carried on `X-Kanban-Client-Id`.
 /// Absent header resolves to [`ClientId::nil`]; a malformed value rejects

--- a/crates/kanban-server/src/client_ident.rs
+++ b/crates/kanban-server/src/client_ident.rs
@@ -71,6 +71,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_header_named_by_the_api_constant_yields_that_client_id() {
+        let uuid = Uuid::new_v4();
+        let mut parts = Request::builder()
+            .uri("/")
+            .header(kanban_service::api::CLIENT_ID_HEADER, uuid.to_string())
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = ClientIdent::from_request_parts(&mut parts, &()).await;
+        match result {
+            Ok(ClientIdent(id)) => assert_eq!(id, ClientId::from(uuid)),
+            Err(_) => panic!("expected Ok"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_malformed_header_returns_422() {
         let mut parts = Request::builder()
             .uri("/")


### PR DESCRIPTION
## Changes

- Move the `x-kanban-client-id` header-name constant from `kanban-server` into `kanban-api` as `CLIENT_ID_HEADER`, re-exported from `kanban-server::client_ident` so `layers.rs` and every server test keep compiling unchanged.
- Add `impl<T> From<FieldUpdate<T>> for Patch<T>`, the mirror of the existing `Patch<T> -> FieldUpdate<T>` conversion (NoChange -> NoChange, Clear -> Clear, Set(v) -> Set(v)).
- Add compile-red-then-green tests: the constant's exact wire name, a server-side extractor test built against the api-crate constant, a direct per-variant mapping test, and a round-trip test.
- List `CLIENT_ID_HEADER` in the crate README's public-exports snippet and add one bullet describing it.
- Add a patch changeset.

Both changes are pure additions with no behaviour change. They are the two mechanical preludes a later RemoteWrites activation card needs so the client and server sides of the HTTP boundary share one constant and one bidirectional patch conversion.

## Notes for reviewers

- `kanban-server/src/layers.rs` and every file under `kanban-server/tests/` are untouched; only `client_ident.rs` changes on the server side.
- kanban-server has no direct `kanban-api` dependency, so the re-export goes through `kanban_service::api::CLIENT_ID_HEADER` rather than adding a new dependency edge.
- Out of scope, reported not fixed: eleven integration-test call sites in `kanban-server/tests/` hard-code the literal `"x-kanban-client-id"` string instead of importing the constant; converting them would balloon this into a much larger diff. `kanban-api/README.md`'s public-exports snippet was already missing several DTOs before this change (`ArchivedBoardResponse`, `ArchivedCardResponse`, batch-request/response types); not repaired here.
