### PR TITLE
KAN-1585 refactor(tui,service,domain): stop requesting the flat column/card/sprint tiers

### DIFF
--- a/.changeset/kan-1585-viewscope-flat-arm-drop.md
+++ b/.changeset/kan-1585-viewscope-flat-arm-drop.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+stop requesting the flat column/card/sprint tiers; the render path and handlers already read the board-scoped ones

--- a/.changeset/kan-1585-viewscope-flat-arm-drop.md
+++ b/.changeset/kan-1585-viewscope-flat-arm-drop.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-stop requesting the flat column/card/sprint tiers; the render path and handlers already read the board-scoped ones
+tui: ViewScope stops requesting the flat column/card/sprint tiers; the render path and handlers already read the board-scoped ones. Consequence: CardDetail's parents/children panel no longer resolves a spawns relative on a different board unless its body was already fetched, since nothing populates the flat fallback any more.

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -559,10 +559,11 @@ mod tests {
             assert_eq!(m.card_index[&card.id], i);
         }
         assert!(m
-            .card_in_collection_status(a.id)
+            .cards_state()
             .loaded()
-            .copied()
-            .is_none());
+            .unwrap()
+            .iter()
+            .all(|c| c.id != a.id));
         assert_eq!(m.card_by_id_state(a.id).loaded().copied().unwrap(), &a);
         assert_eq!(m.card_by_id_state(c.id).loaded().copied().unwrap(), &c);
         assert_eq!(m.card_by_id_state(d.id).loaded().copied().unwrap(), &d);

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -87,24 +87,6 @@ impl Model {
             .unwrap_or(LoadState::NotLoaded)
     }
 
-    /// The flat collection tier alone, with no composition against the
-    /// per-id tier. Answers `NotLoaded` for an id absent from a `Loaded`
-    /// flat list rather than `Missing`, because `list_all_cards` excludes
-    /// archived cards by design: the id may still be requestable through a
-    /// per-id fetch even though the flat list has been read.
-    pub fn card_in_collection_status(&self, id: Uuid) -> LoadState<&Card> {
-        match self.cards.as_ref() {
-            LoadState::Loaded(cards) => {
-                match self.card_index.get(&id).and_then(|&idx| cards.get(idx)) {
-                    Some(card) => LoadState::Loaded(card),
-                    None => LoadState::NotLoaded,
-                }
-            }
-            LoadState::NotLoaded | LoadState::Missing => LoadState::NotLoaded,
-            LoadState::Failed(e) => LoadState::Failed(e),
-        }
-    }
-
     /// Replaces the card set for one column's scoped tier. The only writer
     /// of `cards_by_column`'s membership: `load_from_snapshot` clears the
     /// map and index together, and `mark_failed` transitions state in place

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -59,12 +59,6 @@ pub trait LoadedState {
     fn archived_card_list(&self) -> FetchStatus;
     fn archived_cards_of_board(&self, board_id: Uuid) -> FetchStatus;
     fn archived_board_list(&self) -> FetchStatus;
-    /// The flat-collection tier alone, never the composed per-id tier.
-    /// `NotLoaded` for an id absent from a `Loaded` flat list, because the
-    /// flat lists exclude archived rows by design; use this, not `card`/
-    /// `board`, to decide whether an archived body still needs fetching
-    /// after the flat tier has been replaced by a live-only refetch.
-    fn card_in_collection(&self, id: Uuid) -> FetchStatus;
     fn board_in_collection(&self, id: Uuid) -> FetchStatus;
 }
 
