### PR TITLE
KAN-1577 refactor(service): board-scope the archived-card index read

### DIFF
--- a/.changeset/kan-1577-archived-index-rescope.md
+++ b/.changeset/kan-1577-archived-index-rescope.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+service: `archived_card_index` now takes an optional board scope, so a board-scoped card listing reads only that board's archival markers instead of the workspace-global collection. Board-scoped `card list` now works over a remote (HTTP) locator, which previously failed with `Unsupported: list_archived_cards`. Unscoped listings keep the global read and its decline. Local backends are unchanged: the board-scoped read is the same subset the archival stamping already consulted.

--- a/crates/kanban-backend-http/tests/archived_cards.rs
+++ b/crates/kanban-backend-http/tests/archived_cards.rs
@@ -1,8 +1,8 @@
 use kanban_backend_http::HttpBackend;
-use kanban_domain::{ArchivedCard, DataStore, Model, NoProjections};
+use kanban_domain::{ArchivedCard, ArchivedFilter, CardListFilter, DataStore, Model, NoProjections};
 use kanban_server::test_helpers::TestServer;
 use kanban_service::fetch_plan::{requestable, FetchPlan, FetchRound, LoadedEntities};
-use kanban_service::{AppConfig, KanbanContext, KanbanOperations};
+use kanban_service::{AppConfig, KanbanContext, KanbanError, KanbanOperations};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -28,6 +28,31 @@ fn seed_archived_card(ctx: &mut KanbanContext) -> (Uuid, Uuid, chrono::DateTime<
     ctx.archive_card(card.id).unwrap();
     let seeded = ctx.list_archived_cards_by_board(board.id).unwrap();
     (board.id, card.id, seeded[0].metadata.archived_at)
+}
+
+fn seed_board_with_live_and_archived_card(
+    ctx: &mut KanbanContext,
+) -> (Uuid, Uuid, Uuid, chrono::DateTime<chrono::Utc>) {
+    let board = ctx
+        .create_board("Mixed Board".to_string(), Some("MIX".to_string()))
+        .unwrap();
+    let column = ctx
+        .create_column(board.id, "Col".to_string(), None)
+        .unwrap();
+    let live = ctx
+        .create_card(board.id, column.id, "Live".to_string(), Default::default())
+        .unwrap();
+    let archived = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Archived".to_string(),
+            Default::default(),
+        )
+        .unwrap();
+    ctx.archive_card(archived.id).unwrap();
+    let seeded = ctx.list_archived_cards_by_board(board.id).unwrap();
+    (board.id, live.id, archived.id, seeded[0].metadata.archived_at)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -158,6 +183,68 @@ async fn test_the_archived_card_tier_resolves_over_http() {
         .expect("archived-card tier should resolve to Loaded over HTTP");
     assert_eq!(markers.len(), 1);
     assert_eq!(markers[0].entity_id, card_id);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_board_scoped_card_list_over_http_returns_live_and_archived() {
+    let mut board_id = Uuid::nil();
+    let mut live_id = Uuid::nil();
+    let mut archived_id = Uuid::nil();
+    let mut seeded_at = chrono::Utc::now();
+    let server = TestServer::start_with(|ctx| {
+        let (b, l, a, at) = seed_board_with_live_and_archived_card(ctx);
+        board_id = b;
+        live_id = l;
+        archived_id = a;
+        seeded_at = at;
+    })
+    .await;
+    let backend: Arc<dyn kanban_service::KanbanBackend> =
+        Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+
+    let pairs = blocking(move || {
+        let ctx = KanbanContext::open_deferred(backend, AppConfig::default());
+        ctx.list_cards_detailed(CardListFilter {
+            board_id: Some(board_id),
+            archived: ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap()
+    })
+    .await;
+
+    assert_eq!(pairs.len(), 2);
+    let live_pair = pairs.iter().find(|(c, _)| c.id == live_id).unwrap();
+    let archived_pair = pairs.iter().find(|(c, _)| c.id == archived_id).unwrap();
+    assert_eq!(live_pair.1, None);
+    assert_eq!(archived_pair.1, Some(seeded_at));
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unscoped_card_list_over_http_declines_under_list_archived_cards() {
+    let server = TestServer::start_with(|ctx| {
+        seed_archived_card(ctx);
+    })
+    .await;
+    let backend: Arc<dyn kanban_service::KanbanBackend> =
+        Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+
+    let result = blocking(move || {
+        let ctx = KanbanContext::open_deferred(backend, AppConfig::default());
+        ctx.list_cards_detailed(CardListFilter::default())
+    })
+    .await;
+
+    match result {
+        Err(KanbanError::Unsupported { operation }) => {
+            assert_eq!(operation, "list_archived_cards");
+        }
+        other => panic!("expected Unsupported(\"list_archived_cards\"), got {other:?}"),
+    }
 
     server.shutdown().await;
 }

--- a/crates/kanban-backend-http/tests/archived_cards.rs
+++ b/crates/kanban-backend-http/tests/archived_cards.rs
@@ -1,5 +1,7 @@
 use kanban_backend_http::HttpBackend;
-use kanban_domain::{ArchivedCard, ArchivedFilter, CardListFilter, DataStore, Model, NoProjections};
+use kanban_domain::{
+    ArchivedCard, ArchivedFilter, CardListFilter, DataStore, Model, NoProjections,
+};
 use kanban_server::test_helpers::TestServer;
 use kanban_service::fetch_plan::{requestable, FetchPlan, FetchRound, LoadedEntities};
 use kanban_service::{AppConfig, KanbanContext, KanbanError, KanbanOperations};
@@ -52,7 +54,12 @@ fn seed_board_with_live_and_archived_card(
         .unwrap();
     ctx.archive_card(archived.id).unwrap();
     let seeded = ctx.list_archived_cards_by_board(board.id).unwrap();
-    (board.id, live.id, archived.id, seeded[0].metadata.archived_at)
+    (
+        board.id,
+        live.id,
+        archived.id,
+        seeded[0].metadata.archived_at,
+    )
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/src/context/cards.rs
+++ b/crates/kanban-service/src/context/cards.rs
@@ -35,7 +35,7 @@ impl KanbanContext {
         &self,
         filter: CardListFilter,
     ) -> KanbanResult<Vec<(Card, Option<chrono::DateTime<chrono::Utc>>)>> {
-        let (_ids, at_by_id) = self.archived_card_index()?;
+        let (_ids, at_by_id) = self.archived_card_index(filter.board_id)?;
         Ok(self
             .filter_cards(&filter)?
             .into_iter()

--- a/crates/kanban-service/src/context/filters.rs
+++ b/crates/kanban-service/src/context/filters.rs
@@ -10,10 +10,18 @@ pub(super) type ArchivedCardIndex = (HashSet<Uuid>, HashMap<Uuid, DateTime<Utc>>
 
 impl KanbanContext {
     /// The set of individually-archived card ids plus an `entity_id -> archived_at`
-    /// map, read once from the archived-card markers. Shared by the selector-aware
-    /// gather and by `list_cards_impl`'s `archived_at` stamping.
-    pub(super) fn archived_card_index(&self) -> KanbanResult<ArchivedCardIndex> {
-        let markers = self.backend.list_archived_cards()?;
+    /// map, read from the archived-card markers. `Some(board_id)` reads only that
+    /// board's markers; `None` reads the workspace-global collection. A
+    /// board-scoped result set only ever contains that board's own markers, so the
+    /// scoped read is sufficient there.
+    pub(super) fn archived_card_index(
+        &self,
+        board_id: Option<Uuid>,
+    ) -> KanbanResult<ArchivedCardIndex> {
+        let markers = match board_id {
+            Some(bid) => self.backend.list_archived_cards_by_board(bid)?,
+            None => self.backend.list_archived_cards()?,
+        };
         let mut ids = HashSet::with_capacity(markers.len());
         let mut at_by_id = HashMap::with_capacity(markers.len());
         for m in &markers {
@@ -24,8 +32,6 @@ impl KanbanContext {
     }
 
     pub(super) fn filter_cards(&self, filter: &CardListFilter) -> KanbanResult<Vec<Card>> {
-        let (archived_ids, _at) = self.archived_card_index()?;
-
         // C10a: an explicit `board_id` is a deliberate scoped request, so base the
         // card set on THAT board's own cards (raw) — honoring the board whether it
         // is live or archived. Only the UNSCOPED read stays live-scoped (C3b).
@@ -43,11 +49,14 @@ impl KanbanContext {
                 let board = self.backend.get_board(bid)?;
                 (cards, columns, board)
             }
-            None => (
-                self.gather_unscoped_cards_for_selector(&archived_ids, filter.archived)?,
-                Vec::new(),
-                None,
-            ),
+            None => {
+                let (archived_ids, _at) = self.archived_card_index(None)?;
+                (
+                    self.gather_unscoped_cards_for_selector(&archived_ids, filter.archived)?,
+                    Vec::new(),
+                    None,
+                )
+            }
         };
         let searching = filter.search.as_deref().is_some_and(|q| !q.is_empty());
         let (boards, sprints) = match (&board, searching) {

--- a/crates/kanban-service/src/test_helpers/contract/archive.rs
+++ b/crates/kanban-service/src/test_helpers/contract/archive.rs
@@ -1590,3 +1590,50 @@ pub async fn test_export_board_whole_store_includes_archived_board_and_card(
         "sprint prefix counter reflects both created sprints across both boards"
     );
 }
+
+/// A board-scoped `list_cards_detailed` call must stamp `archived_at` on every
+/// backend using only that board's own archival markers.
+pub async fn test_list_cards_detailed_board_scoped_stamps_archived_at(factory: &BackendFactory) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+
+    let board = ctx.create_board("Board".into(), Some("B".into())).unwrap();
+    let col = ctx.create_column(board.id, "Col".into(), None).unwrap();
+    let live = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived = ctx
+        .create_card(
+            board.id,
+            col.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(archived.id).unwrap();
+
+    ctx.save().await.unwrap();
+    let ctx = KanbanContext::open_deferred(factory(&path), AppConfig::default());
+
+    let pairs = ctx
+        .list_cards_detailed(CardListFilter {
+            board_id: Some(board.id),
+            archived: kanban_domain::ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(pairs.len(), 2);
+    let live_pair = pairs.iter().find(|(c, _)| c.id == live.id).unwrap();
+    let archived_pair = pairs.iter().find(|(c, _)| c.id == archived.id).unwrap();
+    assert_eq!(live_pair.1, None);
+    assert!(archived_pair.1.is_some());
+}

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -344,6 +344,10 @@ macro_rules! context_contract_tests {
         async fn test_list_archived_cards_by_missing_board_returns_empty() {
             $crate::test_helpers::contract::archive::test_list_archived_cards_by_missing_board_returns_empty(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_list_cards_detailed_board_scoped_stamps_archived_at() {
+            $crate::test_helpers::contract::archive::test_list_cards_detailed_board_scoped_stamps_archived_at(&$factory_fn()).await;
+        }
 
         // LegacyEdge tests
         #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/archived_index_scope.rs
+++ b/crates/kanban-service/tests/archived_index_scope.rs
@@ -1,0 +1,153 @@
+//! Requires the `test-helpers` feature; run with
+//! `cargo test -p kanban-service --features test-helpers`.
+#![cfg(feature = "test-helpers")]
+
+use std::sync::Arc;
+
+use kanban_backend_memory::InMemoryStore;
+use kanban_domain::{ArchivedFilter, CardListFilter, CreateCardOptions};
+use kanban_service::test_helpers::FaultInjectingBackend;
+use kanban_service::{AppConfig, KanbanBackend, KanbanContext, KanbanOperations};
+use uuid::Uuid;
+
+struct Seeded {
+    backend: Arc<FaultInjectingBackend>,
+    ctx: KanbanContext,
+    b1: Uuid,
+    live: Uuid,
+    archived: Uuid,
+}
+
+async fn seeded() -> Seeded {
+    let inner = InMemoryStore::new();
+    let backend = Arc::new(FaultInjectingBackend::new(
+        Arc::new(inner) as Arc<dyn KanbanBackend>
+    ));
+    let mut ctx = KanbanContext::open(
+        backend.clone() as Arc<dyn KanbanBackend>,
+        AppConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    let b1 = ctx.create_board("B1".into(), Some("B1".into())).unwrap();
+    let col1 = ctx.create_column(b1.id, "Col".into(), None).unwrap();
+    let live = ctx
+        .create_card(b1.id, col1.id, "Live".into(), CreateCardOptions::default())
+        .unwrap();
+    let archived = ctx
+        .create_card(
+            b1.id,
+            col1.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(archived.id).unwrap();
+
+    let b2 = ctx.create_board("B2".into(), Some("B2".into())).unwrap();
+    let col2 = ctx.create_column(b2.id, "Col".into(), None).unwrap();
+    let b2_archived = ctx
+        .create_card(
+            b2.id,
+            col2.id,
+            "B2 archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    ctx.archive_card(b2_archived.id).unwrap();
+
+    backend.clear_ops();
+
+    Seeded {
+        backend,
+        ctx,
+        b1: b1.id,
+        live: live.id,
+        archived: archived.id,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_board_scoped_list_cards_detailed_never_reads_the_global_marker_collection() {
+    let Seeded {
+        backend,
+        ctx,
+        b1,
+        live,
+        archived,
+    } = seeded().await;
+
+    let pairs = ctx
+        .list_cards_detailed(CardListFilter {
+            board_id: Some(b1),
+            archived: ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(
+        backend.op_count("list_archived_cards"),
+        0,
+        "a board-scoped card listing must never read the workspace-global archival marker collection"
+    );
+    assert!(backend
+        .ops()
+        .iter()
+        .any(|op| op.method == "list_archived_cards_by_board" && op.ids == vec![b1]));
+
+    assert_eq!(pairs.len(), 2);
+    let live_pair = pairs.iter().find(|(c, _)| c.id == live).unwrap();
+    let archived_pair = pairs.iter().find(|(c, _)| c.id == archived).unwrap();
+    assert_eq!(live_pair.1, None);
+    assert!(archived_pair.1.is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_board_scoped_list_cards_detailed_succeeds_when_global_marker_read_is_unsupported() {
+    let Seeded {
+        backend,
+        ctx,
+        b1,
+        live,
+        archived,
+    } = seeded().await;
+
+    let expected_at = backend
+        .inner()
+        .list_archived_cards_by_board(b1)
+        .unwrap()
+        .into_iter()
+        .find(|ac| ac.entity_id == archived)
+        .unwrap()
+        .metadata
+        .archived_at;
+
+    backend.fail("list_archived_cards");
+
+    let pairs = ctx
+        .list_cards_detailed(CardListFilter {
+            board_id: Some(b1),
+            archived: ArchivedFilter::Include,
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(pairs.len(), 2);
+    let live_pair = pairs.iter().find(|(c, _)| c.id == live).unwrap();
+    let archived_pair = pairs.iter().find(|(c, _)| c.id == archived).unwrap();
+    assert_eq!(live_pair.1, None);
+    assert_eq!(archived_pair.1, Some(expected_at));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unscoped_list_cards_still_reads_the_global_marker_collection() {
+    let Seeded { backend, ctx, .. } = seeded().await;
+
+    let _ = ctx.list_cards_detailed(CardListFilter::default()).unwrap();
+
+    assert!(
+        backend.op_count("list_archived_cards") >= 1,
+        "an unscoped listing has no board to narrow by, so it must still fall back to the global read"
+    );
+}

--- a/crates/kanban-service/tests/card_archived_at_scan.rs
+++ b/crates/kanban-service/tests/card_archived_at_scan.rs
@@ -313,7 +313,7 @@ fn test_card_get_by_id_leaves_live_card_archived_at_none() {
 }
 
 #[test]
-fn test_filter_cards_still_uses_archived_card_index() {
+fn test_board_scoped_list_cards_makes_no_global_marker_read() {
     let (backend, mut ctx) = counting_context();
     let board = ctx.create_board("Board".into(), None).unwrap();
     let col = ctx.create_column(board.id, "Todo".into(), None).unwrap();
@@ -335,8 +335,8 @@ fn test_filter_cards_still_uses_archived_card_index() {
     assert_eq!(cards.len(), 2);
     assert_eq!(
         backend.list_archived_cards_call_count(),
-        2,
-        "list_cards's collection-shaped path keeps building the archived index the same way it did before this change"
+        0,
+        "a board-scoped card listing answers from the board's own markers and never reads the workspace-global collection"
     );
 }
 


### PR DESCRIPTION
## Summary

- `KanbanContext::archived_card_index` now takes an `Option<Uuid>` board scope. Given `Some(board_id)` it reads only that board's archival markers via `list_archived_cards_by_board`; given `None` it keeps the existing workspace-global `list_archived_cards` read.
- `filter_cards`'s unscoped (`board_id: None`) arm passes `None`; `list_cards_detailed` passes `filter.board_id`. The board-scoped selector gather (`gather_board_cards_for_selector`) was already board-scoped and is unchanged.
- A board-scoped card listing (`list_cards`/`list_cards_detailed` with `board_id: Some(_)`) no longer performs a workspace-global archival-marker read. Over HTTP this used to fail outright with `Unsupported: list_archived_cards`, since `HttpBackend` declines the global read but wires the board-scoped one; a board-scoped listing over a remote locator now succeeds.
- Unscoped listings are unchanged: they still read the global collection locally and still decline over HTTP under the same name.
- Rewrote `archived_card_index`'s doc comment to state its scope contract instead of naming its callers.

## Tests

- New `crates/kanban-service/tests/archived_index_scope.rs` (behind the `test-helpers` feature): pins, via `FaultInjectingBackend`, that a board-scoped `list_cards_detailed` makes zero `list_archived_cards` calls and one `list_archived_cards_by_board` call, that it still succeeds (with correct `archived_at` stamping) when the global read is faulted, and that an unscoped listing still falls back to the global read.
- Rewrote `test_filter_cards_still_uses_archived_card_index` in `crates/kanban-service/tests/card_archived_at_scan.rs` to `test_board_scoped_list_cards_makes_no_global_marker_read`, flipping its `CountingBackend` assertion from 2 to 0.
- Added `test_list_cards_detailed_board_scoped_stamps_archived_at` to the shared contract suite (`crates/kanban-service/src/test_helpers/contract/archive.rs`), run against in-memory, JSON and SQLite via `context_contract_tests!`.
- Added `test_board_scoped_card_list_over_http_returns_live_and_archived` and `test_unscoped_card_list_over_http_declines_under_list_archived_cards` to `crates/kanban-backend-http/tests/archived_cards.rs`, proving the end-to-end HTTP behavior both ways.
- Mutation-checked the central assertion: reverting `list_cards_detailed` to pass `None` regardless of `filter.board_id` reproduces the two new red failures; restored before committing.

## Verification

- `cargo test -p kanban-service --features test-helpers`: green
- `cargo test -p kanban-backend-http`: green
- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features --workspace`: green
