### PR TITLE
KAN-1583 feat(tui): read handler operations from the board-scoped tiers

### DIFF
--- a/.changeset/kan-1583-handler-scoped-reads.md
+++ b/.changeset/kan-1583-handler-scoped-reads.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+TUI handler operations read board-scoped tiers instead of the flat card/column/sprint collections

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -24,7 +24,7 @@ impl App {
             self.animation.animating.remove(&card_id);
             match animation_type {
                 AnimationType::Archiving => {
-                    if let LoadState::Loaded(cards) = self.model.cards_state() {
+                    if let LoadState::Loaded(cards) = self.controller.live_cards() {
                         if let Some(card_pos) = cards.iter().position(|c| c.id == card_id) {
                             let card = &cards[card_pos];
                             if !affected_columns.contains(&card.column_id) {

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -95,22 +95,16 @@ impl App {
             .and_then(|id| self.model.board_by_id_state(id).loaded().copied());
 
         let (uncompleted_ids, completed_ids) = if let Some(board) = board_opt {
-            if !self.model.columns_state().is_loaded() || !self.model.sprints_state().is_loaded() {
+            let LoadState::Loaded(columns) = self.board_columns_view(board.id) else {
                 self.set_error("Columns or sprints are not loaded yet".to_string());
                 return;
-            }
-            let columns = self
-                .model
-                .columns_state()
-                .loaded()
-                .expect("checked loaded above");
-            let sprints = self
-                .model
-                .sprints_state()
-                .loaded()
-                .expect("checked loaded above");
+            };
+            let LoadState::Loaded(sprints) = self.board_sprints_view(board.id) else {
+                self.set_error("Columns or sprints are not loaded yet".to_string());
+                return;
+            };
             let sorted_sprint_ids =
-                kanban_domain::CardQueryBuilder::new(cards, columns, sprints, board)
+                kanban_domain::CardQueryBuilder::new(cards, &columns, &sprints, board)
                     .in_sprints(std::iter::once(sprint_id))
                     .execute();
             let mut unc = Vec::new();

--- a/crates/kanban-tui/src/app/clipboard.rs
+++ b/crates/kanban-tui/src/app/clipboard.rs
@@ -11,14 +11,14 @@ impl App {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(board) = self.active_board() {
                 if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
-                    let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                    let LoadState::Loaded(sprints) = self.board_sprints_view(board.id) else {
                         self.set_error("Sprints are not loaded yet".to_string());
                         return;
                     };
                     let output = get_output(
                         card,
                         board,
-                        sprints,
+                        &sprints,
                         self.app_config.effective_default_card_prefix(),
                     );
                     if let Err(e) = clipboard::copy_to_clipboard(&output) {

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -54,6 +54,20 @@ impl App {
         }
     }
 
+    /// Ids of the archived cards on `board_id`, from the board-scoped
+    /// archival marker tier. `NotLoaded` collapses to an empty set, matching
+    /// `Model::archived_card_ids()`'s behaviour outside the archived views.
+    pub(crate) fn board_archived_ids(
+        &self,
+        board_id: uuid::Uuid,
+    ) -> std::collections::HashSet<uuid::Uuid> {
+        self.model
+            .board_archived_cards_state(board_id)
+            .loaded()
+            .map(|markers| markers.iter().map(|m| m.entity_id).collect())
+            .unwrap_or_default()
+    }
+
     pub fn get_current_priority_selection_index(&self) -> usize {
         if let Some(active_id) = self.selection.active_card_id {
             if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -1,5 +1,5 @@
 use super::{App, AppMode};
-use kanban_domain::{Column, LoadState, Sprint};
+use kanban_domain::{Card, Column, LoadState, Sprint};
 
 impl App {
     /// The board the render-side scoped tiers (`Controller` card partitions,
@@ -66,6 +66,23 @@ impl App {
             .loaded()
             .map(|markers| markers.iter().map(|m| m.entity_id).collect())
             .unwrap_or_default()
+    }
+
+    /// The live and archived card partitions for the currently scoped board,
+    /// paired for a candidate search across both. `NotLoaded`/`Failed` on the
+    /// live partition propagates; the archived half degrades to empty rather
+    /// than gating, matching its behaviour outside the archived views.
+    pub(crate) fn board_candidate_cards(&self) -> LoadState<(&[Card], &[Card])> {
+        self.controller.live_cards().map(|live| {
+            (
+                live,
+                self.controller
+                    .archived_cards()
+                    .loaded()
+                    .copied()
+                    .unwrap_or(&[]),
+            )
+        })
     }
 
     pub fn get_current_priority_selection_index(&self) -> usize {

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -3,8 +3,11 @@ use kanban_domain::LoadState;
 use uuid::Uuid;
 
 impl App {
+    /// Ended sprints on the ACTIVE board only, or `None` while no board is
+    /// active or its scoped sprint tier has not loaded.
     pub(in crate::app) fn check_ended_sprints(&self) -> Option<Vec<Uuid>> {
-        let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+        let board_id = self.scope_board_id()?;
+        let LoadState::Loaded(sprints) = self.board_sprints_view(board_id) else {
             return None;
         };
         let ended_sprints: Vec<_> = sprints

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -55,7 +55,7 @@ mod tests {
         SprintUpdate,
     };
 
-    fn seed_ended_sprint(app: &mut App) -> uuid::Uuid {
+    fn seed_ended_sprint(app: &mut App) -> (uuid::Uuid, uuid::Uuid) {
         let board = app.ctx.create_board("Board".into(), None).unwrap();
         let sprint = app.ctx.create_sprint(board.id, None, None).unwrap();
         app.ctx
@@ -68,7 +68,7 @@ mod tests {
                 },
             )
             .unwrap();
-        sprint.id
+        (board.id, sprint.id)
     }
 
     #[test]
@@ -88,9 +88,10 @@ mod tests {
     #[test]
     fn test_check_ended_sprints_reports_ended_sprints_in_the_loaded_tier() {
         let mut app = App::test_default();
-        let sprint_id = seed_ended_sprint(&mut app);
+        let (board_id, sprint_id) = seed_ended_sprint(&mut app);
         let snap = kanban_service::read_full_snapshot(app.ctx.data_store()).unwrap();
         let _ = app.model.load_from_snapshot(snap);
+        app.selection.active_board_id = Some(board_id);
         assert!(matches!(app.model.sprints_state(), LoadState::Loaded(_)));
 
         let ended = app.check_ended_sprints();
@@ -101,9 +102,10 @@ mod tests {
     #[test]
     fn test_check_ended_sprints_with_a_not_loaded_boards_tier_skips_the_board_name_lookup() {
         let mut app = App::test_default();
-        let sprint_id = seed_ended_sprint(&mut app);
+        let (board_id, sprint_id) = seed_ended_sprint(&mut app);
         let snap = kanban_service::read_full_snapshot(app.ctx.data_store()).unwrap();
         let _ = app.model.load_from_snapshot(snap);
+        app.selection.active_board_id = Some(board_id);
         assert!(matches!(app.model.sprints_state(), LoadState::Loaded(_)));
 
         let _ = app
@@ -120,5 +122,20 @@ mod tests {
             Some(vec![sprint_id]),
             "the sprint-tier scan must be unaffected by a NotLoaded boards tier"
         );
+    }
+
+    #[test]
+    fn test_check_ended_sprints_scopes_to_the_active_board() {
+        let mut app = App::test_default();
+        let (board_a, sprint_a) = seed_ended_sprint(&mut app);
+        let (_board_b, _sprint_b) = seed_ended_sprint(&mut app);
+        let snap = kanban_service::read_full_snapshot(app.ctx.data_store()).unwrap();
+        let _ = app.model.load_from_snapshot(snap);
+
+        app.selection.active_board_id = Some(board_a);
+        assert_eq!(app.check_ended_sprints(), Some(vec![sprint_a]));
+
+        app.selection.active_board_id = None;
+        assert_eq!(app.check_ended_sprints(), None);
     }
 }

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -13,12 +13,12 @@ impl App {
     pub fn handle_create_card_key(&mut self) {
         if self.focus.active == Focus::Cards && self.active_board().is_some() {
             if let Some(board) = self.active_board().cloned() {
-                let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                let LoadState::Loaded(sprints) = self.board_sprints_view(board.id) else {
                     self.set_error("Sprints are not loaded yet");
                     return;
                 };
                 self.dialog_input.create_card_sprint_picker.reset_for_board(
-                    sprints,
+                    &sprints,
                     &board,
                     chrono::Utc::now(),
                 );
@@ -85,7 +85,7 @@ impl App {
     pub(crate) fn prime_create_card_sprint_field(&mut self) {
         let visible = match self.active_board() {
             Some(board) => kanban_view::sprint_assign_list::sprint_section_is_visible(
-                self.model.sprints_state(),
+                &self.board_sprints_view(board.id),
                 board.id,
                 chrono::Utc::now(),
             ),
@@ -170,13 +170,13 @@ impl App {
 
         if !self.multi_select.selected_cards.is_empty() {
             if let Some(board) = self.active_board().cloned() {
-                let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                let LoadState::Loaded(sprints) = self.board_sprints_view(board.id) else {
                     self.set_error("Sprints are not loaded yet");
                     return;
                 };
                 self.dialog_input
                     .assign_sprint_picker
-                    .reset_for_bulk_card_assignment(sprints, &board, chrono::Utc::now());
+                    .reset_for_bulk_card_assignment(&sprints, &board, chrono::Utc::now());
             }
             self.open_dialog(DialogMode::AssignMultipleCardsToSprint);
         } else if self.get_selected_card_id().is_some() {
@@ -186,12 +186,12 @@ impl App {
             };
             let now = chrono::Utc::now();
             let has_assignable = {
-                let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                let LoadState::Loaded(sprints) = self.board_sprints_view(board_id) else {
                     self.set_error("Sprints are not loaded yet");
                     return;
                 };
                 let entries =
-                    kanban_view::sprint_assign_list::build_entries(sprints, board_id, now);
+                    kanban_view::sprint_assign_list::build_entries(&sprints, board_id, now);
                 entries.iter().any(|e| {
                     matches!(
                         e,
@@ -214,13 +214,13 @@ impl App {
                 .and_then(|c| c.sprint_id);
             // Re-borrow board after the &mut self call above.
             if let Some(board) = self.active_board().cloned() {
-                let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                let LoadState::Loaded(sprints) = self.board_sprints_view(board.id) else {
                     self.set_error("Sprints are not loaded yet");
                     return;
                 };
                 self.dialog_input
                     .assign_sprint_picker
-                    .reset_for_card_assignment(current_sprint_id, sprints, &board, now);
+                    .reset_for_card_assignment(current_sprint_id, &sprints, &board, now);
             }
             self.open_dialog(DialogMode::AssignCardToSprint);
         }
@@ -344,15 +344,23 @@ impl App {
         let card_ids: Vec<uuid::Uuid> = self.multi_select.selected_cards.iter().copied().collect();
         let first_card_id = card_ids.first().copied();
 
-        let LoadState::Loaded(all_cards) = self.model.cards_state() else {
+        if card_ids
+            .iter()
+            .any(|id| self.model.card_by_id_state(*id).is_not_loaded())
+        {
             self.set_error("Cards are not loaded yet");
             return;
-        };
+        }
 
         let updates: Vec<(uuid::Uuid, CardUpdate)> = card_ids
             .iter()
             .filter_map(|card_id| {
-                let card = all_cards.iter().find(|c| c.id == *card_id)?.clone();
+                let card = self
+                    .model
+                    .card_by_id_state(*card_id)
+                    .loaded()
+                    .copied()?
+                    .clone();
                 let new_status = if card.status == CardStatus::Done {
                     CardStatus::Todo
                 } else {
@@ -408,7 +416,7 @@ impl App {
                     self.set_error("Columns are not loaded yet");
                     return;
                 }
-                if !self.model.cards_state().is_loaded() {
+                if !self.model.board_cards_state(bid).is_loaded() {
                     self.set_error("Cards are not loaded yet");
                     return;
                 }
@@ -417,7 +425,7 @@ impl App {
                 let (column_id, position, mark_as_complete, new_column_cmd) = match existing_column
                 {
                     Some(col) => {
-                        let LoadState::Loaded(cards) = self.model.cards_state() else {
+                        let LoadState::Loaded(cards) = self.model.column_cards_state(col.id) else {
                             self.set_error("Cards are not loaded yet");
                             return;
                         };
@@ -570,16 +578,16 @@ impl App {
 
             // Use the pure helper only to resolve the target column for the
             // given direction; the service handles any status sync.
-            let LoadState::Loaded(columns) = self.model.columns_state() else {
+            let LoadState::Loaded(columns) = self.board_columns_view(board.id) else {
                 self.set_error("Columns are not loaded yet");
                 return;
             };
-            let LoadState::Loaded(cards) = self.model.cards_state() else {
+            let LoadState::Loaded(cards) = self.controller.live_cards() else {
                 self.set_error("Cards are not loaded yet");
                 return;
             };
             let move_result = kanban_domain::card_lifecycle::compute_card_column_move(
-                &card, board, columns, cards, direction,
+                &card, board, &columns, cards, direction,
             );
             let move_result = match move_result {
                 Some(r) => r,
@@ -654,11 +662,11 @@ impl App {
 
         // Use the pure helper only to resolve the per-card target column;
         // status sync is chained by the service layer's `update_cards`.
-        let LoadState::Loaded(columns) = self.model.columns_state() else {
+        let LoadState::Loaded(columns) = self.board_columns_view(board.id) else {
             self.set_error("Columns are not loaded yet");
             return;
         };
-        let LoadState::Loaded(cards) = self.model.cards_state() else {
+        let LoadState::Loaded(cards) = self.controller.live_cards() else {
             self.set_error("Cards are not loaded yet");
             return;
         };
@@ -667,7 +675,7 @@ impl App {
             .filter_map(|card_id| {
                 let card = cards.iter().find(|c| c.id == *card_id)?;
                 let result = kanban_domain::card_lifecycle::compute_card_column_move(
-                    card, board, columns, cards, direction,
+                    card, board, &columns, cards, direction,
                 )?;
                 Some((
                     *card_id,
@@ -736,7 +744,7 @@ impl App {
     /// inferring it from whichever archived card lands last in HashMap order.
     fn cursor_archive_anchor(&self) -> Option<(uuid::Uuid, i32)> {
         let card_id = self.get_selected_card_id()?;
-        let LoadState::Loaded(cards) = self.model.cards_state() else {
+        let LoadState::Loaded(cards) = self.controller.live_cards() else {
             return None;
         };
         cards
@@ -759,7 +767,7 @@ impl App {
         use kanban_domain::AnimationType;
         use std::time::Instant;
 
-        let LoadState::Loaded(cards) = self.model.cards_state() else {
+        let LoadState::Loaded(cards) = self.controller.live_cards() else {
             self.set_error("Cards are not loaded yet");
             return;
         };
@@ -890,14 +898,14 @@ impl App {
 
         let target_column_id = match board_id {
             Some(bid) => {
-                let LoadState::Loaded(columns) = self.model.columns_state() else {
+                let LoadState::Loaded(columns) = self.board_columns_view(bid) else {
                     self.set_error("Columns are not loaded yet");
                     return false;
                 };
                 kanban_domain::card_lifecycle::resolve_restore_column(
                     current_column_id,
                     bid,
-                    columns,
+                    &columns,
                 )
                 .unwrap_or(current_column_id)
             }
@@ -1041,19 +1049,27 @@ impl App {
                 },
             };
 
-        let target_is_archived = self.model.archived_card_ids().contains(&card_id);
+        let archived_ids = self.board_archived_ids(board_id);
+        let target_is_archived = archived_ids.contains(&card_id);
 
-        let LoadState::Loaded(cards) = self.model.cards_state() else {
+        let LoadState::Loaded(cards) = self.controller.live_cards() else {
             self.pop_mode();
             self.set_error("Cards are not loaded yet");
             return;
         };
+        let archived = self
+            .controller
+            .archived_cards()
+            .loaded()
+            .copied()
+            .unwrap_or(&[]);
         let eligible_cards: Vec<_> = cards
             .iter()
+            .chain(archived.iter())
             .filter(|c| column_ids.contains(&c.column_id))
             .filter(|c| c.id != card_id)
             .filter(|c| !ancestors.contains(&c.id))
-            .filter(|c| target_is_archived || !self.model.archived_card_ids().contains(&c.id))
+            .filter(|c| target_is_archived || !archived_ids.contains(&c.id))
             .map(|c| c.id)
             .collect();
 
@@ -1517,11 +1533,12 @@ mod cards_tier_decline_tests {
     }
 
     fn invalidate_cards_tier(app: &mut App) {
-        let _ = app
+        let changed = app
             .model
             .invalidate(Invalidation::Entities(EntityIds::cards([
                 uuid::Uuid::new_v4(),
             ])));
+        app.controller.resync(&app.model, changed);
     }
 
     /// Sets `card_by_id_state(card_id)` to `Loaded` via the `by_id` tier

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1612,6 +1612,41 @@ mod cards_tier_decline_tests {
     }
 
     #[test]
+    fn test_toggle_selected_cards_completion_with_a_failed_flat_cards_tier_for_an_unresolvable_id_declines(
+    ) {
+        let mut app = App::test_default();
+        let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
+        refresh(&mut app);
+        let unresolvable_id = uuid::Uuid::new_v4();
+        app.selection.active_board_id = Some(board_id);
+        app.focus.active = Focus::Cards;
+        app.multi_select.selected_cards.insert(card_id);
+        app.multi_select.selected_cards.insert(unresolvable_id);
+        app.multi_select.selection_mode_active = true;
+
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            cards: kanban_domain::resolved::Collection {
+                all: kanban_domain::LoadState::Failed(std::sync::Arc::new(
+                    kanban_domain::KanbanError::unsupported("flat declined"),
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        app.controller.resync(&app.model, changed);
+
+        app.handle_toggle_card_completion();
+
+        assert_error_banner(&app, "Cards are not loaded yet");
+        let card = app.ctx.get_card(card_id).unwrap().unwrap();
+        assert_eq!(
+            card.status,
+            CardStatus::Todo,
+            "a Failed resolution for one selected id must decline the whole batch, not silently toggle the resolvable one"
+        );
+    }
+
+    #[test]
     fn test_create_card_with_a_not_loaded_cards_tier_declines() {
         let mut app = App::test_default();
         let (board_id, _column_id, _card_id) = seed_board_column_card(&mut app);

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -344,10 +344,10 @@ impl App {
         let card_ids: Vec<uuid::Uuid> = self.multi_select.selected_cards.iter().copied().collect();
         let first_card_id = card_ids.first().copied();
 
-        if card_ids
-            .iter()
-            .any(|id| self.model.card_by_id_state(*id).is_not_loaded())
-        {
+        if card_ids.iter().any(|id| {
+            let state = self.model.card_by_id_state(*id);
+            state.is_not_loaded() || state.is_failed()
+        }) {
             self.set_error("Cards are not loaded yet");
             return;
         }
@@ -1052,17 +1052,11 @@ impl App {
         let archived_ids = self.board_archived_ids(board_id);
         let target_is_archived = archived_ids.contains(&card_id);
 
-        let LoadState::Loaded(cards) = self.controller.live_cards() else {
+        let LoadState::Loaded((cards, archived)) = self.board_candidate_cards() else {
             self.pop_mode();
             self.set_error("Cards are not loaded yet");
             return;
         };
-        let archived = self
-            .controller
-            .archived_cards()
-            .loaded()
-            .copied()
-            .unwrap_or(&[]);
         let eligible_cards: Vec<_> = cards
             .iter()
             .chain(archived.iter())

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1185,16 +1185,10 @@ impl App {
         let archived_ids = self.board_archived_ids(board_id);
         let target_is_archived = archived_ids.contains(&card_id);
 
-        let LoadState::Loaded(cards) = self.controller.live_cards() else {
+        let LoadState::Loaded((cards, archived)) = self.board_candidate_cards() else {
             self.set_error("Cards are not loaded yet");
             return;
         };
-        let archived = self
-            .controller
-            .archived_cards()
-            .loaded()
-            .copied()
-            .unwrap_or(&[]);
         let eligible_cards: Vec<_> = cards
             .iter()
             .chain(archived.iter())
@@ -1252,16 +1246,10 @@ impl App {
         let archived_ids = self.board_archived_ids(board_id);
         let target_is_archived = archived_ids.contains(&card_id);
 
-        let LoadState::Loaded(cards) = self.controller.live_cards() else {
+        let LoadState::Loaded((cards, archived)) = self.board_candidate_cards() else {
             self.set_error("Cards are not loaded yet");
             return;
         };
-        let archived = self
-            .controller
-            .archived_cards()
-            .loaded()
-            .copied()
-            .unwrap_or(&[]);
         let eligible_cards: Vec<_> = cards
             .iter()
             .chain(archived.iter())
@@ -1391,10 +1379,10 @@ impl App {
     pub fn toggle_completion_for_card_ids(&mut self, ids: Vec<uuid::Uuid>) {
         use kanban_domain::{CardStatus, CardUpdate};
 
-        if ids
-            .iter()
-            .any(|id| self.model.card_by_id_state(*id).is_not_loaded())
-        {
+        if ids.iter().any(|id| {
+            let state = self.model.card_by_id_state(*id);
+            state.is_not_loaded() || state.is_failed()
+        }) {
             self.set_error("Cards are not loaded yet");
             return;
         }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2755,6 +2755,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_toggle_completion_for_card_ids_with_a_failed_flat_cards_tier_for_an_unresolvable_id_declines(
+    ) {
+        let mut app = App::test_default();
+        let card_id = seed_sprint_with_card(&mut app, "task");
+        let unresolvable_id = uuid::Uuid::new_v4();
+
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            cards: kanban_domain::resolved::Collection {
+                all: kanban_domain::LoadState::Failed(std::sync::Arc::new(
+                    kanban_domain::KanbanError::unsupported("flat declined"),
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        app.controller.resync(&app.model, changed);
+
+        app.toggle_completion_for_card_ids(vec![card_id, unresolvable_id]);
+
+        assert_error_banner(&app, "Cards are not loaded yet");
+        let card = app.ctx.get_card(card_id).unwrap().unwrap();
+        assert_eq!(
+            card.status,
+            CardStatus::Todo,
+            "a Failed resolution for one selected id must decline the whole batch, not silently toggle the resolvable one"
+        );
+    }
+
     fn seed_board_with_scoped_and_flat_sprints(
         app: &mut App,
         build_scoped: impl FnOnce(uuid::Uuid) -> Vec<kanban_domain::Sprint>,

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -761,13 +761,9 @@ impl App {
     /// assign to.
     fn handle_assign_sprint_shortcut(&mut self) {
         if let Some(board) = self.active_board().cloned() {
-            match self.model.sprints_state() {
+            match self.board_sprints_view(board.id) {
                 LoadState::Loaded(all_sprints) => {
-                    let sprint_count = all_sprints
-                        .iter()
-                        .filter(|s| s.board_id == board.id)
-                        .count();
-                    if sprint_count > 0 {
+                    if !all_sprints.is_empty() {
                         let current_sprint_id = self
                             .selection
                             .active_card_id
@@ -777,7 +773,7 @@ impl App {
                             .assign_sprint_picker
                             .reset_for_card_assignment(
                                 current_sprint_id,
-                                all_sprints,
+                                &all_sprints,
                                 &board,
                                 chrono::Utc::now(),
                             );
@@ -795,13 +791,9 @@ impl App {
     fn open_assign_sprint_dialog_for(&mut self, card_id: uuid::Uuid) {
         if self.activate_card(card_id) {
             if let Some(board) = self.active_board().cloned() {
-                match self.model.sprints_state() {
+                match self.board_sprints_view(board.id) {
                     LoadState::Loaded(all_sprints) => {
-                        let sprint_count = all_sprints
-                            .iter()
-                            .filter(|s| s.board_id == board.id)
-                            .count();
-                        if sprint_count > 0 {
+                        if !all_sprints.is_empty() {
                             let current_sprint_id = self
                                 .model
                                 .card_by_id_state(card_id)
@@ -812,7 +804,7 @@ impl App {
                                 .assign_sprint_picker
                                 .reset_for_card_assignment(
                                     current_sprint_id,
-                                    all_sprints,
+                                    &all_sprints,
                                     &board,
                                     chrono::Utc::now(),
                                 );
@@ -978,8 +970,8 @@ impl App {
                             }
                         }
                         CardListAction::Complete(card_id) => {
-                            if let LoadState::Loaded(cards) = self.model.cards_state() {
-                                if let Some(card) = cards.iter().find(|c| c.id == card_id) {
+                            match self.model.card_by_id_state(card_id) {
+                                LoadState::Loaded(card) => {
                                     use kanban_domain::CardStatus;
                                     let new_status = if card.status == CardStatus::Done {
                                         CardStatus::Todo
@@ -1007,8 +999,8 @@ impl App {
                                         }
                                     }
                                 }
-                            } else {
-                                self.set_error("Cards are not loaded yet");
+                                LoadState::Missing => {}
+                                _ => self.set_error("Cards are not loaded yet"),
                             }
                         }
                         CardListAction::TogglePriority(card_id) => {
@@ -1046,12 +1038,13 @@ impl App {
                             }
                         }
                         CardListAction::MoveColumn(card_id, is_right) => {
-                            let LoadState::Loaded(cards) = self.model.cards_state() else {
-                                self.set_error("Cards are not loaded yet");
-                                return;
-                            };
-                            let Some(card) = cards.iter().find(|c| c.id == card_id).cloned() else {
-                                return;
+                            let card = match self.model.card_by_id_state(card_id) {
+                                LoadState::Loaded(card) => card.clone(),
+                                LoadState::Missing => return,
+                                _ => {
+                                    self.set_error("Cards are not loaded yet");
+                                    return;
+                                }
                             };
 
                             let direction = if is_right {
@@ -1062,11 +1055,19 @@ impl App {
 
                             let board = self.active_board().cloned();
                             let move_result = match board {
-                                Some(board) => match self.model.columns_state() {
+                                Some(board) => match self.board_columns_view(board.id) {
                                     LoadState::Loaded(columns) => {
-                                        kanban_domain::card_lifecycle::compute_card_column_move(
-                                            &card, &board, columns, cards, direction,
-                                        )
+                                        match self.controller.live_cards() {
+                                            LoadState::Loaded(cards) => {
+                                                kanban_domain::card_lifecycle::compute_card_column_move(
+                                                    &card, &board, &columns, cards, direction,
+                                                )
+                                            }
+                                            _ => {
+                                                self.set_error("Cards are not loaded yet");
+                                                None
+                                            }
+                                        }
                                     }
                                     _ => {
                                         self.set_error("Columns are not loaded yet");
@@ -1167,12 +1168,8 @@ impl App {
             }
         };
 
-        let column_ids: std::collections::HashSet<_> = match self.model.columns_state() {
-            LoadState::Loaded(columns) => columns
-                .iter()
-                .filter(|c| c.board_id == board_id)
-                .map(|c| c.id)
-                .collect(),
+        let column_ids: std::collections::HashSet<_> = match self.board_columns_view(board_id) {
+            LoadState::Loaded(columns) => columns.iter().map(|c| c.id).collect(),
             _ => {
                 self.set_error("Columns are not loaded yet");
                 return;
@@ -1185,18 +1182,26 @@ impl App {
         };
         let descendants = graph.descendants(card_id);
 
-        let target_is_archived = self.model.archived_card_ids().contains(&card_id);
+        let archived_ids = self.board_archived_ids(board_id);
+        let target_is_archived = archived_ids.contains(&card_id);
 
-        let LoadState::Loaded(cards) = self.model.cards_state() else {
+        let LoadState::Loaded(cards) = self.controller.live_cards() else {
             self.set_error("Cards are not loaded yet");
             return;
         };
+        let archived = self
+            .controller
+            .archived_cards()
+            .loaded()
+            .copied()
+            .unwrap_or(&[]);
         let eligible_cards: Vec<_> = cards
             .iter()
+            .chain(archived.iter())
             .filter(|c| column_ids.contains(&c.column_id))
             .filter(|c| c.id != card_id)
             .filter(|c| !descendants.contains(&c.id))
-            .filter(|c| target_is_archived || !self.model.archived_card_ids().contains(&c.id))
+            .filter(|c| target_is_archived || !archived_ids.contains(&c.id))
             .map(|c| c.id)
             .collect();
 
@@ -1230,12 +1235,8 @@ impl App {
             }
         };
 
-        let column_ids: std::collections::HashSet<_> = match self.model.columns_state() {
-            LoadState::Loaded(columns) => columns
-                .iter()
-                .filter(|c| c.board_id == board_id)
-                .map(|c| c.id)
-                .collect(),
+        let column_ids: std::collections::HashSet<_> = match self.board_columns_view(board_id) {
+            LoadState::Loaded(columns) => columns.iter().map(|c| c.id).collect(),
             _ => {
                 self.set_error("Columns are not loaded yet");
                 return;
@@ -1248,18 +1249,26 @@ impl App {
         };
         let ancestors = graph.ancestors(card_id);
 
-        let target_is_archived = self.model.archived_card_ids().contains(&card_id);
+        let archived_ids = self.board_archived_ids(board_id);
+        let target_is_archived = archived_ids.contains(&card_id);
 
-        let LoadState::Loaded(cards) = self.model.cards_state() else {
+        let LoadState::Loaded(cards) = self.controller.live_cards() else {
             self.set_error("Cards are not loaded yet");
             return;
         };
+        let archived = self
+            .controller
+            .archived_cards()
+            .loaded()
+            .copied()
+            .unwrap_or(&[]);
         let eligible_cards: Vec<_> = cards
             .iter()
+            .chain(archived.iter())
             .filter(|c| column_ids.contains(&c.column_id))
             .filter(|c| c.id != card_id)
             .filter(|c| !ancestors.contains(&c.id))
-            .filter(|c| target_is_archived || !self.model.archived_card_ids().contains(&c.id))
+            .filter(|c| target_is_archived || !archived_ids.contains(&c.id))
             .map(|c| c.id)
             .collect();
 
@@ -1382,15 +1391,23 @@ impl App {
     pub fn toggle_completion_for_card_ids(&mut self, ids: Vec<uuid::Uuid>) {
         use kanban_domain::{CardStatus, CardUpdate};
 
-        let LoadState::Loaded(all_cards) = self.model.cards_state() else {
+        if ids
+            .iter()
+            .any(|id| self.model.card_by_id_state(*id).is_not_loaded())
+        {
             self.set_error("Cards are not loaded yet");
             return;
-        };
+        }
 
         let updates: Vec<(uuid::Uuid, CardUpdate)> = ids
             .iter()
             .filter_map(|card_id| {
-                let card = all_cards.iter().find(|c| c.id == *card_id)?.clone();
+                let card = self
+                    .model
+                    .card_by_id_state(*card_id)
+                    .loaded()
+                    .copied()?
+                    .clone();
                 let new_status = if card.status == CardStatus::Done {
                     CardStatus::Todo
                 } else {
@@ -2642,11 +2659,12 @@ mod tests {
     }
 
     fn invalidate_cards_tier(app: &mut App) {
-        let _ = app
+        let changed = app
             .model
             .invalidate(Invalidation::Entities(EntityIds::cards([
                 uuid::Uuid::new_v4(),
             ])));
+        app.controller.resync(&app.model, changed);
     }
 
     fn pin_card_by_id(app: &mut App, card_id: uuid::Uuid) {

--- a/crates/kanban-tui/src/handlers/dialog_handlers.rs
+++ b/crates/kanban-tui/src/handlers/dialog_handlers.rs
@@ -103,14 +103,14 @@ impl App {
             .active_board_id
             .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
         {
-            let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+            let LoadState::Loaded(sprints) = self.board_sprints_view(board.id) else {
                 self.set_error("Sprints are not loaded yet".to_string());
                 return;
             };
             let now = chrono::Utc::now();
             self.dialog_input
                 .create_card_sprint_picker
-                .handle_key(key_code, sprints, board, now);
+                .handle_key(key_code, &sprints, board, now);
         }
     }
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -653,12 +653,10 @@ impl App {
         if self.relationship.search.is_empty() {
             return Some(self.relationship.card_ids.clone());
         }
-        if self
-            .relationship
-            .card_ids
-            .iter()
-            .any(|id| self.model.card_by_id_state(*id).is_not_loaded())
-        {
+        if self.relationship.card_ids.iter().any(|id| {
+            let state = self.model.card_by_id_state(*id);
+            state.is_not_loaded() || state.is_failed()
+        }) {
             return None;
         }
         let search_lower = self.relationship.search.to_lowercase();

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -436,14 +436,14 @@ impl App {
                     .active_board_id
                     .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                 {
-                    let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                    let LoadState::Loaded(sprints) = self.board_sprints_view(board.id) else {
                         self.set_error("Sprints are not loaded yet".to_string());
                         return;
                     };
                     let now = chrono::Utc::now();
                     self.dialog_input
                         .assign_sprint_picker
-                        .handle_key(key_code, sprints, board, now);
+                        .handle_key(key_code, &sprints, board, now);
                 }
             }
         }
@@ -519,14 +519,14 @@ impl App {
                     .active_board_id
                     .and_then(|id| self.model.board_by_id_state(id).loaded().copied())
                 {
-                    let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                    let LoadState::Loaded(sprints) = self.board_sprints_view(board.id) else {
                         self.set_error("Sprints are not loaded yet".to_string());
                         return;
                     };
                     let now = chrono::Utc::now();
                     self.dialog_input
                         .assign_sprint_picker
-                        .handle_key(key_code, sprints, board, now);
+                        .handle_key(key_code, &sprints, board, now);
                 }
             }
         }
@@ -552,13 +552,12 @@ impl App {
                     match self.model.sprint_by_id_state(source_id) {
                         LoadState::Loaded(sprint) => {
                             let board_id = sprint.board_id;
-                            match self.model.sprints_state() {
+                            match self.board_sprints_view(board_id) {
                                 LoadState::Loaded(sprints) => {
                                     let count = sprints
                                         .iter()
                                         .filter(|s| {
-                                            s.board_id == board_id
-                                                && s.status == kanban_domain::SprintStatus::Planning
+                                            s.status == kanban_domain::SprintStatus::Planning
                                         })
                                         .count();
                                     self.dialog_input.carry_over_sprint_selection.next(count);
@@ -580,14 +579,12 @@ impl App {
                         match self.model.sprint_by_id_state(source_id) {
                             LoadState::Loaded(sprint) => {
                                 let board_id = sprint.board_id;
-                                match self.model.sprints_state() {
+                                match self.board_sprints_view(board_id) {
                                     LoadState::Loaded(sprints) => {
                                         let planning_sprint_ids: Vec<uuid::Uuid> = sprints
                                             .iter()
                                             .filter(|s| {
-                                                s.board_id == board_id
-                                                    && s.status
-                                                        == kanban_domain::SprintStatus::Planning
+                                                s.status == kanban_domain::SprintStatus::Planning
                                             })
                                             .map(|s| s.id)
                                             .collect();
@@ -656,18 +653,23 @@ impl App {
         if self.relationship.search.is_empty() {
             return Some(self.relationship.card_ids.clone());
         }
-        let LoadState::Loaded(cards) = self.model.cards_state() else {
+        if self
+            .relationship
+            .card_ids
+            .iter()
+            .any(|id| self.model.card_by_id_state(*id).is_not_loaded())
+        {
             return None;
-        };
+        }
         let search_lower = self.relationship.search.to_lowercase();
         Some(
             self.relationship
                 .card_ids
                 .iter()
                 .filter(|card_id| {
-                    cards
-                        .iter()
-                        .find(|c| c.id == **card_id)
+                    self.model
+                        .card_by_id_state(**card_id)
+                        .loaded()
                         .map(|c| c.title.to_lowercase().contains(&search_lower))
                         .unwrap_or(false)
                 })

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -803,8 +803,8 @@ mod tests {
     use crate::App;
     use crossterm::event::KeyCode;
     use kanban_domain::{
-        CardPriority, CreateCardOptions, EntityIds, Invalidation, KanbanOperations, Snapshot,
-        SprintStatus, SprintUpdate,
+        CardPriority, CreateCardOptions, DerivedProjections, EntityIds, Invalidation,
+        KanbanOperations, Snapshot, SprintStatus, SprintUpdate,
     };
     use std::collections::HashSet;
 
@@ -1035,6 +1035,49 @@ mod tests {
             .banner
             .as_ref()
             .expect("a NotLoaded cards tier must banner rather than silently show no matches");
+        assert!(
+            banner.message.to_lowercase().contains("not loaded"),
+            "banner should explain the cards tier is not loaded, got: {}",
+            banner.message
+        );
+    }
+
+    #[test]
+    fn test_relationship_search_with_failed_cards_tier_for_an_unresolvable_id_banners() {
+        let mut app = App::test_default();
+        let (_board_id, card_id) = seed_relationship_dialog(&mut app);
+        let unresolvable_id = uuid::Uuid::new_v4();
+        app.relationship.card_ids = vec![card_id, unresolvable_id];
+        app.relationship.selection.set(Some(0));
+
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            cards: kanban_domain::resolved::Collection {
+                all: kanban_domain::LoadState::Failed(std::sync::Arc::new(
+                    kanban_domain::KanbanError::unsupported("flat declined"),
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        app.controller.resync(&app.model, changed);
+
+        app.relationship.search_active = true;
+        app.handle_manage_parents_popup(KeyCode::Char('f'));
+
+        assert_eq!(
+            app.relationship.selection.get(),
+            Some(0),
+            "a Failed flat cards tier must not clear a staged selection"
+        );
+        assert_eq!(
+            app.relationship.card_ids.len(),
+            2,
+            "a Failed flat cards tier must not empty the candidate list"
+        );
+        let banner =
+            app.ui_state.banner.as_ref().expect(
+                "a Failed flat cards tier must banner rather than silently show no matches",
+            );
         assert!(
             banner.message.to_lowercase().contains("not loaded"),
             "banner should explain the cards tier is not loaded, got: {}",

--- a/crates/kanban-tui/src/handlers/sprint_handlers.rs
+++ b/crates/kanban-tui/src/handlers/sprint_handlers.rs
@@ -138,15 +138,13 @@ impl App {
 
                 {
                     use kanban_domain::query::sprint::get_sprint_uncompleted_cards;
-                    let LoadState::Loaded(sprints) = self.model.sprints_state() else {
+                    let LoadState::Loaded(sprints) = self.board_sprints_view(board_id) else {
                         self.set_error("Sprints are not loaded yet".to_string());
                         return;
                     };
-                    let has_planning = sprints.iter().any(|s| {
-                        s.board_id == board_id
-                            && s.status == SprintStatus::Planning
-                            && s.id != sprint_id
-                    });
+                    let has_planning = sprints
+                        .iter()
+                        .any(|s| s.status == SprintStatus::Planning && s.id != sprint_id);
 
                     if has_planning
                         && !get_sprint_uncompleted_cards(
@@ -178,10 +176,10 @@ impl App {
             }
         };
 
-        let has_planning_sprint = match self.model.sprints_state() {
-            LoadState::Loaded(sprints) => sprints
-                .iter()
-                .any(|s| s.board_id == board_id && s.status == SprintStatus::Planning),
+        let has_planning_sprint = match self.board_sprints_view(board_id) {
+            LoadState::Loaded(sprints) => {
+                sprints.iter().any(|s| s.status == SprintStatus::Planning)
+            }
             _ => {
                 self.set_error("Sprints are not loaded yet".to_string());
                 return;
@@ -219,10 +217,8 @@ impl App {
                 .to_string();
 
             let sprint_id = uuid::Uuid::new_v4();
-            let prior_sprint_count = match self.model.sprints_state() {
-                LoadState::Loaded(sprints) => {
-                    sprints.iter().filter(|s| s.board_id == board_id).count()
-                }
+            let prior_sprint_count = match self.board_sprints_view(board_id) {
+                LoadState::Loaded(sprints) => sprints.len(),
                 _ => {
                     self.set_error("Sprints are not loaded yet".to_string());
                     return;

--- a/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
@@ -1,7 +1,8 @@
 use crossterm::event::KeyCode;
 use kanban_domain::resolved::Collection;
 use kanban_domain::{
-    Board, Card, Column, KanbanOperations, LoadState, Model, ModelLoadStates, Resolved, Sprint,
+    Board, Card, Column, DerivedProjections, KanbanOperations, LoadState, Model, ModelLoadStates,
+    Resolved, Sprint,
 };
 use kanban_tui::app::{AppMode, DialogMode};
 use kanban_tui::App;
@@ -30,6 +31,35 @@ fn set_column_by_id(app: &mut App, column_id: Uuid, state: LoadState<Column>) {
         },
         ..Default::default()
     });
+}
+
+fn seed_scoped_partitions(
+    app: &mut App,
+    board_id: Uuid,
+    columns: Vec<Column>,
+    cards_by_column: Vec<(Uuid, Vec<Card>)>,
+) {
+    let changed = app.model.apply_resolved(Resolved {
+        columns: Collection {
+            by_parent: HashMap::from([(board_id, LoadState::Loaded(columns))]),
+            ..Default::default()
+        },
+        cards: Collection {
+            by_parent: cards_by_column
+                .into_iter()
+                .map(|(column_id, cards)| (column_id, LoadState::Loaded(cards)))
+                .collect(),
+            ..Default::default()
+        },
+        archived_cards: Collection {
+            by_parent: HashMap::from([(board_id, LoadState::Loaded(Vec::new()))]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    app.selection.active_board_id = Some(board_id);
+    app.controller.set_scope_board(Some(board_id), &app.model);
+    app.controller.resync(&app.model, changed);
 }
 
 fn assert_error_banner(app: &App) {
@@ -246,13 +276,19 @@ fn test_handle_manage_parents_still_opens_the_dialog_when_everything_is_loaded()
     set_model(
         &mut app,
         ModelLoadStates {
-            cards: LoadState::Loaded(vec![card, other_card]),
+            cards: LoadState::Loaded(vec![card.clone(), other_card.clone()]),
             columns: LoadState::Loaded(vec![column.clone()]),
             graph: LoadState::Loaded(kanban_domain::DependencyGraph::default()),
             ..Default::default()
         },
     );
-    set_column_by_id(&mut app, column_id, LoadState::Loaded(column));
+    set_column_by_id(&mut app, column_id, LoadState::Loaded(column.clone()));
+    seed_scoped_partitions(
+        &mut app,
+        board_id,
+        vec![column],
+        vec![(column_id, vec![card, other_card])],
+    );
     app.selection.active_card_id = Some(card_id);
 
     app.handle_manage_parents();
@@ -330,13 +366,19 @@ fn test_handle_manage_children_still_opens_the_dialog_when_everything_is_loaded(
     set_model(
         &mut app,
         ModelLoadStates {
-            cards: LoadState::Loaded(vec![card, other_card]),
+            cards: LoadState::Loaded(vec![card.clone(), other_card.clone()]),
             columns: LoadState::Loaded(vec![column.clone()]),
             graph: LoadState::Loaded(kanban_domain::DependencyGraph::default()),
             ..Default::default()
         },
     );
-    set_column_by_id(&mut app, column_id, LoadState::Loaded(column));
+    set_column_by_id(&mut app, column_id, LoadState::Loaded(column.clone()));
+    seed_scoped_partitions(
+        &mut app,
+        board_id,
+        vec![column],
+        vec![(column_id, vec![card, other_card])],
+    );
     app.selection.active_card_id = Some(card_id);
 
     app.handle_manage_children();
@@ -382,6 +424,14 @@ fn seed_move_fixture(app: &mut App, columns_loaded: bool) -> (Uuid, Uuid, Uuid, 
             ..Default::default()
         },
     );
+    if columns_loaded {
+        seed_scoped_partitions(
+            app,
+            board.id,
+            vec![left.clone(), right.clone()],
+            vec![(left.id, vec![card.clone()]), (right.id, Vec::new())],
+        );
+    }
     app.selection.active_board_id = Some(board.id);
     app.sprint_view.panel = kanban_tui::app::SprintTaskPanel::Uncompleted;
     app.sprint_view

--- a/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
+++ b/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
@@ -1,4 +1,4 @@
-//! Pins the TUI handlers named by KAN-1583 to the board-scoped tiers
+//! Pins the TUI handlers to the board-scoped tiers
 //! (`App::board_columns_view`/`board_sprints_view`, `Controller::live_cards`/
 //! `archived_cards`, `Model::card_by_id_state`/`column_cards_state`) rather
 //! than the flat `Model::cards_state`/`columns_state`/`sprints_state`

--- a/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
+++ b/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
@@ -1,0 +1,348 @@
+//! Pins the TUI handlers named by KAN-1583 to the board-scoped tiers
+//! (`App::board_columns_view`/`board_sprints_view`, `Controller::live_cards`/
+//! `archived_cards`, `Model::card_by_id_state`/`column_cards_state`) rather
+//! than the flat `Model::cards_state`/`columns_state`/`sprints_state`
+//! collections. Each test seeds a healthy scoped state via `reload_model` +
+//! `prepare_frame`, then fails ONLY the three flat tiers and proves the
+//! handler still acts.
+
+use kanban_domain::resolved::Collection;
+use kanban_domain::{
+    CreateCardOptions, DerivedProjections, KanbanError, KanbanOperations, LoadState, Resolved,
+};
+use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::App;
+use std::sync::Arc;
+use uuid::Uuid;
+
+fn fail_flat_tiers(app: &mut App) {
+    let changed = app.model.apply_resolved(Resolved {
+        cards: Collection {
+            all: LoadState::Failed(Arc::new(KanbanError::unsupported("flat declined"))),
+            ..Default::default()
+        },
+        columns: Collection {
+            all: LoadState::Failed(Arc::new(KanbanError::unsupported("flat declined"))),
+            ..Default::default()
+        },
+        sprints: Collection {
+            all: LoadState::Failed(Arc::new(KanbanError::unsupported("flat declined"))),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    app.controller.resync(&app.model, changed);
+}
+
+fn select_card_in_active_task_list(app: &mut App, card_id: Uuid) {
+    let list = app
+        .view
+        .strategy
+        .get_active_task_list_mut()
+        .expect("active task list");
+    let idx = list
+        .cards
+        .iter()
+        .position(|&id| id == card_id)
+        .expect("card present in active task list");
+    list.set_selected_index(Some(idx));
+}
+
+#[test]
+fn test_handler_acts_on_scoped_tiers_while_flat_tiers_failed() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    app.ctx.create_sprint(board.id, None, None).unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.push_mode(AppMode::BoardDetail);
+    app.reload_model();
+    app.pop_mode();
+    app.prepare_frame();
+    select_card_in_active_task_list(&mut app, card.id);
+    app.focus.active = kanban_tui::app::Focus::Cards;
+
+    fail_flat_tiers(&mut app);
+
+    assert!(
+        app.model.sprints_state().is_failed(),
+        "fixture sanity: flat sprints tier must be Failed"
+    );
+    assert!(
+        app.model.board_sprints_state(board.id).is_loaded(),
+        "fixture sanity: scoped sprints tier must survive the flat failure"
+    );
+
+    app.handle_assign_to_sprint_key();
+
+    assert_eq!(app.mode, AppMode::Dialog(DialogMode::AssignCardToSprint));
+    assert!(
+        app.ui_state.banner.is_none(),
+        "banner: {:?}",
+        app.ui_state.banner
+    );
+}
+
+#[test]
+fn test_move_card_uses_the_scoped_column_and_partition_reads() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let todo = app
+        .ctx
+        .create_column(board.id, "Todo".into(), Some(0))
+        .unwrap();
+    let doing = app
+        .ctx
+        .create_column(board.id, "Doing".into(), Some(1))
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            todo.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+    select_card_in_active_task_list(&mut app, card.id);
+    app.focus.active = kanban_tui::app::Focus::Cards;
+
+    fail_flat_tiers(&mut app);
+
+    app.handle_move_card_right();
+
+    assert!(
+        app.ui_state.banner.is_none(),
+        "banner: {:?}",
+        app.ui_state.banner
+    );
+    let stored = app.ctx.data_store().get_card(card.id).unwrap().unwrap();
+    assert_eq!(stored.column_id, doing.id);
+}
+
+#[test]
+fn test_create_card_position_derives_from_the_column_tier() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), Some(0))
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "First".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Second".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+    app.focus.active = kanban_tui::app::Focus::Cards;
+
+    fail_flat_tiers(&mut app);
+
+    app.input.set("Third".into());
+    app.create_card();
+
+    assert!(
+        app.ui_state.banner.is_none(),
+        "banner: {:?}",
+        app.ui_state.banner
+    );
+    let all = app.ctx.data_store().list_all_cards().unwrap();
+    let created = all
+        .iter()
+        .find(|c| c.title == "Third")
+        .expect("card was created");
+    assert_eq!(created.position, 2);
+}
+
+#[test]
+fn test_toggle_completion_resolves_cards_by_id() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    let a = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "A".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let b = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "B".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+
+    fail_flat_tiers(&mut app);
+
+    assert!(app.model.card_by_id_state(a.id).loaded().is_some());
+    assert!(app.model.card_by_id_state(b.id).loaded().is_some());
+
+    app.toggle_completion_for_card_ids(vec![a.id, b.id]);
+
+    assert!(
+        app.ui_state.banner.is_none(),
+        "banner: {:?}",
+        app.ui_state.banner
+    );
+    let stored_a = app.ctx.data_store().get_card(a.id).unwrap().unwrap();
+    let stored_b = app.ctx.data_store().get_card(b.id).unwrap().unwrap();
+    assert_eq!(stored_a.status, kanban_domain::CardStatus::Done);
+    assert_eq!(stored_b.status, kanban_domain::CardStatus::Done);
+}
+
+fn seed_manage_children_fixture(app: &mut App) -> (Uuid, Uuid, Uuid, Uuid) {
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    let target = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Target".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let live_candidate = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Live".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let archived_candidate = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Archived".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(archived_candidate.id).unwrap();
+    (
+        board.id,
+        target.id,
+        live_candidate.id,
+        archived_candidate.id,
+    )
+}
+
+#[test]
+fn test_manage_children_eligible_set_spans_archived_when_target_archived() {
+    let mut app = App::test_default();
+    let (board_id, target_id, live_id, archived_id) = seed_manage_children_fixture(&mut app);
+    app.ctx.archive_card(target_id).unwrap();
+
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
+    app.prepare_frame();
+    select_card_in_active_task_list(&mut app, target_id);
+
+    app.handle_manage_children_from_list();
+
+    assert!(
+        app.relationship.card_ids.contains(&live_id),
+        "live candidate must be eligible for an archived target"
+    );
+    assert!(
+        app.relationship.card_ids.contains(&archived_id),
+        "archived candidate must be eligible for an archived target"
+    );
+}
+
+#[test]
+fn test_manage_children_eligible_set_excludes_archived_when_target_live() {
+    let mut app = App::test_default();
+    let (board_id, target_id, live_id, archived_id) = seed_manage_children_fixture(&mut app);
+
+    app.selection.active_board_id = Some(board_id);
+    app.reload_model();
+    app.prepare_frame();
+    select_card_in_active_task_list(&mut app, target_id);
+
+    app.handle_manage_children_from_list();
+
+    assert!(
+        app.relationship.card_ids.contains(&live_id),
+        "live candidate must be eligible for a live target"
+    );
+    assert!(
+        !app.relationship.card_ids.contains(&archived_id),
+        "archived candidate must NOT be eligible for a live target"
+    );
+}
+
+#[test]
+fn test_sprint_dialogs_read_the_board_scoped_sprint_tier() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    app.ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    app.ctx.create_sprint(board.id, None, None).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.push_mode(AppMode::Dialog(DialogMode::CreateCard));
+    app.reload_model();
+
+    fail_flat_tiers(&mut app);
+
+    app.dialog_input.create_card_focus = kanban_tui::app::dialog_input::CreateCardFocus::Sprint;
+    app.handle_create_card_dialog(crossterm::event::KeyCode::Down);
+
+    assert!(
+        app.ui_state.banner.is_none(),
+        "banner: {:?}",
+        app.ui_state.banner
+    );
+}

--- a/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
+++ b/crates/kanban-tui/tests/manage_children_parents_archived_candidates_tests.rs
@@ -188,7 +188,8 @@ fn test_manage_children_from_live_card_still_offers_live_candidates() {
 #[test]
 fn test_card_detail_manage_children_excludes_archived_candidates() {
     let mut app = App::test_default();
-    let (_board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    let (board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    app.selection.active_board_id = Some(board_id);
     sync_model_from_store(&mut app);
     app.selection.active_card_id = Some(target_id);
 
@@ -207,7 +208,8 @@ fn test_card_detail_manage_children_excludes_archived_candidates() {
 #[test]
 fn test_card_detail_manage_parents_excludes_archived_candidates() {
     let mut app = App::test_default();
-    let (_board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    let (board_id, target_id, live_id, archived_id) = seed_target_and_candidates(&mut app);
+    app.selection.active_board_id = Some(board_id);
     sync_model_from_store(&mut app);
     app.selection.active_card_id = Some(target_id);
 


### PR DESCRIPTION
## Summary

Sweeps the remaining TUI handler reads of the three retiring flat `Model`
tiers (`cards_state`/`columns_state`/`sprints_state`) plus the global
`archived_card_ids()` reads onto board-scoped reads:

- Sprints and columns route through `App::board_sprints_view`/`board_columns_view`.
- Board-wide live card sets route through `Controller::live_cards()`/`archived_cards()`.
- Id-list card lookups route through `Model::card_by_id_state`.
- Create-card position derives from `Model::column_cards_state`.
- Archived-ness in relationship eligible-set building routes through a new
  `App::board_archived_ids(board_id)` helper instead of the global flat
  `archived_card_ids()`, which also repairs a currently-dead exclusion filter
  (a live relationship target now correctly excludes archived candidates in a
  `reload_model`-driven session, matching KAN-972's intent).
- `check_ended_sprints` now scopes to the active board instead of scanning
  the whole workspace's flat sprint tier.

### Pre-sweep census
48 production flat-tier lines (`cards_state`/`columns_state`/`sprints_state`)
plus 6 `archived_card_ids()` lines, via:
```
git grep -nE '\b(cards_state|columns_state|sprints_state)\(\)' -- crates/kanban-tui/src crates/kanban-view/src | grep -v archived_cards_state
git grep -n 'archived_card_ids()' -- crates/kanban-tui/src
```

### Post-sweep census
Same commands now return exactly seven production sites, all intentionally
out of this card's scope:

- `App::board_columns_view`'s `NotLoaded` fallback arm (query.rs), owned by the c04 ViewScope card (KAN-1585) that removes the fallback arms
- `App::board_sprints_view`'s `NotLoaded` fallback arm (query.rs), same
- `create_card_target_column`'s fallback arm (card_handlers.rs), same
- `handle_manage_children_from_list`'s column-set fallback arm (card_handlers.rs), same
- `prepare_frame`'s two flat gates (view_management.rs), owned by KAN-1585
- `tasks_panel_title`'s `all_tiers_loaded` gate (ui/main_view.rs), owned by KAN-1585

`archived_card_ids()` no longer appears outside `#[cfg(test)]`.

## Testing

Eleven new/updated tests pin the scoped-read behaviour:

- `test_handler_acts_on_scoped_tiers_while_flat_tiers_failed`
- `test_move_card_uses_the_scoped_column_and_partition_reads`
- `test_create_card_position_derives_from_the_column_tier`
- `test_toggle_completion_resolves_cards_by_id`
- `test_manage_children_eligible_set_spans_archived_when_target_archived`
- `test_manage_children_eligible_set_excludes_archived_when_target_live`
- `test_sprint_dialogs_read_the_board_scoped_sprint_tier`
- `test_check_ended_sprints_scopes_to_the_active_board` (inline, sprint_management.rs)

Three pre-existing test files needed fixture updates because they built the
model with `with_load_states`/`Model::with_load_states` or a wholesale
`app.model = ...` replacement, which never populates the scoped tiers or
resyncs the `Controller`'s card partitions: `detail_view_handlers_collapsing_accessor_tests.rs`,
`manage_children_parents_archived_candidates_tests.rs`, and the inline
`invalidate_cards_tier` helpers in `card_handlers.rs`/`detail_view_handlers.rs`
(which invalidated the model but never resynced the controller, leaving its
cached partitions stale rather than `NotLoaded`).

- `test_toggle_selected_cards_completion_with_a_failed_flat_cards_tier_for_an_unresolvable_id_declines`
- `test_toggle_completion_for_card_ids_with_a_failed_flat_cards_tier_for_an_unresolvable_id_declines`
- `test_relationship_search_with_failed_cards_tier_for_an_unresolvable_id_banners`

Behavioural fixes in round 2: `toggle_selected_cards_completion`,
`toggle_completion_for_card_ids` and `filtered_relationship_card_ids` now
decline the whole batch when a selected id's per-id lookup resolves `Failed`
(previously only `NotLoaded`), and the three eligible-set sites consolidate
onto the new `App::board_candidate_cards` helper in query.rs.

## Notes

- `check_ended_sprints` narrows its scope: it now reports `None` whenever no
  board is active, where previously it scanned every board's sprints
  regardless of which one (if any) was open. The three existing inline tests
  were updated to set an active board.
- `handle_manage_parents`/`handle_manage_children` now read `Controller::live_cards()`,
  which is scoped to whichever board `Controller::set_scope_board` was last
  called with. In production this always matches the card's own board (a
  card can only be active while its board is), but two test fixtures that
  set `active_card_id` without ever setting `active_board_id` needed an
  explicit `active_board_id` to keep the controller's scope aligned with the
  card under test.
- The `filtered_relationship_card_ids` and card-completion-toggle handlers
  keep their "not loaded" decline banners (an existing test pins that
  contract), now driven by `Model::card_by_id_state` per candidate instead
  of the flat collection.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`

