### PR TITLE
KAN-1588 feat(server): serve the whole dependency graph over GET /v1/graph

### DIFF
--- a/.changeset/kan-1588-graph-route.md
+++ b/.changeset/kan-1588-graph-route.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+server adds GET /v1/graph returning the whole workspace dependency graph including archived edges; backend-http fetches it instead of declining, and a 404 from an older server is reported as a loud unsupported error rather than an empty graph

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -296,7 +296,14 @@ impl DataStore for HttpBackend {
     }
 
     fn get_graph(&self) -> KanbanResult<DependencyGraph> {
-        Err(KanbanError::unsupported("get_graph"))
+        self.block_on(async {
+            match self.get_json::<DependencyGraph>("/v1/graph").await? {
+                Some(graph) => Ok(graph),
+                None => Err(KanbanError::unsupported(
+                    "get_graph (server has no /v1/graph route)",
+                )),
+            }
+        })
     }
 
     fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {

--- a/crates/kanban-backend-http/tests/decline_rulings.rs
+++ b/crates/kanban-backend-http/tests/decline_rulings.rs
@@ -1,5 +1,5 @@
 use kanban_backend_http::HttpBackend;
-use kanban_domain::{DataStore, KanbanError, Prefix};
+use kanban_domain::{DataStore, DependencyGraph, KanbanError, Prefix};
 use uuid::Uuid;
 
 fn unreachable_backend() -> HttpBackend {
@@ -36,4 +36,21 @@ fn test_list_all_cards_and_siblings_stay_unsupported_under_their_own_names() {
     assert_declines_under_its_own_name(backend.list_all_cards(), "list_all_cards");
     assert_declines_under_its_own_name(backend.list_all_columns(), "list_all_columns");
     assert_declines_under_its_own_name(backend.list_all_sprints(), "list_all_sprints");
+}
+
+#[test]
+fn test_set_graph_stays_declined_under_its_own_name() {
+    let backend = unreachable_backend();
+    let result = backend.set_graph(DependencyGraph::default());
+    assert_declines_under_its_own_name(result, "set_graph");
+}
+
+#[test]
+fn test_get_graph_no_longer_declines_it_reaches_the_transport() {
+    let backend = unreachable_backend();
+    let err = backend
+        .get_graph()
+        .expect_err("no server is listening on port 1");
+    assert!(err.is_transport(), "expected transport error, got {err:?}");
+    assert!(!err.is_unsupported());
 }

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -1,11 +1,17 @@
 use kanban_api::{
-    CreateBoardRequest, CreateCardRequest, CreateColumnRequest, CreateSprintRequest, SortFieldDto,
-    SortOrderDto, TaskListViewDto,
+    AddBlockRequest, AddRelatedRequest, AttachChildrenRequest, CreateBoardRequest,
+    CreateCardRequest, CreateColumnRequest, CreateSprintRequest, RelatesKindDto, SeverityDto,
+    SortFieldDto, SortOrderDto, TaskListViewDto,
 };
 use kanban_backend_http::HttpBackend;
-use kanban_domain::{Board, Card, Column, DataStore, KanbanOperations, Prefix, Sprint};
+use kanban_domain::{
+    Board, Card, Column, DataStore, DependencyGraph, KanbanOperations, LoadState, Model,
+    NoProjections, Prefix, RelatesKind, Severity, Sprint,
+};
 use kanban_server::test_helpers::TestServer;
-use kanban_service::{AppConfig, KanbanBackend, KanbanContext};
+use kanban_service::{
+    requestable, AppConfig, FetchPlan, FetchRound, KanbanBackend, KanbanContext, LoadedEntities,
+};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -786,6 +792,160 @@ async fn test_resolve_card_ids_resolves_a_batch_over_http() {
         .resolve_card_ids(&[card_a.to_string(), "KAN-2".to_string()])
         .unwrap();
     assert_eq!(mixed, vec![card_a, card_b]);
+
+    drop(ctx);
+    drop(backend);
+
+    server.shutdown().await;
+}
+
+async fn attach_children(server: &TestServer, parent: Uuid, children: &[Uuid]) {
+    let req = AttachChildrenRequest {
+        children: children.to_vec(),
+    };
+    let resp = server
+        .client()
+        .post(format!("{}/v1/cards/{parent}/children", server.base_url()))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "attach_children failed: {resp:?}"
+    );
+}
+
+async fn add_block(server: &TestServer, blocker: Uuid, blocked: Uuid, severity: SeverityDto) {
+    let req = AddBlockRequest { blocked, severity };
+    let resp = server
+        .client()
+        .post(format!("{}/v1/cards/{blocker}/blocks", server.base_url()))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "add_block failed: {resp:?}");
+}
+
+async fn add_related(server: &TestServer, subject: Uuid, other: Uuid, kind: RelatesKindDto) {
+    let req = AddRelatedRequest { other, kind };
+    let resp = server
+        .client()
+        .post(format!("{}/v1/cards/{subject}/related", server.base_url()))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "add_related failed: {resp:?}");
+}
+
+async fn archive_card(server: &TestServer, card_id: Uuid) {
+    let resp = server
+        .client()
+        .post(format!("{}/v1/cards/{card_id}/archive", server.base_url()))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "archive_card failed: {resp:?}");
+}
+
+struct GraphOnly;
+
+impl FetchPlan for GraphOnly {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        FetchRound {
+            graph: requestable(loaded.graph()),
+            ..Default::default()
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_graph_against_a_server_without_the_route_errors_instead_of_reporting_an_empty_graph(
+) {
+    let server = TestServer::start().await;
+    let backend = HttpBackend::new(&format!("{}/legacy", server.base_url())).unwrap();
+
+    let err = blocking(move || backend.get_graph())
+        .await
+        .expect_err("a 404 from a route-less server must not be reported as an empty graph");
+
+    match &err {
+        kanban_domain::KanbanError::Unsupported { operation } => {
+            assert!(
+                operation.contains("/v1/graph"),
+                "expected the unsupported operation to mention /v1/graph, got {operation:?}"
+            );
+        }
+        other => panic!("expected Unsupported mentioning /v1/graph, got {other:?}"),
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_remote_get_graph_returns_every_edge_kind_including_archived() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Graph Board").await;
+    let column_id = seed_column(&server, board_id, "Todo", None, None).await;
+    let parent = seed_card(&server, column_id, "Parent", None).await;
+    let child = seed_card(&server, column_id, "Child", None).await;
+    let blocker = seed_card(&server, column_id, "Blocker", None).await;
+    let rel = seed_card(&server, column_id, "Related", None).await;
+    let doomed = seed_card(&server, column_id, "Doomed", None).await;
+
+    attach_children(&server, parent, &[child]).await;
+    add_block(&server, blocker, parent, SeverityDto::High).await;
+    add_related(&server, parent, rel, RelatesKindDto::Duplicates).await;
+    attach_children(&server, parent, &[doomed]).await;
+    archive_card(&server, doomed).await;
+
+    let backend = HttpBackend::new(&server.base_url()).unwrap();
+    let graph: DependencyGraph = blocking(move || backend.get_graph().unwrap()).await;
+
+    let live_spawn = graph
+        .spawns_edges()
+        .iter()
+        .find(|e| e.base.source == parent && e.base.target == child)
+        .expect("expected the live parent->child spawns edge");
+    assert!(live_spawn.base.archived_at.is_none());
+
+    let archived_spawn = graph
+        .spawns_edges()
+        .iter()
+        .find(|e| e.base.source == parent && e.base.target == doomed)
+        .expect("expected the archived parent->doomed spawns edge");
+    assert!(archived_spawn.base.archived_at.is_some());
+
+    assert_eq!(graph.blocks_edges()[0].severity, Severity::High);
+    assert_eq!(graph.relates_edges()[0].kind, RelatesKind::Duplicates);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_remote_graph_tier_resolves_loaded_and_serves_relation_children() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Tier Board").await;
+    let column_id = seed_column(&server, board_id, "Todo", None, None).await;
+    let parent = seed_card(&server, column_id, "Parent", None).await;
+    let child = seed_card(&server, column_id, "Child", None).await;
+    attach_children(&server, parent, &[child]).await;
+
+    let backend: Arc<dyn KanbanBackend> = Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+    let ctx = KanbanContext::open(Arc::clone(&backend), AppConfig::default())
+        .await
+        .unwrap();
+
+    let mut model = Model::default();
+    ctx.sync(&GraphOnly, &mut model, &mut NoProjections);
+
+    let graph = match model.graph_state() {
+        LoadState::Loaded(graph) => graph,
+        other => panic!("expected LoadState::Loaded, got {other:?}"),
+    };
+    assert_eq!(graph.children(parent), vec![child]);
 
     drop(ctx);
     drop(backend);

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -221,6 +221,7 @@ The remaining card routes (get/create/replace/update/delete, and the flat `/v1/c
 
 | Method | Path | Description | Body |
 |---|---|---|---|
+| `GET` | `/v1/graph` | The whole workspace dependency graph as the domain `DependencyGraph` serde shape (`spawns`/`blocks`/`relates`, each `{"edges": [...]}`). Includes archived (tombstoned) edges and every edge's `created_at`, unlike the card-scoped route. Always `200`, `{}`-shaped empty graph when there are no edges, never `404`. | — |
 | `GET` | `/v1/cards/{id}/graph` | The card's dependency edges, scoped to that card: parents/children (spawns), blocked_by/blocks and related, plus `block_edges`/`related_edges` carrying each edge's severity/kind. Only active edges; archived edges are omitted. 404s if the card does not exist, rather than returning empty arrays. | — |
 | `POST` | `/v1/cards/{id}/children` | Attach cards as spawned children of `id`. `200` with the updated `CardGraphResponse`. 404 if `id` or any child is unknown; 409 `CYCLE_DETECTED` if the edge would create a cycle. | `{"children": [uuid, ...]}` |
 | `DELETE` | `/v1/cards/{id}/children/{child_id}` | Detach `child_id` as a spawned child of `id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |

--- a/crates/kanban-server/src/routes/graph.rs
+++ b/crates/kanban-server/src/routes/graph.rs
@@ -7,7 +7,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
-use kanban_domain::{Model, NoProjections};
+use kanban_domain::{DependencyGraph, Model, NoProjections};
 use kanban_service::api::{
     AddBlockRequest, AddRelatedRequest, AttachChildrenRequest, CardGraphResponse, ChangeKind,
     EntityType,
@@ -27,8 +27,18 @@ async fn get_card_graph(
     Ok(Json(CardGraphResponse::from_graph(id, graph)))
 }
 
+async fn get_graph(State(state): State<AppState>) -> Result<Json<DependencyGraph>, AppError> {
+    let guard = state.lock_session().await;
+    let mut model = Model::default();
+    guard.sync(&RouteScope::Graph, &mut model, &mut NoProjections);
+    let graph = require_loaded(model.graph_state().as_ref(), "dependency graph")?;
+    Ok(Json(graph.clone()))
+}
+
 pub fn read_router() -> Router<AppState> {
-    Router::new().route("/v1/cards/{id}/graph", get(get_card_graph))
+    Router::new()
+        .route("/v1/graph", get(get_graph))
+        .route("/v1/cards/{id}/graph", get(get_card_graph))
 }
 
 fn graph_mutation_response(

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -35,6 +35,7 @@ pub enum RouteScope {
         sprint_id: Uuid,
     },
     CardGraph(Uuid),
+    Graph,
 }
 
 fn want_board(round: &mut FetchRound, loaded: &dyn LoadedEntities, board_id: Uuid) {
@@ -144,6 +145,9 @@ impl FetchPlan for RouteScope {
                 if requestable(loaded.card(id)) {
                     round.cards.push(id);
                 }
+            }
+            RouteScope::Graph => {
+                round.graph = requestable(loaded.graph());
             }
         }
 

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -532,6 +532,27 @@ mod tests {
     }
 
     #[test]
+    fn test_route_scope_for_graph_requests_only_the_graph_tier() {
+        let round = RouteScope::Graph.next_round(&Model::default());
+
+        assert_eq!(
+            round,
+            FetchRound {
+                graph: true,
+                ..Default::default()
+            }
+        );
+
+        let mut model = Model::default();
+        let _ = model.apply_resolved(kanban_domain::Resolved {
+            graph: LoadState::Loaded(kanban_domain::DependencyGraph::default()),
+            ..Default::default()
+        });
+        let second_round = RouteScope::Graph.next_round(&model);
+        assert!(second_round.is_empty());
+    }
+
+    #[test]
     fn test_route_scope_retries_a_failed_tier_but_not_a_missing_one() {
         let id = Uuid::new_v4();
 

--- a/crates/kanban-server/tests/graph_read.rs
+++ b/crates/kanban-server/tests/graph_read.rs
@@ -4,7 +4,7 @@
 //! Established via `tower::ServiceExt::oneshot` against the router directly,
 //! with no real TCP socket.
 
-use kanban_domain::{GraphOperations, RelatesKind, Severity};
+use kanban_domain::{DependencyGraph, GraphOperations, RelatesKind, Severity};
 use kanban_server::test_helpers::{json_of, make_sqlite_state, make_state, send};
 use kanban_service::KanbanOperations;
 use serde_json::json;
@@ -246,4 +246,123 @@ async fn test_get_card_graph_on_a_sqlite_locator_returns_the_children() {
     assert_eq!(response.status(), 200);
     let response_json = json_of(response).await;
     assert_eq!(response_json["children"], json!([child]));
+}
+
+fn seed_whole_graph(
+    ctx: &mut (impl KanbanOperations + GraphOperations),
+) -> (Uuid, Uuid, Uuid, Uuid, Uuid, Uuid) {
+    let board = ctx
+        .create_board("Board".to_string(), Some("KAN".to_string()))
+        .unwrap();
+    let column = ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let parent = ctx
+        .create_card(board.id, column.id, "Parent".to_string(), Default::default())
+        .unwrap()
+        .id;
+    let child = ctx
+        .create_card(board.id, column.id, "Child".to_string(), Default::default())
+        .unwrap()
+        .id;
+    let blocker = ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Blocker".to_string(),
+            Default::default(),
+        )
+        .unwrap()
+        .id;
+    let rel = ctx
+        .create_card(board.id, column.id, "Related".to_string(), Default::default())
+        .unwrap()
+        .id;
+    let doomed = ctx
+        .create_card(board.id, column.id, "Doomed".to_string(), Default::default())
+        .unwrap()
+        .id;
+
+    ctx.attach_children(parent, vec![child]).unwrap();
+    ctx.block(blocker, parent, Severity::High).unwrap();
+    ctx.relate(parent, rel, RelatesKind::Duplicates).unwrap();
+    ctx.attach_children(parent, vec![doomed]).unwrap();
+    ctx.archive_card(doomed).unwrap();
+
+    (parent, child, blocker, rel, doomed, board.id)
+}
+
+fn assert_whole_graph_shape(graph: &DependencyGraph, parent: Uuid, child: Uuid, doomed: Uuid) {
+    let live_spawn = graph
+        .spawns_edges()
+        .iter()
+        .find(|e| e.base.source == parent && e.base.target == child)
+        .expect("expected the live parent->child spawns edge");
+    assert!(live_spawn.base.archived_at.is_none());
+
+    let archived_spawn = graph
+        .spawns_edges()
+        .iter()
+        .find(|e| e.base.source == parent && e.base.target == doomed)
+        .expect("expected the archived parent->doomed spawns edge");
+    assert!(archived_spawn.base.archived_at.is_some());
+
+    assert_eq!(graph.blocks_edges()[0].severity, Severity::High);
+    assert_eq!(graph.relates_edges()[0].kind, RelatesKind::Duplicates);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_graph_returns_the_whole_graph_including_archived_edges() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let (parent, child, _blocker, _rel, doomed, _board_id) = {
+        let mut ctx = state.ctx.lock().await;
+        seed_whole_graph(&mut *ctx)
+    };
+
+    let stored_graph = state.ctx.lock().await.data_store().get_graph().unwrap();
+
+    let response = send(&state, "GET", "/v1/graph", None).await;
+    assert_eq!(response.status(), 200);
+    let response_json = json_of(response).await;
+    let deserialized: DependencyGraph = serde_json::from_value(response_json).unwrap();
+
+    assert_eq!(deserialized, stored_graph);
+    assert_whole_graph_shape(&deserialized, parent, child, doomed);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_graph_on_a_sqlite_locator_returns_the_whole_graph_including_archived_edges() {
+    let dir = tempdir().unwrap();
+    let state = make_sqlite_state(&dir.path().join("b.sqlite")).await;
+
+    let (parent, child, _blocker, _rel, doomed, _board_id) = {
+        let mut ctx = state.ctx.lock().await;
+        seed_whole_graph(&mut *ctx)
+    };
+
+    let stored_graph = state.ctx.lock().await.data_store().get_graph().unwrap();
+
+    let response = send(&state, "GET", "/v1/graph", None).await;
+    assert_eq!(response.status(), 200);
+    let response_json = json_of(response).await;
+    let deserialized: DependencyGraph = serde_json::from_value(response_json).unwrap();
+
+    assert_eq!(deserialized, stored_graph);
+    assert_whole_graph_shape(&deserialized, parent, child, doomed);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_graph_on_an_empty_store_returns_an_empty_graph_not_404() {
+    let dir = tempdir().unwrap();
+    let state = make_state(&dir.path().join("s.json"));
+
+    let response = send(&state, "GET", "/v1/graph", None).await;
+    assert_eq!(response.status(), 200);
+    let response_json = json_of(response).await;
+    let deserialized: DependencyGraph = serde_json::from_value(response_json).unwrap();
+
+    assert!(deserialized.is_empty());
+    assert_eq!(deserialized.len(), 0);
 }

--- a/crates/kanban-server/tests/graph_read.rs
+++ b/crates/kanban-server/tests/graph_read.rs
@@ -258,7 +258,12 @@ fn seed_whole_graph(
         .create_column(board.id, "Todo".to_string(), None)
         .unwrap();
     let parent = ctx
-        .create_card(board.id, column.id, "Parent".to_string(), Default::default())
+        .create_card(
+            board.id,
+            column.id,
+            "Parent".to_string(),
+            Default::default(),
+        )
         .unwrap()
         .id;
     let child = ctx
@@ -275,11 +280,21 @@ fn seed_whole_graph(
         .unwrap()
         .id;
     let rel = ctx
-        .create_card(board.id, column.id, "Related".to_string(), Default::default())
+        .create_card(
+            board.id,
+            column.id,
+            "Related".to_string(),
+            Default::default(),
+        )
         .unwrap()
         .id;
     let doomed = ctx
-        .create_card(board.id, column.id, "Doomed".to_string(), Default::default())
+        .create_card(
+            board.id,
+            column.id,
+            "Doomed".to_string(),
+            Default::default(),
+        )
         .unwrap()
         .id;
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/graph` to kanban-server, serving the whole workspace `DependencyGraph` (spawns/blocks/relates, including archived edges) behind a new tier-only `RouteScope::Graph` fetch-plan variant.
- Replaces `HttpBackend::get_graph`'s hard decline with a real fetch against the new route. A 404 (old server without the route) is reported as a loud unsupported error naming `/v1/graph`, never silently reported as an empty graph.
- `HttpBackend::set_graph` stays declined; graph writes still go through the existing per-relation mutation routes.
- Adds a `GET /v1/graph` row to the server README's Graph route table and a changeset.

## Why

Remote CLI `relation children`/`relation parents` and the remote TUI's CardDetail/ManageParents/ManageChildren graph tier used to land `LoadState::Failed` because `HttpBackend::get_graph` unconditionally declined. This closes that gap for reads while leaving graph mutation semantics untouched.

## Out of scope

Remote `relation add`/graph mutation over `KanbanContext` still fails at `get_archived_card`, which also declines on `HttpBackend`. That is a pre-existing gap, unrelated to this route, and is not touched here.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] New server tests: whole graph including archived edges round-trips on both JSON and SQLite backends; empty store returns `200` with an empty graph, never `404`; `RouteScope::Graph` requests only the graph tier
- [x] New backend-http tests: `get_graph` reaches the transport instead of declining; `set_graph` still declines; a 404 from a route-less server is reported as a loud unsupported error naming `/v1/graph`; remote `get_graph` returns every edge kind including an archived one; the graph tier resolves `Loaded` end to end through `KanbanContext::sync` and serves `relation children`
- [x] Manual: started a fresh `kanban-server` on a scratch store, seeded a board/column/two cards and attached a child over HTTP, confirmed `GET /v1/graph` is `200` and `kanban http://<addr> relation children <parent>` exits `0` printing the child (previously exited `1` with `operation not supported by this backend: get_graph`)