@@ -211,9 +205,6 @@ mod tests {
             FetchStatus::NotLoaded
         }
         fn archived_board_list(&self) -> FetchStatus {
-            FetchStatus::NotLoaded
-        }
-        fn card_in_collection(&self, _id: Uuid) -> FetchStatus {
             FetchStatus::NotLoaded
         }
         fn board_in_collection(&self, _id: Uuid) -> FetchStatus {

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -119,9 +119,6 @@ impl LoadedState for StubWorld {
     fn archived_board_list(&self) -> FetchStatus {
         self.archived_board_list
     }
-    fn card_in_collection(&self, id: Uuid) -> FetchStatus {
-        self.card(id)
-    }
     fn board_in_collection(&self, id: Uuid) -> FetchStatus {
         self.board(id)
     }

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -70,10 +70,6 @@ impl LoadedState for Model {
         (&self.archived_boards_state()).into()
     }
 
-    fn card_in_collection(&self, id: Uuid) -> FetchStatus {
-        (&self.card_in_collection_status(id)).into()
-    }
-
     fn board_in_collection(&self, id: Uuid) -> FetchStatus {
         (&self.board_in_collection_status(id)).into()
     }
@@ -206,62 +202,7 @@ mod tests {
     }
 
     #[test]
-    fn test_card_in_collection_reports_not_loaded_for_an_id_absent_from_a_loaded_flat_list() {
-        let column_id = Uuid::new_v4();
-        let live = card_in(column_id);
-        let archived_id = Uuid::new_v4();
-        let mut model = Model::default();
-        let _ = model.apply_resolved(Resolved {
-            cards: Collection {
-                all: LoadState::Loaded(vec![live]),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        assert_eq!(
-            LoadedState::card_in_collection(&model, archived_id),
-            FetchStatus::NotLoaded
-        );
-        assert!(requestable(LoadedState::card_in_collection(
-            &model,
-            archived_id
-        )));
-    }
-
-    #[test]
-    fn test_card_in_collection_ignores_a_loaded_per_id_entry() {
-        let column_id = Uuid::new_v4();
-        let live = card_in(column_id);
-        let archived = card_in(column_id);
-        let archived_id = archived.id;
-        let mut model = Model::default();
-        let mut by_id = std::collections::HashMap::new();
-        by_id.insert(archived_id, LoadState::Loaded(archived));
-        let _ = model.apply_resolved(Resolved {
-            cards: Collection {
-                by_id,
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-        let _ = model.apply_resolved(Resolved {
-            cards: Collection {
-                all: LoadState::Loaded(vec![live]),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        assert_eq!(LoadedState::card(&model, archived_id), FetchStatus::Loaded);
-        assert_eq!(
-            LoadedState::card_in_collection(&model, archived_id),
-            FetchStatus::NotLoaded
-        );
-    }
-
-    #[test]
-    fn test_board_in_collection_mirrors_the_card_accessor() {
+    fn test_board_in_collection_reports_not_loaded_for_an_id_absent_from_a_loaded_flat_list() {
         use kanban_domain::Board;
 
         let live = Board::new("Live", None::<String>);

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -95,13 +95,6 @@ impl LoadedState for Overlay<'_> {
         )
     }
 
-    fn card_in_collection(&self, id: Uuid) -> FetchStatus {
-        match self.pass.cards.by_id.get(&id) {
-            Some(state) => state.into(),
-            None => self.base.card_in_collection(id),
-        }
-    }
-
     fn board_in_collection(&self, id: Uuid) -> FetchStatus {
         match self.pass.boards.by_id.get(&id) {
             Some(state) => state.into(),

--- a/crates/kanban-service/src/resolve/tests/mod.rs
+++ b/crates/kanban-service/src/resolve/tests/mod.rs
@@ -112,14 +112,6 @@ impl LoadedStateTrait for StubLoaded {
     fn archived_board_list(&self) -> FetchStatus {
         (&self.archived_boards.all).into()
     }
-    fn card_in_collection(&self, id: Uuid) -> FetchStatus {
-        self.cards
-            .all
-            .loaded()
-            .and_then(|cards| cards.iter().find(|c| c.id == id))
-            .map(|_| FetchStatus::Loaded)
-            .unwrap_or(FetchStatus::NotLoaded)
-    }
     fn board_in_collection(&self, id: Uuid) -> FetchStatus {
         self.boards
             .all

--- a/crates/kanban-service/tests/archived_bodies_fetch_parity.rs
+++ b/crates/kanban-service/tests/archived_bodies_fetch_parity.rs
@@ -27,11 +27,7 @@ impl FetchPlan for ArchivedBodiesPlan {
             if requestable(loaded.archived_card_list()) {
                 round.archived_card_list = true;
             } else if let Some(markers) = loaded.loaded_archived_card_markers() {
-                let mut ids: Vec<Uuid> = markers
-                    .iter()
-                    .map(|m| m.entity_id)
-                    .filter(|&id| requestable(loaded.card_in_collection(id)))
-                    .collect();
+                let mut ids: Vec<Uuid> = markers.iter().map(|m| m.entity_id).collect();
                 ids.sort_unstable();
                 round.cards.extend(ids);
             }

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -235,6 +235,18 @@ mod board_columns_view_tests {
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);
         resolved.columns = Collection {
+            all: LoadState::Loaded(vec![col_a.clone(), col_b.clone()]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        assert!(
+            app.board_columns_view(board.id).is_not_loaded(),
+            "a populated flat tier must not stand in for a not-loaded scoped tier"
+        );
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
             by_parent: HashMap::from([(
                 board.id,
                 LoadState::Failed(std::sync::Arc::new(
@@ -281,6 +293,18 @@ mod board_sprints_view_tests {
 
         let app = App::test_default();
         assert!(app.board_sprints_view(board.id).is_not_loaded());
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.sprints = Collection {
+            all: LoadState::Loaded(vec![s_on_board.clone()]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        assert!(
+            app.board_sprints_view(board.id).is_not_loaded(),
+            "a populated flat tier must not stand in for a not-loaded scoped tier"
+        );
 
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -12,44 +12,20 @@ impl App {
             .or_else(|| self.board_list.get_selected_board_id())
     }
 
-    /// One column tier per board-scoped feature: the scoped tier when it has
-    /// resolved, otherwise the flat tier filtered to `board_id`. A scoped
-    /// `Loaded` (including an empty one) is authoritative and never falls
-    /// back; only `NotLoaded` triggers the fallback. Unfiltered — callers
-    /// that need the position-ordered, search-narrowed view use
-    /// `visible_board_columns` instead.
+    /// The scoped column tier for `board_id`. Unfiltered: callers that need
+    /// the position-ordered, search-narrowed view use `visible_board_columns`
+    /// instead.
     pub(crate) fn board_columns_view(&self, board_id: uuid::Uuid) -> LoadState<Vec<Column>> {
         match self.model.board_columns_state(board_id) {
             LoadState::Loaded(columns) => LoadState::Loaded(columns.to_vec()),
-            LoadState::NotLoaded => match self.model.columns_state() {
-                LoadState::Loaded(all) => LoadState::Loaded(
-                    all.iter()
-                        .filter(|c| c.board_id == board_id)
-                        .cloned()
-                        .collect(),
-                ),
-                _ => LoadState::NotLoaded,
-            },
             other => other.map(|_| Vec::new()),
         }
     }
 
-    /// One sprint tier per board-scoped feature: the scoped tier when it has
-    /// resolved, otherwise the flat tier filtered to `board_id`. A scoped
-    /// `Loaded` (including an empty one) is authoritative and never falls
-    /// back; only `NotLoaded` triggers the fallback.
+    /// The scoped sprint tier for `board_id`.
     pub(crate) fn board_sprints_view(&self, board_id: uuid::Uuid) -> LoadState<Vec<Sprint>> {
         match self.model.board_sprints_state(board_id) {
             LoadState::Loaded(sprints) => LoadState::Loaded(sprints.to_vec()),
-            LoadState::NotLoaded => match self.model.sprints_state() {
-                LoadState::Loaded(all) => LoadState::Loaded(
-                    all.iter()
-                        .filter(|s| s.board_id == board_id)
-                        .cloned()
-                        .collect(),
-                ),
-                _ => LoadState::NotLoaded,
-            },
             other => other.map(|_| Vec::new()),
         }
     }
@@ -231,12 +207,10 @@ mod board_columns_view_tests {
     }
 
     #[test]
-    fn test_board_columns_view_prefers_the_scoped_tier_and_falls_back_to_the_flat_one() {
+    fn test_board_columns_view_answers_not_loaded_when_the_scoped_tier_is_not_loaded() {
         let board = Board::new("B", None::<String>);
-        let other_board = Board::new("Other", None::<String>);
         let col_a = Column::new(board.id, "A", 0);
         let col_b = Column::new(board.id, "B", 1);
-        let col_other = Column::new(other_board.id, "Other", 0);
 
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);
@@ -253,18 +227,6 @@ mod board_columns_view_tests {
                 assert_eq!(columns, vec![col_a.clone(), col_b.clone()]);
             }
             other => panic!("expected the scoped tier, got {other:?}"),
-        }
-
-        let mut app = App::test_default();
-        let mut resolved = base_resolved(&board);
-        resolved.columns = Collection {
-            all: LoadState::Loaded(vec![col_a.clone(), col_other.clone()]),
-            ..Default::default()
-        };
-        let _ = app.model.apply_resolved(resolved);
-        match app.board_columns_view(board.id) {
-            LoadState::Loaded(columns) => assert_eq!(columns, vec![col_a.clone()]),
-            other => panic!("expected fallback to the flat tier, got {other:?}"),
         }
 
         let app = App::test_default();
@@ -313,25 +275,9 @@ mod board_sprints_view_tests {
     }
 
     #[test]
-    fn test_board_sprints_view_prefers_the_scoped_tier_and_falls_back_to_the_flat_one() {
+    fn test_board_sprints_view_answers_not_loaded_when_the_scoped_tier_is_not_loaded() {
         let board = Board::new("B", None::<String>);
-        let other_board = Board::new("Other", None::<String>);
         let s_on_board = Sprint::new(board.id, 1, None, None::<String>);
-        let s_other_board = Sprint::new(other_board.id, 1, None, None::<String>);
-
-        let mut app = App::test_default();
-        let mut resolved = base_resolved(&board);
-        resolved.sprints = Collection {
-            all: LoadState::Loaded(vec![s_on_board.clone(), s_other_board.clone()]),
-            ..Default::default()
-        };
-        let _ = app.model.apply_resolved(resolved);
-        match app.board_sprints_view(board.id) {
-            LoadState::Loaded(sprints) => {
-                assert_eq!(sprints, vec![s_on_board.clone()]);
-            }
-            other => panic!("expected fallback to the flat tier, got {other:?}"),
-        }
 
         let app = App::test_default();
         assert!(app.board_sprints_view(board.id).is_not_loaded());

--- a/crates/kanban-tui/src/app/view_management.rs
+++ b/crates/kanban-tui/src/app/view_management.rs
@@ -220,8 +220,8 @@ impl App {
                 LoadState::Loaded(all_sprints),
             ) = (
                 cards_for_display,
-                self.model.columns_state().as_ref(),
-                self.model.sprints_state().as_ref(),
+                self.model.board_columns_state(board.id),
+                self.model.board_sprints_state(board.id),
             ) {
                 let search_query = if self.filter.search.is_active {
                     Some(self.filter.search.query())

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -1,7 +1,5 @@
-//! `ViewScope` is the TUI's `FetchPlan`: it names the tiers the current
-//! screen needs. The renderer reads the board-scoped tiers; the handlers
-//! still read the flat `*_list` tiers, so `next_round` requests both
-//! populations together whenever a board subtree is in scope.
+//! `ViewScope` is the TUI's `FetchPlan`: handlers and renderer read the
+//! board-scoped tiers, so `next_round` requests only those.
 
 use uuid::Uuid;
 
@@ -49,21 +47,10 @@ impl FetchPlan for ViewScope {
         }
 
         if let Some(board_id) = self.board {
-            let board_subtree = self.board_columns || self.board_cards;
-
-            if board_subtree {
-                if requestable(loaded.column_list()) {
-                    round.column_list = true;
-                }
-                if requestable(loaded.card_list()) {
-                    round.card_list = true;
-                }
-                if requestable(loaded.sprint_list()) {
-                    round.sprint_list = true;
-                }
-                if requestable(loaded.columns_of_board(board_id)) {
-                    round.columns_by_board.push(board_id);
-                }
+            if (self.board_columns || self.board_cards)
+                && requestable(loaded.columns_of_board(board_id))
+            {
+                round.columns_by_board.push(board_id);
             }
 
             if self.board_sprints && requestable(loaded.sprints_of_board(board_id)) {
@@ -129,6 +116,7 @@ impl App {
             board,
             board_columns: true,
             board_cards: true,
+            board_sprints: true,
             ..Default::default()
         };
 
@@ -140,19 +128,15 @@ impl App {
         match base {
             AppMode::CardDetail => {
                 scope.card = self.selection.active_card_id;
-                scope.board_sprints = true;
                 scope.graph = true;
-            }
-            AppMode::BoardDetail => {
-                scope.board_sprints = true;
             }
             AppMode::SprintDetail => {
                 scope.sprint = self.selection.active_sprint_id;
-                scope.board_sprints = true;
             }
             AppMode::Settings => {
                 scope.board_columns = false;
                 scope.board_cards = false;
+                scope.board_sprints = false;
             }
             AppMode::ArchivedCardsView => {
                 scope.archived_card_markers = true;
@@ -162,7 +146,6 @@ impl App {
                 scope.archived_board_markers = true;
                 scope.archived_board_bodies = true;
                 scope.archived_card_markers = true;
-                scope.board_sprints = true;
             }
             // Card search filters the board already in scope (`board_cards`
             // covers it) and board search filters the board list
@@ -176,23 +159,11 @@ impl App {
             current = inner.as_ref();
         }
 
-        match current {
-            AppMode::Dialog(DialogMode::ManageParents | DialogMode::ManageChildren) => {
-                scope.graph = true;
-            }
-            AppMode::Dialog(
-                DialogMode::CarryOverSprint
-                | DialogMode::AssignCardToSprint
-                | DialogMode::AssignMultipleCardsToSprint
-                | DialogMode::CreateCard
-                | DialogMode::CreateSprint
-                | DialogMode::FilterOptions
-                | DialogMode::SetSprintPrefix
-                | DialogMode::DeleteBoardConfirm,
-            ) => {
-                scope.board_sprints = true;
-            }
-            _ => {}
+        if matches!(
+            current,
+            AppMode::Dialog(DialogMode::ManageParents | DialogMode::ManageChildren)
+        ) {
+            scope.graph = true;
         }
 
         if matches!(current, AppMode::Dialog(DialogMode::DeleteBoardConfirm)) {
@@ -231,7 +202,6 @@ mod tests {
         archived_card_list: FetchStatus,
         archived_cards_of_board: HashMap<Uuid, FetchStatus>,
         archived_board_list: FetchStatus,
-        card_in_collection: HashMap<Uuid, FetchStatus>,
         card_status_by_id: HashMap<Uuid, FetchStatus>,
         board_in_collection: HashMap<Uuid, FetchStatus>,
         archived_card_markers: Option<Vec<kanban_domain::ArchivedCard>>,
@@ -256,7 +226,6 @@ mod tests {
                 archived_card_list: FetchStatus::NotLoaded,
                 archived_cards_of_board: HashMap::new(),
                 archived_board_list: FetchStatus::NotLoaded,
-                card_in_collection: HashMap::new(),
                 card_status_by_id: HashMap::new(),
                 board_in_collection: HashMap::new(),
                 archived_card_markers: None,
@@ -324,12 +293,6 @@ mod tests {
         fn archived_board_list(&self) -> FetchStatus {
             self.archived_board_list
         }
-        fn card_in_collection(&self, id: Uuid) -> FetchStatus {
-            self.card_in_collection
-                .get(&id)
-                .copied()
-                .unwrap_or(FetchStatus::NotLoaded)
-        }
         fn board_in_collection(&self, id: Uuid) -> FetchStatus {
             self.board_in_collection
                 .get(&id)
@@ -376,22 +339,18 @@ mod tests {
             board: Some(board),
             board_columns: true,
             board_cards: true,
+            board_sprints: true,
             ..Default::default()
         };
 
         let round1 = scope.next_round(&stub);
         assert!(round1.board_list);
-        assert!(round1.column_list);
-        assert!(round1.card_list);
-        assert!(round1.sprint_list);
         assert_eq!(round1.columns_by_board, vec![board]);
+        assert_eq!(round1.sprints_by_board, vec![board]);
         assert!(round1.cards_by_column.is_empty());
 
         let stub2 = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: FetchStatus::Loaded,
-            card_list: FetchStatus::Loaded,
-            sprint_list: FetchStatus::Loaded,
             columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
             sprints_of_board: FetchStatus::Loaded,
             loaded_columns: HashMap::from([(board, vec![column(c1), column(c2)])]),
@@ -400,9 +359,6 @@ mod tests {
 
         let round2 = scope.next_round(&stub2);
         assert!(!round2.board_list);
-        assert!(!round2.column_list);
-        assert!(!round2.card_list);
-        assert!(!round2.sprint_list);
         assert!(round2.columns_by_board.is_empty());
         assert!(round2.sprints_by_board.is_empty());
         let mut cards_by_column = round2.cards_by_column.clone();
@@ -413,9 +369,6 @@ mod tests {
 
         let stub3 = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: FetchStatus::Loaded,
-            card_list: FetchStatus::Loaded,
-            sprint_list: FetchStatus::Loaded,
             columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
             sprints_of_board: FetchStatus::Loaded,
             loaded_columns: HashMap::from([(board, vec![column(c1), column(c2)])]),
@@ -581,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn test_board_cards_alone_still_requests_the_flat_and_by_parent_column_tiers() {
+    fn test_board_cards_alone_requests_only_the_by_parent_tiers() {
         let board = Uuid::new_v4();
         let stub = StubLoaded::default();
         let scope = ViewScope {
@@ -593,9 +546,6 @@ mod tests {
 
         let round = scope.next_round(&stub);
         assert_eq!(round.columns_by_board, vec![board]);
-        assert!(round.column_list);
-        assert!(round.card_list);
-        assert!(round.sprint_list);
     }
 
     #[test]

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -429,6 +429,34 @@ mod tests {
     }
 
     #[test]
+    fn test_a_board_screen_with_failed_flat_tiers_plans_an_empty_round() {
+        let board = Uuid::new_v4();
+        let c1 = Uuid::new_v4();
+        let stub = StubLoaded {
+            board_list: FetchStatus::Loaded,
+            column_list: FetchStatus::Failed,
+            card_list: FetchStatus::Failed,
+            sprint_list: FetchStatus::Failed,
+            columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
+            sprints_of_board: FetchStatus::Loaded,
+            loaded_columns: HashMap::from([(board, vec![column(c1)])]),
+            cards_of_column: HashMap::from([(c1, FetchStatus::Loaded)]),
+            ..StubLoaded::default()
+        };
+
+        let scope = ViewScope {
+            board_list: true,
+            board: Some(board),
+            board_columns: true,
+            board_cards: true,
+            board_sprints: true,
+            ..Default::default()
+        };
+
+        assert!(scope.next_round(&stub).is_empty());
+    }
+
+    #[test]
     fn test_a_loaded_tier_is_not_requested_again() {
         let board = Uuid::new_v4();
         let stub = StubLoaded {

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -48,12 +48,7 @@ impl App {
                     .iter()
                     .find(|col| col.board_id == board_id)
                     .map(|col| col.id),
-                _ => self.model.columns_state().loaded().and_then(|columns| {
-                    columns
-                        .iter()
-                        .find(|col| col.board_id == board_id)
-                        .map(|col| col.id)
-                }),
+                _ => None,
             }
         };
 
@@ -1035,18 +1030,11 @@ impl App {
         let column_ids: std::collections::HashSet<_> =
             match self.model.board_columns_state(board_id) {
                 LoadState::Loaded(columns) => columns.iter().map(|c| c.id).collect(),
-                _ => match self.model.columns_state() {
-                    LoadState::Loaded(columns) => columns
-                        .iter()
-                        .filter(|c| c.board_id == board_id)
-                        .map(|c| c.id)
-                        .collect(),
-                    _ => {
-                        self.pop_mode();
-                        self.set_error("Columns are not loaded yet");
-                        return;
-                    }
-                },
+                _ => {
+                    self.pop_mode();
+                    self.set_error("Columns are not loaded yet");
+                    return;
+                }
             };
 
         let archived_ids = self.board_archived_ids(board_id);

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2968,6 +2968,18 @@ mod visible_board_columns_tests {
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);
         resolved.columns = Collection {
+            all: LoadState::Loaded(vec![col_a.clone(), col_b.clone()]),
+            ..Default::default()
+        };
+        let _ = app.model.apply_resolved(resolved);
+        assert!(
+            app.visible_board_columns(board.id).is_not_loaded(),
+            "a populated flat tier must not stand in for a not-loaded scoped tier"
+        );
+
+        let mut app = App::test_default();
+        let mut resolved = base_resolved(&board);
+        resolved.columns = Collection {
             by_parent: HashMap::from([(
                 board.id,
                 LoadState::Failed(std::sync::Arc::new(

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2546,15 +2546,22 @@ mod tests {
     #[test]
     fn test_handle_board_detail_navigation_key_declines_column_navigation_when_columns_not_loaded()
     {
-        use kanban_domain::{Board, LoadState, Model, ModelLoadStates};
+        use kanban_domain::{Board, LoadState, Resolved};
         let mut app = App::test_default();
         let board = Board::new("Board", None::<String>);
         let board_id = board.id;
-        app.model = Model::with_load_states(ModelLoadStates {
-            boards: LoadState::Loaded(vec![board]),
-            sprints: LoadState::Loaded(Vec::new()),
+        let changed = app.model.apply_resolved(Resolved {
+            boards: kanban_domain::resolved::Collection {
+                all: LoadState::Loaded(vec![board]),
+                ..Default::default()
+            },
+            sprints: kanban_domain::resolved::Collection {
+                by_parent: [(board_id, LoadState::Loaded(Vec::new()))].into(),
+                ..Default::default()
+            },
             ..Default::default()
         });
+        NoProjections.resync(&app.model, changed);
         app.selection.active_board_id = Some(board_id);
         app.focus.board_focus = BoardFocus::Sprints;
 
@@ -2792,7 +2799,8 @@ mod tests {
                 ..Default::default()
             },
             columns: Collection {
-                all: LoadState::Loaded(vec![column]),
+                all: LoadState::Loaded(vec![column.clone()]),
+                by_parent: [(board_id, LoadState::Loaded(vec![column]))].into(),
                 ..Default::default()
             },
             cards: Collection {
@@ -2928,9 +2936,8 @@ mod visible_board_columns_tests {
     }
 
     #[test]
-    fn test_visible_board_columns_prefers_the_scoped_tier_and_falls_back_to_the_flat_one() {
+    fn test_visible_board_columns_reads_only_the_scoped_tier() {
         let board = Board::new("B", None::<String>);
-        let other_board = Board::new("Other", None::<String>);
         let col_a = Column::new(board.id, "A", 1);
         let col_b = Column::new(board.id, "B", 0);
 
@@ -2953,21 +2960,6 @@ mod visible_board_columns_tests {
                 );
             }
             other => panic!("expected the scoped tier, got {other:?}"),
-        }
-
-        let col_other = Column::new(other_board.id, "Other", 0);
-        let mut app = App::test_default();
-        let mut resolved = base_resolved(&board);
-        resolved.columns = Collection {
-            all: LoadState::Loaded(vec![col_a.clone(), col_other.clone()]),
-            ..Default::default()
-        };
-        let _ = app.model.apply_resolved(resolved);
-        match app.visible_board_columns(board.id) {
-            LoadState::Loaded(columns) => {
-                assert_eq!(columns, vec![col_a.clone()]);
-            }
-            other => panic!("expected fallback to the flat tier, got {other:?}"),
         }
 
         let app = App::test_default();

--- a/crates/kanban-tui/src/ui/main_view.rs
+++ b/crates/kanban-tui/src/ui/main_view.rs
@@ -165,8 +165,10 @@ pub fn tasks_panel_title(app: &App, with_filter_suffix: bool) -> String {
     // finding 4). Matches `displayed_cards()`, which selects the set the same way.
     let viewing_archived_cards = *app.get_base_mode() == AppMode::ArchivedCardsView;
 
-    let all_tiers_loaded =
-        app.model.columns_state().is_loaded() && app.model.sprints_state().is_loaded();
+    let all_tiers_loaded = app.scope_board_id().is_some_and(|board_id| {
+        app.model.board_columns_state(board_id).is_loaded()
+            && app.model.board_sprints_state(board_id).is_loaded()
+    });
     let active_task_list = match (
         app.controller.displayed_cards(viewing_archived_cards),
         all_tiers_loaded,

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -212,14 +212,11 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
     app.prepare_frame();
     warm_archived_card_markers(&mut app);
 
-    // Unified model: the row stays in `cards_state()`; archival is recorded by the
-    // id set. "Archived" means present in `archived_card_ids`, not removed.
+    // Unified model: the row stays reachable via `card_by_id_state`; archival
+    // is recorded by the id set. "Archived" means present in
+    // `archived_card_ids`, not removed.
     assert!(
-        app.model
-            .cards_state()
-            .loaded_or_empty()
-            .iter()
-            .any(|c| c.id == card_id)
+        app.model.card_by_id_state(card_id).is_loaded()
             && app.model.archived_card_ids().contains(&card_id),
         "card must be archived (marked) after animation completion"
     );
@@ -231,10 +228,10 @@ fn test_archive_animation_completion_is_a_single_undo_step() {
 
     assert!(
         app.model
-            .cards_state()
-            .loaded_or_empty()
-            .iter()
-            .any(|c| c.id == card_id)
+            .board_cards_state(board.id)
+            .loaded()
+            .map(|v| v.iter().any(|c| c.id == card_id))
+            .unwrap_or(false)
             && !app.model.archived_card_ids().contains(&card_id),
         "card must be live again after one undo press — archive + compact must \
          live in a single undo batch"
@@ -313,7 +310,8 @@ fn test_multi_column_archive_compacts_every_affected_column() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = app.model.board_cards_state(board.id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
     let k1 = cards.iter().find(|c| c.id == keep1.id).unwrap();
     let k2 = cards.iter().find(|c| c.id == keep2.id).unwrap();
     assert_eq!(

--- a/crates/kanban-tui/tests/archived_bodies_no_snapshot_tests.rs
+++ b/crates/kanban-tui/tests/archived_bodies_no_snapshot_tests.rs
@@ -126,7 +126,8 @@ async fn test_reload_model_never_calls_snapshot() {
         "expected no snapshot op, got {recorded:?}"
     );
     assert!(app.model.boards_state().is_loaded());
-    assert!(app.model.cards_state().is_loaded());
+    let board_id = app.model.boards_state().loaded_or_empty()[0].id;
+    assert!(app.model.board_cards_state(board_id).is_loaded());
 }
 
 #[tokio::test]

--- a/crates/kanban-tui/tests/card_description_test.rs
+++ b/crates/kanban-tui/tests/card_description_test.rs
@@ -43,7 +43,8 @@ fn test_card_description_appears_in_detail_view() {
     // Verify the card has the description
     app.reload_model();
     app.prepare_frame();
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = app.model.board_cards_state(board.id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
     assert_eq!(cards.len(), 1);
     let displayed_card = &cards[0];
 
@@ -90,7 +91,8 @@ fn test_card_description_preserved_after_edit() {
     app.selection.active_board_id = Some(board.id);
     app.reload_model();
     app.prepare_frame();
-    let cards_before = app.model.cards_state().loaded_or_empty();
+    let cards_before = app.model.board_cards_state(board.id);
+    let cards_before = cards_before.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
     assert_eq!(
         cards_before[0].description,
         Some("Original description".to_string())
@@ -113,7 +115,8 @@ fn test_card_description_preserved_after_edit() {
     // Verify description is still there after update
     app.reload_model();
     app.prepare_frame();
-    let cards_after = app.model.cards_state().loaded_or_empty();
+    let cards_after = app.model.board_cards_state(board.id);
+    let cards_after = cards_after.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
     assert_eq!(cards_after.len(), 1);
     assert_eq!(cards_after[0].title, "Updated Title");
     assert_eq!(
@@ -204,11 +207,12 @@ fn test_card_with_empty_string_description_displays_placeholder() {
     // Verify the card has an empty string description (not None)
     app.reload_model();
     app.prepare_frame();
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = app.model.board_cards_state(board.id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
     assert_eq!(cards[0].description, Some("".to_string()));
 
     // Verify rendering shows placeholder text instead of blank
-    let lines = build_description_lines(&cards[0]);
+    let lines = build_description_lines(cards[0]);
     assert!(
         !lines.is_empty(),
         "Empty string description should show 'No description' placeholder"

--- a/crates/kanban-tui/tests/cold_start_reload_tests.rs
+++ b/crates/kanban-tui/tests/cold_start_reload_tests.rs
@@ -75,8 +75,10 @@ async fn test_cold_start_after_a_sprint_log_migration_loads_the_migrated_state()
 
     let migrated_log_present = app
         .model
-        .cards_state()
-        .loaded_or_empty()
+        .board_cards_state(card.board_id)
+        .loaded()
+        .map(|v| v.as_slice())
+        .unwrap_or(&[])
         .iter()
         .find(|c| c.id == card.id)
         .map(|c| !c.sprint_logs.is_empty())
@@ -119,11 +121,6 @@ async fn test_delete_board_key_after_cold_start_opens_delete_confirm() {
 
     let (mut app, _rx) = App::new(Some(path_str)).await.unwrap();
     app.load_initial_state().await;
-
-    assert!(
-        !app.model.board_sprints_state(board.id).is_loaded(),
-        "precondition: cold start must not have absorbed the sprints tier"
-    );
 
     app.focus.active = Focus::Boards;
     app.board_list.inner_mut().set_selected_index(Some(0));

--- a/crates/kanban-tui/tests/columnless_board_card_tests.rs
+++ b/crates/kanban-tui/tests/columnless_board_card_tests.rs
@@ -77,6 +77,24 @@ fn render_with_colors(app: &mut App, width: u16, height: u16) -> Vec<(String, Op
     result
 }
 
+fn cols_of(app: &App) -> Vec<kanban_domain::Column> {
+    let board_id = app.selection.active_board_id.unwrap();
+    app.model
+        .board_columns_state(board_id)
+        .loaded()
+        .map(|cols| cols.to_vec())
+        .unwrap_or_default()
+}
+
+fn cards_of(app: &App) -> Vec<kanban_domain::Card> {
+    let board_id = app.selection.active_board_id.unwrap();
+    app.model
+        .board_cards_state(board_id)
+        .loaded()
+        .map(|cards| cards.iter().map(|c| (*c).clone()).collect())
+        .unwrap_or_default()
+}
+
 fn row_containing(grid: &str, substring: &str) -> Option<usize> {
     grid.lines()
         .enumerate()
@@ -139,13 +157,7 @@ fn test_the_column_field_names_the_column_the_card_actually_lands_in() {
             .get_active_task_list()
             .map(|l| l.id.clone()),
         Some(CardListId::Column(
-            app.model
-                .columns_state()
-                .loaded_or_empty()
-                .iter()
-                .find(|c| c.name == "Doing")
-                .unwrap()
-                .id
+            cols_of(&app).iter().find(|c| c.name == "Doing").unwrap().id
         ))
     );
     app.handle_create_card_key();
@@ -163,18 +175,13 @@ fn test_the_column_field_names_the_column_the_card_actually_lands_in() {
     }
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
-    let card = app
-        .model
-        .cards_state()
-        .loaded_or_empty()
+    let card = cards_of(&app)
         .iter()
         .find(|c| c.title == "Task")
         .expect("card created")
         .clone();
-    let col = app
-        .model
-        .columns_state()
-        .loaded_or_empty()
+    let cols = cols_of(&app);
+    let col = cols
         .iter()
         .find(|c| c.id == card.column_id)
         .expect("column exists");
@@ -194,7 +201,7 @@ fn test_the_column_field_names_the_column_the_card_actually_lands_in() {
     }
     app2.handle_create_card_dialog(KeyCode::Enter);
     app2.reload_model();
-    let cols2 = app2.model.columns_state().loaded_or_empty();
+    let cols2 = cols_of(&app2);
     assert_eq!(cols2.len(), 1);
     assert_eq!(cols2[0].name, snapshot2);
 }
@@ -280,7 +287,7 @@ fn test_creating_a_card_on_a_columnless_board_creates_the_template_named_column_
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
 
-    let cols = app.model.columns_state().loaded_or_empty();
+    let cols = cols_of(&app);
     assert_eq!(cols.len(), 1);
     assert_eq!(cols[0].name, "TODO");
     assert_eq!(cols[0].default_status, Some(CardStatus::Todo));
@@ -310,17 +317,12 @@ fn test_an_edited_column_name_is_used_for_the_created_column() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
 
-    let cols = app.model.columns_state().loaded_or_empty();
+    let cols = cols_of(&app);
     assert_eq!(cols.len(), 1);
     assert_eq!(cols[0].name, "Inbox");
     assert_eq!(cols[0].default_status, Some(CardStatus::Todo));
-    let card = app
-        .model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .find(|c| c.title == "Probe")
-        .unwrap();
+    let cards = cards_of(&app);
+    let card = cards.iter().find(|c| c.title == "Probe").unwrap();
     assert_eq!(card.column_id, cols[0].id);
 }
 
@@ -345,16 +347,11 @@ fn test_an_emptied_column_name_falls_back_to_the_template_name() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
 
-    let cols = app.model.columns_state().loaded_or_empty();
+    let cols = cols_of(&app);
     assert_eq!(cols.len(), 1);
     assert_eq!(cols[0].name, "TODO");
-    let card = app
-        .model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .find(|c| c.title == "Probe")
-        .unwrap();
+    let cards = cards_of(&app);
+    let card = cards.iter().find(|c| c.title == "Probe").unwrap();
     assert_eq!(card.column_id, cols[0].id);
     assert!(app.ui_state.banner.is_none());
 }
@@ -369,14 +366,14 @@ fn test_undoing_the_card_create_also_removes_the_invented_column() {
     }
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
+    assert_eq!(cards_of(&app).len(), 1);
+    assert_eq!(cols_of(&app).len(), 1);
 
     app.ctx.undo().unwrap();
     app.reload_model();
 
-    assert!(app.model.cards_state().loaded_or_empty().is_empty());
-    assert!(app.model.columns_state().loaded_or_empty().is_empty());
+    assert!(cards_of(&app).is_empty());
+    assert!(cols_of(&app).is_empty());
 }
 
 #[test]
@@ -571,14 +568,9 @@ fn test_a_board_with_existing_columns_gains_no_new_column() {
     app.handle_create_card_dialog(KeyCode::Enter);
     app.reload_model();
 
-    let cols = app.model.columns_state().loaded_or_empty();
+    let cols = cols_of(&app);
     assert_eq!(cols.len(), 2);
-    let card = app
-        .model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .find(|c| c.title == "Task")
-        .unwrap();
+    let cards = cards_of(&app);
+    let card = cards.iter().find(|c| c.title == "Task").unwrap();
     assert_eq!(card.column_id, cols[0].id);
 }

--- a/crates/kanban-tui/tests/create_card_dialog_tests.rs
+++ b/crates/kanban-tui/tests/create_card_dialog_tests.rs
@@ -24,6 +24,14 @@ fn board_id(app: &App) -> uuid::Uuid {
     app.model.boards_state().loaded_or_empty()[0].id
 }
 
+fn cards_of(app: &App, board_id: uuid::Uuid) -> Vec<kanban_domain::Card> {
+    app.model
+        .board_cards_state(board_id)
+        .loaded()
+        .map(|cards| cards.iter().map(|c| (*c).clone()).collect())
+        .unwrap_or_default()
+}
+
 fn setup_app_with_board_and_sprint() -> App {
     let mut app = setup_app_with_board();
     let bid = board_id(&app);
@@ -85,7 +93,7 @@ fn test_create_card_dialog_auto_assigns_sole_active_sprint_on_open() {
 
     confirm_create_card_dialog(&mut app, "Task");
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = cards_of(&app, bid);
     let created = cards
         .iter()
         .find(|c| c.title == "Task")
@@ -120,7 +128,7 @@ fn test_create_card_dialog_space_on_pre_checked_sprint_unchecks_it() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = cards_of(&app, bid);
     let created = cards
         .iter()
         .find(|c| c.title == "Task")
@@ -139,7 +147,7 @@ fn test_create_card_dialog_leaves_card_unassigned_when_no_active_sprint() {
 
     confirm_create_card_dialog(&mut app, "Plain");
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = cards_of(&app, bid);
     let created = cards
         .iter()
         .find(|c| c.title == "Plain")
@@ -160,7 +168,7 @@ fn test_create_card_dialog_leaves_card_unassigned_when_multiple_active_sprints()
 
     confirm_create_card_dialog(&mut app, "Ambig");
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = cards_of(&app, bid);
     let created = cards
         .iter()
         .find(|c| c.title == "Ambig")
@@ -257,7 +265,7 @@ fn test_j_on_sprint_focus_navigates_picker_like_down() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = cards_of(&app, bid);
     let created = cards
         .iter()
         .find(|c| c.title == "Vim")
@@ -302,7 +310,7 @@ fn test_arrow_to_none_row_then_space_explicitly_leaves_card_unassigned() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = cards_of(&app, bid);
     let created = cards
         .iter()
         .find(|c| c.title == "NoSprint")
@@ -344,7 +352,7 @@ fn test_arrow_down_then_space_assigns_navigated_sprint() {
     app.reload_model();
     app.prepare_frame();
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = cards_of(&app, bid);
     let created = cards
         .iter()
         .find(|c| c.title == "Picked")
@@ -373,7 +381,13 @@ fn test_create_card_does_not_carry_sprint_id_from_a_different_board() {
     app.prepare_frame();
 
     // Reset picker for board A.
-    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+    let sprints = app
+        .model
+        .board_sprints_state(board_a)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .to_vec();
     let board_a_ref = app
         .model
         .boards_state()

--- a/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
@@ -154,11 +154,20 @@ fn test_open_assign_sprint_dialog_for_still_opens_when_sprints_loaded() {
         &mut app,
         ModelLoadStates {
             boards: LoadState::Loaded(vec![board]),
-            cards: LoadState::Loaded(vec![card]),
-            sprints: LoadState::Loaded(vec![sprint.clone()]),
             ..Default::default()
         },
     );
+    let _ = app.model.apply_resolved(Resolved {
+        cards: Collection {
+            by_id: HashMap::from([(card_id, LoadState::Loaded(card))]),
+            ..Default::default()
+        },
+        sprints: Collection {
+            by_parent: HashMap::from([(board_id, LoadState::Loaded(vec![sprint.clone()]))]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
     app.selection.active_board_id = Some(board_id);
     app.sprint_view.panel = kanban_tui::app::SprintTaskPanel::Uncompleted;
     app.sprint_view

--- a/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
@@ -136,9 +136,15 @@ fn test_handle_filter_options_popup_with_a_loaded_sprint_tier_does_not_decline()
     let board = Board::new("Board", None::<String>);
     let board_id = board.id;
     let sprint = Sprint::new(board_id, 1, None, None::<String>);
-    app.model = kanban_domain::Model::with_load_states(ModelLoadStates {
-        boards: LoadState::Loaded(vec![board]),
-        sprints: LoadState::Loaded(vec![sprint]),
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        boards: kanban_domain::resolved::Collection {
+            all: LoadState::Loaded(vec![board]),
+            ..Default::default()
+        },
+        sprints: kanban_domain::resolved::Collection {
+            by_parent: [(board_id, LoadState::Loaded(vec![sprint]))].into(),
+            ..Default::default()
+        },
         ..Default::default()
     });
     app.selection.active_board_id = Some(board_id);
@@ -190,9 +196,15 @@ fn test_handle_filter_options_popup_space_with_a_loaded_sprint_tier_does_not_dec
     let board_id = board.id;
     let sprint = Sprint::new(board_id, 1, None, None::<String>);
     let sprint_id = sprint.id;
-    app.model = kanban_domain::Model::with_load_states(ModelLoadStates {
-        boards: LoadState::Loaded(vec![board]),
-        sprints: LoadState::Loaded(vec![sprint]),
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        boards: kanban_domain::resolved::Collection {
+            all: LoadState::Loaded(vec![board]),
+            ..Default::default()
+        },
+        sprints: kanban_domain::resolved::Collection {
+            by_parent: [(board_id, LoadState::Loaded(vec![sprint]))].into(),
+            ..Default::default()
+        },
         ..Default::default()
     });
     app.selection.active_board_id = Some(board_id);

--- a/crates/kanban-tui/tests/export_import_tests.rs
+++ b/crates/kanban-tui/tests/export_import_tests.rs
@@ -244,16 +244,25 @@ fn test_import_valid_format() {
     app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    let board_id = app.model.boards_state().loaded_or_empty()[0].id;
     assert_eq!(
         app.model.boards_state().loaded_or_empty()[0].name,
         "Imported Board"
     );
-    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
-    assert_eq!(
-        app.model.cards_state().loaded_or_empty()[0].title,
-        "Imported Task"
-    );
+    app.selection.active_board_id = Some(board_id);
+    app.reload_model();
+    app.prepare_frame();
+    let cols = app
+        .model
+        .board_columns_state(board_id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[]);
+    assert_eq!(cols.len(), 1);
+    let cards = app.model.board_cards_state(board_id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
+    assert_eq!(cards.len(), 1);
+    assert_eq!(cards[0].title, "Imported Task");
 }
 
 #[test]
@@ -357,11 +366,14 @@ async fn test_async_load_initial_state_sqlite() {
         app.model.boards_state().loaded_or_empty()[0].name,
         "SQLite Board"
     );
-    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
-    assert_eq!(
-        app.model.columns_state().loaded_or_empty()[0].name,
-        "Backlog"
-    );
+    let cols = app
+        .model
+        .board_columns_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[]);
+    assert_eq!(cols.len(), 1);
+    assert_eq!(cols[0].name, "Backlog");
 }
 
 #[test]
@@ -436,19 +448,13 @@ fn test_export_import_sprint_and_card_prefixes() {
     app2.reload_model();
     app2.prepare_frame();
     assert_eq!(app2.model.boards_state().loaded_or_empty().len(), 1);
-    assert_eq!(
-        app2.model.boards_state().loaded_or_empty()[0].sprint_prefix,
-        Some("sprint".to_string())
-    );
-    assert_eq!(
-        app2.model.boards_state().loaded_or_empty()[0].card_prefix,
-        Some("task".to_string())
-    );
-    assert_eq!(app2.model.sprints_state().loaded_or_empty().len(), 1);
-    assert_eq!(
-        app2.model.sprints_state().loaded_or_empty()[0].card_prefix,
-        Some("hotfix".to_string())
-    );
+    let imported_board = app2.model.boards_state().loaded_or_empty()[0].clone();
+    assert_eq!(imported_board.sprint_prefix, Some("sprint".to_string()));
+    assert_eq!(imported_board.card_prefix, Some("task".to_string()));
+    let sprints = app2.model.board_sprints_state(imported_board.id);
+    let sprints = sprints.loaded().copied().unwrap_or(&[]);
+    assert_eq!(sprints.len(), 1);
+    assert_eq!(sprints[0].card_prefix, Some("hotfix".to_string()));
 }
 
 #[test]
@@ -536,11 +542,14 @@ fn test_backward_compat_old_export_format() {
     );
 
     // Verify cards still work
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
-    assert_eq!(
-        app.model.cards_state().loaded_or_empty()[0].title,
-        "Old Card"
-    );
+    let board_id = app.model.boards_state().loaded_or_empty()[0].id;
+    app.selection.active_board_id = Some(board_id);
+    app.reload_model();
+    app.prepare_frame();
+    let cards = app.model.board_cards_state(board_id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
+    assert_eq!(cards.len(), 1);
+    assert_eq!(cards[0].title, "Old Card");
 }
 
 #[test]
@@ -584,9 +593,16 @@ fn test_import_column_missing_default_status_key_defaults_to_none() {
     app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
-    assert_eq!(
-        app.model.columns_state().loaded_or_empty()[0].default_status,
-        None
-    );
+    let board_id = app.model.boards_state().loaded_or_empty()[0].id;
+    app.selection.active_board_id = Some(board_id);
+    app.reload_model();
+    app.prepare_frame();
+    let cols = app
+        .model
+        .board_columns_state(board_id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[]);
+    assert_eq!(cols.len(), 1);
+    assert_eq!(cols[0].default_status, None);
 }

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -111,10 +111,10 @@ fn test_card_mutation_is_visible_in_model_without_a_further_redraw() {
 
     let title_present = app
         .model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .any(|c| c.title == "New card");
+        .board_cards_state(board.id)
+        .loaded()
+        .map(|v| v.iter().any(|c| c.title == "New card"))
+        .unwrap_or(false);
     assert!(
         title_present,
         "create_card's own reload_model must make the new card visible without a further redraw"

--- a/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
+++ b/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
@@ -346,3 +346,80 @@ fn test_sprint_dialogs_read_the_board_scoped_sprint_tier() {
         app.ui_state.banner
     );
 }
+
+#[test]
+fn test_the_tasks_panel_title_counts_from_the_scoped_tiers_while_the_flat_tiers_failed() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    app.ctx.create_sprint(board.id, None, None).unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+
+    fail_flat_tiers(&mut app);
+
+    let title = kanban_tui::ui::tasks_panel_title(&app, false);
+
+    assert!(title.contains('1'), "title: {title}");
+    assert!(!title.contains('\u{2026}'), "title: {title}");
+}
+
+#[test]
+fn test_search_filters_the_scoped_card_tier_without_flat_tiers() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".into(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Todo".into(), None)
+        .unwrap();
+    let alpha = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "alpha".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "beta".into(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    app.prepare_frame();
+
+    fail_flat_tiers(&mut app);
+
+    app.mode = AppMode::Search;
+    app.filter.search.activate();
+    for c in "alpha".chars() {
+        app.filter.search.input.insert_char(c);
+    }
+    app.prepare_frame();
+
+    let active_list = app
+        .view
+        .strategy
+        .get_active_task_list()
+        .expect("active task list");
+    assert_eq!(active_list.cards, vec![alpha.id]);
+}

--- a/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
+++ b/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
@@ -366,6 +366,7 @@ fn test_the_tasks_panel_title_counts_from_the_scoped_tiers_while_the_flat_tiers_
         .unwrap();
 
     app.selection.active_board_id = Some(board.id);
+    app.focus.active = kanban_tui::app::Focus::Cards;
     app.reload_model();
     app.prepare_frame();
 

--- a/crates/kanban-tui/tests/import_failure_safety.rs
+++ b/crates/kanban-tui/tests/import_failure_safety.rs
@@ -132,16 +132,22 @@ async fn test_v2_format_is_imported_correctly() {
     app.reload_model();
     app.prepare_frame();
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    let board_id = app.model.boards_state().loaded_or_empty()[0].id;
     assert_eq!(
         app.model.boards_state().loaded_or_empty()[0].name,
         "My Project"
     );
-    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
-    assert_eq!(
-        app.model.cards_state().loaded_or_empty()[0].title,
-        "Important Task"
-    );
+    let cols = app
+        .model
+        .board_columns_state(board_id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[]);
+    assert_eq!(cols.len(), 1);
+    let cards = app.model.board_cards_state(board_id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
+    assert_eq!(cards.len(), 1);
+    assert_eq!(cards[0].title, "Important Task");
     assert!(
         app.persistence.save_file.is_some(),
         "save_file should remain enabled after successful V2 import"

--- a/crates/kanban-tui/tests/lifecycle_reload_tests.rs
+++ b/crates/kanban-tui/tests/lifecycle_reload_tests.rs
@@ -52,16 +52,22 @@ fn test_import_board_from_file_refreshes_the_whole_model_without_a_further_reloa
         .unwrap();
 
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
+    let board_id = app.model.boards_state().loaded_or_empty()[0].id;
     assert_eq!(
         app.model.boards_state().loaded_or_empty()[0].name,
         "Imported Board"
     );
-    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
-    assert_eq!(
-        app.model.cards_state().loaded_or_empty()[0].title,
-        "Imported Task"
-    );
+    let cols = app
+        .model
+        .board_columns_state(board_id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[]);
+    assert_eq!(cols.len(), 1);
+    let cards = app.model.board_cards_state(board_id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
+    assert_eq!(cards.len(), 1);
+    assert_eq!(cards[0].title, "Imported Task");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/kanban-tui/tests/model_integration_tests.rs
+++ b/crates/kanban-tui/tests/model_integration_tests.rs
@@ -32,8 +32,22 @@ fn test_prepare_frame_populates_model_from_snapshot() {
 
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(app.model.boards_state().loaded_or_empty()[0].name, "Board");
-    assert_eq!(app.model.columns_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model
+            .board_columns_state(board.id)
+            .loaded()
+            .map(|v| v.len())
+            .unwrap_or(0),
+        1
+    );
+    assert_eq!(
+        app.model
+            .board_cards_state(board.id)
+            .loaded()
+            .map(|v| v.len())
+            .unwrap_or(0),
+        1
+    );
     assert_eq!(
         app.model
             .card_by_id_state(card.id)

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -98,7 +98,11 @@ fn select_column(app: &mut App, board_id: Uuid, column_id: Uuid) {
     app.focus.board_focus = BoardFocus::Columns;
     let columns = kanban_domain::card_lifecycle::sorted_board_columns(
         board_id,
-        app.model.columns_state().loaded_or_empty(),
+        app.model
+            .board_columns_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
     );
     let idx = columns
         .iter()
@@ -123,7 +127,6 @@ async fn test_rename_column_refetches_the_column_tiers_without_a_snapshot() {
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_columns_by_board", seed.board),
         "got {refetch:?}"
@@ -193,8 +196,6 @@ async fn test_delete_column_refetches_the_card_tier_because_the_batch_moved_card
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_columns_by_board", board.id),
         "got {refetch:?}"
@@ -203,8 +204,10 @@ async fn test_delete_column_refetches_the_card_tier_because_the_batch_moved_card
 
     let moved: Vec<_> = app
         .model
-        .cards_state()
-        .loaded_or_empty()
+        .column_cards_state(c1.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
         .iter()
         .filter(|card| card.column_id == c1.id)
         .collect();
@@ -252,7 +255,6 @@ async fn test_move_column_up_leaves_an_untouched_columns_card_scope_loaded() {
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_columns_by_board", board.id),
         "got {refetch:?}"
@@ -290,7 +292,6 @@ async fn test_create_column_refetches_the_column_tier_and_the_new_columns_cards(
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_columns_by_board", board.id),
         "got {refetch:?}"
@@ -373,7 +374,6 @@ async fn test_create_board_refetches_the_board_and_column_tiers_without_a_snapsh
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_columns_by_board"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
@@ -395,7 +395,6 @@ async fn test_toggle_card_completion_refetches_the_card_tiers_and_repairs_the_vi
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
         "got {refetch:?}"
@@ -452,7 +451,6 @@ async fn test_move_card_refetches_the_card_tiers_and_leaves_the_column_tier_unto
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", c1.id),
         "got {refetch:?}"
@@ -499,11 +497,11 @@ async fn test_toggle_selected_cards_completion_refetches_once_for_the_whole_batc
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    let list_all_cards_count = refetch
+    let list_cards_by_column_count = refetch
         .iter()
-        .filter(|op| op.method == "list_all_cards")
+        .filter(|op| op.method == "list_cards_by_column")
         .count();
-    assert_eq!(list_all_cards_count, 1, "got {refetch:?}");
+    assert_eq!(list_cards_by_column_count, 1, "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", c1.id),
         "got {refetch:?}"
@@ -551,7 +549,6 @@ async fn test_toggle_completion_for_card_ids_refetches_the_card_tiers_without_a_
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
         "got {refetch:?}"
@@ -594,11 +591,13 @@ async fn test_create_card_falls_back_to_a_whole_model_reset_because_its_inverse_
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_sprints_by_board", seed.board),
         "got {refetch:?}"
     );
 
@@ -681,17 +680,16 @@ async fn test_apply_card_metadata_success_refetches_the_card_tiers() {
 
     let card = app
         .model
-        .cards_state()
+        .board_cards_state(seed.board)
         .loaded()
         .and_then(|cards| cards.iter().find(|c| c.id == seed.k1))
         .cloned()
         .unwrap();
-    let dto = CardMetadataDto::from_entity(&card);
+    let dto = CardMetadataDto::from_entity(card);
     app.apply_card_metadata(seed.k1, dto);
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
         "got {refetch:?}"

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -15,6 +15,22 @@ fn invalidate_graph(app: &mut App) {
         .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
 }
 
+/// `ViewScope` scopes the board-cards tier to the active board only, so a
+/// card on a different board (a cross-board `spawns` relative) never lands
+/// in `card_by_id_state` via `reload_model`/`prepare_frame`. Seed its body
+/// directly, the same way `warm_archived_card_markers` backfills the
+/// archived-marker tier.
+fn warm_card_body(app: &mut App, card_id: Uuid) {
+    let card = app.ctx.get_card(card_id).unwrap().unwrap();
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        cards: kanban_domain::resolved::Collection {
+            by_id: [(card_id, kanban_domain::LoadState::Loaded(card))].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
 /// The dependency graph is only requested by `ViewScope` for `CardDetail`
 /// and the manage-parents/children dialogs. Tests that inspect
 /// `model.graph_state()` directly, without driving one of those handlers,
@@ -71,7 +87,14 @@ fn test_resolve_relationship_cards_returns_only_the_related_cards() {
     app.reload_model();
     warm_graph(&mut app);
 
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 50);
+    assert_eq!(
+        app.model
+            .board_cards_state(board_id)
+            .loaded()
+            .map(|v| v.len())
+            .unwrap_or(0),
+        50
+    );
 
     let ids = [
         app.model
@@ -141,6 +164,7 @@ fn test_resolve_relationship_cards_resolves_cross_board_related_card() {
     app.selection.active_board_id = Some(board_b_id);
     app.reload_model();
     warm_graph(&mut app);
+    warm_card_body(&mut app, cross);
 
     let children = app
         .model
@@ -192,6 +216,7 @@ fn test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan() {
     app.reload_model();
     helpers::warm_archived_card_markers(&mut app);
     warm_graph(&mut app);
+    warm_card_body(&mut app, cross_child);
 
     let mut ids = [
         app.model
@@ -211,15 +236,7 @@ fn test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan() {
 
     let expected: Vec<Uuid> = ids
         .iter()
-        .filter_map(|id| {
-            app.model
-                .cards_state()
-                .loaded_or_empty()
-                .iter()
-                .find(|c| c.id == *id)
-                .cloned()
-        })
-        .map(|c| c.id)
+        .filter_map(|id| app.model.card_by_id_state(*id).loaded().map(|c| c.id))
         .collect();
     assert_eq!(expected.len(), 3);
 
@@ -241,7 +258,14 @@ fn test_resolve_relationship_cards_with_no_ids_returns_empty() {
     app.selection.active_board_id = Some(board_id);
     app.reload_model();
 
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 50);
+    assert_eq!(
+        app.model
+            .board_cards_state(board_id)
+            .loaded()
+            .map(|v| v.len())
+            .unwrap_or(0),
+        50
+    );
 
     let resolved = resolve_relationship_cards(&app.model, &[]);
     assert!(resolved.is_empty());
@@ -265,6 +289,8 @@ fn test_card_detail_children_box_shows_cross_board_child_title() {
     app.selection.active_board_id = Some(board_b_id);
     app.selection.active_card_id = Some(subject);
     app.push_mode(AppMode::CardDetail);
+    warm_graph(&mut app);
+    warm_card_body(&mut app, cross);
     app.relationship.children_list.update_item_count(1);
 
     let output =

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -152,7 +152,7 @@ fn test_resolve_relationship_cards_resolves_archived_related_card() {
 }
 
 #[test]
-fn test_resolve_relationship_cards_resolves_cross_board_related_card() {
+fn test_resolve_relationship_cards_resolves_a_cross_board_card_whose_body_was_fetched() {
     let mut app = App::test_default();
     let (board_b_id, column_b_id) = create_board_and_column(&mut app, "Board B");
     let (board_c_id, column_c_id) = create_board_and_column(&mut app, "Board C");
@@ -272,7 +272,7 @@ fn test_resolve_relationship_cards_with_no_ids_returns_empty() {
 }
 
 #[test]
-fn test_card_detail_children_box_shows_cross_board_child_title() {
+fn test_card_detail_children_box_shows_a_cross_board_child_whose_body_was_fetched() {
     use kanban_tui::app::mode::AppMode;
 
     let mut app = App::test_default();

--- a/crates/kanban-tui/tests/reload_model_failure_tests.rs
+++ b/crates/kanban-tui/tests/reload_model_failure_tests.rs
@@ -50,7 +50,12 @@ fn test_a_failed_reload_leaves_the_previous_model_contents() {
     app.selection.active_board_id = Some(board.id);
     app.reload_model();
     let boards_before = app.model.boards_state().loaded_or_empty().len();
-    let cards_before = app.model.cards_state().loaded_or_empty().len();
+    let cards_before = app
+        .model
+        .board_cards_state(board.id)
+        .loaded()
+        .map(|v| v.len())
+        .unwrap_or(0);
     assert_eq!(boards_before, 1);
     assert_eq!(cards_before, 1);
 
@@ -59,7 +64,14 @@ fn test_a_failed_reload_leaves_the_previous_model_contents() {
     app.reload_model();
 
     assert_eq!(app.model.boards_state().loaded_or_empty().len(), 1);
-    assert_eq!(app.model.cards_state().loaded_or_empty().len(), 1);
+    assert_eq!(
+        app.model
+            .board_cards_state(board.id)
+            .loaded()
+            .map(|v| v.len())
+            .unwrap_or(0),
+        1
+    );
     assert_eq!(app.model.boards_state().loaded_or_empty()[0].id, board.id);
 }
 

--- a/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
+++ b/crates/kanban-tui/tests/sprint_assign_dialog_tests.rs
@@ -84,7 +84,6 @@ fn open_assign_dialog(app: &mut App) {
         .active_card_id
         .and_then(|id| app.model.card_by_id_state(id).loaded().copied())
         .and_then(|c| c.sprint_id);
-    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
     let board = app
         .model
         .boards_state()
@@ -92,6 +91,13 @@ fn open_assign_dialog(app: &mut App) {
         .first()
         .cloned()
         .expect("test app has at least one board");
+    let sprints = app
+        .model
+        .board_sprints_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .to_vec();
     app.dialog_input
         .assign_sprint_picker
         .reset_for_card_assignment(current_sprint_id, &sprints, &board, Utc::now());
@@ -186,24 +192,20 @@ fn test_dialog_renders_completed_in_green_and_ended_in_red() {
     let mut app = fx.app;
     open_assign_dialog(&mut app);
 
+    let board = app.model.boards_state().loaded_or_empty()[0].clone();
+    let board_sprints = app.model.board_sprints_state(board.id);
+    let board_sprints = board_sprints.loaded().copied().unwrap_or(&[]);
     // Find the completed and ended sprint by their formatted names.
-    let completed = app
-        .model
-        .sprints_state()
-        .loaded_or_empty()
+    let completed = board_sprints
         .iter()
         .find(|s| s.id == fx.completed_id)
         .cloned()
         .unwrap();
-    let ended = app
-        .model
-        .sprints_state()
-        .loaded_or_empty()
+    let ended = board_sprints
         .iter()
         .find(|s| s.id == fx.ended_id)
         .cloned()
         .unwrap();
-    let board = app.model.boards_state().loaded_or_empty()[0].clone();
     let completed_name = completed.formatted_name(&board, Some("sprint"));
     let ended_name = ended.formatted_name(&board, Some("sprint"));
 
@@ -315,7 +317,6 @@ fn test_bulk_assign_bare_enter_is_a_no_op_and_does_not_mass_unassign() {
 
     // Pre-assign the card to a sprint so we can detect the regression
     // (unassign-on-open would clear sprint_id).
-    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
     let board = app
         .model
         .boards_state()
@@ -323,6 +324,13 @@ fn test_bulk_assign_bare_enter_is_a_no_op_and_does_not_mass_unassign() {
         .first()
         .cloned()
         .unwrap();
+    let sprints = app
+        .model
+        .board_sprints_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .to_vec();
     let some_sprint = sprints
         .iter()
         .find(|s| s.board_id == board.id)
@@ -358,7 +366,6 @@ fn test_bulk_assign_handler_supports_completed_sprint() {
     // Switch to bulk-assign flow with one selected card, with picker
     // primed (no single "current" sprint in bulk mode).
     app.multi_select.selected_cards.insert(card_id);
-    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
     let board = app
         .model
         .boards_state()
@@ -366,6 +373,13 @@ fn test_bulk_assign_handler_supports_completed_sprint() {
         .first()
         .cloned()
         .unwrap();
+    let sprints = app
+        .model
+        .board_sprints_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .to_vec();
     app.dialog_input
         .assign_sprint_picker
         .reset_for_bulk_card_assignment(&sprints, &board, Utc::now());
@@ -422,8 +436,10 @@ fn test_current_sprint_indicator_does_not_apply_color_override_in_completed_ende
     let board = app.model.boards_state().loaded_or_empty()[0].clone();
     let completed = app
         .model
-        .sprints_state()
-        .loaded_or_empty()
+        .board_sprints_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
         .iter()
         .find(|s| s.id == completed_id)
         .cloned()
@@ -490,8 +506,10 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
     // the bottom of the active section — guaranteed off-screen without scroll.
     let oldest_id = app
         .model
-        .sprints_state()
-        .loaded_or_empty()
+        .board_sprints_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
         .iter()
         .min_by_key(|s| s.sprint_number)
         .map(|s| s.id)
@@ -502,8 +520,10 @@ fn test_dialog_scrolls_to_keep_selected_sprint_visible_when_list_overflows() {
     let board_after = app.model.boards_state().loaded_or_empty()[0].clone();
     let oldest = app
         .model
-        .sprints_state()
-        .loaded_or_empty()
+        .board_sprints_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
         .iter()
         .find(|s| s.id == oldest_id)
         .cloned()

--- a/crates/kanban-tui/tests/sprint_dialog_refetch_tests.rs
+++ b/crates/kanban-tui/tests/sprint_dialog_refetch_tests.rs
@@ -100,7 +100,11 @@ fn has_op_with_id(ops: &[ReadOp], method: &str, id: Uuid) -> bool {
 fn select_column(app: &mut App, board_id: Uuid, column_id: Uuid) {
     let columns = kanban_domain::card_lifecycle::sorted_board_columns(
         board_id,
-        app.model.columns_state().loaded_or_empty(),
+        app.model
+            .board_columns_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
     );
     let idx = columns
         .iter()
@@ -127,7 +131,6 @@ async fn test_activate_sprint_refetches_the_sprint_and_board_tiers_without_a_sna
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_columns_by_board", seed.board),
         "got {refetch:?}"
@@ -188,7 +191,6 @@ async fn test_complete_sprint_refetches_the_sprint_and_board_tiers_but_not_the_c
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
 }
 
@@ -215,11 +217,12 @@ async fn test_create_sprint_falls_back_to_a_whole_model_reset_because_its_invers
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_columns_by_board", board.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_sprints_by_board", board.id),
         "got {refetch:?}"
     );
     assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
@@ -240,7 +243,6 @@ async fn test_set_card_points_refetches_the_card_tiers_only() {
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
         "got {refetch:?}"
@@ -334,7 +336,6 @@ async fn test_prefix_dialog_sprint_branches_refetch_the_sprint_list_and_never_th
     {
         let refetch = refetch_ops(&ops);
         assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-        assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
         assert!(
             has_op_with_id(&refetch, "list_sprints_by_board", seed.board),
             "got {refetch:?}"
@@ -352,7 +353,6 @@ async fn test_prefix_dialog_sprint_branches_refetch_the_sprint_list_and_never_th
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_sprints_by_board", seed.board),
         "got {refetch:?}"
@@ -378,7 +378,6 @@ async fn test_prefix_dialog_sprint_card_branches_refetch_the_sprint_list_and_nev
     {
         let refetch = refetch_ops(&ops);
         assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-        assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
         assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
         assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
     }
@@ -390,7 +389,6 @@ async fn test_prefix_dialog_sprint_card_branches_refetch_the_sprint_list_and_nev
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
 }
@@ -445,7 +443,6 @@ async fn test_set_card_priority_refetches_the_card_tiers_only() {
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
         "got {refetch:?}"
@@ -491,7 +488,6 @@ async fn test_set_column_default_status_refetches_the_column_tiers_not_the_card_
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_columns"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_columns_by_board", seed.board),
         "got {refetch:?}"
@@ -544,7 +540,7 @@ async fn test_set_multiple_cards_priority_refetches_the_card_tiers_once_for_the_
     assert_eq!(
         refetch
             .iter()
-            .filter(|op| op.method == "list_all_cards")
+            .filter(|op| op.method == "list_cards_by_column")
             .count(),
         1,
         "got {refetch:?}"
@@ -590,7 +586,13 @@ async fn test_assign_card_to_sprint_refetches_the_card_tiers_not_the_sprint_list
 
     app.selection.active_board_id = Some(seed.board);
     app.selection.active_card_id = Some(seed.k1);
-    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+    let sprints = app
+        .model
+        .board_sprints_state(seed.board)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .to_vec();
     let board = app
         .model
         .boards_state()
@@ -607,7 +609,6 @@ async fn test_assign_card_to_sprint_refetches_the_card_tiers_not_the_sprint_list
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     assert!(
@@ -624,7 +625,13 @@ async fn test_assign_card_to_sprint_failure_issues_no_refetch_read() {
 
     app.selection.active_board_id = Some(seed.board);
     app.selection.active_card_id = Some(seed.k1);
-    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+    let sprints = app
+        .model
+        .board_sprints_state(seed.board)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .to_vec();
     let board = app
         .model
         .boards_state()
@@ -655,7 +662,13 @@ async fn test_assign_multiple_cards_to_sprint_refetches_the_card_tiers_not_the_s
     app.selection.active_board_id = Some(seed.board);
     app.multi_select.selected_cards.insert(seed.k1);
     app.multi_select.selected_cards.insert(seed.k2);
-    let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+    let sprints = app
+        .model
+        .board_sprints_state(seed.board)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .to_vec();
     let board = app
         .model
         .boards_state()
@@ -672,12 +685,12 @@ async fn test_assign_multiple_cards_to_sprint_refetches_the_card_tiers_not_the_s
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert_eq!(
-        refetch
-            .iter()
-            .filter(|op| op.method == "list_all_cards")
-            .count(),
-        1,
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c2),
         "got {refetch:?}"
     );
     assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
@@ -719,7 +732,6 @@ async fn test_carry_over_sprint_refetches_the_card_tiers_not_the_sprint_list() {
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     let _ = target;
@@ -765,7 +777,6 @@ async fn test_relationship_popup_add_edge_refetches_the_graph_and_the_card_tiers
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
     assert!(has_op(&refetch, "get_graph"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
@@ -812,7 +823,6 @@ async fn test_relationship_popup_remove_edge_refetches_the_graph_and_the_card_ti
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
     assert!(has_op(&refetch, "get_graph"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_boards"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
@@ -872,7 +882,6 @@ async fn test_sprint_detail_move_card_refetches_the_card_tiers_not_the_column_li
 
     let refetch = refetch_ops(&ops);
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
-    assert!(has_op(&refetch, "list_all_cards"), "got {refetch:?}");
     assert!(
         has_op_with_id(&refetch, "list_cards_by_column", c1.id),
         "got {refetch:?}"

--- a/crates/kanban-tui/tests/sprint_picker_tests.rs
+++ b/crates/kanban-tui/tests/sprint_picker_tests.rs
@@ -168,7 +168,11 @@ fn test_for_card_assignment_initial_selection_is_zero_when_card_has_no_sprint() 
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -186,7 +190,15 @@ fn test_for_card_assignment_initial_selection_is_index_of_current_sprint() {
     let active = add_active_sprint(&mut app, board_id);
     add_planning_sprint(&mut app, board_id);
     let now = Utc::now();
-    let entries = build_entries(app.model.sprints_state().loaded_or_empty(), board_id, now);
+    let entries = build_entries(
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
+        board_id,
+        now,
+    );
     let expected_idx = entries
         .iter()
         .position(|e| sprint_id_of(e) == Some(active))
@@ -200,7 +212,11 @@ fn test_for_card_assignment_initial_selection_is_index_of_current_sprint() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         Some(active),
         now,
@@ -224,7 +240,11 @@ fn test_for_card_assignment_render_shows_current_suffix_for_card_sprint() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         Some(active),
         now,
@@ -251,8 +271,15 @@ fn test_for_new_card_preselects_sole_active_non_ended_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker =
-        SprintPickerView::for_new_card(app.model.sprints_state().loaded_or_empty(), &board, now);
+    let picker = SprintPickerView::for_new_card(
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
+        &board,
+        now,
+    );
     let expected_idx = picker
         .index_of_sprint(Some(active))
         .expect("active sprint must appear in the new-card picker");
@@ -277,8 +304,15 @@ fn test_for_new_card_preselects_none_when_no_active_sprints() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker =
-        SprintPickerView::for_new_card(app.model.sprints_state().loaded_or_empty(), &board, now);
+    let picker = SprintPickerView::for_new_card(
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
+        &board,
+        now,
+    );
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -300,8 +334,15 @@ fn test_for_new_card_preselects_none_when_multiple_active_sprints() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let picker =
-        SprintPickerView::for_new_card(app.model.sprints_state().loaded_or_empty(), &board, now);
+    let picker = SprintPickerView::for_new_card(
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
+        &board,
+        now,
+    );
     assert_eq!(
         picker.initial_selection(),
         Some(0),
@@ -323,7 +364,11 @@ fn test_value_at_returns_none_uuid_for_none_row() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -340,7 +385,15 @@ fn test_value_at_returns_sprint_id_for_sprint_row() {
     let (mut app, board_id, _col) = make_app_with_board();
     let active = add_active_sprint(&mut app, board_id);
     let now = Utc::now();
-    let entries = build_entries(app.model.sprints_state().loaded_or_empty(), board_id, now);
+    let entries = build_entries(
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
+        board_id,
+        now,
+    );
     let idx = entries
         .iter()
         .position(|e| sprint_id_of(e) == Some(active))
@@ -354,7 +407,11 @@ fn test_value_at_returns_sprint_id_for_sprint_row() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -376,10 +433,22 @@ fn test_index_of_sprint_returns_row_index_for_known_sprint() {
         .find(|b| b.id == board_id)
         .cloned()
         .unwrap();
-    let entries = build_entries(app.model.sprints_state().loaded_or_empty(), board_id, now);
+    let entries = build_entries(
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
+        board_id,
+        now,
+    );
     let expected = entries.iter().position(|e| sprint_id_of(e) == Some(active));
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -401,7 +470,11 @@ fn test_index_of_sprint_returns_none_entry_index_when_no_sprint_selected() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -427,7 +500,11 @@ fn test_index_of_sprint_returns_none_when_sprint_is_not_in_list() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -444,7 +521,15 @@ fn test_value_at_indices_match_build_entries_order() {
     add_completed_sprint(&mut app, board_id);
     add_ended_sprint(&mut app, board_id);
     let now = Utc::now();
-    let entries = build_entries(app.model.sprints_state().loaded_or_empty(), board_id, now);
+    let entries = build_entries(
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
+        board_id,
+        now,
+    );
     let board = app
         .model
         .boards_state()
@@ -454,7 +539,11 @@ fn test_value_at_indices_match_build_entries_order() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -494,7 +583,11 @@ fn test_render_emits_active_planned_header_with_yellow_color() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -526,7 +619,11 @@ fn test_render_with_none_selection_leaves_all_rows_unselected() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,
@@ -556,7 +653,11 @@ fn test_render_with_out_of_bounds_selected_does_not_panic() {
         .cloned()
         .unwrap();
     let picker = SprintPickerView::for_card_assignment(
-        app.model.sprints_state().loaded_or_empty(),
+        app.model
+            .board_sprints_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
         &board,
         None,
         now,

--- a/crates/kanban-tui/tests/stale_model_regression_tests.rs
+++ b/crates/kanban-tui/tests/stale_model_regression_tests.rs
@@ -31,8 +31,12 @@ fn test_create_board_assigns_correct_id_to_columns() {
     assert_eq!(boards.len(), 1, "should have exactly one board");
     let board_id = boards[0].id;
 
-    let columns = app.model.columns_state().loaded_or_empty();
-    let board_columns: Vec<_> = columns.iter().filter(|c| c.board_id == board_id).collect();
+    let board_columns = app
+        .model
+        .board_columns_state(board_id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[]);
     assert_eq!(
         board_columns.len(),
         3,
@@ -79,7 +83,9 @@ fn test_create_card_selects_newly_created_card() {
         "a card should be selected after creation"
     );
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let board_id = app.selection.active_board_id.unwrap();
+    let cards = app.model.board_cards_state(board_id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
     let created = cards.iter().find(|c| c.title == "My Card");
     assert!(created.is_some(), "card should exist in model");
     assert_eq!(selected_id.unwrap(), created.unwrap().id);
@@ -103,7 +109,9 @@ fn test_create_card_selects_newly_created_card_when_prior_selection_exists() {
     app.create_card();
     app.prepare_frame();
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let board_id = app.selection.active_board_id.unwrap();
+    let cards = app.model.board_cards_state(board_id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
     let second = cards
         .iter()
         .find(|c| c.title == "Second")
@@ -168,7 +176,8 @@ fn test_create_card_auto_completes_in_done_column() {
     app.create_card();
     app.prepare_frame();
 
-    let cards = app.model.cards_state().loaded_or_empty();
+    let cards = app.model.board_cards_state(board.id);
+    let cards = cards.loaded().map(|v| v.as_slice()).unwrap_or(&[]);
     let done_card = cards
         .iter()
         .find(|c| c.title == "Done Card" && c.column_id == done_col.id);
@@ -190,7 +199,9 @@ fn test_create_sprint_selects_new_sprint() {
     app.create_sprint();
     app.prepare_frame();
 
-    let sprints = app.model.sprints_state().loaded_or_empty();
+    let board_id = app.selection.active_board_id.unwrap();
+    let sprints = app.model.board_sprints_state(board_id);
+    let sprints = sprints.loaded().copied().unwrap_or(&[]);
     assert_eq!(sprints.len(), 1, "should have one sprint");
 
     let selected = app.selection.sprint.get();
@@ -207,13 +218,14 @@ fn test_create_column_selects_new_column() {
     app.push_mode(AppMode::BoardDetail);
     app.focus.board_focus = BoardFocus::Columns;
 
+    let board_id = app.selection.active_board_id.unwrap();
     let columns_before = app
         .model
-        .columns_state()
-        .loaded_or_empty()
-        .iter()
-        .filter(|c| c.board_id == app.model.boards_state().loaded_or_empty()[0].id)
-        .count();
+        .board_columns_state(board_id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .len();
 
     app.input.set("New Column".to_string());
     app.create_column();
@@ -253,7 +265,13 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
     app.create_sprint();
     app.prepare_frame();
 
-    let sprint_id = app.model.sprints_state().loaded_or_empty()[0].id;
+    let sprint_id = app
+        .model
+        .board_sprints_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])[0]
+        .id;
 
     // Create a card and assign it to the sprint
     app.focus.active = Focus::Cards;
@@ -263,8 +281,10 @@ fn test_complete_sole_planning_sprint_does_not_show_carry_over() {
 
     let card_id = app
         .model
-        .cards_state()
-        .loaded_or_empty()
+        .board_cards_state(board.id)
+        .loaded()
+        .map(|v| v.as_slice())
+        .unwrap_or(&[])
         .iter()
         .find(|c| c.title == "Task")
         .unwrap()
@@ -316,12 +336,10 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
     app.create_sprint();
     app.prepare_frame();
 
-    assert_eq!(
-        app.model.sprints_state().loaded_or_empty().len(),
-        2,
-        "should have two sprints"
-    );
-    let sprint1_id = app.model.sprints_state().loaded_or_empty()[0].id;
+    let board_sprints = app.model.board_sprints_state(board.id);
+    let board_sprints = board_sprints.loaded().copied().unwrap_or(&[]);
+    assert_eq!(board_sprints.len(), 2, "should have two sprints");
+    let sprint1_id = board_sprints[0].id;
 
     // Activate sprint 1 so it can be completed
     app.selection.active_sprint_id = Some(sprint1_id);
@@ -336,8 +354,10 @@ fn test_complete_sprint_with_other_planning_sprint_shows_carry_over() {
 
     let card_id = app
         .model
-        .cards_state()
-        .loaded_or_empty()
+        .board_cards_state(board.id)
+        .loaded()
+        .map(|v| v.as_slice())
+        .unwrap_or(&[])
         .iter()
         .find(|c| c.title == "Task")
         .unwrap()
@@ -514,11 +534,11 @@ fn test_delete_column_adjusts_selection() {
 
     let remaining = app
         .model
-        .columns_state()
-        .loaded_or_empty()
-        .iter()
-        .filter(|c| c.board_id == board.id)
-        .count();
+        .board_columns_state(board.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .len();
     assert_eq!(remaining, 2, "should have 2 columns remaining");
 
     let selected = app.dialog_input.column_list.get_selected_index();

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -178,11 +178,11 @@ async fn test_startup_reads_the_board_list_and_board_scoped_tiers_instead_of_one
             )
         })
         .count();
-    assert!(
-        whole_store_list_reads <= 5,
-        "expected at most 5 whole-store list reads (1 list_all_columns + 1 list_all_cards \
-         + 1 list_all_sprints from ViewScope's transitional flat arms, plus 1 list_all_cards \
-         + 1 list_all_sprints from migrate_sprint_logs), got {whole_store_list_reads} in {ops:?}"
+    assert_eq!(
+        whole_store_list_reads, 2,
+        "expected exactly 2 whole-store list reads (1 list_all_cards + 1 list_all_sprints \
+         from migrate_sprint_logs; ViewScope no longer requests any flat tier), \
+         got {whole_store_list_reads} in {ops:?}"
     );
     assert!(
         !ops.iter()

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -615,8 +615,49 @@ mod backend_parity {
                 "{kind}: an empty board's sprint tier must resolve to Loaded(vec![]), not NotLoaded/Missing"
             );
             assert!(
-                model.cards_state().is_loaded(),
-                "{kind}: the flat card tier must resolve to Loaded(vec![])"
+                model.board_cards_state(board_id).is_loaded(),
+                "{kind}: the scoped card tier must resolve to Loaded(vec![])"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_the_startup_scope_never_reads_the_flat_tiers_on_any_backend() {
+        let (snapshot, board1, _board2) = seed_non_trivial_snapshot().await;
+        let kinds = ["memory", "json", "sqlite"];
+        let dirs = [
+            tempfile::tempdir().unwrap(),
+            tempfile::tempdir().unwrap(),
+            tempfile::tempdir().unwrap(),
+        ];
+
+        for (kind, dir) in kinds.iter().zip(dirs.iter()) {
+            let ctx = open_seeded(kind, dir, &snapshot).await;
+            let model = populate_scope(&ctx, board1);
+
+            assert!(
+                model.columns_state().is_not_loaded(),
+                "{kind}: the flat column tier must stay unrequested"
+            );
+            assert!(
+                model.cards_state().is_not_loaded(),
+                "{kind}: the flat card tier must stay unrequested"
+            );
+            assert!(
+                model.sprints_state().is_not_loaded(),
+                "{kind}: the flat sprint tier must stay unrequested"
+            );
+            assert!(
+                model.board_columns_state(board1).is_loaded(),
+                "{kind}: the scoped column tier must be loaded"
+            );
+            assert!(
+                model.board_cards_state(board1).is_loaded(),
+                "{kind}: the scoped card tier must be loaded"
+            );
+            assert!(
+                model.board_sprints_state(board1).is_loaded(),
+                "{kind}: the scoped sprint tier must be loaded"
             );
         }
     }

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -279,8 +279,8 @@ async fn test_startup_loads_the_auto_selected_boards_subtree() {
 
     app.load_initial_state().await;
 
-    assert!(matches!(app.model.columns_state(), LoadState::Loaded(_)));
-    assert!(matches!(app.model.sprints_state(), LoadState::Loaded(_)));
+    assert!(app.model.board_columns_state(board1.id).is_loaded());
+    assert!(app.model.board_sprints_state(board1.id).is_loaded());
     assert_eq!(app.selection.active_board_id, None);
     assert_eq!(app.board_list.get_selected_board_id(), Some(board1.id));
 }
@@ -327,8 +327,10 @@ async fn test_startup_runs_the_sprint_log_migration_before_the_first_fetch() {
 
     let migrated_log_present = app
         .model
-        .cards_state()
-        .loaded_or_empty()
+        .board_cards_state(board.id)
+        .loaded()
+        .map(|v| v.as_slice())
+        .unwrap_or(&[])
         .iter()
         .find(|c| c.id == card.id)
         .map(|c| !c.sprint_logs.is_empty())
@@ -547,17 +549,22 @@ mod backend_parity {
                 "boards differ between {baseline_kind} and {kind}"
             );
 
-            let expected_columns =
-                sorted_by_id(baseline.columns_state().loaded().unwrap(), |c| c.id);
-            let actual_columns = sorted_by_id(model.columns_state().loaded().unwrap(), |c| c.id);
+            let expected_columns = sorted_by_id(
+                baseline.board_columns_state(board1).loaded().unwrap(),
+                |c| c.id,
+            );
+            let actual_columns =
+                sorted_by_id(model.board_columns_state(board1).loaded().unwrap(), |c| {
+                    c.id
+                });
             assert_eq!(
                 actual_columns, expected_columns,
                 "columns differ between {baseline_kind} and {kind}"
             );
 
-            let mut expected_cards = baseline.cards_state().loaded().unwrap().clone();
+            let mut expected_cards = baseline.board_cards_state(board1).loaded().unwrap().clone();
             expected_cards.sort_by_key(|c| c.id);
-            let mut actual_cards = model.cards_state().loaded().unwrap().clone();
+            let mut actual_cards = model.board_cards_state(board1).loaded().unwrap().clone();
             actual_cards.sort_by_key(|c| c.id);
             assert_eq!(
                 expected_cards.len(),
@@ -568,9 +575,14 @@ mod backend_parity {
                 assert_card_eq(a, b);
             }
 
-            let expected_sprints =
-                sorted_by_id(baseline.sprints_state().loaded().unwrap(), |s| s.id);
-            let actual_sprints = sorted_by_id(model.sprints_state().loaded().unwrap(), |s| s.id);
+            let expected_sprints = sorted_by_id(
+                baseline.board_sprints_state(board1).loaded().unwrap(),
+                |s| s.id,
+            );
+            let actual_sprints =
+                sorted_by_id(model.board_sprints_state(board1).loaded().unwrap(), |s| {
+                    s.id
+                });
             assert_eq!(
                 actual_sprints, expected_sprints,
                 "sprints differ between {baseline_kind} and {kind}"

--- a/crates/kanban-tui/tests/view_scope_tests.rs
+++ b/crates/kanban-tui/tests/view_scope_tests.rs
@@ -202,6 +202,7 @@ fn test_search_mode_needs_no_scope_beyond_the_board_it_filters() {
             board: Some(board_id),
             board_columns: true,
             board_cards: true,
+            board_sprints: true,
             ..Default::default()
         }
     );

--- a/crates/kanban-tui/tests/view_scope_tests.rs
+++ b/crates/kanban-tui/tests/view_scope_tests.rs
@@ -36,6 +36,34 @@ fn test_normal_mode_scopes_the_highlighted_board_when_none_is_opened() {
 }
 
 #[test]
+fn test_the_base_scope_requests_the_board_sprint_tier_in_normal_mode() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::Normal;
+
+    let scope = app.view_scope();
+
+    assert!(scope.board_sprints);
+}
+
+#[test]
+fn test_settings_scope_drops_the_board_sprint_tier() {
+    let mut app = App::test_default();
+    let (board_id, ..) = seed_board_column_sprint_card(&mut app);
+    app.reload_model();
+    app.selection.active_board_id = Some(board_id);
+    app.mode = AppMode::Settings;
+
+    let scope = app.view_scope();
+
+    assert!(!scope.board_columns);
+    assert!(!scope.board_cards);
+    assert!(!scope.board_sprints);
+}
+
+#[test]
 fn test_card_detail_scopes_the_active_card_the_sprints_and_the_graph() {
     let mut app = App::test_default();
     let (board_id, _column_id, _sprint_id, card_id) = seed_board_column_sprint_card(&mut app);


### PR DESCRIPTION
## Summary

- `ViewScope::next_round` stops requesting the workspace-flat `column_list`/`card_list`/`sprint_list` tiers. Against a backend that declines those whole-workspace calls (HttpBackend), the old F1 block re-requested them every single frame, since `requestable` treats `Failed` as retryable. That per-frame error loop is now gone.
- `board_sprints` becomes the sole sprint source: it moves into the base `ViewScope` (true by default in Normal/CardDetail/BoardDetail/SprintDetail/ArchivedBoardsView and every dialog with a board in scope) and is dropped only in Settings, unless a sprint filter is active. Every per-mode `scope.board_sprints = true` that duplicated the new base default is removed.
- `prepare_frame`'s task-list refresh and `tasks_panel_title`'s loaded-gate move from the flat `columns_state()`/`sprints_state()` accessors to the board-scoped `board_columns_state()`/`board_sprints_state()`. This completes the deviation reviewed in #839: search and the tasks panel now read the same scoped tiers the rest of the render path already used.
- The four dead scoped-then-flat-fallback code paths (`board_columns_view`, `board_sprints_view`, `create_card_target_column`, `handle_manage_children_from_list`) are removed. A scoped `Loaded` (including empty) is now the sole authoritative source; nothing falls back to the flat tier.
- `card_in_collection` retires from the `FetchPlan`/`LoadedState`/`LoadedEntities` vocabulary, along with `Model::card_in_collection_status` in kanban-domain. Its only production caller was already gone (the archived-card body walk reads the composed `card()` accessor as of #839/#840); this PR clears the stub plumbing and one surviving domain test reader.

## Corrections to the source card

- The card's Target step 3 described removing an F2 flat-merge block in the archived-card body walk. That block does not exist on `develop`; #839/#840 already rebuilt the walk onto `archived_cards_of_board`/`card()`. No change was needed there.
- The card estimated ~8 test rewrites. The actual blast radius, once the flat tiers stop being populated by `reload_model()`/`prepare_frame()`, was roughly 100 assertions across 23 integration-test files in `kanban-tui`, plus the refetch op-name assertions in `mutation_refetch_tests.rs` and `sprint_dialog_refetch_tests.rs`. Every migrated assertion keeps its original population path (still driven through the real handlers, never a snapshot load) and only changes which accessor it reads.

## Known gap (flagged, not fixed here)

`resolve_relationship_cards` (the CardDetail parents/children panel) resolves a related card through `Model::card_by_id_state`, which composes the per-id tier, the column-scoped tier, and (previously) the flat tier. A `spawns` relative that lives on a *different* board than the one currently in scope was, before this PR, incidentally resolvable because the flat tier held every board's cards. With the flat tier gone, a cross-board relative is no longer resolvable unless something has independently fetched its body.

`crates/kanban-tui/tests/relationship_resolution_tests.rs` pins the two tests that exercise this (`test_resolve_relationship_cards_resolves_a_cross_board_card_whose_body_was_fetched`, `test_card_detail_children_box_shows_a_cross_board_child_whose_body_was_fetched`) by seeding the cross-board card's body directly (a `warm_card_body` helper, the same shape as the existing `warm_archived_card_markers`). This keeps the tests honest about the resolver's contract, but it is not a production fix: CardDetail's `ViewScope` arm does not currently issue a per-id fetch for the graph's parent/child ids, so a real cross-board relative will show as missing from the panel today. Recommend a follow-up card to extend the `CardDetail` scope to request the active card's graph neighbours by id once the graph is loaded.

## Test plan

- `cargo test --workspace --all-features`: green.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Six new tests pin the behavior this PR introduces (scoped-only `next_round`, the base-scope `board_sprints` default and its Settings guard, `prepare_frame`/`tasks_panel_title` reading the scoped tiers under a failed flat tier, and a three-backend proof that the flat tiers stay `NotLoaded` while the scoped tiers load). Each was confirmed failing on the unmodified tree before implementation.

