### PR TITLE
KAN-1576 feat(server,backend-http): add GET /v1/cards/lookup and wire HttpBackend to it

### DIFF
--- a/.changeset/kan-1576-card-lookup-route.md
+++ b/.changeset/kan-1576-card-lookup-route.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server: adds GET /v1/cards/lookup, resolving a card identifier (KAN-7 or a bare 7) against the locked Session::find_cards_by_identifier surface. Always answers 200 with an unpaginated JSON array of CardResponse; empty for no match or an unparseable identifier, never 404. backend-http: HttpBackend replaces its list_cards_by_prefix_and_number and list_cards_by_number declines with overrides against the new route, so kanban <url> card get KAN-N and the MCP card-by-identifier tools now work against a remote server.

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -13,6 +13,18 @@ use kanban_domain::{
 };
 use uuid::Uuid;
 
+impl HttpBackend {
+    fn lookup_cards(&self, identifier: &str) -> KanbanResult<Vec<Card>> {
+        self.block_on(async {
+            let resp: Vec<CardResponse> = self
+                .get_json_with_query("/v1/cards/lookup", &[("identifier", identifier)])
+                .await?
+                .unwrap_or_default();
+            Ok(resp.iter().map(card_from_response).collect())
+        })
+    }
+}
+
 impl DataStore for HttpBackend {
     fn get_prefix(&self, name: &str) -> KanbanResult<Option<Prefix>> {
         self.block_on(async {
@@ -317,24 +329,23 @@ impl DataStore for HttpBackend {
             .find(|c| c.card_number == card_number))
     }
 
-    /// No route filters cards by a bare `card_number` across every namespace,
-    /// and the inherited default would fetch every card in the workspace to
-    /// answer a one-row lookup. Declines under its own name instead of
-    /// inheriting.
-    fn list_cards_by_number(&self, _card_number: u32) -> KanbanResult<Vec<Card>> {
-        Err(KanbanError::unsupported("list_cards_by_number"))
+    fn list_cards_by_number(&self, card_number: u32) -> KanbanResult<Vec<Card>> {
+        self.lookup_cards(&card_number.to_string())
     }
 
-    /// No route filters cards by `(prefix, card_number)`, and the inherited
-    /// default would both fetch every card in the workspace AND re-implement
-    /// `Prefix::normalize` client-side, a second source of truth for a server
-    /// rule. Declines under its own name instead of inheriting.
+    /// Re-encodes the pair as `{prefix}-{card_number}` and re-parses it
+    /// server-side, faithful because `parse_identifier` splits on the last
+    /// dash and lowercases both sides. An empty `prefix` is the one shape
+    /// that cannot round-trip through that reconstruction, but no caller
+    /// reaches this method with one: `find_cards_by_identifier` only ever
+    /// dispatches here with a prefix `parse_identifier` has already accepted,
+    /// and it rejects the empty-prefix shape before dispatch.
     fn list_cards_by_prefix_and_number(
         &self,
-        _prefix: &str,
-        _card_number: u32,
+        prefix: &str,
+        card_number: u32,
     ) -> KanbanResult<Vec<Card>> {
-        Err(KanbanError::unsupported("list_cards_by_prefix_and_number"))
+        self.lookup_cards(&format!("{prefix}-{card_number}"))
     }
 
     /// The cards route accepts a single `column_id` filter

--- a/crates/kanban-backend-http/tests/decline_rulings.rs
+++ b/crates/kanban-backend-http/tests/decline_rulings.rs
@@ -24,20 +24,6 @@ fn test_get_card_by_board_and_number_declines_under_its_own_name() {
 }
 
 #[test]
-fn test_list_cards_by_number_declines_under_its_own_name() {
-    let backend = unreachable_backend();
-    let result = backend.list_cards_by_number(1);
-    assert_declines_under_its_own_name(result, "list_cards_by_number");
-}
-
-#[test]
-fn test_list_cards_by_prefix_and_number_declines_under_its_own_name() {
-    let backend = unreachable_backend();
-    let result = backend.list_cards_by_prefix_and_number("kan", 1);
-    assert_declines_under_its_own_name(result, "list_cards_by_prefix_and_number");
-}
-
-#[test]
 fn test_upsert_prefix_declines_under_its_own_name() {
     let backend = unreachable_backend();
     let result = backend.upsert_prefix(Prefix::new("kan"));

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -3,8 +3,10 @@ use kanban_api::{
     SortOrderDto, TaskListViewDto,
 };
 use kanban_backend_http::HttpBackend;
-use kanban_domain::{Board, Card, Column, DataStore, Prefix, Sprint};
+use kanban_domain::{Board, Card, Column, DataStore, KanbanOperations, Prefix, Sprint};
 use kanban_server::test_helpers::TestServer;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use std::sync::Arc;
 use uuid::Uuid;
 
 async fn blocking<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
@@ -669,4 +671,95 @@ fn test_a_read_against_an_unreachable_server_maps_to_a_transport_error() {
 
     assert!(err.is_transport(), "expected transport error, got {err:?}");
     assert!(!err.is_unsupported());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_by_prefix_and_number_round_trips_over_http() {
+    let server = TestServer::start().await;
+    let board_id = seed_board_with_card_prefix(&server, "KAN").await;
+    let column_id = seed_column(&server, board_id, "Col", None, None).await;
+    let card_id = seed_card(&server, column_id, "Card", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let cards: Vec<Card> =
+        blocking(move || backend.list_cards_by_prefix_and_number("kan", 1).unwrap()).await;
+
+    assert_eq!(cards.len(), 1);
+    assert_eq!(cards[0].id, card_id);
+    assert_eq!(cards[0].card_number, 1);
+    assert!(!cards[0].prefix.is_empty());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_cards_by_number_round_trips_over_http_including_the_ambiguous_case() {
+    let server = TestServer::start().await;
+    let board_a = seed_board_with_card_prefix(&server, "aaa").await;
+    let col_a = seed_column(&server, board_a, "Col", None, None).await;
+    let card_a = seed_card(&server, col_a, "Card A", None).await;
+    let board_b = seed_board_with_card_prefix(&server, "bbb").await;
+    let col_b = seed_column(&server, board_b, "Col", None, None).await;
+    let card_b = seed_card(&server, col_b, "Card B", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let cards: Vec<Card> = blocking(move || backend.list_cards_by_number(1).unwrap()).await;
+
+    let ids: std::collections::HashSet<Uuid> = cards.iter().map(|c| c.id).collect();
+    assert_eq!(ids, [card_a, card_b].into_iter().collect());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lookup_miss_returns_empty_vec_over_http() {
+    let server = TestServer::start().await;
+    let board_id = seed_board_with_card_prefix(&server, "KAN").await;
+    let column_id = seed_column(&server, board_id, "Col", None, None).await;
+    seed_card(&server, column_id, "Card", None).await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let by_prefix: kanban_domain::KanbanResult<Vec<Card>> = blocking({
+        let backend = HttpBackend::new(&server.base_url()).unwrap();
+        move || backend.list_cards_by_prefix_and_number("kan", 999)
+    })
+    .await;
+    assert!(by_prefix.is_ok(), "expected Ok, got {by_prefix:?}");
+    assert!(by_prefix.unwrap().is_empty());
+
+    let by_number: kanban_domain::KanbanResult<Vec<Card>> =
+        blocking(move || backend.list_cards_by_number(999)).await;
+    assert!(by_number.is_ok(), "expected Ok, got {by_number:?}");
+    assert!(by_number.unwrap().is_empty());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_find_cards_by_identifier_resolves_over_http() {
+    let server = TestServer::start().await;
+    let board_id = seed_board_with_card_prefix(&server, "KAN").await;
+    let column_id = seed_column(&server, board_id, "Col", None, None).await;
+    let card_id = seed_card(&server, column_id, "Card", None).await;
+
+    let backend: Arc<dyn KanbanBackend> = Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+    let ctx = KanbanContext::open(Arc::clone(&backend), AppConfig::default())
+        .await
+        .unwrap();
+
+    let by_prefix = ctx.find_cards_by_identifier("KAN-1").unwrap();
+    assert_eq!(by_prefix.len(), 1);
+    assert_eq!(by_prefix[0].id, card_id);
+
+    let by_number = ctx.find_cards_by_identifier("1").unwrap();
+    assert_eq!(by_number.len(), 1);
+    assert_eq!(by_number[0].id, card_id);
+
+    let miss = ctx.find_cards_by_identifier("KAN-999").unwrap();
+    assert!(miss.is_empty());
+
+    drop(ctx);
+    drop(backend);
+
+    server.shutdown().await;
 }

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -213,6 +213,7 @@ Column writes (create/update/delete) aren't implemented yet.
 | `POST` | `/v1/cards/batch/move` | Move up to N cards into `column_id`. `200` with `BatchOperationResponse`. If moving would violate the target column's WIP limit, every id in the request fails with no card moved. | `BatchMoveRequest` (`{"ids": [uuid, ...], "column_id": uuid}`) |
 | `POST` | `/v1/cards/batch/assign-sprint` | Assign up to N cards to `sprint_id`. `200` with `BatchOperationResponse`. An unknown sprint id fails every card id. | `BatchAssignSprintRequest` (`{"ids": [uuid, ...], "sprint_id": uuid}`) |
 | `POST` | `/v1/cards/batch/update` | Apply a per-card `UpdateCardRequest`-shaped patch to each id, all-or-nothing. `200` with `BatchOperationResponse` (`failed` always empty) on full success; an unknown id or any other execution error is an ordinary `ApiError` envelope and no card is modified. | `BatchUpdateRequest` (`{"updates": [{"id": uuid, ...UpdateCardRequest fields}, ...]}`) |
+| `GET` | `/v1/cards/lookup` | Resolve a card identifier (`KAN-7` or a bare `7`). Requires `?identifier=`. Returns an unpaginated JSON array of `CardResponse`; an empty array for no match or an unparseable identifier, never 404. A bare number matches across every namespace. | — |
 
 The remaining card routes (get/create/replace/update/delete, and the flat `/v1/cards/{id}` aliases) exist but aren't documented in this table yet.
 

--- a/crates/kanban-server/src/routes/cards.rs
+++ b/crates/kanban-server/src/routes/cards.rs
@@ -518,8 +518,30 @@ async fn restore_card_route(
     Ok(Json(CardResponse::from(&card)))
 }
 
+#[derive(Debug, Deserialize)]
+struct CardLookupQuery {
+    identifier: String,
+}
+
+/// Resolves a card identifier (`KAN-7` or a bare `7`) against every board's
+/// live cards. Always answers 200 with a JSON array: one element per match,
+/// empty for no match or an identifier that does not parse. Never 404,
+/// because a miss is folded into `Ok(None)` by the client read path.
+async fn lookup_cards(
+    State(state): State<AppState>,
+    Query(q): Query<CardLookupQuery>,
+) -> Result<Json<Vec<CardResponse>>, AppError> {
+    let guard = state.lock_session().await;
+    let cards = guard
+        .find_cards_by_identifier(&q.identifier)
+        .map_err(|e| AppError::from(&e))?;
+    Ok(Json(cards.iter().map(CardResponse::from).collect()))
+}
+
 pub fn flat_read_router() -> Router<AppState> {
-    Router::new().route("/v1/cards/{id}", get(get_card_flat))
+    Router::new()
+        .route("/v1/cards/lookup", get(lookup_cards))
+        .route("/v1/cards/{id}", get(get_card_flat))
 }
 
 pub fn flat_write_router() -> Router<AppState> {

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -1,8 +1,10 @@
 //! A `RouteScope` is built from the matched route plus its path/query
 //! params. The tiers a variant names are the tiers that route's response
-//! body reads; `GET /v1/prefixes` has no variant because no prefix tier
-//! exists in `FetchRound` at any level, so that route stays a lock-only
-//! read outside this plan.
+//! body reads. Two routes have no variant and stay lock-only reads outside
+//! this plan: `GET /v1/prefixes`, because no prefix tier exists in
+//! `FetchRound` at any level, and `GET /v1/cards/lookup`, because it
+//! dispatches straight to the indexed store reads behind
+//! `find_cards_by_identifier` rather than through any `FetchRound` tier.
 
 use kanban_domain::ArchivedFilter;
 use kanban_service::{requestable, FetchPlan, FetchRound, LoadedEntities};

--- a/crates/kanban-server/tests/cards_lookup.rs
+++ b/crates/kanban-server/tests/cards_lookup.rs
@@ -1,0 +1,135 @@
+#![cfg(feature = "test-helpers")]
+
+//! GET /v1/cards/lookup?identifier=<string> resolves a card identifier
+//! (`KAN-7` or a bare `7`) to zero or more cards, without touching a board.
+
+use axum::http::StatusCode;
+use kanban_domain::KanbanOperations;
+use kanban_server::state::AppState;
+use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
+use tempfile::tempdir;
+use uuid::Uuid;
+
+async fn seed_card_with_prefix(state: &AppState, card_prefix: &str) -> Uuid {
+    let mut ctx = state.ctx.lock().await;
+    let board_id = ctx
+        .create_board("Board".to_string(), Some(card_prefix.to_string()))
+        .unwrap()
+        .id;
+    let col = ctx
+        .create_column(board_id, "To Do".to_string(), None)
+        .unwrap();
+    ctx.create_card(board_id, col.id, "Task".to_string(), Default::default())
+        .unwrap()
+        .id
+}
+
+#[tokio::test]
+async fn test_lookup_by_prefix_and_number_returns_single_match() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let card_id = seed_card_with_prefix(&state, "KAN").await;
+
+    let response = send(&state, "GET", "/v1/cards/lookup?identifier=KAN-1", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    let arr = body.as_array().expect("array body");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], card_id.to_string());
+    assert_eq!(arr[0]["card_number"], 1);
+}
+
+#[tokio::test]
+async fn test_lookup_normalizes_prefix_case_server_side() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let card_id = seed_card_with_prefix(&state, "KAN").await;
+
+    let response = send(&state, "GET", "/v1/cards/lookup?identifier=kan-1", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    let arr = body.as_array().expect("array body");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], card_id.to_string());
+}
+
+#[tokio::test]
+async fn test_lookup_bare_number_matches_across_boards() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    let a = seed_card_with_prefix(&state, "AAA").await;
+    let b = seed_card_with_prefix(&state, "BBB").await;
+
+    let response = send(&state, "GET", "/v1/cards/lookup?identifier=1", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    let arr = body.as_array().expect("array body");
+    assert_eq!(arr.len(), 2);
+    let ids: std::collections::HashSet<String> = arr
+        .iter()
+        .map(|c| c["id"].as_str().unwrap().to_string())
+        .collect();
+    let expected: std::collections::HashSet<String> =
+        [a.to_string(), b.to_string()].into_iter().collect();
+    assert_eq!(ids, expected);
+}
+
+#[tokio::test]
+async fn test_lookup_no_match_returns_empty_array_not_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    seed_card_with_prefix(&state, "KAN").await;
+
+    let response = send(&state, "GET", "/v1/cards/lookup?identifier=KAN-999", None).await;
+    assert_ne!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "no match must not be a 404"
+    );
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body, serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn test_lookup_unparseable_identifier_returns_empty_array() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+    seed_card_with_prefix(&state, "KAN").await;
+
+    let response = send(&state, "GET", "/v1/cards/lookup?identifier=---", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body, serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn test_lookup_missing_identifier_is_a_400_naming_the_identifier_param() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = send(&state, "GET", "/v1/cards/lookup", None).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        text.contains("identifier"),
+        "expected body to name the missing `identifier` param, got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_lookup_on_sqlite_backend_returns_match() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("s.db")).await;
+    let card_id = seed_card_with_prefix(&state, "KAN").await;
+
+    let response = send(&state, "GET", "/v1/cards/lookup?identifier=KAN-1", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    let arr = body.as_array().expect("array body");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], card_id.to_string());
+}

--- a/crates/kanban-server/tests/cards_lookup.rs
+++ b/crates/kanban-server/tests/cards_lookup.rs
@@ -24,7 +24,7 @@ async fn seed_card_with_prefix(state: &AppState, card_prefix: &str) -> Uuid {
         .id
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_lookup_by_prefix_and_number_returns_single_match() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
@@ -39,7 +39,7 @@ async fn test_lookup_by_prefix_and_number_returns_single_match() {
     assert_eq!(arr[0]["card_number"], 1);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_lookup_normalizes_prefix_case_server_side() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
@@ -53,7 +53,7 @@ async fn test_lookup_normalizes_prefix_case_server_side() {
     assert_eq!(arr[0]["id"], card_id.to_string());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_lookup_bare_number_matches_across_boards() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
@@ -74,7 +74,7 @@ async fn test_lookup_bare_number_matches_across_boards() {
     assert_eq!(ids, expected);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_lookup_no_match_returns_empty_array_not_404() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
@@ -91,7 +91,7 @@ async fn test_lookup_no_match_returns_empty_array_not_404() {
     assert_eq!(body, serde_json::json!([]));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_lookup_unparseable_identifier_returns_empty_array() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
@@ -103,7 +103,7 @@ async fn test_lookup_unparseable_identifier_returns_empty_array() {
     assert_eq!(body, serde_json::json!([]));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_lookup_missing_identifier_is_a_400_naming_the_identifier_param() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
@@ -120,7 +120,7 @@ async fn test_lookup_missing_identifier_is_a_400_naming_the_identifier_param() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_lookup_on_sqlite_backend_returns_match() {
     let dir = tempdir().unwrap();
     let state = make_sqlite_state(&dir.path().join("s.db")).await;


### PR DESCRIPTION
## Summary

- Adds `GET /v1/cards/lookup?identifier=<string>`, a lock-only read that forwards to the already-locked `Session::find_cards_by_identifier`. Always answers 200 with an unpaginated JSON array of `CardResponse`; the array is empty for no match or an unparseable identifier, never 404.
- Replaces `HttpBackend`'s two declines, `list_cards_by_prefix_and_number` and `list_cards_by_number`, with overrides that call the new route through a shared `lookup_cards` helper, so `kanban <url> card get KAN-N` and the MCP card-by-identifier tools now work against a remote server.
- Documents the two lock-only reads (`GET /v1/prefixes`, `GET /v1/cards/lookup`) in the `RouteScope` module doc, and adds the new route to the kanban-server README card-routes table.

## Test plan

- [x] `crates/kanban-server/tests/cards_lookup.rs`: prefix+number match, case normalization, cross-board bare-number match, no-match returns `[]` not 404, unparseable identifier returns `[]`, missing `identifier` param is a 400 naming the param, and the same prefix+number match on a real SQLite backend.
- [x] `crates/kanban-backend-http/tests/remote_reads.rs`: `list_cards_by_prefix_and_number` and `list_cards_by_number` round-trip over HTTP, including the cross-board ambiguous case and the miss case; `KanbanContext::open` over `HttpBackend` plus `find_cards_by_identifier` for prefix, bare number, and miss.
- [x] `crates/kanban-backend-http/tests/decline_rulings.rs`: the two now-obsolete decline pins removed; the remaining declines (`get_card_by_board_and_number`, `upsert_prefix`, `list_all_cards`/`list_all_columns`/`list_all_sprints`) still pass.
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --all-features --workspace` all green.
