### PR TITLE
KAN-1571 feat(backend,service): remote writes divert before local prework

### DIFF
--- a/.changeset/kan-1571-remote-writes-divert-arms.md
+++ b/.changeset/kan-1571-remote-writes-divert-arms.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+backend,service: RemoteWrites trait returns the server-derived Invalidation, and the nine v1 mutators divert to it when a backend opts in

--- a/crates/kanban-backend/src/remote_writes.rs
+++ b/crates/kanban-backend/src/remote_writes.rs
@@ -1,25 +1,45 @@
 use kanban_domain::{
-    Board, BoardUpdate, Card, CardUpdate, Column, ColumnUpdate, KanbanResult, NewBoard, NewCard,
-    NewColumn,
+    Board, BoardUpdate, Card, CardUpdate, Column, ColumnUpdate, Invalidation, KanbanResult,
+    NewBoard, NewCard, NewColumn,
 };
 use uuid::Uuid;
 
 /// Optional backend capability: delegate the nine core CRUD mutations
 /// directly to a remote authority (a `kanban-server` instance) instead of
-/// `KanbanContext`'s local command-execute-then-log path. `HttpBackend`
-/// (KAN-697) is the only real implementor; local backends (JSON/SQLite/
-/// InMemory) never override `KanbanBackend::remote_writes()`, so this trait
-/// has exactly one live implementation.
+/// `KanbanContext`'s local command-execute-then-log path. When
+/// `KanbanBackend::remote_writes()` returns `Some`, `KanbanContext`'s nine
+/// v1 mutators divert to these methods before any local prework (id
+/// minting, FK checks, cascade building) runs, and pass the returned
+/// `Invalidation` straight through to the caller as the remote authority's
+/// own answer. Local backends (JSON/SQLite/InMemory) never override
+/// `KanbanBackend::remote_writes()`, so today this trait has no production
+/// implementor.
 pub trait RemoteWrites: Send + Sync {
-    fn create_board(&self, id: Option<Uuid>, spec: &NewBoard) -> KanbanResult<Board>;
-    fn update_board(&self, id: Uuid, updates: &BoardUpdate) -> KanbanResult<Board>;
-    fn delete_board(&self, id: Uuid) -> KanbanResult<()>;
+    fn create_board(
+        &self,
+        id: Option<Uuid>,
+        spec: &NewBoard,
+    ) -> KanbanResult<(Board, Invalidation)>;
+    fn update_board(
+        &self,
+        id: Uuid,
+        updates: &BoardUpdate,
+    ) -> KanbanResult<(Board, Invalidation)>;
+    fn delete_board(&self, id: Uuid) -> KanbanResult<Invalidation>;
 
-    fn create_column(&self, board_id: Uuid, spec: &NewColumn) -> KanbanResult<Column>;
-    fn update_column(&self, id: Uuid, updates: &ColumnUpdate) -> KanbanResult<Column>;
-    fn delete_column(&self, id: Uuid) -> KanbanResult<()>;
+    fn create_column(
+        &self,
+        board_id: Uuid,
+        spec: &NewColumn,
+    ) -> KanbanResult<(Column, Invalidation)>;
+    fn update_column(
+        &self,
+        id: Uuid,
+        updates: &ColumnUpdate,
+    ) -> KanbanResult<(Column, Invalidation)>;
+    fn delete_column(&self, id: Uuid) -> KanbanResult<Invalidation>;
 
-    fn create_card(&self, id: Option<Uuid>, spec: &NewCard) -> KanbanResult<Card>;
-    fn update_card(&self, id: Uuid, updates: &CardUpdate) -> KanbanResult<Card>;
-    fn delete_card(&self, id: Uuid) -> KanbanResult<()>;
+    fn create_card(&self, id: Option<Uuid>, spec: &NewCard) -> KanbanResult<(Card, Invalidation)>;
+    fn update_card(&self, id: Uuid, updates: &CardUpdate) -> KanbanResult<(Card, Invalidation)>;
+    fn delete_card(&self, id: Uuid) -> KanbanResult<Invalidation>;
 }

