### PR TITLE
KAN-1530 fix(domain,view,tui): resync honours ModelChanged and skips no-op partition rebuilds

### DIFF
--- a/.changeset/kan-1530-resync-honours-modelchanged.md
+++ b/.changeset/kan-1530-resync-honours-modelchanged.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+domain,view,tui: `ModelChanged` now carries whether the mutator that minted it actually wrote, exposed as `any()`, and `merge` folds two receipts by disjunction instead of discarding the second one. `apply_resolved` of an untouched `Resolved` and `invalidate` of an empty `EntityIds` report unchanged, while `load_from_snapshot`, `invalidate(Invalidation::All)` and every touched `apply_resolved` still report changed. `Controller::resync` skips rebuilding the archived-at side map and both live/archived partitions when the receipt reports unchanged, so a keystroke that mutates nothing no longer clones every `Card` and `Board` and re-sorts both board partitions. `Model` gains `replace_with`, and `App::reload_model`'s failure-rollback now restores the pre-reload model through that receipt-returning call instead of a direct field assignment paired with a no-op `apply_resolved` used purely to force a rebuild.

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -257,6 +257,103 @@ mod tests {
     }
 
     #[test]
+    fn test_a_receipt_from_an_untouched_apply_reports_nothing_changed() {
+        let mut m = Model::default();
+        let changed = m.apply_resolved(Resolved::default());
+        assert!(!changed.any());
+        NoProjections.resync(&m, changed);
+    }
+
+    #[test]
+    fn test_a_receipt_from_a_touched_apply_reports_changed() {
+        let mut m = Model::default();
+        assert!(m
+            .apply_resolved(Resolved {
+                boards: Collection {
+                    all: LoadState::Loaded(Vec::new()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .any());
+
+        let card_id = Uuid::new_v4();
+        let mut cards_by_id = HashMap::new();
+        cards_by_id.insert(
+            card_id,
+            LoadState::Loaded(Card::new(Uuid::new_v4(), Uuid::new_v4(), "c", 0)),
+        );
+        assert!(m
+            .apply_resolved(Resolved {
+                cards: Collection {
+                    by_id: cards_by_id,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .any());
+
+        let board_id = Uuid::new_v4();
+        let mut columns_by_parent = HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(Vec::new()));
+        assert!(m
+            .apply_resolved(Resolved {
+                columns: Collection {
+                    by_parent: columns_by_parent,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .any());
+
+        assert!(m
+            .apply_resolved(Resolved {
+                archived_cards: Collection {
+                    all: LoadState::Loaded(Vec::new()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .any());
+
+        assert!(m
+            .apply_resolved(Resolved {
+                archived_boards: Collection {
+                    all: LoadState::Loaded(Vec::new()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .any());
+
+        assert!(m
+            .apply_resolved(Resolved {
+                graph: LoadState::Loaded(DependencyGraph::default()),
+                ..Default::default()
+            })
+            .any());
+    }
+
+    #[test]
+    fn test_mark_failed_with_empty_ids_reports_unchanged() {
+        let mut m = Model::default();
+        let err = Arc::new(KanbanError::unsupported("x"));
+        let changed = m.mark_failed(EntityIds::default(), err);
+        assert!(!changed.any());
+        assert!(m.boards_state().is_not_loaded());
+        assert!(m.cards_state().is_not_loaded());
+    }
+
+    #[test]
+    fn test_mark_failed_with_ids_reports_changed() {
+        let mut m = Model::default();
+        let card_id = Uuid::new_v4();
+        let err = Arc::new(KanbanError::unsupported("x"));
+        let changed = m.mark_failed(EntityIds::cards([card_id]), err);
+        assert!(changed.any());
+    }
+
+    #[test]
     fn test_mark_failed_returns_a_model_changed_receipt() {
         let mut m = Model::default();
         let card_id = Uuid::new_v4();

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -81,6 +81,13 @@ impl Model {
     pub fn apply_resolved(&mut self, resolved: Resolved) -> ModelChanged {
         let boards_touched = !resolved.boards.is_untouched();
         let cards_touched = !resolved.cards.is_untouched();
+        let touched = boards_touched
+            || cards_touched
+            || !resolved.columns.is_untouched()
+            || !resolved.sprints.is_untouched()
+            || !resolved.archived_cards.is_untouched()
+            || !resolved.archived_boards.is_untouched()
+            || !resolved.graph.is_not_loaded();
 
         let Collection {
             all: boards_all,
@@ -173,7 +180,11 @@ impl Model {
             self.rebuild_board_index();
         }
 
-        ModelChanged::new()
+        if touched {
+            ModelChanged::new()
+        } else {
+            ModelChanged::unchanged()
+        }
     }
 
     /// Marks the flat collection, the per-id entries and the parent scopes
@@ -185,6 +196,7 @@ impl Model {
     /// whatever derives from this `Model` is stale until a
     /// [`DerivedProjections`] implementor consumes it.
     pub fn mark_failed(&mut self, ids: EntityIds, err: Arc<KanbanError>) -> ModelChanged {
+        let touched = !ids.is_empty();
         if !ids.boards.is_empty() {
             self.boards = LoadState::Failed(Arc::clone(&err));
             self.rebuild_board_index();
@@ -227,7 +239,11 @@ impl Model {
             self.graph = LoadState::Failed(err);
         }
 
-        ModelChanged::new()
+        if touched {
+            ModelChanged::new()
+        } else {
+            ModelChanged::unchanged()
+        }
     }
 }
 

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -40,7 +40,8 @@ impl ModelChanged {
 /// layer below it has to name the implementor.
 pub trait DerivedProjections {
     /// Recompute everything derived from `model`. Consumes the receipt, so this
-    /// cannot be called without a mutation having produced one.
+    /// cannot be called without a mutation having produced one. An implementor
+    /// may skip its recompute entirely when `changed.any()` is false.
     fn resync(&mut self, model: &Model, changed: ModelChanged);
 }
 

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -74,8 +74,10 @@ mod tests {
     #[test]
     fn test_model_changed_keeps_its_must_use_attribute_and_private_field() {
         let prod = include_str!("changed.rs")
+            .replace("\r\n", "\n")
             .split("#[cfg(test)]")
             .next()
+            .map(str::to_owned)
             .unwrap();
         assert!(prod.contains(
             "#[must_use = \"derived projections are stale until resync consumes this\"]"

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -63,7 +63,30 @@ mod tests {
         assert!(prod.contains(
             "#[must_use = \"derived projections are stale until resync consumes this\"]"
         ));
-        assert!(prod.contains("pub struct ModelChanged(());"));
+        assert!(prod.contains("pub struct ModelChanged {"));
+        assert!(prod.contains("\n    dirty: bool,\n"));
+        assert!(!prod.contains("pub dirty"));
+    }
+
+    #[test]
+    fn test_merge_of_an_unchanged_and_a_changed_receipt_reports_changed() {
+        let mut m = Model::default();
+
+        let unchanged_a = m.apply_resolved(crate::Resolved::default());
+        let unchanged_b = m.apply_resolved(crate::Resolved::default());
+        assert!(!unchanged_a.merge(unchanged_b).any());
+
+        let unchanged = m.apply_resolved(crate::Resolved::default());
+        let changed = m.load_from_snapshot(Snapshot::default());
+        assert!(unchanged.merge(changed).any());
+
+        let changed = m.load_from_snapshot(Snapshot::default());
+        let unchanged = m.apply_resolved(crate::Resolved::default());
+        assert!(changed.merge(unchanged).any());
+
+        let changed_a = m.load_from_snapshot(Snapshot::default());
+        let changed_b = m.load_from_snapshot(Snapshot::default());
+        assert!(changed_a.merge(changed_b).any());
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -1,21 +1,37 @@
 use super::Model;
 
-/// Proof that a `Model` mutation happened and that whatever derives from it has
-/// not been recomputed yet. Minted only by the `Model` mutators, since the field
-/// is private, and consumed by a `DerivedProjections` implementor.
+/// Proof that a `Model` mutation ran and that whatever derives from it may be
+/// stale. Minted only by the `Model` mutators, since the field is private, and
+/// consumed by a `DerivedProjections` implementor. `any()` reports whether the
+/// mutator actually wrote anything, so a mutator that ran but touched nothing
+/// (an untouched `apply_resolved`, an `invalidate` of an empty `EntityIds`)
+/// can tell its consumer there is nothing to recompute.
 #[derive(Debug)]
 #[must_use = "derived projections are stale until resync consumes this"]
-pub struct ModelChanged(());
+pub struct ModelChanged {
+    dirty: bool,
+}
 
 impl ModelChanged {
     pub(crate) fn new() -> Self {
-        Self(())
+        Self { dirty: true }
     }
 
-    /// Folds two receipts into one so a caller performing several mutations
-    /// resyncs once instead of discarding the extras.
-    pub fn merge(self, _other: Self) -> Self {
-        self
+    pub(crate) fn unchanged() -> Self {
+        Self { dirty: false }
+    }
+
+    /// Whether the mutator that minted this receipt actually wrote.
+    pub fn any(&self) -> bool {
+        self.dirty
+    }
+
+    /// Folds two receipts into one, as a disjunction, so a caller performing
+    /// several mutations resyncs once instead of discarding the extras.
+    pub fn merge(self, other: Self) -> Self {
+        Self {
+            dirty: self.dirty || other.dirty,
+        }
     }
 }
 

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -702,6 +702,22 @@ mod tests {
     }
 
     #[test]
+    fn test_invalidate_of_an_empty_entity_set_reports_unchanged() {
+        let (mut m, ..) = seeded();
+        let changed = m.invalidate(Invalidation::Entities(EntityIds::default()));
+        assert!(!changed.any());
+        assert!(m.boards_state().is_loaded());
+    }
+
+    #[test]
+    fn test_invalidate_all_reports_changed() {
+        let (mut m, ..) = seeded();
+        let changed = m.invalidate(Invalidation::All);
+        assert!(changed.any());
+        assert!(m.cards_state().is_not_loaded());
+    }
+
+    #[test]
     fn test_invalidate_a_column_id_drops_that_column_and_the_column_collection() {
         let (mut m, _board, col_a, col_b, _c1, _c2, _sprint) = seeded();
 

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -35,7 +35,7 @@ impl Model {
                 *self = Self::default();
                 return ModelChanged::new();
             }
-            Invalidation::Entities(ids) if ids.is_empty() => return ModelChanged::new(),
+            Invalidation::Entities(ids) if ids.is_empty() => return ModelChanged::unchanged(),
             Invalidation::Entities(ids) => ids,
         };
 

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -237,6 +237,13 @@ mod tests {
     }
 
     #[test]
+    fn test_load_from_snapshot_always_reports_changed() {
+        let mut m = Model::default();
+        let changed = m.load_from_snapshot(Snapshot::default());
+        assert!(changed.any());
+    }
+
+    #[test]
     fn test_load_from_snapshot_populates_boards_and_columns() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -90,9 +90,10 @@ fn scoped_state<T>(map: &HashMap<Uuid, LoadState<Vec<T>>>, parent: Uuid) -> Load
 }
 
 impl Model {
-    /// Returns a [`ModelChanged`] receipt: whatever derives from this
-    /// `Model` is stale until a [`DerivedProjections`] implementor consumes
-    /// it.
+    /// Returns a [`ModelChanged`] receipt that always reports `any()`: even
+    /// an empty `snapshot` moves every tier from whatever it held to
+    /// `Loaded`, which is itself a real change a `DerivedProjections`
+    /// implementor must observe.
     pub fn load_from_snapshot(&mut self, snapshot: Snapshot) -> ModelChanged {
         // Reference-marker model: `snapshot.cards`/`snapshot.boards` each carry
         // EVERY row — live AND archived — with archival recorded by markers
@@ -122,6 +123,15 @@ impl Model {
         self.rebuild_board_index();
         self.rebuild_board_scoped_tiers();
 
+        ModelChanged::new()
+    }
+
+    /// Replaces the whole `Model` with `other` and always reports `any()`.
+    /// For a caller restoring a kept-aside `Model` (e.g. a failed reload's
+    /// rollback), so the restore goes through a receipt instead of a direct
+    /// field assignment a `DerivedProjections` implementor never sees.
+    pub fn replace_with(&mut self, other: Model) -> ModelChanged {
+        *self = other;
         ModelChanged::new()
     }
 

--- a/crates/kanban-service/src/context/sync/tests.rs
+++ b/crates/kanban-service/src/context/sync/tests.rs
@@ -217,7 +217,7 @@ fn test_sync_invalidated_with_an_empty_entity_set_and_a_satisfied_plan_reports_u
     );
 
     assert_eq!(recording.any_flags.last(), Some(&true));
-    assert_eq!(recording.any_flags[recording.any_flags.len() - 2], false);
+    assert!(!recording.any_flags[recording.any_flags.len() - 2]);
 }
 
 #[test]

--- a/crates/kanban-service/src/context/sync/tests.rs
+++ b/crates/kanban-service/src/context/sync/tests.rs
@@ -66,6 +66,17 @@ impl DerivedProjections for CountingProjections {
     }
 }
 
+#[derive(Default)]
+struct RecordingProjections {
+    any_flags: Vec<bool>,
+}
+
+impl DerivedProjections for RecordingProjections {
+    fn resync(&mut self, _model: &Model, changed: ModelChanged) {
+        self.any_flags.push(changed.any());
+    }
+}
+
 fn ctx_with_seeded_board() -> (KanbanContext, Board) {
     let store = InMemoryStore::new();
     let board = Board::new("Seeded", None::<String>);
@@ -170,6 +181,43 @@ fn test_sync_invalidated_refetches_the_invalidated_card_before_planning() {
         model_b.card_by_id_state(card_b.id).loaded().unwrap().title,
         "before"
     );
+}
+
+#[test]
+fn test_sync_over_an_already_satisfied_plan_reports_an_unchanged_receipt() {
+    let (ctx, _board) = ctx_with_seeded_board();
+    let mut model = Model::default();
+    let mut recording = RecordingProjections::default();
+
+    ctx.sync(&BoardListPlan, &mut model, &mut recording);
+    ctx.sync(&BoardListPlan, &mut model, &mut recording);
+
+    assert_eq!(recording.any_flags, vec![true, false]);
+}
+
+#[test]
+fn test_sync_invalidated_with_an_empty_entity_set_and_a_satisfied_plan_reports_unchanged() {
+    let (ctx, board) = ctx_with_seeded_board();
+    let mut model = Model::default();
+    let mut recording = RecordingProjections::default();
+
+    ctx.sync(&BoardListPlan, &mut model, &mut recording);
+
+    ctx.sync_invalidated(
+        Invalidation::Entities(kanban_domain::EntityIds::default()),
+        &BoardListPlan,
+        &mut model,
+        &mut recording,
+    );
+    ctx.sync_invalidated(
+        Invalidation::Entities(kanban_domain::EntityIds::boards([board.id])),
+        &BoardListPlan,
+        &mut model,
+        &mut recording,
+    );
+
+    assert_eq!(recording.any_flags.last(), Some(&true));
+    assert_eq!(recording.any_flags[recording.any_flags.len() - 2], false);
 }
 
 #[test]

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -2,7 +2,7 @@ use super::{App, AppMode, ViewScope};
 use crate::view_strategy::UnifiedViewStrategy;
 use kanban_domain::{
     filter_and_sort_boards, Board, BoardListFilter, Card, DerivedProjections, Invalidation,
-    KanbanResult, LoadState, Resolved, Snapshot, UndoOperations,
+    KanbanResult, LoadState, Snapshot, UndoOperations,
 };
 use kanban_view::view_strategy::{ViewRefreshContext, ViewStrategy};
 use std::collections::HashMap;
@@ -127,8 +127,7 @@ impl App {
             &mut self.controller,
         );
         if self.surface_load_failures() {
-            self.model = previous;
-            let changed = self.model.apply_resolved(Resolved::default());
+            let changed = self.model.replace_with(previous);
             self.controller.resync(&self.model, changed);
         }
     }

--- a/crates/kanban-tui/tests/reload_model_rollback_tests.rs
+++ b/crates/kanban-tui/tests/reload_model_rollback_tests.rs
@@ -1,0 +1,42 @@
+use kanban_domain::KanbanOperations;
+use kanban_service::test_helpers::FaultInjectingBackend;
+use kanban_tui::App;
+use std::sync::Arc;
+
+#[test]
+fn test_reload_model_keeps_the_controller_partitions_on_the_restored_model_when_a_read_fails() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.reload_model();
+
+    assert_eq!(
+        app.controller
+            .displayed_boards(false)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|b| b.id)
+            .collect::<Vec<_>>(),
+        vec![board.id]
+    );
+
+    let fault = Arc::new(FaultInjectingBackend::new(app.ctx.backend()));
+    app.ctx.replace_backend(fault.clone());
+    fault.fail("list_boards");
+
+    app.reload_model();
+
+    assert!(app.ui_state.banner.is_some());
+    assert_eq!(
+        app.controller
+            .displayed_boards(false)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|b| b.id)
+            .collect::<Vec<_>>(),
+        vec![board.id]
+    );
+}

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -57,7 +57,10 @@ impl Default for Controller {
 }
 
 impl DerivedProjections for Controller {
-    fn resync(&mut self, model: &Model, _changed: ModelChanged) {
+    fn resync(&mut self, model: &Model, changed: ModelChanged) {
+        if !changed.any() {
+            return;
+        }
         self.archived_board_at = model
             .archived_boards()
             .iter()

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -289,6 +289,175 @@ mod tests {
         );
     }
 
+    fn seed_non_empty_model() -> (Model, Controller) {
+        let board = seed_board("B", 0);
+        let column = Column::new(board.id, "Col", 0);
+        let live = Card::new(board.id, column.id, "live", 0);
+        let archived = Card::new(board.id, column.id, "archived", 1);
+        let archived_id = archived.id;
+        let mut model = Model::default();
+        let changed = model.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            columns: vec![column],
+            cards: vec![live, archived],
+            archived_cards: vec![ArchivedCard::new(archived_id, Uuid::nil())],
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model, changed);
+        (model, controller)
+    }
+
+    #[test]
+    fn test_resync_with_an_unchanged_receipt_leaves_the_cached_partitions_untouched() {
+        let (mut model, mut controller) = seed_non_empty_model();
+        let cards_before = controller
+            .displayed_cards(false)
+            .loaded()
+            .copied()
+            .unwrap()
+            .as_ptr();
+        let boards_before = controller
+            .displayed_boards(false)
+            .loaded()
+            .copied()
+            .unwrap()
+            .as_ptr();
+
+        let unchanged = model.apply_resolved(Resolved::default());
+        assert!(!unchanged.any());
+        controller.resync(&model, unchanged);
+
+        assert_eq!(
+            controller
+                .displayed_cards(false)
+                .loaded()
+                .copied()
+                .unwrap()
+                .as_ptr(),
+            cards_before
+        );
+        assert_eq!(
+            controller
+                .displayed_boards(false)
+                .loaded()
+                .copied()
+                .unwrap()
+                .as_ptr(),
+            boards_before
+        );
+    }
+
+    #[test]
+    fn test_resync_with_a_changed_receipt_rebuilds_the_partitions() {
+        let (mut model, mut controller) = seed_non_empty_model();
+        let cards_before = controller
+            .displayed_cards(false)
+            .loaded()
+            .copied()
+            .unwrap()
+            .as_ptr();
+
+        let board = seed_board("B", 0);
+        let column = Column::new(board.id, "Col", 0);
+        let mut live_edited = Card::new(board.id, column.id, "live edited", 0);
+        let live_id = model.cards_state().loaded().unwrap()[0].id;
+        live_edited.id = live_id;
+        let changed = model.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Loaded(vec![live_edited.clone()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        assert!(changed.any());
+        controller.resync(&model, changed);
+
+        let cards_after = controller.displayed_cards(false).loaded().copied().unwrap();
+        assert_ne!(cards_after.as_ptr(), cards_before);
+        assert_eq!(cards_after[0].title, "live edited");
+    }
+
+    #[test]
+    fn test_resync_after_a_whole_model_replacement_rebuilds_the_partitions() {
+        let board_a1 = seed_board("A1", 0);
+        let board_a2 = seed_board("A2", 1);
+        let mut model_a = Model::default();
+        let changed = model_a.load_from_snapshot(Snapshot {
+            boards: vec![board_a1, board_a2],
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model_a, changed);
+        assert_eq!(
+            controller
+                .displayed_boards(false)
+                .loaded()
+                .copied()
+                .unwrap()
+                .len(),
+            2
+        );
+
+        let board_b = seed_board("B", 0);
+        let board_b_id = board_b.id;
+        let mut model_b = Model::default();
+        let _ = model_b.load_from_snapshot(Snapshot {
+            boards: vec![board_b],
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+
+        let changed = model_a.replace_with(model_b);
+        assert!(changed.any());
+        controller.resync(&model_a, changed);
+
+        let boards: Vec<Uuid> = controller
+            .displayed_boards(false)
+            .loaded()
+            .copied()
+            .unwrap()
+            .iter()
+            .map(|b| b.id)
+            .collect();
+        assert_eq!(boards, vec![board_b_id]);
+    }
+
+    #[test]
+    fn test_board_sort_change_after_a_skipped_resync_still_reorders() {
+        let mut zed = Board::new("Zed", None::<String>);
+        zed.position = 0;
+        let mut alpha = Board::new("Alpha", None::<String>);
+        alpha.position = 1;
+        let zed_id = zed.id;
+        let alpha_id = alpha.id;
+        let mut model = Model::default();
+        let changed = model.load_from_snapshot(Snapshot {
+            boards: vec![zed, alpha],
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model, changed);
+
+        let unchanged = model.apply_resolved(Resolved::default());
+        assert!(!unchanged.any());
+        controller.resync(&model, unchanged);
+
+        controller.set_board_sort(false, BoardSortField::Name, SortOrder::Descending);
+        let order: Vec<Uuid> = controller
+            .displayed_boards(false)
+            .loaded()
+            .copied()
+            .unwrap()
+            .iter()
+            .map(|b| b.id)
+            .collect();
+        assert_eq!(order, vec![zed_id, alpha_id]);
+    }
+
     #[test]
     fn test_a_projections_implementor_cannot_mint_a_receipt() {
         let src = std::fs::read_to_string(concat!(


### PR DESCRIPTION
## Summary

- `ModelChanged` now carries a private `dirty: bool`, exposed as `pub fn any(&self) -> bool`. `merge` folds two receipts by disjunction instead of discarding the second one.
- `apply_resolved` of an untouched `Resolved` and `invalidate` of an empty `EntityIds` now report unchanged. `load_from_snapshot`, `invalidate(Invalidation::All)`, `mark_failed` with named ids, and every touched `apply_resolved` still report changed.
- `Controller::resync` early-returns when `!changed.any()`, so a keystroke that mutates nothing no longer rebuilds the archived-at side map or clones/re-sorts both live and archived card and board partitions.
- `Model` gains `replace_with(Model) -> ModelChanged`. `App::reload_model`'s failure-rollback now uses it instead of assigning `self.model = previous` directly and minting a no-op `apply_resolved(Resolved::default())` purely to force a rebuild, closing the one production hole where that previously-harmless no-op mutator call was load-bearing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace` (297 test binaries, 0 failures)
- [x] Mutation-checked the central assertions: reverting the `Controller::resync` early return and reverting the `reload_model` rollback fix each independently made their pinning test fail, then restored
- [x] New pinning tests: unchanged receipt leaves cached partition pointers untouched; a changed receipt reallocates them; a whole-model replacement rebuilds them; a sort change applied after a skipped resync still reorders the cached partitions; a faulted `list_boards` reload keeps the pre-reload partitions on the controller
