### PR TITLE
KAN-1587 feat(tui,backend-http,server): stream SSE change events into a live remote session

### DIFF
--- a/.changeset/kan-1587-sse-remote-freshness.md
+++ b/.changeset/kan-1587-sse-remote-freshness.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+TUI sessions on a remote server now stay fresh via SSE, receiving other clients' changes live instead of only on manual refresh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/kanban-backend-http/Cargo.toml
+++ b/crates/kanban-backend-http/Cargo.toml
@@ -25,6 +25,7 @@ serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 kanban-server = { path = "../kanban-server", features = ["test-helpers"] }

--- a/crates/kanban-backend-http/src/events.rs
+++ b/crates/kanban-backend-http/src/events.rs
@@ -54,8 +54,12 @@ mod tests {
 
     #[test]
     fn test_sse_parser_parses_single_data_line_into_frame() {
-        let frame = ChangeEventFrame::now(Uuid::new_v4(), Uuid::new_v4(), ClientId::from(Uuid::new_v4()))
-            .with_invalidation(InvalidationDto::All);
+        let frame = ChangeEventFrame::now(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            ClientId::from(Uuid::new_v4()),
+        )
+        .with_invalidation(InvalidationDto::All);
         let json = serde_json::to_string(&frame).unwrap();
         let wire = format!("data: {json}\n\n");
 

--- a/crates/kanban-backend-http/src/events.rs
+++ b/crates/kanban-backend-http/src/events.rs
@@ -1,3 +1,50 @@
+use kanban_api::ChangeEventFrame;
+use std::time::Duration;
+
+#[derive(Default)]
+pub(crate) struct SseParser {
+    buf: Vec<u8>,
+    data: String,
+}
+
+impl SseParser {
+    pub(crate) fn push(&mut self, chunk: &[u8]) -> Vec<ChangeEventFrame> {
+        self.buf.extend_from_slice(chunk);
+        let mut frames = Vec::new();
+
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let line_bytes: Vec<u8> = self.buf.drain(..=pos).collect();
+            let line = String::from_utf8_lossy(&line_bytes[..line_bytes.len() - 1]);
+            let line = line.strip_suffix('\r').unwrap_or(&line).to_string();
+
+            if line.is_empty() {
+                if !self.data.is_empty() {
+                    let data = std::mem::take(&mut self.data);
+                    match serde_json::from_str::<ChangeEventFrame>(&data) {
+                        Ok(frame) => frames.push(frame),
+                        Err(e) => {
+                            tracing::warn!("dropping malformed SSE change frame: {e}");
+                        }
+                    }
+                }
+            } else if line.starts_with(':') {
+            } else if let Some(rest) = line.strip_prefix("data:") {
+                let rest = rest.strip_prefix(' ').unwrap_or(rest);
+                if !self.data.is_empty() {
+                    self.data.push('\n');
+                }
+                self.data.push_str(rest);
+            }
+        }
+
+        frames
+    }
+}
+
+pub(crate) fn next_backoff(cur: Duration) -> Duration {
+    (cur * 2).min(Duration::from_secs(30))
+}
+
 #[cfg(test)]
 mod tests {
     use kanban_api::{ChangeEventFrame, InvalidationDto};

--- a/crates/kanban-backend-http/src/events.rs
+++ b/crates/kanban-backend-http/src/events.rs
@@ -1,0 +1,85 @@
+#[cfg(test)]
+mod tests {
+    use kanban_api::{ChangeEventFrame, InvalidationDto};
+    use kanban_core::ClientId;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_sse_parser_parses_single_data_line_into_frame() {
+        let frame = ChangeEventFrame::now(Uuid::new_v4(), Uuid::new_v4(), ClientId::from(Uuid::new_v4()))
+            .with_invalidation(InvalidationDto::All);
+        let json = serde_json::to_string(&frame).unwrap();
+        let wire = format!("data: {json}\n\n");
+
+        let mut parser = super::SseParser::default();
+        let frames = parser.push(wire.as_bytes());
+
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].issued_by, frame.issued_by);
+        assert_eq!(frames[0].invalidation, frame.invalidation);
+    }
+
+    #[test]
+    fn test_sse_parser_ignores_keep_alive_comment_lines() {
+        let mut parser = super::SseParser::default();
+        let frames = parser.push(b":\n\n:\n\n: keep-alive\n\n");
+        assert!(frames.is_empty());
+
+        let frame = ChangeEventFrame::now(Uuid::new_v4(), Uuid::new_v4(), ClientId::nil());
+        let json = serde_json::to_string(&frame).unwrap();
+        let wire = format!("data: {json}\n\n");
+        let frames = parser.push(wire.as_bytes());
+        assert_eq!(frames.len(), 1);
+    }
+
+    #[test]
+    fn test_sse_parser_reassembles_frame_split_across_chunks() {
+        let frame = ChangeEventFrame::now(Uuid::new_v4(), Uuid::new_v4(), ClientId::nil());
+        let json = serde_json::to_string(&frame).unwrap();
+        let wire = format!("data: {json}\n\n");
+        let bytes = wire.as_bytes();
+        let mid = bytes.len() / 2;
+
+        let mut parser = super::SseParser::default();
+        let first = parser.push(&bytes[..mid]);
+        assert!(first.is_empty());
+
+        let second = parser.push(&bytes[mid..]);
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].writer_instance_id, frame.writer_instance_id);
+    }
+
+    #[test]
+    fn test_sse_parser_skips_malformed_data_line_and_continues() {
+        let frame = ChangeEventFrame::now(Uuid::new_v4(), Uuid::new_v4(), ClientId::nil());
+        let json = serde_json::to_string(&frame).unwrap();
+        let wire = format!("data: {{not json\n\ndata: {json}\n\n");
+
+        let mut parser = super::SseParser::default();
+        let frames = parser.push(wire.as_bytes());
+
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].writer_instance_id, frame.writer_instance_id);
+    }
+
+    #[test]
+    fn test_next_backoff_doubles_and_caps_at_thirty_seconds() {
+        assert_eq!(
+            super::next_backoff(Duration::from_secs(1)),
+            Duration::from_secs(2)
+        );
+        assert_eq!(
+            super::next_backoff(Duration::from_secs(2)),
+            Duration::from_secs(4)
+        );
+        assert_eq!(
+            super::next_backoff(Duration::from_secs(16)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            super::next_backoff(Duration::from_secs(30)),
+            Duration::from_secs(30)
+        );
+    }
+}

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -131,6 +131,54 @@ impl HttpBackend {
     pub(crate) fn client(&self) -> &reqwest::Client {
         &self.client
     }
+
+    pub fn subscribe(&self) -> tokio::sync::mpsc::Receiver<kanban_api::ChangeEventFrame> {
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        let client = self.client().clone();
+        let url = format!("{}/v1/events", self.base_url());
+        let runtime = self
+            .runtime
+            .as_ref()
+            .expect("the runtime is taken only while dropping");
+
+        runtime.handle().spawn(async move {
+            let mut backoff = std::time::Duration::from_secs(1);
+            loop {
+                if let Ok(mut resp) = client.get(&url).send().await {
+                    if resp.status().is_success() {
+                        backoff = std::time::Duration::from_secs(1);
+                        let synthetic = kanban_api::ChangeEventFrame::now(
+                            uuid::Uuid::nil(),
+                            uuid::Uuid::new_v4(),
+                            kanban_core::ClientId::nil(),
+                        );
+                        if tx.send(synthetic).await.is_err() {
+                            return;
+                        }
+                        let mut parser = events::SseParser::default();
+                        while let Ok(Some(chunk)) = resp.chunk().await {
+                            for frame in parser.push(&chunk) {
+                                if tx.send(frame).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                    } else {
+                        tracing::warn!(
+                            "SSE subscription to {url} rejected with status {}",
+                            resp.status()
+                        );
+                    }
+                } else {
+                    tracing::warn!("SSE subscription to {url} failed to connect");
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = events::next_backoff(backoff);
+            }
+        });
+
+        rx
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -259,4 +259,16 @@ mod tests {
         assert_eq!(backend_ref.instance_id(), backend.instance_id);
         Ok(())
     }
+
+    #[test]
+    fn test_http_backend_as_any_downcasts_to_http_backend() -> kanban_domain::KanbanResult<()> {
+        let backend = HttpBackend::new("http://example.com")?;
+        let backend_ref: &dyn kanban_backend::KanbanBackend = &backend;
+        let downcast = backend_ref
+            .as_any()
+            .and_then(|a| a.downcast_ref::<HttpBackend>());
+        let downcast = downcast.expect("expected as_any to downcast to HttpBackend");
+        assert_eq!(downcast.instance_id(), backend.instance_id());
+        Ok(())
+    }
 }

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -3,6 +3,7 @@ mod command_store;
 mod conversions;
 mod conversions_out;
 mod data_store;
+mod events;
 mod http;
 mod http_mutation;
 mod remote_writes;

--- a/crates/kanban-backend-http/src/lib.rs
+++ b/crates/kanban-backend-http/src/lib.rs
@@ -38,6 +38,10 @@ impl kanban_backend::KanbanBackend for HttpBackend {
         self.instance_id
     }
 
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
     async fn probe(&self) -> kanban_domain::KanbanResult<()> {
         let url = format!("{}/health", self.base_url());
         let resp = self.client().get(&url).send().await.map_err(|e| {

--- a/crates/kanban-backend-http/tests/sse_subscription.rs
+++ b/crates/kanban-backend-http/tests/sse_subscription.rs
@@ -9,13 +9,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
-async fn ctx_over(server: &TestServer) -> KanbanContext {
-    let backend = Arc::new(HttpBackend::new(&server.base_url()).unwrap());
-    KanbanContext::open(backend, AppConfig::default())
-        .await
-        .unwrap()
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_delivers_synthetic_all_frame_on_connect() {
     let server = TestServer::start().await;
@@ -30,6 +23,8 @@ async fn test_subscribe_delivers_synthetic_all_frame_on_connect() {
     assert!(frame.invalidation.is_none());
     assert_eq!(frame.issued_by, ClientId::nil());
 
+    drop(rx);
+    drop(backend);
     server.shutdown().await;
 }
 
@@ -74,13 +69,15 @@ async fn test_foreign_mutation_produces_frame_with_converting_invalidation() {
         other => panic!("expected Invalidation::Entities, got {other:?}"),
     }
 
+    drop(rx);
+    drop(backend);
     server.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_own_mutation_frame_carries_own_instance_id_as_issued_by() {
     let server = TestServer::start().await;
-    let backend = HttpBackend::new(&server.base_url()).unwrap();
+    let backend = Arc::new(HttpBackend::new(&server.base_url()).unwrap());
     let own_instance_id = backend.instance_id();
 
     let mut rx = backend.subscribe();
@@ -89,7 +86,10 @@ async fn test_own_mutation_frame_carries_own_instance_id_as_issued_by() {
         .expect("timed out waiting for the connect synthetic")
         .expect("channel closed before delivering the connect synthetic");
 
-    let mut ctx = ctx_over(&server).await;
+    let dyn_backend: Arc<dyn kanban_service::KanbanBackend> = backend.clone();
+    let mut ctx = KanbanContext::open(dyn_backend, AppConfig::default())
+        .await
+        .unwrap();
     ctx.create_board("Own Board".to_string(), Some("OWN".to_string()))
         .unwrap();
 
@@ -101,5 +101,8 @@ async fn test_own_mutation_frame_carries_own_instance_id_as_issued_by() {
     assert_eq!(frame.issued_by, ClientId::from(own_instance_id));
     assert_ne!(frame.issued_by, ClientId::nil());
 
+    drop(rx);
+    drop(ctx);
+    drop(backend);
     server.shutdown().await;
 }

--- a/crates/kanban-backend-http/tests/sse_subscription.rs
+++ b/crates/kanban-backend-http/tests/sse_subscription.rs
@@ -1,0 +1,105 @@
+use kanban_backend::KanbanBackend;
+use kanban_backend_http::HttpBackend;
+use kanban_core::ClientId;
+use kanban_domain::KanbanOperations;
+use kanban_server::test_helpers::TestServer;
+use kanban_service::{AppConfig, KanbanContext};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+async fn ctx_over(server: &TestServer) -> KanbanContext {
+    let backend = Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+    KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscribe_delivers_synthetic_all_frame_on_connect() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let mut rx = backend.subscribe();
+    let frame = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for the connect synthetic")
+        .expect("channel closed before delivering the connect synthetic");
+
+    assert!(frame.invalidation.is_none());
+    assert_eq!(frame.issued_by, ClientId::nil());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_foreign_mutation_produces_frame_with_converting_invalidation() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+
+    let mut rx = backend.subscribe();
+    let _synthetic = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for the connect synthetic")
+        .expect("channel closed before delivering the connect synthetic");
+
+    let foreign_client_id = Uuid::new_v4();
+    let response = server
+        .client()
+        .post(format!("{}/v1/boards", server.base_url()))
+        .header("x-kanban-client-id", foreign_client_id.to_string())
+        .json(&json!({"name": "Foreign Board", "card_prefix": "FRN"}))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = response.json().await.unwrap();
+    let board_id: Uuid = body["id"].as_str().unwrap().parse().unwrap();
+
+    let frame = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for the mutation frame")
+        .expect("channel closed before delivering the mutation frame");
+
+    assert_eq!(frame.issued_by, ClientId::from(foreign_client_id));
+    let invalidation_dto = frame
+        .invalidation
+        .as_ref()
+        .expect("expected the mutation frame to carry an invalidation");
+    let invalidation = kanban_domain::Invalidation::from(invalidation_dto);
+    match invalidation {
+        kanban_domain::Invalidation::Entities(ids) => {
+            assert!(ids.boards.contains(&board_id));
+        }
+        other => panic!("expected Invalidation::Entities, got {other:?}"),
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_own_mutation_frame_carries_own_instance_id_as_issued_by() {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+    let own_instance_id = backend.instance_id();
+
+    let mut rx = backend.subscribe();
+    let _synthetic = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for the connect synthetic")
+        .expect("channel closed before delivering the connect synthetic");
+
+    let mut ctx = ctx_over(&server).await;
+    ctx.create_board("Own Board".to_string(), Some("OWN".to_string()))
+        .unwrap();
+
+    let frame = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for the mutation frame")
+        .expect("channel closed before delivering the mutation frame");
+
+    assert_eq!(frame.issued_by, ClientId::from(own_instance_id));
+    assert_ne!(frame.issued_by, ClientId::nil());
+
+    server.shutdown().await;
+}

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -95,6 +95,12 @@ pub trait KanbanBackend: DataStore + CommandStore + Send + Sync {
         None
     }
 
+    /// Some(...) when a caller needs to downcast to the concrete backend type.
+    /// `None` (the default) for backends that offer no such hook.
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
+
     /// Run `f` as an atomic batch: every mutation commits or rolls back
     /// together.
     ///

--- a/crates/kanban-backend/src/lib.rs
+++ b/crates/kanban-backend/src/lib.rs
@@ -331,6 +331,13 @@ mod tests {
     }
 
     #[test]
+    fn test_kanban_backend_as_any_defaults_to_none() {
+        let backend = StubBackend::default();
+        let backend: &dyn KanbanBackend = &backend;
+        assert!(backend.as_any().is_none());
+    }
+
+    #[test]
     fn test_mark_dirty_is_callable_on_a_backend_that_does_not_override_it() {
         let backend = StubBackend::default();
         let backend: &dyn KanbanBackend = &backend;

--- a/crates/kanban-core/src/client_id.rs
+++ b/crates/kanban-core/src/client_id.rs
@@ -14,6 +14,10 @@ impl ClientId {
     pub fn nil() -> Self {
         Self(Uuid::nil())
     }
+
+    pub fn is_nil(&self) -> bool {
+        self.0.is_nil()
+    }
 }
 
 impl Default for ClientId {

--- a/crates/kanban-core/src/client_id.rs
+++ b/crates/kanban-core/src/client_id.rs
@@ -90,4 +90,11 @@ mod tests {
     fn test_client_id_default_is_nil() {
         assert_eq!(ClientId::default(), ClientId::nil());
     }
+
+    #[test]
+    fn test_client_id_is_nil_matches_nil_constructor() {
+        assert!(ClientId::nil().is_nil());
+        assert!(!ClientId::new().is_nil());
+        assert!(ClientId::from(Uuid::nil()).is_nil());
+    }
 }

--- a/crates/kanban-server/src/routes/events.rs
+++ b/crates/kanban-server/src/routes/events.rs
@@ -34,11 +34,14 @@ async fn events(
     State(state): State<AppState>,
 ) -> Sse<impl futures_util::stream::Stream<Item = Result<Event, Infallible>> + Send> {
     let rx = state.event_tx.subscribe();
-    let stream = stream::unfold((rx, state.instance_id), |(mut rx, instance_id)| async move {
-        next_event_frame(&mut rx, instance_id)
-            .await
-            .map(|frame| (Ok(frame_to_event(&frame)), (rx, instance_id)))
-    });
+    let stream = stream::unfold(
+        (rx, state.instance_id),
+        |(mut rx, instance_id)| async move {
+            next_event_frame(&mut rx, instance_id)
+                .await
+                .map(|frame| (Ok(frame_to_event(&frame)), (rx, instance_id)))
+        },
+    );
     Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
 }
 

--- a/crates/kanban-server/src/routes/events.rs
+++ b/crates/kanban-server/src/routes/events.rs
@@ -19,18 +19,14 @@ async fn next_event_frame(
     rx: &mut broadcast::Receiver<ChangeEventFrame>,
     instance_id: uuid::Uuid,
 ) -> Option<ChangeEventFrame> {
-    loop {
-        match rx.recv().await {
-            Ok(frame) => return Some(frame),
-            Err(broadcast::error::RecvError::Lagged(_)) => {
-                return Some(ChangeEventFrame::now(
-                    instance_id,
-                    uuid::Uuid::new_v4(),
-                    kanban_core::ClientId::nil(),
-                ));
-            }
-            Err(broadcast::error::RecvError::Closed) => return None,
-        }
+    match rx.recv().await {
+        Ok(frame) => Some(frame),
+        Err(broadcast::error::RecvError::Lagged(_)) => Some(ChangeEventFrame::now(
+            instance_id,
+            uuid::Uuid::new_v4(),
+            kanban_core::ClientId::nil(),
+        )),
+        Err(broadcast::error::RecvError::Closed) => None,
     }
 }
 

--- a/crates/kanban-server/src/routes/events.rs
+++ b/crates/kanban-server/src/routes/events.rs
@@ -38,6 +38,8 @@ pub fn router() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kanban_core::ClientId;
+    use uuid::Uuid;
 
     #[test]
     fn test_change_event_frame_maps_to_sse_data_json() {
@@ -47,9 +49,33 @@ mod tests {
             kanban_core::ClientId::new(),
         );
         let event = frame_to_event(&frame);
-        // axum's Event doesn't expose accessors, but as long as frame_to_event
-        // doesn't panic on a real frame, the integration tests will verify
-        // the actual JSON shape reaching the wire is correct.
         let _ = event;
+    }
+
+    #[tokio::test]
+    async fn test_lagged_subscriber_receives_synthetic_all_frame() {
+        let (tx, mut rx) = broadcast::channel::<ChangeEventFrame>(2);
+        let instance_id = Uuid::new_v4();
+        let oldest_retained_correlation_id = Uuid::from_bytes([2; 16]);
+
+        for i in 0..4u8 {
+            let _ = tx.send(ChangeEventFrame::now(
+                instance_id,
+                Uuid::from_bytes([i; 16]),
+                ClientId::new(),
+            ));
+        }
+
+        let frame = next_event_frame(&mut rx, instance_id).await;
+        let frame = frame.expect("expected a synthetic frame after lag");
+        assert!(frame.invalidation.is_none());
+        assert_eq!(frame.issued_by, ClientId::nil());
+        assert_eq!(frame.writer_instance_id, instance_id);
+
+        let next = next_event_frame(&mut rx, instance_id)
+            .await
+            .expect("expected the oldest retained real frame");
+        assert_eq!(next.correlation_id, oldest_retained_correlation_id);
+        assert_ne!(next.issued_by, ClientId::nil());
     }
 }

--- a/crates/kanban-server/src/routes/events.rs
+++ b/crates/kanban-server/src/routes/events.rs
@@ -15,18 +15,33 @@ fn frame_to_event(frame: &ChangeEventFrame) -> Event {
         .expect("ChangeEventFrame always serializes")
 }
 
+async fn next_event_frame(
+    rx: &mut broadcast::Receiver<ChangeEventFrame>,
+    instance_id: uuid::Uuid,
+) -> Option<ChangeEventFrame> {
+    loop {
+        match rx.recv().await {
+            Ok(frame) => return Some(frame),
+            Err(broadcast::error::RecvError::Lagged(_)) => {
+                return Some(ChangeEventFrame::now(
+                    instance_id,
+                    uuid::Uuid::new_v4(),
+                    kanban_core::ClientId::nil(),
+                ));
+            }
+            Err(broadcast::error::RecvError::Closed) => return None,
+        }
+    }
+}
+
 async fn events(
     State(state): State<AppState>,
 ) -> Sse<impl futures_util::stream::Stream<Item = Result<Event, Infallible>> + Send> {
     let rx = state.event_tx.subscribe();
-    let stream = stream::unfold(rx, |mut rx| async move {
-        loop {
-            match rx.recv().await {
-                Ok(frame) => return Some((Ok(frame_to_event(&frame)), rx)),
-                Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                Err(broadcast::error::RecvError::Closed) => return None,
-            }
-        }
+    let stream = stream::unfold((rx, state.instance_id), |(mut rx, instance_id)| async move {
+        next_event_frame(&mut rx, instance_id)
+            .await
+            .map(|frame| (Ok(frame_to_event(&frame)), (rx, instance_id)))
     });
     Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
 }

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -89,6 +89,14 @@ impl App {
                 if let Some(ref f) = save_file {
                     tracing::info!("Remote storage location; skipping file watcher: {f}");
                 }
+                let backend = self.ctx.backend();
+                if let Some(http) = backend
+                    .as_any()
+                    .and_then(|a| a.downcast_ref::<kanban_backend_http::HttpBackend>())
+                {
+                    tracing::info!("Remote storage location; subscribing to SSE change events");
+                    self.persistence.remote_change_rx = Some(http.subscribe());
+                }
                 None
             }
         };
@@ -336,6 +344,15 @@ impl App {
                             tracing::warn!("External file change detected with local changes");
                             self.open_dialog(DialogMode::ExternalChangeDetected);
                         }
+                    }
+                    Some(frame) = async {
+                        if let Some(ref mut rx) = &mut self.persistence.remote_change_rx {
+                            rx.recv().await
+                        } else {
+                            std::future::pending().await
+                        }
+                    } => {
+                        self.handle_remote_change_frame(frame);
                     }
                 }
 

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -55,6 +55,7 @@ mod main_loop;
 mod mode_stack;
 mod query;
 mod reload_watch;
+mod remote_change;
 mod sprint_management;
 mod ui_feedback;
 mod view_management;

--- a/crates/kanban-tui/src/app/persistence.rs
+++ b/crates/kanban-tui/src/app/persistence.rs
@@ -6,6 +6,8 @@ pub struct PersistenceState {
     pub save_worker_handle: Option<tokio::task::JoinHandle<()>>,
     pub save_completion_rx: Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
     pub save_error_rx: Option<tokio::sync::mpsc::UnboundedReceiver<String>>,
+    pub remote_change_rx:
+        Option<tokio::sync::mpsc::Receiver<kanban_service::api::ChangeEventFrame>>,
 }
 
 impl PersistenceState {
@@ -20,6 +22,7 @@ impl PersistenceState {
             save_worker_handle: None,
             save_completion_rx,
             save_error_rx: None,
+            remote_change_rx: None,
         }
     }
 }

--- a/crates/kanban-tui/src/app/remote_change.rs
+++ b/crates/kanban-tui/src/app/remote_change.rs
@@ -1,0 +1,31 @@
+use super::{App, AppMode, DialogMode};
+use kanban_core::ClientId;
+use kanban_domain::Invalidation;
+use kanban_service::api::ChangeEventFrame;
+
+impl App {
+    #[doc(hidden)]
+    pub fn handle_remote_change_frame(&mut self, frame: ChangeEventFrame) {
+        let own_id = ClientId::from(self.ctx.backend().instance_id());
+        if frame.issued_by == own_id && !frame.issued_by.is_nil() {
+            return;
+        }
+
+        self.needs_redraw = true;
+
+        if self.ctx.save_coordinator.has_pending_saves() {
+            tracing::debug!("Remote change frame ignored: own save in flight");
+        } else if !self.ctx.is_dirty() {
+            let inv = frame
+                .invalidation
+                .as_ref()
+                .map(Invalidation::from)
+                .unwrap_or(Invalidation::All);
+            self.resolve_after_command(inv);
+        } else if self.mode != AppMode::Dialog(DialogMode::ConflictResolution)
+            && self.mode != AppMode::Dialog(DialogMode::ExternalChangeDetected)
+        {
+            self.open_dialog(DialogMode::ExternalChangeDetected);
+        }
+    }
+}

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -47,10 +47,16 @@ pub struct CountingBackend {
     reads: Arc<AtomicUsize>,
     ops: ReadOpLog,
     failing: Arc<Mutex<HashSet<&'static str>>>,
+    instance_id: Uuid,
 }
 
 impl CountingBackend {
     pub fn wrap(inner: Arc<dyn KanbanBackend>) -> WrappedBackend {
+        Self::wrap_with_instance_id(inner, Uuid::nil())
+    }
+
+    /// Like [`Self::wrap`], but `instance_id()` reports `id` instead of `Uuid::nil()`.
+    pub fn wrap_with_instance_id(inner: Arc<dyn KanbanBackend>, id: Uuid) -> WrappedBackend {
         let reads = Arc::new(AtomicUsize::new(0));
         let ops: ReadOpLog = Arc::new(Mutex::new(Vec::new()));
         let backend: Arc<dyn KanbanBackend> = Arc::new(Self {
@@ -58,6 +64,7 @@ impl CountingBackend {
             reads: reads.clone(),
             ops: ops.clone(),
             failing: Arc::new(Mutex::new(HashSet::new())),
+            instance_id: id,
         });
         (backend, reads, ops)
     }
@@ -75,6 +82,7 @@ impl CountingBackend {
             reads: Arc::new(AtomicUsize::new(0)),
             ops: Arc::new(Mutex::new(Vec::new())),
             failing: Arc::new(Mutex::new(failing)),
+            instance_id: Uuid::nil(),
         })
     }
 
@@ -309,6 +317,10 @@ impl KanbanBackend for CountingBackend {
 
     fn with_transaction(&self, f: TransactionFn<'_>) -> KanbanResult<()> {
         self.inner.with_transaction(f)
+    }
+
+    fn instance_id(&self) -> Uuid {
+        self.instance_id
     }
 }
 

--- a/crates/kanban-tui/tests/remote_freshness_tests.rs
+++ b/crates/kanban-tui/tests/remote_freshness_tests.rs
@@ -1,0 +1,195 @@
+mod helpers;
+
+use helpers::{CountingBackend, ReadOpLog};
+use kanban_core::ClientId;
+use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_service::api::{ChangeEventFrame, EntityIdsDto, InvalidationDto};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+use uuid::Uuid;
+
+struct Seed {
+    board: Uuid,
+    card: Uuid,
+}
+
+fn seed_board_column_card(app: &mut App) -> Seed {
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Column".to_string(), Some(0))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    Seed {
+        board: board.id,
+        card: card.id,
+    }
+}
+
+async fn prime(app: &mut App) -> ReadOpLog {
+    let (backend, _reads, ops) = CountingBackend::wrap(app.ctx.backend());
+    app.ctx.replace_backend(backend);
+    app.load_initial_state().await;
+    ops.lock().unwrap().clear();
+    ops
+}
+
+async fn prime_with_instance_id(app: &mut App, id: Uuid) -> ReadOpLog {
+    let (backend, _reads, ops) = CountingBackend::wrap_with_instance_id(app.ctx.backend(), id);
+    app.ctx.replace_backend(backend);
+    app.load_initial_state().await;
+    ops.lock().unwrap().clear();
+    ops
+}
+
+fn has_op(ops: &ReadOpLog, method: &str) -> bool {
+    ops.lock().unwrap().iter().any(|op| op.method == method)
+}
+
+fn foreign_frame(issued_by: ClientId, invalidation: Option<InvalidationDto>) -> ChangeEventFrame {
+    let frame = ChangeEventFrame::now(Uuid::new_v4(), Uuid::new_v4(), issued_by);
+    match invalidation {
+        Some(inv) => frame.with_invalidation(inv),
+        None => frame,
+    }
+}
+
+fn rename_card_out_of_band(app: &App, card_id: Uuid, new_title: &str) {
+    let store = app.ctx.backend();
+    let mut card = store
+        .as_data_store()
+        .get_card(card_id)
+        .unwrap()
+        .expect("card exists");
+    card.title = new_title.to_string();
+    store.as_data_store().upsert_card(card).unwrap();
+}
+
+fn rename_board_out_of_band(app: &App, board_id: Uuid, new_name: &str) {
+    let store = app.ctx.backend();
+    let mut board = store
+        .as_data_store()
+        .get_board(board_id)
+        .unwrap()
+        .expect("board exists");
+    board.name = new_name.to_string();
+    store.as_data_store().upsert_board(board).unwrap();
+}
+
+#[tokio::test]
+async fn test_foreign_frame_invalidation_refreshes_model_via_resolve_after_command() {
+    let mut app = App::test_default();
+    let seed = seed_board_column_card(&mut app);
+    app.selection.active_board_id = Some(seed.board);
+    let ops = prime(&mut app).await;
+
+    rename_card_out_of_band(&app, seed.card, "Renamed");
+    ops.lock().unwrap().clear();
+
+    let frame = foreign_frame(
+        ClientId::from(Uuid::new_v4()),
+        Some(InvalidationDto::Entities(EntityIdsDto {
+            cards: vec![seed.card],
+            ..Default::default()
+        })),
+    );
+    app.handle_remote_change_frame(frame);
+
+    let card = app.model.card_by_id_state(seed.card).loaded().copied();
+    assert_eq!(card.map(|c| c.title.clone()), Some("Renamed".to_string()));
+    assert!(!has_op(&ops, "list_boards"));
+}
+
+#[tokio::test]
+async fn test_frame_without_invalidation_resolves_as_all() {
+    let mut app = App::test_default();
+    let seed = seed_board_column_card(&mut app);
+    app.selection.active_board_id = Some(seed.board);
+    let ops = prime(&mut app).await;
+
+    rename_board_out_of_band(&app, seed.board, "Renamed Board");
+    ops.lock().unwrap().clear();
+
+    let frame = foreign_frame(ClientId::from(Uuid::new_v4()), None);
+    app.handle_remote_change_frame(frame);
+
+    let board = app.model.board_by_id_state(seed.board).loaded().copied();
+    assert_eq!(
+        board.map(|b| b.name.clone()),
+        Some("Renamed Board".to_string())
+    );
+    assert!(has_op(&ops, "list_boards"));
+}
+
+#[tokio::test]
+async fn test_own_frame_matching_backend_instance_id_is_suppressed() {
+    let mut app = App::test_default();
+    let seed = seed_board_column_card(&mut app);
+    app.selection.active_board_id = Some(seed.board);
+    let own_id = Uuid::new_v4();
+    let ops = prime_with_instance_id(&mut app, own_id).await;
+
+    rename_board_out_of_band(&app, seed.board, "Renamed Board");
+    ops.lock().unwrap().clear();
+    app.needs_redraw = false;
+
+    let frame = foreign_frame(ClientId::from(own_id), Some(InvalidationDto::All));
+    app.handle_remote_change_frame(frame);
+
+    let board = app.model.board_by_id_state(seed.board).loaded().copied();
+    assert_eq!(board.map(|b| b.name.clone()), Some("Board".to_string()));
+    assert!(ops.lock().unwrap().is_empty());
+    assert!(!app.needs_redraw);
+    assert_eq!(app.mode, AppMode::Normal);
+}
+
+#[tokio::test]
+async fn test_nil_issued_by_frame_is_never_suppressed() {
+    let mut app = App::test_default();
+    let seed = seed_board_column_card(&mut app);
+    app.selection.active_board_id = Some(seed.board);
+    let ops = prime(&mut app).await;
+
+    rename_board_out_of_band(&app, seed.board, "Renamed Board");
+    ops.lock().unwrap().clear();
+
+    let frame = foreign_frame(ClientId::nil(), None);
+    app.handle_remote_change_frame(frame);
+
+    let board = app.model.board_by_id_state(seed.board).loaded().copied();
+    assert_eq!(
+        board.map(|b| b.name.clone()),
+        Some("Renamed Board".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_dirty_model_frame_opens_external_change_dialog() {
+    let mut app = App::test_default();
+    let seed = seed_board_column_card(&mut app);
+    app.selection.active_board_id = Some(seed.board);
+    let ops = prime(&mut app).await;
+
+    app.ctx.mark_dirty();
+    rename_board_out_of_band(&app, seed.board, "Renamed Board");
+    ops.lock().unwrap().clear();
+
+    let frame = foreign_frame(ClientId::from(Uuid::new_v4()), Some(InvalidationDto::All));
+    app.handle_remote_change_frame(frame);
+
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::ExternalChangeDetected)
+    );
+    let board = app.model.board_by_id_state(seed.board).loaded().copied();
+    assert_eq!(board.map(|b| b.name.clone()), Some("Board".to_string()));
+    assert!(ops.lock().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary

A TUI session opened on an `http(s)://` locator has never had a freshness source: the file watcher only wires up for local files. This gives it one, over Server-Sent Events.

- `HttpBackend::subscribe()` connects to the server's `/v1/events` stream, emits a synthetic "resync everything" frame on every (re)connect ahead of the server's real frames, and reconnects with backoff on any connect failure or non-success status. Uses `Response::chunk()` rather than the `stream` feature, since the crate has no `futures-util` to drive a bare `futures_core::Stream`.
- `App::handle_remote_change_frame` folds each frame into the same `resolve_after_command` seam every local mutation already uses: a frame the session itself issued is suppressed by instance id (nil is never suppressed), a dirty session opens the external-change dialog instead of resolving, and everything else does a scoped invalidation resync (or a full one, when the frame carries no invalidation).
- `main_loop.rs` wires the subscription only in the file watcher's `None` arm, and only when the backend downcasts to `HttpBackend` - a fileless in-memory session subscribes to nothing.
- `KanbanBackend` gains an `as_any()` default (returning `None`) so `HttpBackend` can be downcast to reach `subscribe()`; every other backend is unaffected.
- Server-side: a lagged SSE subscriber now gets a synthetic resync frame instead of being silently dropped (`next_event_frame` in `routes/events.rs`), and `ClientId::is_nil` was added to support the suppression check.

## Test plan

- [x] `cargo test -p kanban-core -p kanban-backend -p kanban-backend-http -p kanban-server -p kanban-tui`
- [x] `cargo test --all-features --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Mutation-tested the suppression predicate (both the instance-id equality and the nil-guard clauses) by breaking each in turn and confirming the matching test fails, then restored it.