--- a/crates/kanban-backend/src/remote_writes.rs
+++ b/crates/kanban-backend/src/remote_writes.rs
@@ -20,11 +20,7 @@ pub trait RemoteWrites: Send + Sync {
         id: Option<Uuid>,
         spec: &NewBoard,
     ) -> KanbanResult<(Board, Invalidation)>;
-    fn update_board(
-        &self,
-        id: Uuid,
-        updates: &BoardUpdate,
-    ) -> KanbanResult<(Board, Invalidation)>;
+    fn update_board(&self, id: Uuid, updates: &BoardUpdate) -> KanbanResult<(Board, Invalidation)>;
     fn delete_board(&self, id: Uuid) -> KanbanResult<Invalidation>;
 
     fn create_column(

--- a/crates/kanban-service/src/backend_test_support.rs
+++ b/crates/kanban-service/src/backend_test_support.rs
@@ -4,6 +4,7 @@ use kanban_domain::{
     Board, BoardUpdate, Card, CardUpdate, Column, ColumnUpdate, CommandBatch, CommandStore,
     DataStore, Invalidation, KanbanResult, NewBoard, NewCard, NewColumn,
 };
+use std::sync::Arc;
 use uuid::Uuid;
 
 pub struct MockRemoteWritesImpl;
@@ -50,11 +51,7 @@ impl RemoteWrites for MockRemoteWritesImpl {
     ) -> KanbanResult<(Card, Invalidation)> {
         unimplemented!("test should not call this")
     }
-    fn update_card(
-        &self,
-        _id: Uuid,
-        _updates: &CardUpdate,
-    ) -> KanbanResult<(Card, Invalidation)> {
+    fn update_card(&self, _id: Uuid, _updates: &CardUpdate) -> KanbanResult<(Card, Invalidation)> {
         unimplemented!("test should not call this")
     }
     fn delete_card(&self, _id: Uuid) -> KanbanResult<Invalidation> {
@@ -64,14 +61,21 @@ impl RemoteWrites for MockRemoteWritesImpl {
 
 pub struct MockBackend {
     inner: InMemoryStore,
-    mock: MockRemoteWritesImpl,
+    mock: Arc<dyn RemoteWrites>,
 }
 
 impl MockBackend {
     pub fn new() -> Self {
         Self {
             inner: InMemoryStore::new(),
-            mock: MockRemoteWritesImpl,
+            mock: Arc::new(MockRemoteWritesImpl),
+        }
+    }
+
+    pub fn with_remote_writes(mock: Arc<dyn RemoteWrites>) -> Self {
+        Self {
+            inner: InMemoryStore::new(),
+            mock,
         }
     }
 }
@@ -238,7 +242,7 @@ impl KanbanBackend for MockBackend {
     }
 
     fn remote_writes(&self) -> Option<&dyn RemoteWrites> {
-        Some(&self.mock)
+        Some(self.mock.as_ref())
     }
 
     fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {

--- a/crates/kanban-service/src/backend_test_support.rs
+++ b/crates/kanban-service/src/backend_test_support.rs
@@ -2,38 +2,62 @@ use kanban_backend::{KanbanBackend, RemoteWrites, TransactionFn};
 use kanban_backend_memory::InMemoryStore;
 use kanban_domain::{
     Board, BoardUpdate, Card, CardUpdate, Column, ColumnUpdate, CommandBatch, CommandStore,
-    DataStore, KanbanResult, NewBoard, NewCard, NewColumn,
+    DataStore, Invalidation, KanbanResult, NewBoard, NewCard, NewColumn,
 };
 use uuid::Uuid;
 
 pub struct MockRemoteWritesImpl;
 
 impl RemoteWrites for MockRemoteWritesImpl {
-    fn create_board(&self, _id: Option<Uuid>, _spec: &NewBoard) -> KanbanResult<Board> {
+    fn create_board(
+        &self,
+        _id: Option<Uuid>,
+        _spec: &NewBoard,
+    ) -> KanbanResult<(Board, Invalidation)> {
         unimplemented!("test should not call this")
     }
-    fn update_board(&self, _id: Uuid, _updates: &BoardUpdate) -> KanbanResult<Board> {
+    fn update_board(
+        &self,
+        _id: Uuid,
+        _updates: &BoardUpdate,
+    ) -> KanbanResult<(Board, Invalidation)> {
         unimplemented!("test should not call this")
     }
-    fn delete_board(&self, _id: Uuid) -> KanbanResult<()> {
+    fn delete_board(&self, _id: Uuid) -> KanbanResult<Invalidation> {
         unimplemented!("test should not call this")
     }
-    fn create_column(&self, _board_id: Uuid, _spec: &NewColumn) -> KanbanResult<Column> {
+    fn create_column(
+        &self,
+        _board_id: Uuid,
+        _spec: &NewColumn,
+    ) -> KanbanResult<(Column, Invalidation)> {
         unimplemented!("test should not call this")
     }
-    fn update_column(&self, _id: Uuid, _updates: &ColumnUpdate) -> KanbanResult<Column> {
+    fn update_column(
+        &self,
+        _id: Uuid,
+        _updates: &ColumnUpdate,
+    ) -> KanbanResult<(Column, Invalidation)> {
         unimplemented!("test should not call this")
     }
-    fn delete_column(&self, _id: Uuid) -> KanbanResult<()> {
+    fn delete_column(&self, _id: Uuid) -> KanbanResult<Invalidation> {
         unimplemented!("test should not call this")
     }
-    fn create_card(&self, _id: Option<Uuid>, _spec: &NewCard) -> KanbanResult<Card> {
+    fn create_card(
+        &self,
+        _id: Option<Uuid>,
+        _spec: &NewCard,
+    ) -> KanbanResult<(Card, Invalidation)> {
         unimplemented!("test should not call this")
     }
-    fn update_card(&self, _id: Uuid, _updates: &CardUpdate) -> KanbanResult<Card> {
+    fn update_card(
+        &self,
+        _id: Uuid,
+        _updates: &CardUpdate,
+    ) -> KanbanResult<(Card, Invalidation)> {
         unimplemented!("test should not call this")
     }
-    fn delete_card(&self, _id: Uuid) -> KanbanResult<()> {
+    fn delete_card(&self, _id: Uuid) -> KanbanResult<Invalidation> {
         unimplemented!("test should not call this")
     }
 }

--- a/crates/kanban-service/src/context/boards.rs
+++ b/crates/kanban-service/src/context/boards.rs
@@ -25,6 +25,9 @@ impl KanbanContext {
         id: Option<Uuid>,
         spec: NewBoard,
     ) -> KanbanResult<(Board, Invalidation)> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.create_board(id, &spec);
+        }
         let id = id.unwrap_or_else(Uuid::new_v4);
         if self.backend.get_board(id)?.is_some() {
             return Err(KanbanError::already_exists("Board", id));
@@ -212,6 +215,9 @@ impl KanbanContext {
         id: Uuid,
         updates: BoardUpdate,
     ) -> KanbanResult<(Board, Invalidation)> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.update_board(id, &updates);
+        }
         use kanban_domain::commands::UpdateBoard;
         let cmd = Command::Board(BoardCommand::Update(UpdateBoard {
             board_id: id,
@@ -225,6 +231,9 @@ impl KanbanContext {
     }
 
     pub fn delete_board_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.delete_board(id);
+        }
         let commands = crate::cascade::delete_board(self.backend.as_data_store(), id)?;
         self.execute(commands)
     }

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -94,6 +94,9 @@ impl KanbanContext {
         client_id: Option<Uuid>,
         spec: NewCard,
     ) -> KanbanResult<(Card, Invalidation)> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.create_card(client_id, &spec);
+        }
         // FK: column must exist; derive the owning board from it.
         let column = self.require_column(spec.column_id)?;
         let board_id = column.board_id;
@@ -362,6 +365,9 @@ impl KanbanContext {
         id: Uuid,
         updates: CardUpdate,
     ) -> KanbanResult<(Card, Invalidation)> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.update_card(id, &updates);
+        }
         let (_count, invalidation) = self.update_cards_impl(vec![(id, updates)])?;
         let card = self
             .get_card_impl(id)?
@@ -469,6 +475,9 @@ impl KanbanContext {
     }
 
     pub fn delete_card_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.delete_card(id);
+        }
         use kanban_domain::commands::DeleteCard;
         let cmd = Command::Card(CardCommand::Delete(DeleteCard { card_id: id }));
         self.execute(vec![cmd])

--- a/crates/kanban-service/src/context/columns.rs
+++ b/crates/kanban-service/src/context/columns.rs
@@ -21,6 +21,9 @@ impl KanbanContext {
         id: Option<Uuid>,
         spec: NewColumn,
     ) -> KanbanResult<(Column, Invalidation)> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.create_column(spec.board_id, &spec);
+        }
         self.require_board(spec.board_id)?;
         let id = id.unwrap_or_else(Uuid::new_v4);
         if self.backend.get_column(id)?.is_some() {
@@ -136,6 +139,9 @@ impl KanbanContext {
         id: Uuid,
         updates: ColumnUpdate,
     ) -> KanbanResult<(Column, Invalidation)> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.update_column(id, &updates);
+        }
         use kanban_domain::commands::UpdateColumn;
         let cmd = Command::Column(ColumnCommand::Update(UpdateColumn {
             column_id: id,
@@ -149,6 +155,9 @@ impl KanbanContext {
     }
 
     pub fn delete_column_impl(&mut self, id: Uuid) -> KanbanResult<Invalidation> {
+        if let Some(rw) = self.backend.remote_writes() {
+            return rw.delete_column(id);
+        }
         use kanban_domain::commands::DeleteColumn;
         let cmd = Command::Column(ColumnCommand::Delete(DeleteColumn { column_id: id }));
         self.execute(vec![cmd])

--- a/crates/kanban-service/src/context/mod.rs
+++ b/crates/kanban-service/src/context/mod.rs
@@ -23,6 +23,8 @@ mod graph;
 pub use graph::BoardRelations;
 mod mutation_ops;
 mod persistence;
+#[cfg(test)]
+mod remote_writes_divert;
 mod sprints;
 mod sync;
 mod undo;

--- a/crates/kanban-service/src/context/remote_writes_divert.rs
+++ b/crates/kanban-service/src/context/remote_writes_divert.rs
@@ -5,8 +5,8 @@ use crate::backend_test_support::MockBackend;
 use kanban_backend::RemoteWrites;
 use kanban_core::AppConfig;
 use kanban_domain::{
-    Board, BoardUpdate, Card, Column, ColumnUpdate, DataStore, EntityIds, Invalidation,
-    KanbanResult, NewBoard, NewCard, NewColumn, UndoOperations,
+    Board, BoardUpdate, Card, Column, ColumnUpdate, EntityIds, Invalidation, KanbanResult,
+    NewBoard, NewCard, NewColumn, UndoOperations,
 };
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;

--- a/crates/kanban-service/src/context/remote_writes_divert.rs
+++ b/crates/kanban-service/src/context/remote_writes_divert.rs
@@ -1,0 +1,324 @@
+#![cfg(test)]
+
+use super::KanbanContext;
+use crate::backend_test_support::MockBackend;
+use kanban_backend::RemoteWrites;
+use kanban_core::AppConfig;
+use kanban_domain::{
+    Board, BoardUpdate, Card, Column, ColumnUpdate, DataStore, EntityIds, Invalidation,
+    KanbanResult, NewBoard, NewCard, NewColumn, UndoOperations,
+};
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+const SENTINEL: Uuid = Uuid::from_u128(0x1571);
+
+fn canned_inv() -> Invalidation {
+    Invalidation::Entities(EntityIds::boards([SENTINEL]))
+}
+
+struct RecordingRemoteWrites {
+    calls: Mutex<Vec<String>>,
+    canned: Invalidation,
+}
+
+impl RecordingRemoteWrites {
+    fn new(canned: Invalidation) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            canned,
+        }
+    }
+
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().unwrap().clone()
+    }
+
+    fn record(&self, call: String) {
+        self.calls.lock().unwrap().push(call);
+    }
+}
+
+impl RemoteWrites for RecordingRemoteWrites {
+    fn create_board(
+        &self,
+        id: Option<Uuid>,
+        _spec: &NewBoard,
+    ) -> KanbanResult<(Board, Invalidation)> {
+        self.record(format!("create_board:{id:?}"));
+        Ok((Board::new("remote", None::<String>), self.canned.clone()))
+    }
+
+    fn update_board(
+        &self,
+        id: Uuid,
+        _updates: &BoardUpdate,
+    ) -> KanbanResult<(Board, Invalidation)> {
+        self.record(format!("update_board:{id}"));
+        let mut board = Board::new("remote", None::<String>);
+        board.id = id;
+        Ok((board, self.canned.clone()))
+    }
+
+    fn delete_board(&self, id: Uuid) -> KanbanResult<Invalidation> {
+        self.record(format!("delete_board:{id}"));
+        Ok(self.canned.clone())
+    }
+
+    fn create_column(
+        &self,
+        board_id: Uuid,
+        _spec: &NewColumn,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        self.record(format!("create_column:{board_id}"));
+        Ok((Column::new(board_id, "remote", 0), self.canned.clone()))
+    }
+
+    fn update_column(
+        &self,
+        id: Uuid,
+        _updates: &ColumnUpdate,
+    ) -> KanbanResult<(Column, Invalidation)> {
+        self.record(format!("update_column:{id}"));
+        let mut column = Column::new(Uuid::nil(), "remote", 0);
+        column.id = id;
+        Ok((column, self.canned.clone()))
+    }
+
+    fn delete_column(&self, id: Uuid) -> KanbanResult<Invalidation> {
+        self.record(format!("delete_column:{id}"));
+        Ok(self.canned.clone())
+    }
+
+    fn create_card(&self, id: Option<Uuid>, _spec: &NewCard) -> KanbanResult<(Card, Invalidation)> {
+        self.record(format!("create_card:{id:?}"));
+        Ok((
+            Card::new(Uuid::nil(), Uuid::nil(), "remote", 0),
+            self.canned.clone(),
+        ))
+    }
+
+    fn update_card(
+        &self,
+        id: Uuid,
+        _updates: &kanban_domain::CardUpdate,
+    ) -> KanbanResult<(Card, Invalidation)> {
+        self.record(format!("update_card:{id}"));
+        let mut card = Card::new(Uuid::nil(), Uuid::nil(), "remote", 0);
+        card.id = id;
+        Ok((card, self.canned.clone()))
+    }
+
+    fn delete_card(&self, id: Uuid) -> KanbanResult<Invalidation> {
+        self.record(format!("delete_card:{id}"));
+        Ok(self.canned.clone())
+    }
+}
+
+async fn open_ctx(rw: Arc<RecordingRemoteWrites>) -> KanbanContext {
+    let backend = Arc::new(MockBackend::with_remote_writes(rw));
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+fn new_board() -> NewBoard {
+    NewBoard {
+        name: "board".into(),
+        description: None,
+        sprint_prefix: None,
+        card_prefix: None,
+        task_sort_field: None,
+        task_sort_order: None,
+        sprint_duration_days: None,
+        task_list_view: None,
+    }
+}
+
+fn new_column(board_id: Uuid) -> NewColumn {
+    NewColumn {
+        board_id,
+        name: "column".into(),
+        wip_limit: None,
+        default_status: None,
+    }
+}
+
+fn new_card(column_id: Uuid) -> NewCard {
+    NewCard {
+        column_id,
+        title: "card".into(),
+        description: None,
+        priority: kanban_domain::CardPriority::Medium,
+        due_date: None,
+        points: None,
+        sprint_id: None,
+    }
+}
+
+#[tokio::test]
+async fn test_create_board_from_spec_with_remote_writes_diverts_before_local_prework() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+
+    let (_, inv) = ctx.create_board_from_spec(None, new_board()).unwrap();
+
+    assert_eq!(rw.calls(), vec!["create_board:None".to_string()]);
+    assert_eq!(inv, canned_inv());
+    assert!(ctx.data_store().list_boards().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_update_board_with_remote_writes_diverts_and_returns_the_server_invalidation() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+    let id = Uuid::new_v4();
+
+    let (board, inv) = ctx.update_board_impl(id, BoardUpdate::default()).unwrap();
+
+    assert_eq!(rw.calls(), vec![format!("update_board:{id}")]);
+    assert_eq!(board.id, id);
+    assert_eq!(inv, canned_inv());
+}
+
+#[tokio::test]
+async fn test_delete_board_with_remote_writes_diverts_without_building_a_local_cascade() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+
+    let board = Board::new("local", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "col", 0);
+    let column_id = column.id;
+    let card = Card::new(board_id, column_id, "card", 0);
+    let card_id = card.id;
+    ctx.data_store().upsert_board(board).unwrap();
+    ctx.data_store().upsert_column(column).unwrap();
+    ctx.data_store().upsert_card(card).unwrap();
+
+    let inv = ctx.delete_board_impl(board_id).unwrap();
+
+    assert_eq!(rw.calls(), vec![format!("delete_board:{board_id}")]);
+    assert_eq!(inv, canned_inv());
+    assert!(ctx.data_store().get_board(board_id).unwrap().is_some());
+    assert!(ctx.data_store().get_column(column_id).unwrap().is_some());
+    assert!(ctx.data_store().get_card(card_id).unwrap().is_some());
+}
+
+#[tokio::test]
+async fn test_create_column_from_spec_with_remote_writes_diverts() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+    let board_id = Uuid::new_v4();
+
+    let (_, inv) = ctx
+        .create_column_from_spec(None, new_column(board_id))
+        .unwrap();
+
+    assert_eq!(rw.calls(), vec![format!("create_column:{board_id}")]);
+    assert_eq!(inv, canned_inv());
+    assert!(ctx
+        .data_store()
+        .list_columns_by_board(board_id)
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_update_column_with_remote_writes_diverts() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+    let id = Uuid::new_v4();
+
+    let (column, inv) = ctx.update_column_impl(id, ColumnUpdate::default()).unwrap();
+
+    assert_eq!(rw.calls(), vec![format!("update_column:{id}")]);
+    assert_eq!(column.id, id);
+    assert_eq!(inv, canned_inv());
+}
+
+#[tokio::test]
+async fn test_delete_column_with_remote_writes_diverts() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+
+    let board_id = Uuid::new_v4();
+    let column = Column::new(board_id, "col", 0);
+    let column_id = column.id;
+    ctx.data_store().upsert_column(column).unwrap();
+
+    let inv = ctx.delete_column_impl(column_id).unwrap();
+
+    assert_eq!(rw.calls(), vec![format!("delete_column:{column_id}")]);
+    assert_eq!(inv, canned_inv());
+    assert!(ctx.data_store().get_column(column_id).unwrap().is_some());
+}
+
+#[tokio::test]
+async fn test_create_card_from_spec_with_remote_writes_diverts_without_number_allocation() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+
+    let board = Board::new("board", None::<String>);
+    let board_id = board.id;
+    let column = Column::new(board_id, "col", 0);
+    let column_id = column.id;
+    ctx.data_store().upsert_board(board.clone()).unwrap();
+    ctx.data_store().upsert_column(column).unwrap();
+
+    let (_, inv) = ctx
+        .create_card_from_spec(None, new_card(column_id))
+        .unwrap();
+
+    assert_eq!(rw.calls(), vec!["create_card:None".to_string()]);
+    assert_eq!(inv, canned_inv());
+    assert!(ctx.data_store().list_all_cards().unwrap().is_empty());
+    assert_eq!(ctx.data_store().get_board(board_id).unwrap(), Some(board));
+}
+
+#[tokio::test]
+async fn test_update_card_with_remote_writes_diverts_and_returns_the_server_invalidation() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+    let id = Uuid::new_v4();
+
+    let (card, inv) = ctx
+        .update_card_impl(id, kanban_domain::CardUpdate::default())
+        .unwrap();
+
+    assert_eq!(rw.calls(), vec![format!("update_card:{id}")]);
+    assert_eq!(card.id, id);
+    assert_eq!(inv, canned_inv());
+    assert!(!UndoOperations::can_undo(&ctx));
+}
+
+#[tokio::test]
+async fn test_delete_card_with_remote_writes_diverts() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+
+    let board_id = Uuid::new_v4();
+    let column_id = Uuid::new_v4();
+    let card = Card::new(board_id, column_id, "card", 0);
+    let card_id = card.id;
+    ctx.data_store().upsert_card(card).unwrap();
+
+    let inv = ctx.delete_card_impl(card_id).unwrap();
+
+    assert_eq!(rw.calls(), vec![format!("delete_card:{card_id}")]);
+    assert_eq!(inv, canned_inv());
+    assert!(ctx.data_store().get_card(card_id).unwrap().is_some());
+}
+
+#[tokio::test]
+async fn test_create_column_with_explicit_position_still_hits_the_fence() {
+    let rw = Arc::new(RecordingRemoteWrites::new(canned_inv()));
+    let mut ctx = open_ctx(rw.clone()).await;
+    let board_id = Uuid::new_v4();
+
+    let result = ctx.create_column_impl(board_id, "c".into(), Some(0));
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().is_unsupported());
+    assert!(rw.calls().is_empty());
+}


### PR DESCRIPTION
## Summary

- Grow the nine `RemoteWrites` trait methods (`crates/kanban-backend/src/remote_writes.rs`) to return `KanbanResult<(T, Invalidation)>` for creates/updates and `KanbanResult<Invalidation>` for deletes, so a diverted mutation can hand back the remote authority's own invalidation instead of forcing the caller to re-derive one locally. Rewrite the trait doc to describe the divert behaviour instead of claiming `HttpBackend` implements it today (it does not).
- Add a divert arm as the first statement of each of the nine v1 mutators on `KanbanContext`: `create_board_from_spec`, `update_board_impl`, `delete_board_impl`, `create_column_from_spec`, `update_column_impl`, `delete_column_impl`, `create_card_from_spec`, `update_card_impl`, `delete_card_impl`. When `KanbanBackend::remote_writes()` returns `Some`, the mutator bypasses local id minting, FK checks and cascade building entirely and returns the remote authority's `Invalidation` untouched.
- No arm on `create_column_impl`'s explicit-position branch, `update_cards_impl`, or any other mutator (archive/restore, move, sprint, graph, batch ops); those still hit the existing `execute_with_extra` fence.
- This is dead code in production today: no backend overrides `remote_writes()` yet. Proven with a new recording `RemoteWrites` test double over the existing `MockBackend` (`crates/kanban-service/src/backend_test_support.rs`, now parameterized behind `Arc<dyn RemoteWrites>` via `MockBackend::with_remote_writes`).
- Nine new tests in `crates/kanban-service/src/context/remote_writes_divert.rs`, one per mutator, plus a guard test confirming the explicit-position column-create branch still hits the fence. The `undo.rs` fence, its error message, the undo-stack push site, and its existing test are all untouched (`git diff origin/develop -- crates/kanban-service/src/context/undo.rs` is empty).

## Out of scope, reported for follow-up

- `create_or_replace_board`, `create_or_replace_column` and `create_or_replace_card` each read the local store to decide create-vs-replace before calling into the armed inherent fn. Over a remote backend that local read would see an empty or stale store, so the replace arm would become unreachable and every PUT would take the create arm. These are server-seam-only APIs and no production backend returns `Some` from `remote_writes()` yet, so this is not fixed here.
- `crates/kanban-backend-http/src/remote_writes/{mod,boards,cards,columns}.rs` already exist on develop as empty scaffolding from KAN-697 with no `impl RemoteWrites`. Not touched here; that's KAN-1573.

## Deviation from CLAUDE.md test-location convention

`kanban-service`'s test table says integration tests belong in `tests/`, but `backend_test_support` (which the recording mock and `MockBackend` live in) is a private `#[cfg(test)]` module, unreachable from `tests/`. The divert tests are therefore an inline `#[cfg(test)]` module at `crates/kanban-service/src/context/remote_writes_divert.rs`, following the same pattern as the existing fence pin test in `undo.rs`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` (all green)
- Mutation check: removed the divert arm from `update_card_impl`, confirmed `test_update_card_with_remote_writes_diverts_and_returns_the_server_invalidation` fails, restored the arm.
