### PR TITLE
KAN-1579 feat(backend-http): add the json mutation transport and outbound conversions

### DIFF
--- a/.changeset/kan-1579-mutation-transport-and-conversions.md
+++ b/.changeset/kan-1579-mutation-transport-and-conversions.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+backend-http: add the json mutation transport and outbound domain-to-request conversions

--- a/crates/kanban-backend-http/src/conversions_out/boards.rs
+++ b/crates/kanban-backend-http/src/conversions_out/boards.rs
@@ -1,13 +1,64 @@
 use kanban_api::{CreateBoardRequest, Patch, UpdateBoardRequest};
-use kanban_domain::{BoardUpdate, KanbanError, KanbanResult, NewBoard};
+use kanban_domain::{BoardUpdate, FieldUpdate, KanbanError, KanbanResult, NewBoard};
 use uuid::Uuid;
 
-pub(crate) fn create_board_request(_id: Option<Uuid>, _spec: &NewBoard) -> CreateBoardRequest {
-    unimplemented!()
+pub(crate) fn create_board_request(id: Option<Uuid>, spec: &NewBoard) -> CreateBoardRequest {
+    let NewBoard {
+        name,
+        description,
+        sprint_prefix,
+        card_prefix,
+        task_sort_field,
+        task_sort_order,
+        sprint_duration_days,
+        task_list_view,
+    } = spec;
+    CreateBoardRequest {
+        id,
+        name: name.clone(),
+        description: description.clone(),
+        sprint_prefix: sprint_prefix.clone(),
+        card_prefix: card_prefix.clone(),
+        task_sort_field: task_sort_field.map(Into::into),
+        task_sort_order: task_sort_order.map(Into::into),
+        sprint_duration_days: *sprint_duration_days,
+        task_list_view: task_list_view.map(Into::into),
+    }
 }
 
-pub(crate) fn update_board_request(_updates: &BoardUpdate) -> KanbanResult<UpdateBoardRequest> {
-    unimplemented!()
+pub(crate) fn update_board_request(updates: &BoardUpdate) -> KanbanResult<UpdateBoardRequest> {
+    let BoardUpdate {
+        name,
+        description,
+        sprint_prefix,
+        card_prefix,
+        task_sort_field,
+        task_sort_order,
+        sprint_duration_days,
+        task_list_view,
+        active_sprint_id,
+        position,
+    } = updates;
+    if !matches!(active_sprint_id, FieldUpdate::NoChange) {
+        return Err(KanbanError::unsupported(
+            "update_board.active_sprint_id over HTTP (server-managed field)",
+        ));
+    }
+    if position.is_some() {
+        return Err(KanbanError::unsupported(
+            "update_board.position over HTTP (server-managed field)",
+        ));
+    }
+    Ok(UpdateBoardRequest {
+        name: name.clone(),
+        description: Patch::from(description.clone()),
+        sprint_prefix: Patch::from(sprint_prefix.clone()),
+        card_prefix: Patch::from(card_prefix.clone()),
+        task_sort_field: task_sort_field.map(Into::into),
+        task_sort_order: task_sort_order.map(Into::into),
+        sprint_duration_days: Patch::from(sprint_duration_days.clone()),
+        task_list_view: task_list_view.map(Into::into),
+    })
 }
 
 #[cfg(test)]

--- a/crates/kanban-backend-http/src/conversions_out/boards.rs
+++ b/crates/kanban-backend-http/src/conversions_out/boards.rs
@@ -1,0 +1,114 @@
+use kanban_api::{CreateBoardRequest, Patch, UpdateBoardRequest};
+use kanban_domain::{BoardUpdate, KanbanError, KanbanResult, NewBoard};
+use uuid::Uuid;
+
+pub(crate) fn create_board_request(_id: Option<Uuid>, _spec: &NewBoard) -> CreateBoardRequest {
+    unimplemented!()
+}
+
+pub(crate) fn update_board_request(_updates: &BoardUpdate) -> KanbanResult<UpdateBoardRequest> {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_api::{SortFieldDto, SortOrderDto, TaskListViewDto};
+    use kanban_domain::{FieldUpdate, SortField, SortOrder, TaskListView};
+
+    #[test]
+    fn test_create_board_request_carries_the_client_id_and_every_new_board_field() {
+        let id = Uuid::new_v4();
+        let spec = NewBoard {
+            name: "Roadmap".to_string(),
+            description: Some("desc".to_string()),
+            sprint_prefix: Some("SPR".to_string()),
+            card_prefix: Some("KAN".to_string()),
+            task_sort_field: Some(SortField::Priority),
+            task_sort_order: Some(SortOrder::Descending),
+            sprint_duration_days: Some(21),
+            task_list_view: Some(TaskListView::GroupedByColumn),
+        };
+
+        let req = create_board_request(Some(id), &spec);
+
+        assert_eq!(req.id, Some(id));
+        assert_eq!(req.name, "Roadmap");
+        assert_eq!(req.description, Some("desc".to_string()));
+        assert_eq!(req.sprint_prefix, Some("SPR".to_string()));
+        assert_eq!(req.card_prefix, Some("KAN".to_string()));
+        assert_eq!(req.task_sort_field, Some(SortFieldDto::Priority));
+        assert_eq!(req.task_sort_order, Some(SortOrderDto::Descending));
+        assert_eq!(req.sprint_duration_days, Some(21));
+        assert_eq!(req.task_list_view, Some(TaskListViewDto::GroupedByColumn));
+    }
+
+    #[test]
+    fn test_update_board_request_bridges_every_field_update_to_its_patch() {
+        let updates = BoardUpdate {
+            name: Some("Renamed".to_string()),
+            description: FieldUpdate::Set("d".to_string()),
+            sprint_prefix: FieldUpdate::Clear,
+            card_prefix: FieldUpdate::NoChange,
+            task_sort_field: Some(SortField::Priority),
+            task_sort_order: Some(SortOrder::Ascending),
+            sprint_duration_days: FieldUpdate::Set(14),
+            task_list_view: Some(TaskListView::Flat),
+            active_sprint_id: FieldUpdate::NoChange,
+            position: None,
+        };
+
+        let req = update_board_request(&updates).unwrap();
+
+        assert_eq!(req.name, Some("Renamed".to_string()));
+        assert_eq!(req.description, Patch::Set("d".to_string()));
+        assert_eq!(req.sprint_prefix, Patch::Clear);
+        assert_eq!(req.card_prefix, Patch::NoChange);
+        assert_eq!(req.task_sort_field, Some(SortFieldDto::Priority));
+        assert_eq!(req.task_sort_order, Some(SortOrderDto::Ascending));
+        assert_eq!(req.sprint_duration_days, Patch::Set(14));
+        assert_eq!(req.task_list_view, Some(TaskListViewDto::Flat));
+    }
+
+    #[test]
+    fn test_update_board_request_with_active_sprint_id_set_returns_unsupported_not_silent_drop() {
+        let updates = BoardUpdate {
+            active_sprint_id: FieldUpdate::Set(Uuid::new_v4()),
+            ..Default::default()
+        };
+
+        let err = update_board_request(&updates).unwrap_err();
+
+        assert!(err.is_unsupported());
+        assert_eq!(
+            err.to_string(),
+            KanbanError::unsupported("update_board.active_sprint_id over HTTP (server-managed field)")
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn test_update_board_request_with_active_sprint_id_cleared_returns_unsupported_not_silent_drop(
+    ) {
+        let updates = BoardUpdate {
+            active_sprint_id: FieldUpdate::Clear,
+            ..Default::default()
+        };
+
+        let err = update_board_request(&updates).unwrap_err();
+
+        assert!(err.is_unsupported());
+    }
+
+    #[test]
+    fn test_update_board_request_with_position_set_returns_unsupported_not_silent_drop() {
+        let updates = BoardUpdate {
+            position: Some(3),
+            ..Default::default()
+        };
+
+        let err = update_board_request(&updates).unwrap_err();
+
+        assert!(err.is_unsupported());
+    }
+}

--- a/crates/kanban-backend-http/src/conversions_out/boards.rs
+++ b/crates/kanban-backend-http/src/conversions_out/boards.rs
@@ -133,14 +133,16 @@ mod tests {
         assert!(err.is_unsupported());
         assert_eq!(
             err.to_string(),
-            KanbanError::unsupported("update_board.active_sprint_id over HTTP (server-managed field)")
-                .to_string()
+            KanbanError::unsupported(
+                "update_board.active_sprint_id over HTTP (server-managed field)"
+            )
+            .to_string()
         );
     }
 
     #[test]
-    fn test_update_board_request_with_active_sprint_id_cleared_returns_unsupported_not_silent_drop(
-    ) {
+    fn test_update_board_request_with_active_sprint_id_cleared_returns_unsupported_not_silent_drop()
+    {
         let updates = BoardUpdate {
             active_sprint_id: FieldUpdate::Clear,
             ..Default::default()

--- a/crates/kanban-backend-http/src/conversions_out/cards.rs
+++ b/crates/kanban-backend-http/src/conversions_out/cards.rs
@@ -1,0 +1,69 @@
+use kanban_api::{CreateCardRequest, UpdateCardRequest};
+use kanban_domain::{CardUpdate, NewCard};
+use uuid::Uuid;
+
+pub(crate) fn create_card_request(_id: Option<Uuid>, _spec: &NewCard) -> (String, CreateCardRequest) {
+    unimplemented!()
+}
+
+pub(crate) fn update_card_request(_updates: &CardUpdate) -> UpdateCardRequest {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_api::{CardPriorityDto, CardStatusDto, Patch};
+    use kanban_domain::{CardPriority, CardStatus, FieldUpdate};
+
+    #[test]
+    fn test_create_card_request_puts_column_id_in_the_path_and_always_sends_the_priority() {
+        let column_id = Uuid::new_v4();
+        let id = Uuid::new_v4();
+        let spec = NewCard {
+            column_id,
+            title: "Task".to_string(),
+            description: None,
+            priority: CardPriority::High,
+            due_date: None,
+            points: None,
+            sprint_id: None,
+        };
+
+        let (path, body) = create_card_request(Some(id), &spec);
+
+        assert_eq!(path, format!("/v1/columns/{column_id}/cards"));
+        assert_eq!(body.id, Some(id));
+        assert_eq!(body.priority, Some(CardPriorityDto::High));
+        let value = serde_json::to_value(&body).unwrap();
+        assert!(value.get("column_id").is_none());
+    }
+
+    #[test]
+    fn test_update_card_request_bridges_all_four_patch_fields_and_copies_the_rest() {
+        let column_id = Uuid::new_v4();
+        let updates = CardUpdate {
+            title: Some("New".to_string()),
+            description: FieldUpdate::Set("d".to_string()),
+            priority: Some(CardPriority::Low),
+            status: Some(CardStatus::Done),
+            position: Some(2),
+            column_id: Some(column_id),
+            due_date: FieldUpdate::Clear,
+            points: FieldUpdate::Set(3),
+            sprint_id: FieldUpdate::NoChange,
+        };
+
+        let req = update_card_request(&updates);
+
+        assert_eq!(req.title, Some("New".to_string()));
+        assert_eq!(req.description, Patch::Set("d".to_string()));
+        assert_eq!(req.priority, Some(CardPriorityDto::Low));
+        assert_eq!(req.status, Some(CardStatusDto::Done));
+        assert_eq!(req.position, Some(2));
+        assert_eq!(req.column_id, Some(column_id));
+        assert_eq!(req.due_date, Patch::Clear);
+        assert_eq!(req.points, Patch::Set(3));
+        assert_eq!(req.sprint_id, Patch::NoChange);
+    }
+}

--- a/crates/kanban-backend-http/src/conversions_out/cards.rs
+++ b/crates/kanban-backend-http/src/conversions_out/cards.rs
@@ -2,10 +2,7 @@ use kanban_api::{CreateCardRequest, Patch, UpdateCardRequest};
 use kanban_domain::{CardUpdate, NewCard};
 use uuid::Uuid;
 
-pub(crate) fn create_card_request(
-    id: Option<Uuid>,
-    spec: &NewCard,
-) -> (String, CreateCardRequest) {
+pub(crate) fn create_card_request(id: Option<Uuid>, spec: &NewCard) -> (String, CreateCardRequest) {
     let NewCard {
         column_id,
         title,

--- a/crates/kanban-backend-http/src/conversions_out/cards.rs
+++ b/crates/kanban-backend-http/src/conversions_out/cards.rs
@@ -1,13 +1,56 @@
-use kanban_api::{CreateCardRequest, UpdateCardRequest};
+use kanban_api::{CreateCardRequest, Patch, UpdateCardRequest};
 use kanban_domain::{CardUpdate, NewCard};
 use uuid::Uuid;
 
-pub(crate) fn create_card_request(_id: Option<Uuid>, _spec: &NewCard) -> (String, CreateCardRequest) {
-    unimplemented!()
+pub(crate) fn create_card_request(
+    id: Option<Uuid>,
+    spec: &NewCard,
+) -> (String, CreateCardRequest) {
+    let NewCard {
+        column_id,
+        title,
+        description,
+        priority,
+        due_date,
+        points,
+        sprint_id,
+    } = spec;
+    let path = format!("/v1/columns/{column_id}/cards");
+    let body = CreateCardRequest {
+        id,
+        title: title.clone(),
+        description: description.clone(),
+        priority: Some((*priority).into()),
+        due_date: *due_date,
+        points: *points,
+        sprint_id: *sprint_id,
+    };
+    (path, body)
 }
 
-pub(crate) fn update_card_request(_updates: &CardUpdate) -> UpdateCardRequest {
-    unimplemented!()
+pub(crate) fn update_card_request(updates: &CardUpdate) -> UpdateCardRequest {
+    let CardUpdate {
+        title,
+        description,
+        priority,
+        status,
+        position,
+        column_id,
+        due_date,
+        points,
+        sprint_id,
+    } = updates;
+    UpdateCardRequest {
+        title: title.clone(),
+        priority: priority.map(Into::into),
+        status: status.map(Into::into),
+        position: *position,
+        column_id: *column_id,
+        description: Patch::from(description.clone()),
+        due_date: Patch::from(due_date.clone()),
+        points: Patch::from(points.clone()),
+        sprint_id: Patch::from(sprint_id.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-backend-http/src/conversions_out/columns.rs
+++ b/crates/kanban-backend-http/src/conversions_out/columns.rs
@@ -1,0 +1,81 @@
+use kanban_api::{CreateColumnRequest, UpdateColumnRequest};
+use kanban_domain::{ColumnUpdate, NewColumn};
+
+pub(crate) fn create_column_request(_spec: &NewColumn) -> (String, CreateColumnRequest) {
+    unimplemented!()
+}
+
+pub(crate) fn update_column_request(_updates: &ColumnUpdate) -> UpdateColumnRequest {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_api::{CardStatusDto, Patch};
+    use kanban_domain::{CardStatus, FieldUpdate};
+    use uuid::Uuid;
+
+    #[test]
+    fn test_create_column_request_puts_board_id_in_the_path_and_never_in_the_body() {
+        let board_id = Uuid::new_v4();
+        let spec = NewColumn {
+            board_id,
+            name: "Doing".to_string(),
+            wip_limit: Some(3),
+            default_status: Some(CardStatus::Done),
+        };
+
+        let (path, body) = create_column_request(&spec);
+
+        assert_eq!(path, format!("/v1/boards/{board_id}/columns"));
+        assert_eq!(body.id, None);
+        assert_eq!(body.wip_limit, Some(3));
+        assert_eq!(body.default_status, Some(CardStatusDto::Done));
+        let value = serde_json::to_value(&body).unwrap();
+        assert!(value.get("board_id").is_none());
+    }
+
+    #[test]
+    fn test_update_column_request_bridges_the_three_state_default_status() {
+        let no_change = ColumnUpdate {
+            default_status: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            update_column_request(&no_change).default_status,
+            Patch::NoChange
+        );
+
+        let clear = ColumnUpdate {
+            default_status: Some(None),
+            ..Default::default()
+        };
+        assert_eq!(update_column_request(&clear).default_status, Patch::Clear);
+
+        let set = ColumnUpdate {
+            default_status: Some(Some(CardStatus::Done)),
+            ..Default::default()
+        };
+        assert_eq!(
+            update_column_request(&set).default_status,
+            Patch::Set(CardStatusDto::Done)
+        );
+    }
+
+    #[test]
+    fn test_update_column_request_bridges_wip_limit_and_copies_name_and_position() {
+        let updates = ColumnUpdate {
+            name: Some("Done".to_string()),
+            position: Some(4),
+            wip_limit: FieldUpdate::Clear,
+            default_status: None,
+        };
+
+        let req = update_column_request(&updates);
+
+        assert_eq!(req.name, Some("Done".to_string()));
+        assert_eq!(req.position, Some(4));
+        assert_eq!(req.wip_limit, Patch::Clear);
+    }
+}

--- a/crates/kanban-backend-http/src/conversions_out/columns.rs
+++ b/crates/kanban-backend-http/src/conversions_out/columns.rs
@@ -1,12 +1,40 @@
-use kanban_api::{CreateColumnRequest, UpdateColumnRequest};
+use kanban_api::{CreateColumnRequest, Patch, UpdateColumnRequest};
 use kanban_domain::{ColumnUpdate, NewColumn};
 
-pub(crate) fn create_column_request(_spec: &NewColumn) -> (String, CreateColumnRequest) {
-    unimplemented!()
+pub(crate) fn create_column_request(spec: &NewColumn) -> (String, CreateColumnRequest) {
+    let NewColumn {
+        board_id,
+        name,
+        wip_limit,
+        default_status,
+    } = spec;
+    let path = format!("/v1/boards/{board_id}/columns");
+    let body = CreateColumnRequest {
+        id: None,
+        name: name.clone(),
+        wip_limit: *wip_limit,
+        default_status: default_status.map(Into::into),
+    };
+    (path, body)
 }
 
-pub(crate) fn update_column_request(_updates: &ColumnUpdate) -> UpdateColumnRequest {
-    unimplemented!()
+pub(crate) fn update_column_request(updates: &ColumnUpdate) -> UpdateColumnRequest {
+    let ColumnUpdate {
+        name,
+        position,
+        wip_limit,
+        default_status,
+    } = updates;
+    UpdateColumnRequest {
+        name: name.clone(),
+        position: *position,
+        wip_limit: Patch::from(wip_limit.clone()),
+        default_status: match default_status {
+            None => Patch::NoChange,
+            Some(None) => Patch::Clear,
+            Some(Some(status)) => Patch::Set((*status).into()),
+        },
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-backend-http/src/conversions_out/mod.rs
+++ b/crates/kanban-backend-http/src/conversions_out/mod.rs
@@ -1,6 +1,6 @@
 //! Outbound domain -> request-DTO conversions for the v1 mutation routes; no
 //! in-crate caller until the `RemoteWrites` impl lands.
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 mod boards;
 mod cards;

--- a/crates/kanban-backend-http/src/conversions_out/mod.rs
+++ b/crates/kanban-backend-http/src/conversions_out/mod.rs
@@ -1,0 +1,11 @@
+//! Outbound domain -> request-DTO conversions for the v1 mutation routes; no
+//! in-crate caller until the `RemoteWrites` impl lands.
+#![allow(dead_code)]
+
+mod boards;
+mod cards;
+mod columns;
+
+pub(crate) use boards::{create_board_request, update_board_request};
+pub(crate) use cards::{create_card_request, update_card_request};
+pub(crate) use columns::{create_column_request, update_column_request};

--- a/crates/kanban-backend-http/src/http.rs
+++ b/crates/kanban-backend-http/src/http.rs
@@ -3,7 +3,7 @@ use kanban_api::{ApiError, Page};
 use kanban_domain::{KanbanError, KanbanResult};
 use serde::de::DeserializeOwned;
 
-fn map_error_response(status: reqwest::StatusCode, body: &str) -> KanbanError {
+pub(crate) fn map_error_response(status: reqwest::StatusCode, body: &str) -> KanbanError {
     match serde_json::from_str::<ApiError>(body) {
         Ok(api_err) => KanbanError::from(api_err),
         Err(_) => KanbanError::Internal(format!("HTTP {status}: {body}")),

--- a/crates/kanban-backend-http/src/http_mutation.rs
+++ b/crates/kanban-backend-http/src/http_mutation.rs
@@ -1,5 +1,6 @@
 use crate::HttpBackend;
-use kanban_api::{ApiError, ErrorCode};
+use kanban_api::{ApiError, ErrorCode, CLIENT_ID_HEADER};
+use kanban_backend::KanbanBackend;
 use kanban_domain::{KanbanError, KanbanResult};
 use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
@@ -8,21 +9,49 @@ impl HttpBackend {
     #[allow(dead_code)]
     pub(crate) async fn send_json_mutation<B, T>(
         &self,
-        _method: Method,
-        _path: &str,
-        _body: Option<&B>,
+        method: Method,
+        path: &str,
+        body: Option<&B>,
     ) -> KanbanResult<T>
     where
         B: serde::Serialize + ?Sized,
         T: DeserializeOwned,
     {
-        unimplemented!()
+        let url = format!("{}{}", self.base_url(), path);
+        let mut request = self
+            .client()
+            .request(method, &url)
+            .header(CLIENT_ID_HEADER, self.instance_id().to_string());
+        if let Some(body) = body {
+            request = request.json(body);
+        }
+        let resp = request
+            .send()
+            .await
+            .map_err(|e| KanbanError::Transport(e.to_string()))?;
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| KanbanError::Transport(e.to_string()))?;
+        if !status.is_success() {
+            return Err(map_mutation_error(status, &body_text, &url));
+        }
+        serde_json::from_str(&body_text).map_err(|e| KanbanError::Serialization(e.to_string()))
     }
 }
 
 #[allow(dead_code)]
-fn map_mutation_error(_status: StatusCode, _body: &str, _url: &str) -> KanbanError {
-    unimplemented!()
+fn map_mutation_error(status: StatusCode, body: &str, url: &str) -> KanbanError {
+    if let Ok(api_err) = serde_json::from_str::<ApiError>(body) {
+        if api_err.code == ErrorCode::ConflictDetected {
+            return KanbanError::ConflictDetected {
+                path: url.to_string(),
+                source: None,
+            };
+        }
+    }
+    crate::http::map_error_response(status, body)
 }
 
 #[cfg(test)]

--- a/crates/kanban-backend-http/src/http_mutation.rs
+++ b/crates/kanban-backend-http/src/http_mutation.rs
@@ -1,0 +1,265 @@
+use crate::HttpBackend;
+use kanban_api::{ApiError, ErrorCode};
+use kanban_domain::{KanbanError, KanbanResult};
+use reqwest::{Method, StatusCode};
+use serde::de::DeserializeOwned;
+
+impl HttpBackend {
+    #[allow(dead_code)]
+    pub(crate) async fn send_json_mutation<B, T>(
+        &self,
+        _method: Method,
+        _path: &str,
+        _body: Option<&B>,
+    ) -> KanbanResult<T>
+    where
+        B: serde::Serialize + ?Sized,
+        T: DeserializeOwned,
+    {
+        unimplemented!()
+    }
+}
+
+#[allow(dead_code)]
+fn map_mutation_error(_status: StatusCode, _body: &str, _url: &str) -> KanbanError {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_api::{BoardResponse, CreateBoardRequest, DeleteResponse, MutationResponse};
+    use kanban_backend::KanbanBackend;
+    use kanban_domain::Invalidation;
+    use kanban_server::test_helpers::TestServer;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use uuid::Uuid;
+
+    async fn stub_once(
+        status_line: &'static str,
+        body: &'static str,
+    ) -> (String, tokio::task::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}");
+        let handle = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            let mut content_length = 0usize;
+            let mut headers_end = None;
+            loop {
+                let n = socket.read(&mut tmp).await.unwrap();
+                buf.extend_from_slice(&tmp[..n]);
+                if let Some(pos) = find_headers_end(&buf) {
+                    headers_end = Some(pos);
+                    let header_text = String::from_utf8_lossy(&buf[..pos]).to_lowercase();
+                    content_length = header_text
+                        .lines()
+                        .find_map(|l| l.strip_prefix("content-length:"))
+                        .map(|v| v.trim().parse::<usize>().unwrap_or(0))
+                        .unwrap_or(0);
+                }
+                if let Some(pos) = headers_end {
+                    if buf.len() >= pos + 4 + content_length {
+                        break;
+                    }
+                }
+                if n == 0 {
+                    break;
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+            socket.shutdown().await.ok();
+            String::from_utf8_lossy(&buf).to_string()
+        });
+        (url, handle)
+    }
+
+    fn find_headers_end(buf: &[u8]) -> Option<usize> {
+        buf.windows(4).position(|w| w == b"\r\n\r\n")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_json_mutation_patch_returns_the_parsed_mutation_response() {
+        let server = TestServer::start().await;
+        let backend = HttpBackend::new(&server.base_url()).unwrap();
+        let create_resp: MutationResponse<BoardResponse> = server
+            .client()
+            .post(format!("{}/v1/boards", server.base_url()))
+            .json(&CreateBoardRequest {
+                id: None,
+                name: "Original".to_string(),
+                description: None,
+                sprint_prefix: None,
+                card_prefix: None,
+                task_sort_field: None,
+                task_sort_order: None,
+                sprint_duration_days: None,
+                task_list_view: None,
+            })
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let id = create_resp.entity.id;
+
+        let update = kanban_api::UpdateBoardRequest {
+            name: Some("Renamed".to_string()),
+            ..Default::default()
+        };
+        let resp: MutationResponse<BoardResponse> = backend
+            .send_json_mutation(Method::PATCH, &format!("/v1/boards/{id}"), Some(&update))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.entity.name, "Renamed");
+        let invalidation = Invalidation::from(&resp.invalidation);
+        match invalidation {
+            Invalidation::Entities(ids) => assert!(ids.boards.contains(&id)),
+            Invalidation::All => panic!("expected a scoped invalidation"),
+        }
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_json_mutation_post_treats_201_created_as_success() {
+        let server = TestServer::start().await;
+        let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+        let create = CreateBoardRequest {
+            id: None,
+            name: "Fresh".to_string(),
+            description: None,
+            sprint_prefix: None,
+            card_prefix: None,
+            task_sort_field: None,
+            task_sort_order: None,
+            sprint_duration_days: None,
+            task_list_view: None,
+        };
+        let resp: MutationResponse<BoardResponse> = backend
+            .send_json_mutation(Method::POST, "/v1/boards", Some(&create))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.entity.name, "Fresh");
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_json_mutation_delete_with_no_body_parses_the_delete_response() {
+        let server = TestServer::start().await;
+        let backend = HttpBackend::new(&server.base_url()).unwrap();
+        let create_resp: MutationResponse<BoardResponse> = server
+            .client()
+            .post(format!("{}/v1/boards", server.base_url()))
+            .json(&CreateBoardRequest {
+                id: None,
+                name: "ToDelete".to_string(),
+                description: None,
+                sprint_prefix: None,
+                card_prefix: None,
+                task_sort_field: None,
+                task_sort_order: None,
+                sprint_duration_days: None,
+                task_list_view: None,
+            })
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let id = create_resp.entity.id;
+
+        let resp: DeleteResponse = backend
+            .send_json_mutation::<(), DeleteResponse>(
+                Method::DELETE,
+                &format!("/v1/boards/{id}"),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let invalidation = Invalidation::from(&resp.invalidation);
+        match invalidation {
+            Invalidation::Entities(ids) => assert!(ids.boards.contains(&id)),
+            Invalidation::All => panic!("expected a scoped invalidation"),
+        }
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_json_mutation_maps_a_404_to_the_servers_not_found_error() {
+        let server = TestServer::start().await;
+        let backend = HttpBackend::new(&server.base_url()).unwrap();
+        let missing = Uuid::new_v4();
+
+        let update = kanban_api::UpdateBoardRequest::default();
+        let result: KanbanResult<MutationResponse<BoardResponse>> = backend
+            .send_json_mutation(
+                Method::PATCH,
+                &format!("/v1/boards/{missing}"),
+                Some(&update),
+            )
+            .await;
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("NOT_FOUND"), "got: {err}");
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_json_mutation_maps_a_conflict_detected_body_to_conflict_detected() {
+        let (url, handle) = stub_once(
+            "409 Conflict",
+            r#"{"code":"CONFLICT_DETECTED","message":"reload and retry"}"#,
+        )
+        .await;
+        let backend = HttpBackend::new(&url).unwrap();
+
+        let update = kanban_api::UpdateBoardRequest::default();
+        let result: KanbanResult<MutationResponse<BoardResponse>> = backend
+            .send_json_mutation(Method::PATCH, "/v1/boards/x", Some(&update))
+            .await;
+
+        let err = result.unwrap_err();
+        assert!(err.is_conflict_detected(), "got: {err:?}");
+        if let KanbanError::ConflictDetected { path, .. } = &err {
+            assert!(path.contains("/v1/boards/x"), "got path: {path}");
+        } else {
+            panic!("expected ConflictDetected, got {err:?}");
+        }
+
+        handle.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_json_mutation_attaches_the_client_id_header_valued_with_the_instance_id() {
+        let (url, handle) = stub_once("200 OK", r#"{"invalidation":{"scope":"all"}}"#).await;
+        let backend = HttpBackend::new(&url).unwrap();
+        let instance_id = backend.instance_id().to_string();
+
+        let _result: KanbanResult<DeleteResponse> = backend
+            .send_json_mutation::<(), DeleteResponse>(Method::DELETE, "/v1/boards/x", None)
+            .await;
+
+        let captured = handle.await.unwrap().to_lowercase();
+        assert!(
+            captured.contains(&format!("x-kanban-client-id: {}", instance_id.to_lowercase())),
+            "got: {captured}"
+        );
+    }
+}

--- a/crates/kanban-backend-http/src/http_mutation.rs
+++ b/crates/kanban-backend-http/src/http_mutation.rs
@@ -294,7 +294,10 @@ mod tests {
 
         let captured = handle.await.unwrap().to_lowercase();
         assert!(
-            captured.contains(&format!("x-kanban-client-id: {}", instance_id.to_lowercase())),
+            captured.contains(&format!(
+                "x-kanban-client-id: {}",
+                instance_id.to_lowercase()
+            )),
             "got: {captured}"
         );
     }

--- a/crates/kanban-backend-http/src/http_mutation.rs
+++ b/crates/kanban-backend-http/src/http_mutation.rs
@@ -1,3 +1,10 @@
+//! A non-success status is always an error, including a 404 -- there is no
+//! `Ok(None)` short-circuit for a mutation, unlike the read-side `get_json`.
+//! `CONFLICT_DETECTED` is remapped to `KanbanError::ConflictDetected`
+//! explicitly, because `From<ApiError>` otherwise classifies it as a plain
+//! validation error. No `If-Match` header is sent: v1 mutations are
+//! last-writer-wins.
+
 use crate::HttpBackend;
 use kanban_api::{ApiError, ErrorCode, CLIENT_ID_HEADER};
 use kanban_backend::KanbanBackend;

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -4,6 +4,7 @@ mod conversions;
 mod conversions_out;
 mod data_store;
 mod http;
+mod http_mutation;
 mod remote_writes;
 
 pub use backend_factory::HttpBackendFactory;

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -1,6 +1,7 @@
 mod backend_factory;
 mod command_store;
 mod conversions;
+mod conversions_out;
 mod data_store;
 mod http;
 mod remote_writes;


### PR DESCRIPTION
## Summary

- Adds `HttpBackend::send_json_mutation`, a generic JSON mutation transport that attaches the `x-kanban-client-id` header, treats any non-2xx status as an error (no `Ok(None)` short-circuit for a wire 404), and remaps a `CONFLICT_DETECTED` wire error to `KanbanError::ConflictDetected` explicitly.
- Adds the outbound domain-to-request conversion layer in `conversions_out/{boards,columns,cards}.rs`: `create_board_request`, `update_board_request`, `create_column_request`, `update_column_request`, `create_card_request`, `update_card_request`. Board-update declines `active_sprint_id` and `position` with `KanbanError::unsupported` since both are server-managed and have no wire representation.
- Widens `map_error_response` in `http.rs` to `pub(crate)` so the mutation transport can reuse it for the non-conflict error path.
- Nothing in this PR is wired to `RemoteWrites`; `remote_writes()` stays `None` and the trait is untouched. The activation card (KAN-1573) consumes this transport and these conversions.

## Test plan

- [x] `cargo test -p kanban-backend-http` green, including 16 new tests (6 transport, 10 conversion), red before green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --all-features --workspace` green
- [x] Mutation-checked the conflict remap, the 2xx status check, the client-id header, and the active_sprint_id Clear-guard: each deliberate break reproduced a test failure, then was reverted
