### PR TITLE
KAN-1575 fix(service,tui): board sort persists only the sort preference, not session storage keys

### DIFF
--- a/.changeset/kan-1575-settings-only-storage-persist.md
+++ b/.changeset/kan-1575-settings-only-storage-persist.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+board sort now writes only the sort preference to config, never session-injected storage keys

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -130,8 +130,8 @@ impl CliContext {
     }
 
     /// Persist the default board-list sort through the service helper (R3):
-    /// persist-first via `config::save`, no context rebuild. The canonical
-    /// on-disk strings come from the domain `Display` (R1).
+    /// persist-first via `config::save_board_sort`, no context rebuild. The
+    /// canonical on-disk strings come from the domain `Display` (R1).
     pub fn set_board_sort(&mut self, field: BoardSortField, order: SortOrder) -> KanbanResult<()> {
         self.inner.set_board_sort(field, order)
     }

--- a/crates/kanban-service/src/config.rs
+++ b/crates/kanban-service/src/config.rs
@@ -97,6 +97,24 @@ pub fn save_to(config: &AppConfig, path: &Path) -> CoreResult<()> {
     Ok(())
 }
 
+pub fn save_board_sort(
+    config: &AppConfig,
+    field: kanban_domain::BoardSortField,
+    order: kanban_domain::SortOrder,
+) -> CoreResult<()> {
+    let location = effective_configuration_location(config);
+    if location.is_empty() {
+        return Err(kanban_core::CoreError::Config(
+            "No configuration location configured".to_string(),
+        ));
+    }
+    let path = PathBuf::from(location);
+    let mut persisted = load_from(&path);
+    persisted.board_sort_field = Some(field.to_string());
+    persisted.board_sort_order = Some(order.to_string());
+    save_to(&persisted, &path)
+}
+
 pub fn move_config(old_path: &Path, new_path: &Path) -> CoreResult<()> {
     if old_path == new_path || !old_path.exists() {
         return Ok(());

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -189,18 +189,17 @@ impl KanbanContext {
     /// Persist a board-sort preference and reflect it in the held `app_config`.
     ///
     /// The shared entry point CLI (R4) and MCP (R5) both call to change the
-    /// default board sort. Persists to disk FIRST via [`crate::config::save`] on
-    /// a clone with the canonical strings set (via `Display`); only on save
-    /// success is the in-memory `app_config` mutated IN PLACE. On save failure it
-    /// returns the error and leaves `app_config` untouched. It deliberately does
-    /// NOT rebuild the context (no `open_deferred`), so the session id and the
+    /// default board sort. Persists to disk FIRST via
+    /// [`crate::config::save_board_sort`], which reads the on-disk config and
+    /// writes back only the two sort fields; only on save success is the
+    /// in-memory `app_config` mutated IN PLACE. On save failure it returns the
+    /// error and leaves `app_config` untouched. It deliberately does NOT
+    /// rebuild the context (no `open_deferred`), so the session id and the
     /// per-session undo/redo history survive the change.
     pub fn set_board_sort(&mut self, field: BoardSortField, order: SortOrder) -> KanbanResult<()> {
-        let mut next = self.app_config.clone();
-        next.board_sort_field = Some(field.to_string());
-        next.board_sort_order = Some(order.to_string());
-        crate::config::save(&next)?;
-        self.app_config = next;
+        crate::config::save_board_sort(&self.app_config, field, order)?;
+        self.app_config.board_sort_field = Some(field.to_string());
+        self.app_config.board_sort_order = Some(order.to_string());
         Ok(())
     }
 

--- a/crates/kanban-service/tests/set_board_sort.rs
+++ b/crates/kanban-service/tests/set_board_sort.rs
@@ -2,8 +2,8 @@
 //!
 //! `set_board_sort` is the shared entry point CLI (R4) and MCP (R5) call to
 //! persist a board-sort preference. It must:
-//!   1. persist to disk FIRST (via `kanban_service::config::save`) and only
-//!      mutate the held `app_config` in place on save success, and
+//!   1. persist to disk FIRST (via `kanban_service::config::save_board_sort`)
+//!      and only mutate the held `app_config` in place on save success, and
 //!   2. NOT rebuild the context (no `open_deferred`), so the session_id and
 //!      per-session undo history survive the change.
 
@@ -113,5 +113,61 @@ async fn test_set_board_sort_save_failure_leaves_config_unchanged() {
         ctx.app_config().board_sort_order,
         order_before,
         "app_config order unchanged after failed save"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_board_sort_does_not_persist_session_injected_storage_keys() {
+    let dir = tempdir().unwrap();
+    let store_path = dir.path().join("board.json");
+    let config_path = dir.path().join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        "default_card_prefix = \"proj\"\nstorage_backend = \"json\"\nstorage_location = \"/home/user/boards.json\"\n",
+    )
+    .unwrap();
+
+    let config = AppConfig {
+        configuration_location: Some(config_path.to_string_lossy().into_owned()),
+        storage_backend: Some("sqlite".into()),
+        storage_location: Some(dir.path().join("scratch.json").to_string_lossy().into_owned()),
+        ..Default::default()
+    };
+    let mut ctx = KanbanContext::open(make_json_backend(&store_path), config)
+        .await
+        .unwrap();
+
+    ctx.set_board_sort(BoardSortField::Name, SortOrder::Descending)
+        .expect("set_board_sort persists successfully");
+
+    let persisted = kanban_service::config::load_from(&config_path);
+    assert_eq!(
+        persisted.storage_location.as_deref(),
+        Some("/home/user/boards.json"),
+        "user's own on-disk storage_location survives verbatim"
+    );
+    assert_eq!(
+        persisted.storage_backend.as_deref(),
+        Some("json"),
+        "session-injected storage_backend never lands on disk"
+    );
+    assert_eq!(
+        persisted.default_card_prefix.as_deref(),
+        Some("proj"),
+        "unrelated on-disk value is not wiped by the partial write"
+    );
+    assert_eq!(persisted.board_sort_field.as_deref(), Some("name"));
+    assert_eq!(persisted.board_sort_order.as_deref(), Some("descending"));
+
+    assert_eq!(
+        ctx.app_config().storage_backend.as_deref(),
+        Some("sqlite"),
+        "session storage_backend is untouched"
+    );
+    assert_eq!(
+        ctx.app_config().storage_location.as_deref(),
+        Some(dir.path().join("scratch.json").to_string_lossy().as_ref()),
+        "session storage_location is untouched"
     );
 }

--- a/crates/kanban-service/tests/set_board_sort.rs
+++ b/crates/kanban-service/tests/set_board_sort.rs
@@ -131,7 +131,12 @@ async fn test_set_board_sort_does_not_persist_session_injected_storage_keys() {
     let config = AppConfig {
         configuration_location: Some(config_path.to_string_lossy().into_owned()),
         storage_backend: Some("sqlite".into()),
-        storage_location: Some(dir.path().join("scratch.json").to_string_lossy().into_owned()),
+        storage_location: Some(
+            dir.path()
+                .join("scratch.json")
+                .to_string_lossy()
+                .into_owned(),
+        ),
         ..Default::default()
     };
     let mut ctx = KanbanContext::open(make_json_backend(&store_path), config)

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -401,18 +401,19 @@ impl App {
     }
 
     /// Persist the LIVE board-list sort field/order to AppConfig via
-    /// `kanban_service::config::save`, mirroring how the card toggle persists its
-    /// sort (there via `SetTaskSort` onto the board; here onto the global config,
-    /// since the projects-panel sort is a global UI preference, not per-board).
-    /// Callers must only invoke this for the live context — the archived sort is
-    /// session-only and never persisted.
+    /// `kanban_service::config::save_board_sort`, which writes only the two
+    /// sort keys to the on-disk config, mirroring how the card toggle persists
+    /// its sort (there via `SetTaskSort` onto the board; here onto the global
+    /// config, since the projects-panel sort is a global UI preference, not
+    /// per-board). Callers must only invoke this for the live context — the
+    /// archived sort is session-only and never persisted.
     fn persist_board_sort(&mut self) {
         let (field, order) = self.controller.board_sort(false);
         let mut config = self.app_config.clone();
         config.board_sort_field = Some(field.to_string());
         config.board_sort_order = Some(order.to_string());
         self.set_app_config(config);
-        if let Err(e) = kanban_service::config::save(&self.app_config) {
+        if let Err(e) = kanban_service::config::save_board_sort(&self.app_config, field, order) {
             tracing::error!("Failed to persist board sort: {}", e);
             self.set_error(format!("Failed to persist board sort: {}", e));
         }

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -2191,4 +2191,68 @@ mod tests {
             "both archived boards remain archived (nothing restored)"
         );
     }
+
+    fn app_with_injected_storage(
+        storage_backend: Option<&str>,
+        storage_location: &str,
+    ) -> (App, tempfile::TempDir, std::path::PathBuf) {
+        let mut app = App::test_default();
+        let cfg_dir = tempfile::tempdir().unwrap();
+        let cfg_path = cfg_dir.path().join("config.toml");
+        app.app_config.configuration_location = Some(cfg_path.display().to_string());
+        app.app_config.storage_location = Some(storage_location.to_string());
+        app.app_config.storage_backend = storage_backend.map(|s| s.to_string());
+        (app, cfg_dir, cfg_path)
+    }
+
+    #[test]
+    fn test_sort_change_under_cli_file_override_does_not_persist_the_override() {
+        let cfg_dir = tempfile::tempdir().unwrap();
+        let injected = cfg_dir.path().join("injected.json");
+        let (mut app, _cfg_dir_guard, cfg_path) =
+            app_with_injected_storage(None, injected.to_str().unwrap());
+
+        app.apply_board_sort(kanban_domain::BoardSortField::Name, SortOrder::Ascending);
+
+        let persisted = kanban_service::config::load_from(&cfg_path);
+        assert_eq!(
+            persisted.board_sort_field.as_deref(),
+            Some("name"),
+            "sort write actually happened"
+        );
+        assert_eq!(
+            persisted.board_sort_order.as_deref(),
+            Some("ascending"),
+            "sort write actually happened"
+        );
+        assert!(
+            persisted.storage_location.is_none(),
+            "session-injected storage_location must not reach disk"
+        );
+        assert!(
+            persisted.storage_backend.is_none(),
+            "session-injected storage_backend must not reach disk"
+        );
+        assert!(
+            app.app_config.storage_location.is_some(),
+            "session keeps talking to its launch target"
+        );
+    }
+
+    #[test]
+    fn test_sort_change_under_remote_url_locator_does_not_persist_the_locator() {
+        let (mut app, _cfg_dir_guard, cfg_path) =
+            app_with_injected_storage(Some("http"), "http://127.0.0.1:9999");
+
+        app.apply_board_sort(kanban_domain::BoardSortField::Name, SortOrder::Ascending);
+
+        let persisted = kanban_service::config::load_from(&cfg_path);
+        assert_eq!(persisted.board_sort_field.as_deref(), Some("name"));
+        assert_eq!(persisted.board_sort_order.as_deref(), Some("ascending"));
+        assert!(
+            persisted.storage_location.is_none(),
+            "a remote locator pointed at by this session must not become the persisted default"
+        );
+        assert!(persisted.storage_backend.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

A board-sort keystroke in the TUI, or `board set-sort` on the CLI/MCP, wrote the whole session `AppConfig` to disk. If the session had a launch-injected storage location (a CLI file argument, a remote `http://` locator, or a `sync_backend_with_file` backend correction), that value silently became the persisted default in the user's config file. Settings was meant to be the only flow that changes persisted storage keys; this closed the other two paths that were leaking them.

- Adds `kanban_service::config::save_board_sort`, a read-modify-write helper: it loads the on-disk config at the effective configuration location, sets only `board_sort_field`/`board_sort_order`, and writes it back. It does not seed any other field from the caller's in-memory config.
- Routes `KanbanContext::set_board_sort` (crates/kanban-service/src/context/boards.rs) and the TUI's `persist_board_sort` (crates/kanban-tui/src/handlers/board_handlers.rs) through the new helper instead of the whole-config `config::save`.
- Updates the doc comments that named `config::save` as the sort-persist mechanism (boards.rs, kanban-cli/src/context.rs, board_handlers.rs, the set_board_sort.rs test module doc) to name `config::save_board_sort`.
- The settings flow (crates/kanban-tui/src/handlers/settings_handlers.rs) is untouched: it remains the only place that can change persisted storage keys.

## Tests

- New: `test_set_board_sort_does_not_persist_session_injected_storage_keys` (kanban-service) proves the user's on-disk `storage_location`/`storage_backend`/an unrelated key all survive a sort save untouched, while the sort fields are written.
- New: `test_sort_change_under_cli_file_override_does_not_persist_the_override` and `test_sort_change_under_remote_url_locator_does_not_persist_the_locator` (kanban-tui) cover the same property through the TUI's `persist_board_sort` path.
- All three were confirmed failing against the prior implementation, and confirmed to fail again when the fix was reverted locally (mutation check), before being restored.
- Existing sort-persistence and settings-storage-lock regression tests are unmodified and green.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` (287 test results, 0 failed)
