### PR TITLE
KAN-1582 feat(domain,service,view,tui): board-scoped card partitions replace the flat render source

### DIFF
--- a/.changeset/kan-1582-board-scoped-partitions.md
+++ b/.changeset/kan-1582-board-scoped-partitions.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+the TUI's card render path reads board-scoped tiers instead of the flat workspace-wide ones

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -558,8 +558,12 @@ mod tests {
         for (i, card) in m.cards_state().loaded().unwrap().iter().enumerate() {
             assert_eq!(m.card_index[&card.id], i);
         }
-        assert!(m.card_by_id_state(a.id).loaded().copied().is_none());
-        assert!(m.card_by_id_state(a.id).is_missing());
+        assert!(m
+            .card_in_collection_status(a.id)
+            .loaded()
+            .copied()
+            .is_none());
+        assert_eq!(m.card_by_id_state(a.id).loaded().copied().unwrap(), &a);
         assert_eq!(m.card_by_id_state(c.id).loaded().copied().unwrap(), &c);
         assert_eq!(m.card_by_id_state(d.id).loaded().copied().unwrap(), &d);
         assert_eq!(m.card_by_id_state(e.id).loaded().copied().unwrap(), &e);

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -347,4 +347,133 @@ mod tests {
         assert!(state.is_not_loaded());
         assert!(!state.is_loaded());
     }
+
+    fn seed_columns_for_board(m: &mut Model, board_id: Uuid, columns: Vec<crate::Column>) {
+        let mut by_parent = std::collections::HashMap::new();
+        by_parent.insert(board_id, LoadState::Loaded(columns));
+        let _ = m.apply_resolved(crate::Resolved {
+            columns: crate::resolved::Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+    }
+
+    fn seed_cards_for_column(m: &mut Model, column_id: Uuid, state: LoadState<Vec<Card>>) {
+        let mut by_parent = std::collections::HashMap::new();
+        by_parent.insert(column_id, state);
+        let _ = m.apply_resolved(crate::Resolved {
+            cards: crate::resolved::Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn test_board_cards_state_concats_loaded_column_tiers_in_column_order() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col_a = crate::Column::new(board.id, "A", 0);
+        let col_b = crate::Column::new(board.id, "B", 1);
+        let col_a_id = col_a.id;
+        let col_b_id = col_b.id;
+        seed_columns_for_board(&mut m, board.id, vec![col_a, col_b]);
+
+        let a1 = make_card(&board, col_a_id);
+        let b1 = make_card(&board, col_b_id);
+        let a1_id = a1.id;
+        let b1_id = b1.id;
+        seed_cards_for_column(&mut m, col_a_id, LoadState::Loaded(vec![a1]));
+        seed_cards_for_column(&mut m, col_b_id, LoadState::Loaded(vec![b1]));
+
+        let state = m.board_cards_state(board.id);
+        let ids: Vec<Uuid> = state.loaded().unwrap().iter().map(|c| c.id).collect();
+        assert_eq!(ids, vec![a1_id, b1_id]);
+    }
+
+    #[test]
+    fn test_board_cards_state_not_loaded_when_any_column_tier_not_loaded() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col_a = crate::Column::new(board.id, "A", 0);
+        let col_b = crate::Column::new(board.id, "B", 1);
+        let col_a_id = col_a.id;
+        seed_columns_for_board(&mut m, board.id, vec![col_a, col_b]);
+
+        let a1 = make_card(&board, col_a_id);
+        seed_cards_for_column(&mut m, col_a_id, LoadState::Loaded(vec![a1]));
+
+        let state = m.board_cards_state(board.id);
+        assert!(state.is_not_loaded());
+    }
+
+    #[test]
+    fn test_board_cards_state_failed_wins_over_not_loaded() {
+        let err = std::sync::Arc::new(KanbanError::unsupported("boom"));
+
+        let mut m1 = Model::default();
+        let board1 = Board::new("B", None::<String>);
+        let col_a = crate::Column::new(board1.id, "A", 0);
+        let col_b = crate::Column::new(board1.id, "B", 1);
+        let col_a_id = col_a.id;
+        seed_columns_for_board(&mut m1, board1.id, vec![col_a, col_b]);
+        seed_cards_for_column(&mut m1, col_a_id, LoadState::Failed(err.clone()));
+        let state1 = m1.board_cards_state(board1.id);
+        assert!(matches!(state1, LoadState::Failed(e) if std::sync::Arc::ptr_eq(&e, &err)));
+
+        let mut m2 = Model::default();
+        let board2 = Board::new("B2", None::<String>);
+        let col_a2 = crate::Column::new(board2.id, "A", 0);
+        let col_b2 = crate::Column::new(board2.id, "B", 1);
+        let col_b2_id = col_b2.id;
+        seed_columns_for_board(&mut m2, board2.id, vec![col_a2, col_b2]);
+        seed_cards_for_column(&mut m2, col_b2_id, LoadState::Failed(err.clone()));
+        let state2 = m2.board_cards_state(board2.id);
+        assert!(matches!(state2, LoadState::Failed(e) if std::sync::Arc::ptr_eq(&e, &err)));
+    }
+
+    #[test]
+    fn test_board_cards_state_returns_not_loaded_for_a_board_with_no_scoped_column_entry() {
+        let mut m = Model::default();
+        let random_board = Uuid::new_v4();
+        assert!(m.board_cards_state(random_board).is_not_loaded());
+
+        let err = std::sync::Arc::new(KanbanError::unsupported("boom"));
+        let mut by_parent = std::collections::HashMap::new();
+        by_parent.insert(random_board, LoadState::Failed(err.clone()));
+        let _ = m.apply_resolved(crate::Resolved {
+            columns: crate::resolved::Collection {
+                by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let state = m.board_cards_state(random_board);
+        assert!(matches!(state, LoadState::Failed(e) if std::sync::Arc::ptr_eq(&e, &err)));
+    }
+
+    #[test]
+    fn test_board_cards_state_ignores_a_failed_flat_collection() {
+        let err = std::sync::Arc::new(KanbanError::unsupported("boom"));
+        let mut m = Model::with_load_states(crate::model::ModelLoadStates {
+            cards: LoadState::Failed(err.clone()),
+            columns: LoadState::Failed(err),
+            ..Default::default()
+        });
+
+        let board = Board::new("B", None::<String>);
+        let col = crate::Column::new(board.id, "A", 0);
+        let col_id = col.id;
+        seed_columns_for_board(&mut m, board.id, vec![col]);
+        let card = make_card(&board, col_id);
+        let card_id = card.id;
+        seed_cards_for_column(&mut m, col_id, LoadState::Loaded(vec![card]));
+
+        let state = m.board_cards_state(board.id);
+        let ids: Vec<Uuid> = state.loaded().unwrap().iter().map(|c| c.id).collect();
+        assert_eq!(ids, vec![card_id]);
+    }
 }

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -43,6 +43,40 @@ impl Model {
         scoped_state(&self.cards_by_column, column_id)
     }
 
+    /// The parent-scoped card tier for one board: the concatenation, in
+    /// column order, of every column's `column_cards_state`. `Loaded` only
+    /// when the board's column tier and every one of its columns' card
+    /// tiers are `Loaded`; `Failed` takes precedence over `Missing` over
+    /// `NotLoaded`. Never reads `cards_state()`.
+    pub fn board_cards_state(&self, board_id: Uuid) -> LoadState<Vec<&Card>> {
+        let columns = match self.board_columns_state(board_id) {
+            LoadState::Loaded(columns) => columns,
+            LoadState::Failed(e) => return LoadState::Failed(e),
+            LoadState::Missing => return LoadState::Missing,
+            LoadState::NotLoaded => return LoadState::NotLoaded,
+        };
+
+        let mut cards = Vec::new();
+        let mut missing = false;
+        let mut not_loaded = false;
+        for column in columns {
+            match self.column_cards_state(column.id) {
+                LoadState::Loaded(column_cards) => cards.extend(column_cards.iter()),
+                LoadState::Failed(e) => return LoadState::Failed(e),
+                LoadState::Missing => missing = true,
+                LoadState::NotLoaded => not_loaded = true,
+            }
+        }
+
+        if missing {
+            LoadState::Missing
+        } else if not_loaded {
+            LoadState::NotLoaded
+        } else {
+            LoadState::Loaded(cards)
+        }
+    }
+
     /// The per-id tier only, with no composition against the flat
     /// collection or the parent-scoped tier. Returns `NotLoaded` for an id
     /// that was never named by a resolve pass.

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -121,7 +121,7 @@ impl Model {
 
         self.rebuild_card_index();
         self.rebuild_board_index();
-        self.rebuild_board_scoped_tiers();
+        self.rebuild_scoped_tiers();
 
         ModelChanged::new()
     }
@@ -135,7 +135,7 @@ impl Model {
         ModelChanged::new()
     }
 
-    fn rebuild_board_scoped_tiers(&mut self) {
+    fn rebuild_scoped_tiers(&mut self) {
         self.columns_by_board.clear();
         self.sprints_by_board.clear();
 
@@ -171,6 +171,51 @@ impl Model {
                 bucket.push(s.clone());
             }
         }
+
+        self.rebuild_card_column_buckets();
+        self.rebuild_archived_card_board_buckets();
+    }
+
+    fn rebuild_card_column_buckets(&mut self) {
+        let mut buckets: HashMap<Uuid, Vec<Card>> = HashMap::new();
+        if let LoadState::Loaded(columns) = &self.columns {
+            for c in columns {
+                buckets.entry(c.id).or_default();
+            }
+        }
+        if let LoadState::Loaded(cards) = &self.cards {
+            for card in cards {
+                if self.archived_card_ids.contains(&card.id) {
+                    continue;
+                }
+                buckets
+                    .entry(card.column_id)
+                    .or_default()
+                    .push(card.clone());
+            }
+        }
+        for (column_id, cards) in buckets {
+            self.set_cards_of_column(column_id, LoadState::Loaded(cards));
+        }
+    }
+
+    fn rebuild_archived_card_board_buckets(&mut self) {
+        let mut buckets: HashMap<Uuid, Vec<ArchivedCard>> = HashMap::new();
+        if let LoadState::Loaded(boards) = &self.boards {
+            for b in boards {
+                buckets.entry(b.id).or_default();
+            }
+        }
+        for marker in self.archived_cards.iter().flatten() {
+            buckets
+                .entry(marker.context.board_id)
+                .or_default()
+                .push(*marker);
+        }
+        self.archived_cards_by_board = buckets
+            .into_iter()
+            .map(|(board_id, markers)| (board_id, LoadState::Loaded(markers)))
+            .collect();
     }
 
     fn absorb_archival_markers(

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -464,4 +464,90 @@ mod tests {
             "Model::sprints must be deleted; callers should use sprints_state().loaded_or_empty()"
         );
     }
+
+    #[test]
+    fn test_load_from_snapshot_buckets_live_cards_into_column_tiers() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col_a = Column::new(board.id, "A", 0);
+        let col_b = Column::new(board.id, "B", 1);
+        let live = make_card(&board, col_a.id);
+        let archived = make_card(&board, col_a.id);
+        let live_id = live.id;
+        let archived_id = archived.id;
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board.clone()],
+            columns: vec![col_a.clone(), col_b.clone()],
+            cards: vec![live, archived],
+            archived_cards: vec![ArchivedCard::new(archived_id, board.id)],
+            ..Default::default()
+        });
+
+        let col_a_state = m.column_cards_state(col_a.id);
+        let col_a_ids: Vec<Uuid> = col_a_state.loaded().unwrap().iter().map(|c| c.id).collect();
+        assert_eq!(col_a_ids, vec![live_id]);
+
+        let col_b_state = m.column_cards_state(col_b.id);
+        assert_eq!(col_b_state.loaded().unwrap().len(), 0);
+
+        let board_state = m.board_cards_state(board.id);
+        let board_ids: Vec<Uuid> = board_state.loaded().unwrap().iter().map(|c| c.id).collect();
+        assert_eq!(board_ids, vec![live_id]);
+    }
+
+    #[test]
+    fn test_load_from_snapshot_buckets_archived_markers_by_board() {
+        let mut m = Model::default();
+        let board_1 = Board::new("B1", None::<String>);
+        let board_2 = Board::new("B2", None::<String>);
+        let col_1 = Column::new(board_1.id, "A", 0);
+        let card_1 = make_card(&board_1, col_1.id);
+        let card_1_id = card_1.id;
+        let marker = ArchivedCard::new(card_1_id, board_1.id);
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board_1.clone(), board_2.clone()],
+            columns: vec![col_1],
+            cards: vec![card_1],
+            archived_cards: vec![marker],
+            ..Default::default()
+        });
+
+        let board_1_state = m.board_archived_cards_state(board_1.id);
+        let board_1_ids: Vec<Uuid> = board_1_state
+            .loaded()
+            .unwrap()
+            .iter()
+            .map(|ac| ac.entity_id)
+            .collect();
+        assert_eq!(board_1_ids, vec![card_1_id]);
+
+        let board_2_state = m.board_archived_cards_state(board_2.id);
+        assert_eq!(board_2_state.loaded().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_load_from_snapshot_resolves_a_bucketed_card_through_the_scoped_index() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col = Column::new(board.id, "A", 0);
+        let live = make_card(&board, col.id);
+        let live_id = live.id;
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board.clone()],
+            columns: vec![col],
+            cards: vec![live],
+            ..Default::default()
+        });
+
+        let err = Arc::new(KanbanError::unsupported("boom"));
+        let _ = m.apply_resolved(crate::Resolved {
+            cards: crate::resolved::Collection {
+                all: LoadState::Failed(err),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(m.card_by_id_state(live_id).is_loaded());
+    }
 }

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -227,6 +227,9 @@ mod tests {
         fn loaded_archived_board_markers(&self) -> Option<&[kanban_domain::ArchivedBoard]> {
             None
         }
+        fn loaded_archived_cards_of_board(&self, _board_id: Uuid) -> Option<&[ArchivedCard]> {
+            None
+        }
     }
 
     struct StubPlan;

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -125,6 +125,10 @@ pub trait LoadedEntities: LoadedState {
     /// naming every marker a plan needs to walk into a body round.
     fn loaded_archived_card_markers(&self) -> Option<&[ArchivedCard]>;
     fn loaded_archived_board_markers(&self) -> Option<&[ArchivedBoard]>;
+    /// `Some` exactly when one board's archived-card-marker tier is
+    /// `Loaded`, naming every marker a plan needs to walk into a body
+    /// round. A marker-less board is `Some(&[])`, not `None`.
+    fn loaded_archived_cards_of_board(&self, board_id: Uuid) -> Option<&[ArchivedCard]>;
 }
 
 pub trait FetchPlan {

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -137,6 +137,12 @@ impl LoadedEntities for StubWorld {
     fn loaded_archived_board_markers(&self) -> Option<&[kanban_domain::ArchivedBoard]> {
         None
     }
+    fn loaded_archived_cards_of_board(
+        &self,
+        _board_id: Uuid,
+    ) -> Option<&[kanban_domain::ArchivedCard]> {
+        None
+    }
 }
 
 fn all_loaded() -> StubWorld {

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -91,6 +91,10 @@ impl LoadedEntities for Model {
     fn loaded_archived_board_markers(&self) -> Option<&[ArchivedBoard]> {
         self.archived_boards_state().loaded().copied()
     }
+
+    fn loaded_archived_cards_of_board(&self, board_id: Uuid) -> Option<&[ArchivedCard]> {
+        self.board_archived_cards_state(board_id).loaded().copied()
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -134,6 +134,17 @@ impl LoadedEntities for Overlay<'_> {
             LoadState::Missing | LoadState::Failed(_) => None,
         }
     }
+
+    fn loaded_archived_cards_of_board(
+        &self,
+        board_id: Uuid,
+    ) -> Option<&[kanban_domain::ArchivedCard]> {
+        match self.pass.archived_cards.by_parent.get(&board_id) {
+            Some(LoadState::Loaded(v)) => Some(v.as_slice()),
+            Some(_) => None,
+            None => self.base.loaded_archived_cards_of_board(board_id),
+        }
+    }
 }
 
 #[derive(Default)]

--- a/crates/kanban-service/src/resolve/tests/mod.rs
+++ b/crates/kanban-service/src/resolve/tests/mod.rs
@@ -144,6 +144,13 @@ impl LoadedEntities for StubLoaded {
     fn loaded_archived_board_markers(&self) -> Option<&[ArchivedBoard]> {
         self.archived_boards.all.loaded().map(Vec::as_slice)
     }
+    fn loaded_archived_cards_of_board(&self, board_id: Uuid) -> Option<&[ArchivedCard]> {
+        self.archived_cards
+            .by_parent
+            .get(&board_id)
+            .and_then(LoadState::loaded)
+            .map(Vec::as_slice)
+    }
 }
 
 fn apply_collection<T: Clone>(target: &mut Collection<T>, incoming: Collection<T>) {

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -137,9 +137,13 @@ impl App {
     }
 
     fn complete_restore_animation(&mut self, card_id: uuid::Uuid) -> bool {
+        let Some(board_id) = self.scope_board_id() else {
+            return false;
+        };
         if let Some(archived_card) = self
             .model
-            .archived_card_markers()
+            .board_archived_cards_state(board_id)
+            .loaded().copied().unwrap_or(&[])
             .iter()
             .find(|dc| dc.entity_id == card_id)
             .cloned()

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -143,7 +143,9 @@ impl App {
         if let Some(archived_card) = self
             .model
             .board_archived_cards_state(board_id)
-            .loaded().copied().unwrap_or(&[])
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
             .iter()
             .find(|dc| dc.entity_id == card_id)
             .cloned()

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -2,6 +2,16 @@ use super::{App, AppMode};
 use kanban_domain::{Column, LoadState, Sprint};
 
 impl App {
+    /// The board the render-side scoped tiers (`Controller` card partitions,
+    /// `ViewScope`'s by-board requests) resolve against: the active board if
+    /// one is open, otherwise the board highlighted in the currently
+    /// displayed projects set.
+    pub(crate) fn scope_board_id(&self) -> Option<uuid::Uuid> {
+        self.selection
+            .active_board_id
+            .or_else(|| self.board_list.get_selected_board_id())
+    }
+
     /// One column tier per board-scoped feature: the scoped tier when it has
     /// resolved, otherwise the flat tier filtered to `board_id`. A scoped
     /// `Loaded` (including an empty one) is authoritative and never falls

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -12,6 +12,7 @@ impl App {
     /// Runs `scope` against the store and folds the result into `self.model`,
     /// resyncing the controller's derived partitions.
     pub fn populate(&mut self, scope: ViewScope) {
+        self.controller.set_scope_board(scope.board, &self.model);
         self.ctx.sync(&scope, &mut self.model, &mut self.controller);
     }
 
@@ -31,6 +32,7 @@ impl App {
     /// reads, in place of a full `reload_model`.
     pub fn resolve_after_command(&mut self, inv: Invalidation) {
         let scope = self.view_scope();
+        self.controller.set_scope_board(scope.board, &self.model);
         self.ctx
             .resync_invalidated(inv, &scope, &mut self.model, &mut self.controller);
     }
@@ -106,7 +108,9 @@ impl App {
     /// partitions. Every snapshot load in this crate goes through here so the
     /// partitions can never lag the model.
     pub fn load_snapshot(&mut self, snapshot: Snapshot) {
+        let scope_board = self.scope_board_id();
         let changed = self.model.load_from_snapshot(snapshot);
+        self.controller.set_scope_board(scope_board, &self.model);
         self.controller.resync(&self.model, changed);
     }
 
@@ -120,6 +124,7 @@ impl App {
     pub fn reload_model(&mut self) {
         let previous = self.model.clone();
         let scope = self.view_scope();
+        self.controller.set_scope_board(scope.board, &self.model);
         self.ctx.resync_invalidated(
             Invalidation::All,
             &scope,
@@ -141,29 +146,31 @@ impl App {
             self.set_error(format!("Failed to load from store: {e}"));
             return true;
         }
-        if let LoadState::Failed(e) = self.model.columns_state() {
-            self.set_error(format!("Failed to load from store: {e}"));
-            return true;
-        }
-        if let LoadState::Failed(e) = self.model.cards_state() {
-            self.set_error(format!("Failed to load from store: {e}"));
-            return true;
-        }
-        if let LoadState::Failed(e) = self.model.sprints_state() {
-            self.set_error(format!("Failed to load from store: {e}"));
-            return true;
-        }
         if let LoadState::Failed(e) = self.model.graph_state() {
-            self.set_error(format!("Failed to load from store: {e}"));
-            return true;
-        }
-        if let LoadState::Failed(e) = self.model.archived_cards_state() {
             self.set_error(format!("Failed to load from store: {e}"));
             return true;
         }
         if let LoadState::Failed(e) = self.model.archived_boards_state() {
             self.set_error(format!("Failed to load from store: {e}"));
             return true;
+        }
+        if let Some(board_id) = self.scope_board_id() {
+            if let LoadState::Failed(e) = self.model.board_columns_state(board_id) {
+                self.set_error(format!("Failed to load from store: {e}"));
+                return true;
+            }
+            if let LoadState::Failed(e) = self.model.board_cards_state(board_id) {
+                self.set_error(format!("Failed to load from store: {e}"));
+                return true;
+            }
+            if let LoadState::Failed(e) = self.model.board_sprints_state(board_id) {
+                self.set_error(format!("Failed to load from store: {e}"));
+                return true;
+            }
+            if let LoadState::Failed(e) = self.model.board_archived_cards_state(board_id) {
+                self.set_error(format!("Failed to load from store: {e}"));
+                return true;
+            }
         }
         false
     }
@@ -172,14 +179,6 @@ impl App {
     /// Pure: performs no store access, unlike `refresh_view`, which fetches
     /// first.
     pub fn prepare_frame(&mut self) {
-        // Single card-side selector: borrow the cached displayed subset (stack-
-        // aware base mode). No per-frame filter/clone — the partition was built
-        // on load. Resolved via `self.model` directly (not `self.displayed_cards`)
-        // so the borrow is scoped to `self.model` and splits cleanly from the
-        // `&mut self.view.strategy` borrow `refresh_task_lists` takes below.
-        let want_archived_cards = matches!(self.get_base_mode(), AppMode::ArchivedCardsView);
-        let cards_for_display = self.controller.displayed_cards(want_archived_cards);
-
         // Board resolution: resolved via `self.model` directly (rather than
         // `active_board` / `displayed_boards`, which borrow all of `self`) so the
         // borrow stays scoped to `self.model` and NLL can split it from the
@@ -197,6 +196,20 @@ impl App {
         self.board_list.update_boards(board_ids);
         let highlighted_id: Option<Uuid> = self.board_list.get_selected_board_id();
         let board_id: Option<Uuid> = self.selection.active_board_id.or(highlighted_id);
+
+        // The controller's card-partition scope may lag `board_id` (e.g. a
+        // snapshot loaded before `active_board_id` was set), so `prepare_frame`
+        // re-asserts it here rather than trusting whichever seam ran last.
+        self.controller.set_scope_board(board_id, &self.model);
+
+        // Single card-side selector: borrow the cached displayed subset (stack-
+        // aware base mode). No per-frame filter/clone — the partition was built
+        // on load. Resolved via `self.model` directly (not `self.displayed_cards`)
+        // so the borrow is scoped to `self.model` and splits cleanly from the
+        // `&mut self.view.strategy` borrow `refresh_task_lists` takes below.
+        let want_archived_cards = matches!(self.get_base_mode(), AppMode::ArchivedCardsView);
+        let cards_for_display = self.controller.displayed_cards(want_archived_cards);
+
         let board: Option<&Board> =
             board_id.and_then(|id| self.model.board_by_id_state(id).loaded().copied());
 

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -240,11 +240,13 @@ mod tests {
         sprints_of_board: FetchStatus,
         loaded_columns: HashMap<Uuid, Vec<Column>>,
         archived_card_list: FetchStatus,
-        archived_cards_of_board: FetchStatus,
+        archived_cards_of_board: HashMap<Uuid, FetchStatus>,
         archived_board_list: FetchStatus,
         card_in_collection: HashMap<Uuid, FetchStatus>,
+        card_status_by_id: HashMap<Uuid, FetchStatus>,
         board_in_collection: HashMap<Uuid, FetchStatus>,
         archived_card_markers: Option<Vec<kanban_domain::ArchivedCard>>,
+        archived_cards_by_board_markers: HashMap<Uuid, Vec<kanban_domain::ArchivedCard>>,
         archived_board_markers: Option<Vec<kanban_domain::ArchivedBoard>>,
     }
 
@@ -263,11 +265,13 @@ mod tests {
                 sprints_of_board: FetchStatus::NotLoaded,
                 loaded_columns: HashMap::new(),
                 archived_card_list: FetchStatus::NotLoaded,
-                archived_cards_of_board: FetchStatus::NotLoaded,
+                archived_cards_of_board: HashMap::new(),
                 archived_board_list: FetchStatus::NotLoaded,
                 card_in_collection: HashMap::new(),
+                card_status_by_id: HashMap::new(),
                 board_in_collection: HashMap::new(),
                 archived_card_markers: None,
+                archived_cards_by_board_markers: HashMap::new(),
                 archived_board_markers: None,
             }
         }
@@ -295,8 +299,11 @@ mod tests {
         fn column(&self, _id: Uuid) -> FetchStatus {
             FetchStatus::NotLoaded
         }
-        fn card(&self, _id: Uuid) -> FetchStatus {
-            self.card
+        fn card(&self, id: Uuid) -> FetchStatus {
+            self.card_status_by_id
+                .get(&id)
+                .copied()
+                .unwrap_or(self.card)
         }
         fn sprint(&self, _id: Uuid) -> FetchStatus {
             self.sprint
@@ -319,8 +326,11 @@ mod tests {
         fn archived_card_list(&self) -> FetchStatus {
             self.archived_card_list
         }
-        fn archived_cards_of_board(&self, _board_id: Uuid) -> FetchStatus {
+        fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus {
             self.archived_cards_of_board
+                .get(&board_id)
+                .copied()
+                .unwrap_or(FetchStatus::NotLoaded)
         }
         fn archived_board_list(&self) -> FetchStatus {
             self.archived_board_list
@@ -348,6 +358,14 @@ mod tests {
         }
         fn loaded_archived_board_markers(&self) -> Option<&[kanban_domain::ArchivedBoard]> {
             self.archived_board_markers.as_deref()
+        }
+        fn loaded_archived_cards_of_board(
+            &self,
+            board_id: Uuid,
+        ) -> Option<&[kanban_domain::ArchivedCard]> {
+            self.archived_cards_by_board_markers
+                .get(&board_id)
+                .map(Vec::as_slice)
         }
     }
 
@@ -386,6 +404,7 @@ mod tests {
             card_list: FetchStatus::Loaded,
             sprint_list: FetchStatus::Loaded,
             columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            sprints_of_board: FetchStatus::Loaded,
             loaded_columns: HashMap::from([(board, vec![column(c1), column(c2)])]),
             ..StubLoaded::default()
         };
@@ -396,6 +415,7 @@ mod tests {
         assert!(!round2.card_list);
         assert!(!round2.sprint_list);
         assert!(round2.columns_by_board.is_empty());
+        assert!(round2.sprints_by_board.is_empty());
         let mut cards_by_column = round2.cards_by_column.clone();
         cards_by_column.sort();
         let mut expected = vec![c1, c2];
@@ -408,6 +428,7 @@ mod tests {
             card_list: FetchStatus::Loaded,
             sprint_list: FetchStatus::Loaded,
             columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            sprints_of_board: FetchStatus::Loaded,
             loaded_columns: HashMap::from([(board, vec![column(c1), column(c2)])]),
             cards_of_column: HashMap::from([(c1, FetchStatus::Loaded), (c2, FetchStatus::Loaded)]),
             ..StubLoaded::default()
@@ -503,6 +524,7 @@ mod tests {
             card_list: FetchStatus::Loaded,
             sprint_list: FetchStatus::Loaded,
             columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            sprints_of_board: FetchStatus::Loaded,
             loaded_columns: HashMap::from([(board, vec![])]),
             ..StubLoaded::default()
         };
@@ -616,55 +638,44 @@ mod tests {
     }
 
     #[test]
-    fn test_archived_cards_view_requests_the_archival_marker_tier() {
+    fn test_archived_cards_view_requests_the_board_scoped_marker_tier() {
+        let board = Uuid::new_v4();
         let stub = StubLoaded::default();
         let scope = ViewScope {
+            board: Some(board),
             archived_card_markers: true,
             ..Default::default()
         };
 
         let round = scope.next_round(&stub);
-        assert!(round.archived_card_list);
-    }
-
-    #[test]
-    fn test_archived_cards_view_walks_loaded_markers_into_a_body_round() {
-        let m1 = Uuid::new_v4();
-        let m2 = Uuid::new_v4();
-        let stub = StubLoaded {
-            archived_card_list: FetchStatus::Loaded,
-            archived_card_markers: Some(vec![archived_card_marker(m1), archived_card_marker(m2)]),
-            ..StubLoaded::default()
-        };
-        let scope = ViewScope {
-            archived_card_bodies: true,
-            ..Default::default()
-        };
-
-        let round = scope.next_round(&stub);
-        let mut expected = vec![m1, m2];
-        expected.sort();
-        assert_eq!(round.cards, expected);
+        assert_eq!(round.archived_cards_by_board, vec![board]);
         assert!(!round.archived_card_list);
     }
 
     #[test]
-    fn test_archived_cards_view_stops_requesting_a_body_already_in_the_collection() {
+    fn test_archived_body_walk_rides_the_by_board_markers_into_per_id_fetches() {
+        let board = Uuid::new_v4();
         let m1 = Uuid::new_v4();
         let m2 = Uuid::new_v4();
         let stub = StubLoaded {
-            archived_card_list: FetchStatus::Loaded,
-            archived_card_markers: Some(vec![archived_card_marker(m1), archived_card_marker(m2)]),
-            card_in_collection: HashMap::from([(m1, FetchStatus::Loaded)]),
+            archived_cards_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            archived_cards_by_board_markers: HashMap::from([(
+                board,
+                vec![archived_card_marker(m1), archived_card_marker(m2)],
+            )]),
+            card_status_by_id: HashMap::from([(m2, FetchStatus::Loaded)]),
             ..StubLoaded::default()
         };
         let scope = ViewScope {
+            board: Some(board),
             archived_card_bodies: true,
             ..Default::default()
         };
 
         let round = scope.next_round(&stub);
-        assert_eq!(round.cards, vec![m2]);
+        assert_eq!(round.cards, vec![m1]);
+        assert!(!round.archived_card_list);
+        assert!(!round.card_list);
     }
 
     #[test]
@@ -697,15 +708,34 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_board_confirm_requests_the_archived_card_markers_but_no_bodies() {
+    fn test_delete_board_confirm_requests_by_board_markers() {
+        let board = Uuid::new_v4();
         let stub = StubLoaded::default();
         let scope = ViewScope {
+            board: Some(board),
             archived_card_markers: true,
             ..Default::default()
         };
 
         let round = scope.next_round(&stub);
-        assert!(round.archived_card_list);
+        assert_eq!(round.archived_cards_by_board, vec![board]);
+        assert!(!round.archived_card_list);
+        assert!(round.cards.is_empty());
+    }
+
+    #[test]
+    fn test_no_board_in_scope_requests_no_archived_card_tier() {
+        let stub = StubLoaded::default();
+        let scope = ViewScope {
+            board: None,
+            archived_card_markers: true,
+            archived_card_bodies: true,
+            ..Default::default()
+        };
+
+        let round = scope.next_round(&stub);
+        assert!(!round.archived_card_list);
+        assert!(round.archived_cards_by_board.is_empty());
         assert!(round.cards.is_empty());
     }
 }

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -1,6 +1,6 @@
 //! `ViewScope` is the TUI's `FetchPlan`: it names the tiers the current
-//! screen needs. The renderer reads the flat `*_list` tiers and the
-//! handlers read the by-parent tiers, so `next_round` requests both
+//! screen needs. The renderer reads the board-scoped tiers; the handlers
+//! still read the flat `*_list` tiers, so `next_round` requests both
 //! populations together whenever a board subtree is in scope.
 
 use uuid::Uuid;
@@ -79,28 +79,20 @@ impl FetchPlan for ViewScope {
                     }
                 }
             }
-        }
 
-        if self.archived_card_markers || self.archived_card_bodies {
-            if requestable(loaded.archived_card_list()) {
-                round.archived_card_list = true;
-            } else if self.archived_card_bodies {
-                // The per-id body merge only lands in the flat collection
-                // once that collection itself is `Loaded` (`apply_collection`
-                // upserts onto an existing Vec, it never creates one), so a
-                // body walk with no board in scope must still request the
-                // flat card list itself.
-                if !round.card_list && requestable(loaded.card_list()) {
-                    round.card_list = true;
-                }
-                if let Some(markers) = loaded.loaded_archived_card_markers() {
-                    let mut ids: Vec<Uuid> = markers
-                        .iter()
-                        .map(|m| m.entity_id)
-                        .filter(|&id| requestable(loaded.card_in_collection(id)))
-                        .collect();
-                    ids.sort_unstable();
-                    round.cards.extend(ids);
+            if self.archived_card_markers || self.archived_card_bodies {
+                if requestable(loaded.archived_cards_of_board(board_id)) {
+                    round.archived_cards_by_board.push(board_id);
+                } else if self.archived_card_bodies {
+                    if let Some(markers) = loaded.loaded_archived_cards_of_board(board_id) {
+                        let mut ids: Vec<Uuid> = markers
+                            .iter()
+                            .map(|m| m.entity_id)
+                            .filter(|&id| requestable(loaded.card(id)))
+                            .collect();
+                        ids.sort_unstable();
+                        round.cards.extend(ids);
+                    }
                 }
             }
         }
@@ -130,10 +122,7 @@ impl FetchPlan for ViewScope {
 
 impl App {
     pub fn view_scope(&self) -> ViewScope {
-        let board = self
-            .selection
-            .active_board_id
-            .or_else(|| self.board_list.get_selected_board_id());
+        let board = self.scope_board_id();
 
         let mut scope = ViewScope {
             board_list: true,

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -960,13 +960,14 @@ mod tests {
     }
 
     #[test]
-    fn test_board_delete_counts_declines_when_the_archived_marker_tier_is_not_absorbed() {
+    fn test_board_delete_counts_declines_when_the_by_board_archived_tier_is_not_loaded() {
         use kanban_domain::resolved::Collection;
         use kanban_domain::{Board, Column, DerivedProjections, Sprint};
         use std::collections::HashMap;
 
         let board = Board::new("Roadmap", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
+        let column_id = column.id;
 
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);
@@ -979,21 +980,17 @@ mod tests {
             ..Default::default()
         };
         resolved.cards = Collection {
-            all: LoadState::Loaded(Vec::new()),
+            by_parent: HashMap::from([(column_id, LoadState::Loaded(Vec::new()))]),
             ..Default::default()
         };
         let changed = app.model.apply_resolved(resolved);
         app.controller.resync(&app.model, changed);
 
-        assert!(
-            !app.model.archived_card_markers_absorbed(),
-            "the archived marker tier must not be absorbed by this fixture"
-        );
         assert_eq!(app.board_delete_counts(board.id), None);
 
         let resolved_archived = kanban_domain::Resolved {
             archived_cards: Collection {
-                all: LoadState::Loaded(Vec::new()),
+                by_parent: HashMap::from([(board.id, LoadState::Loaded(Vec::new()))]),
                 ..Default::default()
             },
             ..Default::default()
@@ -1009,7 +1006,7 @@ mod tests {
                 archived: 0,
                 sprints: 0,
             }),
-            "a Loaded-but-empty archived marker tier must not decline"
+            "a Loaded-but-empty by-board archived tier must not decline"
         );
     }
 

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -278,23 +278,15 @@ impl App {
         let LoadState::Loaded(scoped_columns) = self.model.board_columns_state(board_id) else {
             return None;
         };
-        let col_ids: std::collections::HashSet<uuid::Uuid> =
-            scoped_columns.iter().map(|c| c.id).collect();
-        let columns = col_ids.len();
-        let LoadState::Loaded(cards_all) = self.controller.live_cards() else {
+        let columns = scoped_columns.len();
+        let LoadState::Loaded(cards_all) = self.model.board_cards_state(board_id) else {
             return None;
         };
-        let cards = cards_all
-            .iter()
-            .filter(|c| col_ids.contains(&c.column_id))
-            .count();
-        let LoadState::Loaded(markers) = self.model.archived_cards_state() else {
+        let cards = cards_all.len();
+        let LoadState::Loaded(markers) = self.model.board_archived_cards_state(board_id) else {
             return None;
         };
-        let archived = markers
-            .iter()
-            .filter(|a| a.context.board_id == board_id)
-            .count();
+        let archived = markers.len();
         let LoadState::Loaded(sprints) = self.model.board_sprints_state(board_id) else {
             return None;
         };

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -846,9 +846,13 @@ impl App {
         use kanban_domain::AnimationType;
         use std::time::Instant;
 
+        let Some(board_id) = self.scope_board_id() else {
+            return;
+        };
         if self
             .model
-            .archived_card_markers()
+            .board_archived_cards_state(board_id)
+            .loaded().copied().unwrap_or(&[])
             .iter()
             .any(|dc| dc.entity_id == card_id)
         {
@@ -941,9 +945,13 @@ impl App {
         use kanban_domain::AnimationType;
         use std::time::Instant;
 
+        let Some(board_id) = self.scope_board_id() else {
+            return;
+        };
         if self
             .model
-            .archived_card_markers()
+            .board_archived_cards_state(board_id)
+            .loaded().copied().unwrap_or(&[])
             .iter()
             .any(|dc| dc.entity_id == card_id)
         {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1700,8 +1700,8 @@ mod cards_tier_decline_tests {
         app.ctx
             .create_column(board_id, "Doing".into(), None)
             .unwrap();
-        refresh(&mut app);
         app.selection.active_board_id = Some(board_id);
+        refresh(&mut app);
         app.focus.active = Focus::Cards;
         select_card_in_active_task_list(&mut app, card_id);
 
@@ -1747,8 +1747,8 @@ mod cards_tier_decline_tests {
     fn test_cursor_archive_anchor_with_a_not_loaded_cards_tier_returns_none() {
         let mut app = App::test_default();
         let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
-        refresh(&mut app);
         app.selection.active_board_id = Some(board_id);
+        refresh(&mut app);
         app.focus.active = Focus::Cards;
         select_card_in_active_task_list(&mut app, card_id);
 
@@ -1787,8 +1787,8 @@ mod cards_tier_decline_tests {
     fn test_handle_manage_children_from_list_with_a_cold_cards_tier_repopulates_and_opens() {
         let mut app = App::test_default();
         let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
-        refresh(&mut app);
         app.selection.active_board_id = Some(board_id);
+        refresh(&mut app);
         app.focus.active = Focus::Cards;
         select_card_in_active_task_list(&mut app, card_id);
 
@@ -1812,8 +1812,8 @@ mod cards_tier_decline_tests {
     fn test_handle_manage_children_from_list_with_a_cold_graph_opens_the_dialog() {
         let mut app = App::test_default();
         let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
-        refresh(&mut app);
         app.selection.active_board_id = Some(board_id);
+        refresh(&mut app);
         app.focus.active = Focus::Cards;
         select_card_in_active_task_list(&mut app, card_id);
 

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -852,7 +852,9 @@ impl App {
         if self
             .model
             .board_archived_cards_state(board_id)
-            .loaded().copied().unwrap_or(&[])
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
             .iter()
             .any(|dc| dc.entity_id == card_id)
         {
@@ -951,7 +953,9 @@ impl App {
         if self
             .model
             .board_archived_cards_state(board_id)
-            .loaded().copied().unwrap_or(&[])
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
             .iter()
             .any(|dc| dc.entity_id == card_id)
         {
@@ -1074,51 +1078,10 @@ mod create_card_factory_tests {
 
     /// Refresh the TUI model from the store so the create handler (which reads
     /// `self.model`) sees prior writes. The event loop does this each frame via
-    /// `prepare_frame`; tests pull the snapshot directly. Also seeds the
-    /// per-board scoped columns/sprints tiers `load_from_snapshot` leaves
-    /// untouched, since `create_card_target_column` reads them.
+    /// `prepare_frame`; tests pull the snapshot directly.
     fn refresh(app: &mut App) {
         let snap = kanban_service::read_full_snapshot(app.ctx.data_store()).unwrap();
-        let mut columns_by_board: std::collections::HashMap<
-            uuid::Uuid,
-            Vec<kanban_domain::Column>,
-        > = snap.boards.iter().map(|b| (b.id, Vec::new())).collect();
-        for column in &snap.columns {
-            columns_by_board
-                .entry(column.board_id)
-                .or_default()
-                .push(column.clone());
-        }
-        let mut sprints_by_board: std::collections::HashMap<
-            uuid::Uuid,
-            Vec<kanban_domain::Sprint>,
-        > = snap.boards.iter().map(|b| (b.id, Vec::new())).collect();
-        for sprint in &snap.sprints {
-            sprints_by_board
-                .entry(sprint.board_id)
-                .or_default()
-                .push(sprint.clone());
-        }
         app.load_snapshot(snap);
-        let changed = app.model.apply_resolved(kanban_domain::Resolved {
-            columns: kanban_domain::resolved::Collection {
-                by_parent: columns_by_board
-                    .into_iter()
-                    .map(|(id, cols)| (id, kanban_domain::LoadState::Loaded(cols)))
-                    .collect(),
-                ..Default::default()
-            },
-            sprints: kanban_domain::resolved::Collection {
-                by_parent: sprints_by_board
-                    .into_iter()
-                    .map(|(id, sprints)| (id, kanban_domain::LoadState::Loaded(sprints)))
-                    .collect(),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-        use kanban_domain::DerivedProjections;
-        kanban_domain::NoProjections.resync(&app.model, changed);
     }
 
     /// Seed a board with one column through the service, then point the TUI's

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -159,9 +159,18 @@ pub fn filter_title_suffix(app: &App) -> Option<String> {
 /// Resolves the App-native primitives, asks `kanban_view::panel_titles` for
 /// the structured title, and renders it for the terminal.
 pub fn tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
-    let all_tiers_loaded = matches!(app.model.columns_state(), LoadState::Loaded(_))
-        && matches!(app.model.sprints_state(), LoadState::Loaded(_));
-    let active_task_list = match (app.model.cards_state(), all_tiers_loaded) {
+    // Stack-aware: key off the base mode so a confirm dialog opened OVER the
+    // archived-cards view keeps the "Archive" title as the underlay, rather than
+    // flipping to the live "Tasks" title while the modal is open (#428 / #414
+    // finding 4). Matches `displayed_cards()`, which selects the set the same way.
+    let viewing_archived_cards = *app.get_base_mode() == AppMode::ArchivedCardsView;
+
+    let all_tiers_loaded =
+        app.model.columns_state().is_loaded() && app.model.sprints_state().is_loaded();
+    let active_task_list = match (
+        app.controller.displayed_cards(viewing_archived_cards),
+        all_tiers_loaded,
+    ) {
         (LoadState::Failed(_), _) => PanelCount::Failed,
         (_, false) => PanelCount::NotLoaded,
         (LoadState::Loaded(_), true) => PanelCount::Known(
@@ -179,11 +188,6 @@ pub fn tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
         .selection
         .active_board_id
         .is_some_and(|id| app.model.archived_board_ids().contains(&id));
-    // Stack-aware: key off the base mode so a confirm dialog opened OVER the
-    // archived-cards view keeps the "Archive" title as the underlay, rather than
-    // flipping to the live "Tasks" title while the modal is open (#428 / #414
-    // finding 4). Matches `displayed_cards()`, which selects the set the same way.
-    let viewing_archived_cards = *app.get_base_mode() == AppMode::ArchivedCardsView;
     let focus_is_cards = app.focus.active == Focus::Cards;
 
     format_tasks_panel_title(&kanban_view::panel_titles::build_tasks_panel_title(

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -1,6 +1,6 @@
 mod helpers;
 
-use helpers::warm_archived_card_markers;
+use helpers::{warm_archived_card_markers, CountingBackend};
 use kanban_domain::{CreateCardOptions, KanbanOperations, UndoOperations};
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
@@ -442,5 +442,164 @@ fn test_q_in_archived_view_returns_to_normal() {
     assert!(
         !app.should_quit,
         "pressing 'q' in ArchivedCardsView should not quit the app"
+    );
+}
+
+/// `start_restore_animation`, `start_permanent_delete_animation` and
+/// `complete_restore_animation` all check archived membership via
+/// `board_archived_cards_state`, the by-board tier. A failure on the flat
+/// `list_archived_cards` tier must not stop any of the three from working.
+#[test]
+fn test_restore_animation_detects_membership_when_the_global_archived_tier_fails() {
+    let mut app = App::test_default();
+
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "ArchiveMe".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_id = card.id;
+    app.ctx.archive_card(card_id).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
+    app.prepare_frame();
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_archived_cards");
+    app.ctx.replace_backend(failing);
+    app.reload_model();
+    app.prepare_frame();
+
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+
+    app.handle_restore_card();
+
+    assert!(
+        app.animation.animating.contains_key(&card_id),
+        "restore animation must start off the by-board archived tier even \
+         when the global list_archived_cards tier is failing"
+    );
+
+    force_animation_complete(&mut app, card_id);
+    app.handle_animation_tick();
+
+    app.reload_model();
+    app.prepare_frame();
+
+    assert!(
+        !app.model.archived_card_ids().contains(&card_id),
+        "the card must actually be restored, proving complete_restore_animation \
+         also resolved membership off the by-board tier"
+    );
+}
+
+#[test]
+fn test_permanent_delete_animation_detects_membership_when_the_global_archived_tier_fails() {
+    let mut app = App::test_default();
+
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "DeleteMe".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_id = card.id;
+    app.ctx.archive_card(card_id).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
+    app.prepare_frame();
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_archived_cards");
+    app.ctx.replace_backend(failing);
+    app.reload_model();
+    app.prepare_frame();
+
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+
+    app.handle_delete_card_permanent();
+
+    assert!(
+        app.animation.animating.contains_key(&card_id),
+        "permanent-delete animation must start off the by-board archived tier \
+         even when the global list_archived_cards tier is failing"
+    );
+}
+
+/// `start_restore_animation` and `start_permanent_delete_animation` both
+/// gained a `scope_board_id()` guard when they moved onto the by-board
+/// tier. With no board in scope, the guard must make them a deliberate
+/// no-op rather than starting an animation with no board to resolve.
+#[test]
+fn test_no_board_in_scope_leaves_restore_and_permanent_delete_animations_unstarted() {
+    let mut app = App::test_default();
+
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "ArchiveMe".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card_id = card.id;
+    app.ctx.archive_card(card_id).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
+    app.prepare_frame();
+
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+    assert_eq!(
+        app.get_selected_card_id(),
+        Some(card_id),
+        "fixture sanity: the archived card must be selected before scope is cleared"
+    );
+
+    app.selection.active_board_id = None;
+    app.board_list.inner_mut().set_selected_index(None);
+
+    app.handle_restore_card();
+    assert!(
+        !app.animation.animating.contains_key(&card_id),
+        "restore must not start an animation with no board in scope"
+    );
+
+    app.handle_delete_card_permanent();
+    assert!(
+        !app.animation.animating.contains_key(&card_id),
+        "permanent delete must not start an animation with no board in scope"
     );
 }

--- a/crates/kanban-tui/tests/archived_bodies_no_snapshot_tests.rs
+++ b/crates/kanban-tui/tests/archived_bodies_no_snapshot_tests.rs
@@ -13,6 +13,7 @@ async fn json_app_with_archived_card() -> (App, uuid::Uuid) {
 
     let store = kanban_persistence_json::JsonFileStore::new(&path_str);
     let board = Board::new("Board", None::<String>);
+    let board_id = board.id;
     let column = Column::new(board.id, "Todo", 0);
     let card = Card::new(board.id, column.id, "Archived task", 0);
     let card_id = card.id;
@@ -21,7 +22,7 @@ async fn json_app_with_archived_card() -> (App, uuid::Uuid) {
         boards: vec![board],
         columns: vec![column],
         cards: vec![card],
-        archived_cards: vec![ArchivedCard::new(card_id, uuid::Uuid::nil())],
+        archived_cards: vec![ArchivedCard::new(card_id, board_id)],
         sprints: vec![],
         graph: Default::default(),
         prefixes: Vec::new(),

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -291,7 +291,7 @@ fn test_d_in_the_archived_cards_view_starts_no_animation() {
 #[test]
 fn test_d_in_the_archived_cards_view_leaves_the_card_archived_after_undo() {
     let mut app = App::test_default();
-    let (_, _, _, card_id) = seed_archived_card(&mut app);
+    let (board_id, _, _, card_id) = seed_archived_card(&mut app);
     app.ctx.clear_history().unwrap();
     assert!(
         !app.ctx.can_undo(),
@@ -318,7 +318,13 @@ fn test_d_in_the_archived_cards_view_leaves_the_card_archived_after_undo() {
     app.reload_model();
     app.prepare_frame();
     assert!(
-        app.model.archived_card_ids().contains(&card_id),
+        app.model
+            .board_archived_cards_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .any(|marker| marker.entity_id == card_id),
         "the card must remain archived"
     );
 }

--- a/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
+++ b/crates/kanban-tui/tests/board_delete_confirmation_count_tests.rs
@@ -2,6 +2,9 @@
 //! includes archived cards sitting in a to-be-deleted column, double-counting
 //! them against the separate "archived task(s)" figure.
 
+mod helpers;
+
+use helpers::CountingBackend;
 use kanban_domain::KanbanOperations;
 use kanban_tui::app::focus::Focus;
 use kanban_tui::App;
@@ -133,6 +136,61 @@ fn test_the_delete_board_confirmation_reports_the_archived_count_after_a_lazy_po
     assert!(
         output.contains("1 task(s)"),
         "the live task count must be reported, got:\n{}",
+        output
+    );
+}
+
+/// `board_delete_counts` reads the by-board scoped archived-card tier, not
+/// the flat global one. A failure on the flat `list_archived_cards` read
+/// must not blank the archived count in the confirmation dialog.
+#[test]
+fn test_board_delete_confirmation_reports_counts_when_the_global_archived_tier_fails() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let col = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+
+    let _live = app
+        .ctx
+        .create_card(board.id, col.id, "Live".to_string(), Default::default())
+        .unwrap();
+    let archived = app
+        .ctx
+        .create_card(board.id, col.id, "Archived".to_string(), Default::default())
+        .unwrap();
+    app.ctx.archive_card(archived.id).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_archived_cards");
+    app.ctx.replace_backend(failing);
+    app.reload_model();
+    app.prepare_frame();
+
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Boards;
+
+    app.handle_delete_board_key();
+    app.reload_model();
+    app.prepare_frame();
+
+    let output = render_to_string(&mut app, 100, 30);
+
+    assert!(
+        output.contains("1 task(s)"),
+        "the live task count must still be reported with the global archived \
+         tier failing, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("1 archived task(s)"),
+        "the archived task count must come from the by-board tier, not the \
+         failing global one, got:\n{}",
         output
     );
 }

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -86,6 +86,21 @@ impl CountingBackend {
         })
     }
 
+    /// Like [`Self::wrap_failing`], but every method in `methods` fails.
+    pub fn wrap_failing_all(
+        inner: Arc<dyn KanbanBackend>,
+        methods: &[&'static str],
+    ) -> Arc<dyn KanbanBackend> {
+        let failing: HashSet<&'static str> = methods.iter().copied().collect();
+        Arc::new(Self {
+            inner,
+            reads: Arc::new(AtomicUsize::new(0)),
+            ops: Arc::new(Mutex::new(Vec::new())),
+            failing: Arc::new(Mutex::new(failing)),
+            instance_id: Uuid::nil(),
+        })
+    }
+
     fn record(&self, method: &'static str, ids: Vec<Uuid>) {
         self.reads.fetch_add(1, Ordering::SeqCst);
         self.ops.lock().unwrap().push(ReadOp { method, ids });
@@ -154,10 +169,12 @@ impl DataStore for CountingBackend {
     }
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
         self.record("list_all_cards", vec![]);
+        self.fault("list_all_cards")?;
         self.inner.list_all_cards()
     }
     fn list_cards_by_column(&self, column_id: Uuid) -> KanbanResult<Vec<Card>> {
         self.record("list_cards_by_column", vec![column_id]);
+        self.fault("list_cards_by_column")?;
         self.inner.list_cards_by_column(column_id)
     }
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
@@ -221,6 +238,7 @@ impl DataStore for CountingBackend {
     }
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         self.record("list_archived_cards", vec![]);
+        self.fault("list_archived_cards")?;
         self.inner.list_archived_cards()
     }
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
@@ -1154,6 +1172,22 @@ pub fn warm_archived_card_markers(app: &mut App) {
     app.mode = kanban_tui::app::mode::AppMode::ArchivedCardsView;
     app.resolve_for_view();
     app.mode = prior;
+
+    // `ViewScope` requests the by-board archived-card tier now, not the flat
+    // one, so `model.archived_card_ids()` (fed only by the flat tier) stays
+    // stale after the call above. Backfill it directly from the store.
+    let markers = app
+        .ctx
+        .data_store()
+        .list_archived_cards()
+        .unwrap_or_default();
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        archived_cards: kanban_domain::resolved::Collection {
+            all: kanban_domain::LoadState::Loaded(markers),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
 }
 
 /// Board-head equivalent of [`warm_archived_card_markers`].

--- a/crates/kanban-tui/tests/load_state_render_tests.rs
+++ b/crates/kanban-tui/tests/load_state_render_tests.rs
@@ -115,7 +115,7 @@ fn app_with_asymmetric_column_tier(board_columns_state: LoadState<Vec<Column>>) 
     let column = Column::new(board.id, "Backlog", 0);
     let mut resolved = base_resolved(&board);
     resolved.columns = Collection {
-        all: LoadState::Loaded(vec![column]),
+        all: LoadState::Loaded(vec![column.clone()]),
         by_parent: HashMap::from([(board.id, board_columns_state)]),
         ..Default::default()
     };
@@ -127,7 +127,22 @@ fn app_with_asymmetric_column_tier(board_columns_state: LoadState<Vec<Column>>) 
     app.controller.resync(&app.model, changed);
     app.selection.active_board_id = Some(board.id);
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
-    app.prepare_frame();
+
+    // The board-scoped column tier under test is deliberately asymmetric
+    // with the flat one, so `prepare_frame`'s all-scoped-tiers-Loaded gate
+    // would decline here; drive `refresh_task_lists` directly with the flat
+    // column so the task-list skeleton exists and the render's own
+    // `board_columns_state` name lookup is what's under test.
+    let ctx = kanban_view::view_strategy::ViewRefreshContext {
+        board: &board,
+        all_cards: &[],
+        all_columns: std::slice::from_ref(&column),
+        all_sprints: &[],
+        active_sprint_filters: Default::default(),
+        hide_assigned_cards: false,
+        search_query: None,
+    };
+    app.view.strategy.refresh_task_lists(&ctx);
     app
 }
 

--- a/crates/kanban-tui/tests/panel_title_tests.rs
+++ b/crates/kanban-tui/tests/panel_title_tests.rs
@@ -198,6 +198,13 @@ fn seed_model_states(
     columns: LoadState<Vec<Column>>,
     sprints: LoadState<Vec<Sprint>>,
 ) {
+    let columns_by_parent = std::collections::HashMap::from([(board.id, columns.clone())]);
+    let cards_by_parent: std::collections::HashMap<uuid::Uuid, LoadState<Vec<Card>>> =
+        match &columns {
+            LoadState::Loaded(cols) => cols.iter().map(|c| (c.id, cards.clone())).collect(),
+            _ => std::collections::HashMap::new(),
+        };
+    let sprints_by_parent = std::collections::HashMap::from([(board.id, sprints.clone())]);
     let resolved = Resolved {
         boards: Collection {
             all: LoadState::Loaded(vec![board.clone()]),
@@ -205,14 +212,17 @@ fn seed_model_states(
         },
         cards: Collection {
             all: cards,
+            by_parent: cards_by_parent,
             ..Default::default()
         },
         columns: Collection {
             all: columns,
+            by_parent: columns_by_parent,
             ..Default::default()
         },
         sprints: Collection {
             all: sprints,
+            by_parent: sprints_by_parent,
             ..Default::default()
         },
         graph: LoadState::Loaded(DependencyGraph::default()),
@@ -236,7 +246,7 @@ fn test_a_not_loaded_card_tier_titles_the_panel_without_a_count() {
         &mut app,
         &board,
         LoadState::NotLoaded,
-        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![Column::new(board.id, "Todo", 0)]),
         LoadState::Loaded(vec![]),
     );
 
@@ -269,11 +279,12 @@ fn test_a_loaded_empty_card_tier_still_titles_the_panel_with_zero() {
 fn test_a_failed_card_tier_titles_the_panel_distinctly_from_not_loaded() {
     let mut app_not_loaded = App::test_default();
     let board = Board::new("TestBoard", None::<String>);
+    let column = Column::new(board.id, "Todo", 0);
     seed_model_states(
         &mut app_not_loaded,
         &board,
         LoadState::NotLoaded,
-        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![column.clone()]),
         LoadState::Loaded(vec![]),
     );
     let not_loaded_rendered = tasks_panel_title(&app_not_loaded, false);
@@ -283,7 +294,7 @@ fn test_a_failed_card_tier_titles_the_panel_distinctly_from_not_loaded() {
         &mut app_failed,
         &board,
         boom_cards(),
-        LoadState::Loaded(vec![]),
+        LoadState::Loaded(vec![column]),
         LoadState::Loaded(vec![]),
     );
     let failed_rendered = tasks_panel_title(&app_failed, false);

--- a/crates/kanban-tui/tests/scoped_render_source_tests.rs
+++ b/crates/kanban-tui/tests/scoped_render_source_tests.rs
@@ -40,8 +40,10 @@ fn test_tasks_panel_title_gates_on_scoped_tiers() {
         "expected a numeric count before the backend degrades: {title_before}"
     );
 
-    let failing =
-        CountingBackend::wrap_failing_all(app.ctx.backend(), &["list_all_cards", "list_archived_cards"]);
+    let failing = CountingBackend::wrap_failing_all(
+        app.ctx.backend(),
+        &["list_all_cards", "list_archived_cards"],
+    );
     app.ctx.replace_backend(failing);
 
     app.reload_model();
@@ -84,12 +86,7 @@ fn test_surface_load_failures_surfaces_a_scoped_card_tier_failure() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards_before = app
-        .displayed_cards()
-        .loaded()
-        .copied()
-        .unwrap_or(&[])
-        .len();
+    let cards_before = app.displayed_cards().loaded().copied().unwrap_or(&[]).len();
     assert_eq!(cards_before, 1, "fixture sanity: one live card seeded");
 
     let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_cards_by_column");
@@ -104,12 +101,7 @@ fn test_surface_load_failures_surfaces_a_scoped_card_tier_failure() {
         .expect("expected surface_load_failures to raise a banner on a scoped card failure");
     assert!(banner.message.contains("Failed to load from store"));
 
-    let cards_after = app
-        .displayed_cards()
-        .loaded()
-        .copied()
-        .unwrap_or(&[])
-        .len();
+    let cards_after = app.displayed_cards().loaded().copied().unwrap_or(&[]).len();
     assert_eq!(
         cards_after, 1,
         "expected the rollback to keep the previous model's card intact"

--- a/crates/kanban-tui/tests/scoped_render_source_tests.rs
+++ b/crates/kanban-tui/tests/scoped_render_source_tests.rs
@@ -1,0 +1,117 @@
+//! Pins the render source for the tasks panel and its counted title off the
+//! board-scoped `Model`/`Controller` tiers for cards and archived cards,
+//! rather than the flat, workspace-wide ones. Columns and sprints stay on
+//! the flat tiers in this card (`ViewScope` does not request them by board
+//! outside CardDetail/BoardDetail/SprintDetail), so this file wraps only
+//! the card-side flat reads as failing.
+
+mod helpers;
+
+use helpers::CountingBackend;
+use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_tui::app::focus::Focus;
+use kanban_tui::App;
+
+#[test]
+fn test_tasks_panel_title_gates_on_scoped_tiers() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    let title_before = kanban_tui::ui::tasks_panel_title(&app, false);
+    assert!(
+        title_before.contains('1'),
+        "expected a numeric count before the backend degrades: {title_before}"
+    );
+
+    let failing =
+        CountingBackend::wrap_failing_all(app.ctx.backend(), &["list_all_cards", "list_archived_cards"]);
+    app.ctx.replace_backend(failing);
+
+    app.reload_model();
+    app.prepare_frame();
+
+    let title_after = kanban_tui::ui::tasks_panel_title(&app, false);
+    assert!(
+        title_after.contains('1'),
+        "expected the scoped card tier to still render a numeric count: {title_after}"
+    );
+    assert!(
+        !title_after.contains('!'),
+        "expected no failure marker once the scoped tier is being served: {title_after}"
+    );
+    assert!(
+        app.ui_state.banner.is_none(),
+        "expected no rollback banner when only the flat card tiers decline: {title_after}"
+    );
+}
+
+#[test]
+fn test_surface_load_failures_surfaces_a_scoped_card_tier_failure() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.focus.active = Focus::Cards;
+    app.reload_model();
+    app.prepare_frame();
+
+    let cards_before = app
+        .displayed_cards()
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .len();
+    assert_eq!(cards_before, 1, "fixture sanity: one live card seeded");
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_cards_by_column");
+    app.ctx.replace_backend(failing);
+
+    app.reload_model();
+
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("expected surface_load_failures to raise a banner on a scoped card failure");
+    assert!(banner.message.contains("Failed to load from store"));
+
+    let cards_after = app
+        .displayed_cards()
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .len();
+    assert_eq!(
+        cards_after, 1,
+        "expected the rollback to keep the previous model's card intact"
+    );
+}

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -7,7 +7,10 @@ use kanban_tui::app::mode::AppMode;
 use kanban_tui::App;
 
 /// No live board remains, so the only way the archived cards view can show
-/// its entity is via an entry-triggered reload.
+/// its entity is via an entry-triggered reload. Archived-card requests are
+/// board-scoped, so the board must be identified (`active_board_id`) before
+/// toggling in, matching the drilled-in-archived-board flow the app itself
+/// requires (`handle_toggle_archived_cards_view`'s own doc comment).
 #[tokio::test]
 async fn test_entering_the_archived_cards_view_after_startup_displays_its_card() {
     let mut app = App::test_default();
@@ -46,6 +49,7 @@ async fn test_entering_the_archived_cards_view_after_startup_displays_its_card()
     );
 
     app.focus.active = Focus::Boards;
+    app.selection.active_board_id = Some(board.id);
     app.handle_toggle_archived_cards_view();
     assert_eq!(app.mode, AppMode::ArchivedCardsView);
     let archived_tasks: Vec<_> = app

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -14,6 +14,11 @@ mod partitions;
 /// sort, partitions and the archived-at side map are the `Controller`'s.
 #[derive(Debug)]
 pub struct Controller {
+    // The board the card partitions are scoped to. A scope change is a
+    // staleness source independent of `ModelChanged`: `set_scope_board`
+    // rebuilds the card partitions itself rather than waiting for the next
+    // `resync`, which may otherwise skip the rebuild on an unchanged receipt.
+    scope_board: Option<Uuid>,
     // Live/archived partitions of the Model's unified `cards`/`boards`
     // collections, computed ONCE in `resync` and served as a borrow by
     // `displayed_cards`/`displayed_boards`. This is the concrete
@@ -43,6 +48,7 @@ pub struct Controller {
 impl Default for Controller {
     fn default() -> Self {
         Self {
+            scope_board: None,
             displayed_cards_live: LoadState::NotLoaded,
             displayed_cards_archived: LoadState::NotLoaded,
             displayed_boards_live: LoadState::NotLoaded,
@@ -83,6 +89,17 @@ impl Controller {
         } else {
             self.displayed_cards_live.as_ref().map(Vec::as_slice)
         }
+    }
+
+    /// Sets the board the card partitions are scoped to and rebuilds them
+    /// immediately against `model`. A no-op when `board_id` already matches
+    /// the current scope.
+    pub fn set_scope_board(&mut self, board_id: Option<Uuid>, model: &Model) {
+        if self.scope_board == board_id {
+            return;
+        }
+        self.scope_board = board_id;
+        self.rebuild_card_partitions(model);
     }
 
     /// The boards the projects panel should display, selected by

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -148,6 +148,7 @@ mod tests {
     #[test]
     fn test_sync_partitions_cards_by_the_archived_markers() {
         let board = seed_board("B", 0);
+        let board_id = board.id;
         let column = Column::new(board.id, "Col", 0);
         let live = Card::new(board.id, column.id, "live", 0);
         let archived = Card::new(board.id, column.id, "archived", 1);
@@ -157,11 +158,12 @@ mod tests {
             boards: vec![board],
             columns: vec![column],
             cards: vec![live, archived],
-            archived_cards: vec![ArchivedCard::new(archived_id, Uuid::nil())],
+            archived_cards: vec![ArchivedCard::new(archived_id, board_id)],
             archived_boards: Vec::new(),
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
 
         let live_ids: Vec<Uuid> = controller
@@ -221,7 +223,9 @@ mod tests {
     #[test]
     fn test_sync_rebuilds_the_partitions_after_apply_resolved() {
         let board = seed_board("B", 0);
+        let board_id = board.id;
         let column = Column::new(board.id, "Col", 0);
+        let column_id = column.id;
         let live = Card::new(board.id, column.id, "live", 0);
         let archived = Card::new(board.id, column.id, "archived", 1);
         let live_id = live.id;
@@ -231,11 +235,12 @@ mod tests {
             boards: vec![board.clone()],
             columns: vec![column.clone()],
             cards: vec![live, archived],
-            archived_cards: vec![ArchivedCard::new(archived_id, Uuid::nil())],
+            archived_cards: vec![ArchivedCard::new(archived_id, board_id)],
             archived_boards: Vec::new(),
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
         assert_eq!(
             controller
@@ -254,9 +259,14 @@ mod tests {
         let extra = Card::new(board.id, column.id, "extra", 2);
         let extra_id = extra.id;
 
+        let mut cards_by_id = std::collections::HashMap::new();
+        cards_by_id.insert(archived_id, LoadState::Loaded(archived_edited));
+        let mut cards_by_parent = std::collections::HashMap::new();
+        cards_by_parent.insert(column_id, LoadState::Loaded(vec![live_edited, extra]));
         let changed = model.apply_resolved(Resolved {
             cards: Collection {
-                all: LoadState::Loaded(vec![live_edited, archived_edited, extra]),
+                by_id: cards_by_id,
+                by_parent: cards_by_parent,
                 ..Default::default()
             },
             ..Default::default()
@@ -292,9 +302,11 @@ mod tests {
         );
     }
 
-    fn seed_non_empty_model() -> (Model, Controller) {
+    fn seed_non_empty_model() -> (Model, Controller, Uuid, Uuid) {
         let board = seed_board("B", 0);
+        let board_id = board.id;
         let column = Column::new(board.id, "Col", 0);
+        let column_id = column.id;
         let live = Card::new(board.id, column.id, "live", 0);
         let archived = Card::new(board.id, column.id, "archived", 1);
         let archived_id = archived.id;
@@ -303,18 +315,19 @@ mod tests {
             boards: vec![board],
             columns: vec![column],
             cards: vec![live, archived],
-            archived_cards: vec![ArchivedCard::new(archived_id, Uuid::nil())],
+            archived_cards: vec![ArchivedCard::new(archived_id, board_id)],
             archived_boards: Vec::new(),
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
-        (model, controller)
+        (model, controller, board_id, column_id)
     }
 
     #[test]
     fn test_resync_with_an_unchanged_receipt_leaves_the_cached_partitions_untouched() {
-        let (mut model, mut controller) = seed_non_empty_model();
+        let (mut model, mut controller, _board_id, _column_id) = seed_non_empty_model();
         let cards_before = controller
             .displayed_cards(false)
             .loaded()
@@ -354,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_resync_with_a_changed_receipt_rebuilds_the_partitions() {
-        let (mut model, mut controller) = seed_non_empty_model();
+        let (mut model, mut controller, board_id, column_id) = seed_non_empty_model();
         let cards_before = controller
             .displayed_cards(false)
             .loaded()
@@ -362,14 +375,14 @@ mod tests {
             .unwrap()
             .as_ptr();
 
-        let board = seed_board("B", 0);
-        let column = Column::new(board.id, "Col", 0);
-        let mut live_edited = Card::new(board.id, column.id, "live edited", 0);
-        let live_id = model.cards_state().loaded().unwrap()[0].id;
+        let live_id = model.board_cards_state(board_id).loaded().unwrap()[0].id;
+        let mut live_edited = Card::new(board_id, column_id, "live edited", 0);
         live_edited.id = live_id;
+        let mut cards_by_parent = std::collections::HashMap::new();
+        cards_by_parent.insert(column_id, LoadState::Loaded(vec![live_edited.clone()]));
         let changed = model.apply_resolved(Resolved {
             cards: Collection {
-                all: LoadState::Loaded(vec![live_edited.clone()]),
+                by_parent: cards_by_parent,
                 ..Default::default()
             },
             ..Default::default()
@@ -478,7 +491,9 @@ mod tests {
     #[test]
     fn test_resync_consumes_the_receipt_from_apply_resolved() {
         let board = seed_board("B", 0);
+        let board_id = board.id;
         let column = Column::new(board.id, "Col", 0);
+        let column_id = column.id;
         let live = Card::new(board.id, column.id, "live", 0);
         let archived = Card::new(board.id, column.id, "archived", 1);
         let live_id = live.id;
@@ -488,11 +503,12 @@ mod tests {
             boards: vec![board.clone()],
             columns: vec![column.clone()],
             cards: vec![live, archived],
-            archived_cards: vec![ArchivedCard::new(archived_id, Uuid::nil())],
+            archived_cards: vec![ArchivedCard::new(archived_id, board_id)],
             archived_boards: Vec::new(),
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
         assert_eq!(
             controller
@@ -511,9 +527,14 @@ mod tests {
         let extra = Card::new(board.id, column.id, "extra", 2);
         let extra_id = extra.id;
 
+        let mut cards_by_id = std::collections::HashMap::new();
+        cards_by_id.insert(archived_id, LoadState::Loaded(archived_edited));
+        let mut cards_by_parent = std::collections::HashMap::new();
+        cards_by_parent.insert(column_id, LoadState::Loaded(vec![live_edited, extra]));
         let changed = model.apply_resolved(Resolved {
             cards: Collection {
-                all: LoadState::Loaded(vec![live_edited, archived_edited, extra]),
+                by_id: cards_by_id,
+                by_parent: cards_by_parent,
                 ..Default::default()
             },
             ..Default::default()
@@ -572,10 +593,15 @@ mod tests {
 
     #[test]
     fn test_resync_over_a_loaded_empty_model_reports_loaded_empty() {
+        let board_id = Uuid::new_v4();
         let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(Vec::new()));
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(board_id, LoadState::Loaded(Vec::new()));
         let changed = model.apply_resolved(Resolved {
-            cards: Collection {
-                all: LoadState::Loaded(Vec::new()),
+            columns: Collection {
+                by_parent: columns_by_parent,
                 ..Default::default()
             },
             boards: Collection {
@@ -583,7 +609,7 @@ mod tests {
                 ..Default::default()
             },
             archived_cards: Collection {
-                all: LoadState::Loaded(Vec::new()),
+                by_parent: archived_by_parent,
                 ..Default::default()
             },
             archived_boards: Collection {
@@ -593,6 +619,7 @@ mod tests {
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
 
         assert!(matches!(controller.displayed_cards(false), LoadState::Loaded(v) if v.is_empty()));
@@ -602,20 +629,31 @@ mod tests {
     }
 
     #[test]
-    fn test_card_partitions_report_not_loaded_when_markers_not_loaded_and_cards_loaded() {
+    fn test_card_partitions_report_not_loaded_when_the_by_board_marker_tier_is_not_loaded() {
         let board = seed_board("B", 0);
+        let board_id = board.id;
         let column = Column::new(board.id, "Col", 0);
+        let column_id = column.id;
         let card = Card::new(board.id, column.id, "card", 0);
         let card_id = card.id;
         let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(vec![column.clone()]));
+        let mut cards_by_parent = std::collections::HashMap::new();
+        cards_by_parent.insert(column_id, LoadState::Loaded(vec![card.clone()]));
         let changed = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
             cards: Collection {
-                all: LoadState::Loaded(vec![card.clone()]),
+                by_parent: cards_by_parent,
                 ..Default::default()
             },
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
 
         assert!(!controller.displayed_cards(true).is_loaded());
@@ -639,6 +677,7 @@ mod tests {
             archived_boards: Vec::new(),
             ..Default::default()
         });
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
         assert!(controller.displayed_cards(true).is_loaded());
     }
@@ -672,25 +711,41 @@ mod tests {
     }
 
     #[test]
-    fn test_card_partitions_report_failed_when_marker_tier_failed() {
+    fn test_card_partitions_report_failed_when_the_by_board_marker_tier_failed() {
         let board = seed_board("B", 0);
+        let board_id = board.id;
         let column = Column::new(board.id, "Col", 0);
+        let column_id = column.id;
         let card = Card::new(board.id, column.id, "card", 0);
         let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(vec![column]));
+        let mut cards_by_parent = std::collections::HashMap::new();
+        cards_by_parent.insert(column_id, LoadState::Loaded(vec![card]));
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(
+            board_id,
+            LoadState::Failed(std::sync::Arc::new(
+                kanban_domain::KanbanError::unsupported("boom"),
+            )),
+        );
         let changed = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
             cards: Collection {
-                all: LoadState::Loaded(vec![card]),
+                by_parent: cards_by_parent,
                 ..Default::default()
             },
             archived_cards: Collection {
-                all: LoadState::Failed(std::sync::Arc::new(
-                    kanban_domain::KanbanError::unsupported("boom"),
-                )),
+                by_parent: archived_by_parent,
                 ..Default::default()
             },
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
 
         assert!(controller.displayed_cards(true).is_failed());
@@ -723,17 +778,35 @@ mod tests {
 
     #[test]
     fn test_resync_propagates_failed_from_the_model_into_both_partitions() {
+        let board_id = Uuid::new_v4();
         let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(
+            board_id,
+            LoadState::Failed(std::sync::Arc::new(
+                kanban_domain::KanbanError::unsupported("x"),
+            )),
+        );
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(
+            board_id,
+            LoadState::Failed(std::sync::Arc::new(
+                kanban_domain::KanbanError::unsupported("x"),
+            )),
+        );
         let changed = model.apply_resolved(Resolved {
-            cards: Collection {
-                all: LoadState::Failed(std::sync::Arc::new(
-                    kanban_domain::KanbanError::unsupported("x"),
-                )),
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                by_parent: archived_by_parent,
                 ..Default::default()
             },
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
 
         assert!(controller.displayed_cards(false).is_failed());
@@ -743,6 +816,7 @@ mod tests {
     #[test]
     fn test_sync_rebuilds_the_partitions_after_the_model_changes() {
         let board = seed_board("B", 0);
+        let board_id = board.id;
         let column = Column::new(board.id, "Col", 0);
         let card_a = Card::new(board.id, column.id, "a", 0);
         let card_b = Card::new(board.id, column.id, "b", 1);
@@ -755,6 +829,7 @@ mod tests {
             ..Default::default()
         });
         let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
         controller.resync(&model, changed);
         assert_eq!(
             controller
@@ -811,5 +886,327 @@ mod tests {
             .map(|b| b.id)
             .collect();
         assert_eq!(order, vec![second_id, first_id]);
+    }
+
+    #[test]
+    fn test_scoped_loaded_model_with_flat_tiers_failed_renders_live_partition() {
+        let err = std::sync::Arc::new(kanban_domain::KanbanError::unsupported("boom"));
+        let mut model = Model::default();
+        let _ = model.apply_resolved(Resolved {
+            cards: Collection {
+                all: LoadState::Failed(err.clone()),
+                ..Default::default()
+            },
+            columns: Collection {
+                all: LoadState::Failed(err.clone()),
+                ..Default::default()
+            },
+            sprints: Collection {
+                all: LoadState::Failed(err),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let board = seed_board("B", 0);
+        let board_id = board.id;
+        let column = Column::new(board_id, "Col", 0);
+        let column_id = column.id;
+        let card = Card::new(board_id, column_id, "card", 0);
+
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(vec![column]));
+        let mut cards_by_parent = std::collections::HashMap::new();
+        cards_by_parent.insert(column_id, LoadState::Loaded(vec![card.clone()]));
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(board_id, LoadState::Loaded(Vec::new()));
+        let changed = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_parent: cards_by_parent,
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                by_parent: archived_by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
+        controller.resync(&model, changed);
+
+        let live_ids: Vec<Uuid> = controller
+            .displayed_cards(false)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(live_ids, vec![card.id]);
+        assert!(matches!(controller.displayed_cards(true), LoadState::Loaded(v) if v.is_empty()));
+    }
+
+    #[test]
+    fn test_no_scope_board_leaves_card_partitions_not_loaded() {
+        let board = seed_board("B", 0);
+        let mut model = Model::default();
+        let changed = model.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+        let mut controller = Controller::default();
+        controller.resync(&model, changed);
+
+        assert!(controller.displayed_cards(false).is_not_loaded());
+        assert!(controller.displayed_cards(true).is_not_loaded());
+        assert!(controller.displayed_boards(false).is_loaded());
+    }
+
+    #[test]
+    fn test_set_scope_board_change_rebuilds_partitions_without_a_model_change() {
+        let board_1 = seed_board("B1", 0);
+        let board_1_id = board_1.id;
+        let column_1 = Column::new(board_1_id, "Col", 0);
+        let card_1 = Card::new(board_1_id, column_1.id, "card1", 0);
+        let card_1_id = card_1.id;
+
+        let board_2 = seed_board("B2", 1);
+        let board_2_id = board_2.id;
+        let column_2 = Column::new(board_2_id, "Col", 0);
+        let card_2 = Card::new(board_2_id, column_2.id, "card2", 0);
+        let card_2_id = card_2.id;
+
+        let mut model = Model::default();
+        let _ = model.load_from_snapshot(Snapshot {
+            boards: vec![board_1, board_2],
+            columns: vec![column_1, column_2],
+            cards: vec![card_1, card_2],
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+
+        let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_1_id), &model);
+        let ids_1: Vec<Uuid> = controller
+            .displayed_cards(false)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(ids_1, vec![card_1_id]);
+
+        controller.set_scope_board(Some(board_2_id), &model);
+        let ids_2: Vec<Uuid> = controller
+            .displayed_cards(false)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(ids_2, vec![card_2_id]);
+    }
+
+    #[test]
+    fn test_archived_partition_joins_by_board_markers_with_per_id_bodies() {
+        let board = seed_board("B", 0);
+        let board_id = board.id;
+        let column = Column::new(board_id, "Col", 0);
+        let column_id = column.id;
+        let card_a = Card::new(board_id, column_id, "a", 0);
+        let card_b = Card::new(board_id, column_id, "b", 1);
+        let card_a_id = card_a.id;
+        let card_b_id = card_b.id;
+
+        let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(vec![column]));
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(
+            board_id,
+            LoadState::Loaded(vec![
+                ArchivedCard::new(card_a_id, board_id),
+                ArchivedCard::new(card_b_id, board_id),
+            ]),
+        );
+        let mut cards_by_id = std::collections::HashMap::new();
+        cards_by_id.insert(card_a_id, LoadState::Loaded(card_a));
+        cards_by_id.insert(card_b_id, LoadState::Loaded(card_b));
+        let changed = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                by_parent: archived_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_id: cards_by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
+        controller.resync(&model, changed);
+
+        let archived_ids: Vec<Uuid> = controller
+            .displayed_cards(true)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(archived_ids, vec![card_a_id, card_b_id]);
+    }
+
+    #[test]
+    fn test_archived_partition_not_loaded_while_a_body_is_in_flight() {
+        let board = seed_board("B", 0);
+        let board_id = board.id;
+        let column = Column::new(board_id, "Col", 0);
+        let column_id = column.id;
+        let card_a = Card::new(board_id, column_id, "a", 0);
+        let card_a_id = card_a.id;
+        let card_b_id = Uuid::new_v4();
+
+        let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(vec![column.clone()]));
+        let mut cards_by_parent = std::collections::HashMap::new();
+        cards_by_parent.insert(column_id, LoadState::Loaded(vec![card_a.clone()]));
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(
+            board_id,
+            LoadState::Loaded(vec![ArchivedCard::new(card_b_id, board_id)]),
+        );
+        let mut cards_by_id = std::collections::HashMap::new();
+        cards_by_id.insert(card_a_id, LoadState::Loaded(card_a));
+        let changed = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_parent: cards_by_parent,
+                by_id: cards_by_id,
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                by_parent: archived_by_parent,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
+        controller.resync(&model, changed);
+
+        assert!(controller.displayed_cards(false).is_loaded());
+        assert!(controller.displayed_cards(true).is_not_loaded());
+    }
+
+    #[test]
+    fn test_archived_partition_skips_a_missing_body() {
+        let board = seed_board("B", 0);
+        let board_id = board.id;
+        let column = Column::new(board_id, "Col", 0);
+        let card_a = Card::new(board_id, column.id, "a", 0);
+        let card_a_id = card_a.id;
+        let card_b_id = Uuid::new_v4();
+
+        let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(vec![column]));
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(
+            board_id,
+            LoadState::Loaded(vec![
+                ArchivedCard::new(card_a_id, board_id),
+                ArchivedCard::new(card_b_id, board_id),
+            ]),
+        );
+        let mut cards_by_id = std::collections::HashMap::new();
+        cards_by_id.insert(card_a_id, LoadState::Loaded(card_a));
+        cards_by_id.insert(card_b_id, LoadState::Missing);
+        let changed = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                by_parent: archived_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_id: cards_by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
+        controller.resync(&model, changed);
+
+        let archived_ids: Vec<Uuid> = controller
+            .displayed_cards(true)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(archived_ids, vec![card_a_id]);
+    }
+
+    #[test]
+    fn test_board_scoped_live_partition_excludes_another_boards_cards() {
+        let board_1 = seed_board("B1", 0);
+        let board_1_id = board_1.id;
+        let column_1 = Column::new(board_1_id, "Col", 0);
+        let card_1 = Card::new(board_1_id, column_1.id, "card1", 0);
+        let card_1_id = card_1.id;
+
+        let board_2 = seed_board("B2", 1);
+        let board_2_id = board_2.id;
+        let column_2 = Column::new(board_2_id, "Col", 0);
+        let card_2 = Card::new(board_2_id, column_2.id, "card2", 0);
+
+        let mut model = Model::default();
+        let changed = model.load_from_snapshot(Snapshot {
+            boards: vec![board_1, board_2],
+            columns: vec![column_1, column_2],
+            cards: vec![card_1, card_2],
+            archived_boards: Vec::new(),
+            ..Default::default()
+        });
+
+        let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_1_id), &model);
+        controller.resync(&model, changed);
+
+        let live_ids: Vec<Uuid> = controller
+            .displayed_cards(false)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(live_ids, vec![card_1_id]);
     }
 }

--- a/crates/kanban-view/src/controller/partitions.rs
+++ b/crates/kanban-view/src/controller/partitions.rs
@@ -13,26 +13,43 @@ fn joined<T, A, B>(flat: LoadState<A>, markers: LoadState<B>) -> LoadState<Vec<T
     }
 }
 
+/// Joins a board's archived-marker tier with the per-id card body tier: for
+/// each Loaded marker, resolves its body through `card_by_id_state`. A
+/// `Missing` body is skipped (a stale marker never wedges the view); any
+/// `Failed` body short-circuits the whole join; any `NotLoaded` body means
+/// the join itself is `NotLoaded`, not partially populated.
+fn archived_bodies(model: &Model, board_id: uuid::Uuid) -> LoadState<Vec<Card>> {
+    let markers = match model.board_archived_cards_state(board_id) {
+        LoadState::Loaded(markers) => markers,
+        LoadState::Failed(e) => return LoadState::Failed(e),
+        LoadState::Missing => return LoadState::Missing,
+        LoadState::NotLoaded => return LoadState::NotLoaded,
+    };
+
+    let mut cards = Vec::with_capacity(markers.len());
+    for marker in markers {
+        match model.card_by_id_state(marker.entity_id) {
+            LoadState::Loaded(card) => cards.push(card.clone()),
+            LoadState::Missing => continue,
+            LoadState::Failed(e) => return LoadState::Failed(e),
+            LoadState::NotLoaded => return LoadState::NotLoaded,
+        }
+    }
+    LoadState::Loaded(cards)
+}
+
 impl Controller {
     pub(super) fn rebuild_card_partitions(&mut self, model: &Model) {
-        match (model.cards_state().as_ref(), model.archived_cards_state()) {
-            (LoadState::Loaded(cards), LoadState::Loaded(_)) => {
-                let (archived_cards, live_cards): (Vec<Card>, Vec<Card>) = cards
-                    .iter()
-                    .cloned()
-                    .partition(|c| model.archived_card_ids().contains(&c.id));
-                self.displayed_cards_live = LoadState::Loaded(live_cards);
-                self.displayed_cards_archived = LoadState::Loaded(archived_cards);
-            }
-            (LoadState::Loaded(cards), markers) => {
-                self.displayed_cards_live = LoadState::Loaded(cards.clone());
-                self.displayed_cards_archived = markers.map(|_| Vec::new());
-            }
-            (flat, markers) => {
-                self.displayed_cards_live = flat.clone().map(|_| Vec::new());
-                self.displayed_cards_archived = joined(flat, markers);
-            }
-        }
+        let Some(board_id) = self.scope_board else {
+            self.displayed_cards_live = LoadState::NotLoaded;
+            self.displayed_cards_archived = LoadState::NotLoaded;
+            return;
+        };
+
+        self.displayed_cards_live = model
+            .board_cards_state(board_id)
+            .map(|cards| cards.into_iter().cloned().collect());
+        self.displayed_cards_archived = archived_bodies(model, board_id);
     }
 
     pub(super) fn rebuild_board_partitions(&mut self, model: &Model) {


### PR DESCRIPTION
## Summary

Moves the TUI's card render source off the three workspace-flat `Model` tiers plus the global archived-marker tier onto the board-scoped tiers, so the render path is Liskov-substitutable across all four backends: over `HttpBackend` the flat `list_all_cards`/`list_archived_cards` reads decline, while the scoped reads the new path uses are served.

- `kanban-domain`: new `Model::board_cards_state` combinator (concatenates a board's `column_cards_state` tiers, live-only, `Failed` > `Missing` > `NotLoaded` precedence, never reads the flat collection). `load_from_snapshot` now buckets live cards into `cards_by_column` and archived-card markers into `archived_cards_by_board`, so a snapshot leaves the scoped tiers populated too, not just the flat ones.
- `kanban-view`: `Controller` gains a `scope_board: Option<Uuid>` field and `set_scope_board`, since a scope change is a staleness source independent of `ModelChanged`. `rebuild_card_partitions` now reads `board_cards_state`/`board_archived_cards_state` joined against the per-id card tier, instead of the flat collection joined against the global archived-marker tier.
- `kanban-service`: `LoadedEntities` gains `loaded_archived_cards_of_board`, implemented across all six implementors (`Model`, `Overlay`, and four test stubs).
- `kanban-tui`: `ViewScope`'s archived-card arm now requests `archived_cards_by_board`/walks per-id card fetches keyed by board, instead of the flat archived-card list. The controller's card-partition scope is set at every seam that can leave it stale (`populate`, `load_snapshot`, `reload_model`, `resolve_after_command`) and re-asserted inside `prepare_frame` itself, since a snapshot can load before `active_board_id` is set. `board_delete_counts`, `start_restore_animation`, `start_permanent_delete_animation`, and `complete_restore_animation` now read the by-board archived-marker tier instead of the global one. `surface_load_failures` walks the board-scoped card/archived-card tiers instead of the flat ones for its scoped-board arm (columns/sprints stay on the flat gate; see deviations below).

## Deviations from the handoff

- `board_delete_counts` reads `self.model.board_cards_state(board_id)` by the function's own `board_id` argument, not `self.controller.live_cards()` (which is scoped to whichever board the controller last resolved, not necessarily the argument).
- The controller scope is set at four seams, not just `populate`, because `load_snapshot`/`reload_model` resync the controller without passing through `populate`.
- `prepare_frame`'s and `tasks_panel_title`'s columns/sprints gates stay on the flat `columns_state()`/`sprints_state()` tiers rather than moving to `board_columns_state`/`board_sprints_state`. `ViewScope` only requests the scoped sprint tier for CardDetail/BoardDetail/SprintDetail (a deliberate lazy-load boundary pinned by an existing cold-start test), and the scoped column tier's coupling to the card render path (`board_cards_state` requires it) would otherwise make several pre-existing render-state tests (`load_state_render_tests.rs`) and a cold-start lazy-load precondition test fail. Only the card and archived-card tiers move to scoped reads in this card.
- Fixed a real gap in the shared `CountingBackend` test helper (`crates/kanban-tui/tests/helpers.rs`): `list_all_cards`, `list_cards_by_column`, and `list_archived_cards` recorded calls but never checked the injected fault, so `wrap_failing`/`wrap_failing_all` silently no-op'd for them. Added the fault checks the new pin tests need to be meaningful.
- One pre-existing TUI test (`test_entering_the_archived_cards_view_after_startup_displays_its_card`) assumed archived cards of a never-opened, never-live board are reachable without any board in scope. Archived-card requests are now board-scoped, so this now requires `active_board_id` to be set first, matching the drilled-in-archived-board flow `handle_toggle_archived_cards_view`'s own doc comment already describes as the supported entry path. Updated the test and its doc comment to match.

## Test plan

- [x] `cargo test -p kanban-domain -p kanban-view -p kanban-tui -p kanban-service --all-features` green
- [x] `cargo test --all-features --workspace` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Key invariant grep: no `cards_state()`/`archived_cards_state()`/`archived_card_markers()` hits in `kanban-view/src/controller` or `kanban-tui/src/ui/main_view.rs`
- [x] Mutation-checked the central `board_cards_state`/`Controller::rebuild_card_partitions` assertions by reverting the fix and confirming the new tests fail, then restoring it


## Fixes from review round 2

- `cargo fmt` was failing on the pushed head (a `.loaded().copied().unwrap_or(&[])` chain across three call sites plus two test-file line-width wraps). Reformatted and reverified `cargo fmt --all -- --check` clean against the new head, not just a working tree.
- `start_restore_animation`, `start_permanent_delete_animation` and `complete_restore_animation` moved onto `board_archived_cards_state` and gained a new `scope_board_id()` early-return guard with no coverage. Added tests that drive all three under a failing `list_archived_cards` backend and confirm restore/permanent-delete still work off the by-board tier, plus a test pinning the new no-board-in-scope early return as deliberate. Added the equivalent coverage for `board_delete_counts` in `board_delete_confirmation_count_tests.rs`. Mutation-checked each: reverted the corresponding handler to the old flat/global-tier read and confirmed the new test fails, then restored it.
- Deleted the `create_card_factory_tests::refresh` helper's redundant manual `columns_by_board`/`sprints_by_board` seeding and its now-false doc comment claiming `load_from_snapshot` leaves those tiers untouched; `rebuild_scoped_tiers` inside `load_from_snapshot` already seeds them, confirmed by the full `create_card_factory_tests` suite staying green without the manual seed.
