### PR TITLE
KAN-1586 refactor(service): retire the flat column/card/sprint fetch tiers

### DIFF
--- a/.changeset/kan-1586-retire-flat-fetch-tiers.md
+++ b/.changeset/kan-1586-retire-flat-fetch-tiers.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+retire the flat column/card/sprint fetch-round tiers, leaving per-parent-scope and per-id fetches as the only expressible reads

--- a/crates/kanban-mcp/src/scope.rs
+++ b/crates/kanban-mcp/src/scope.rs
@@ -229,9 +229,6 @@ mod tests {
         let round = scope.next_round(&Model::default());
         assert_eq!(round.columns_by_board, vec![board_id]);
         assert_eq!(round.sprints_by_board, vec![board_id]);
-        assert!(!round.column_list);
-        assert!(!round.sprint_list);
-        assert!(!round.card_list);
         assert!(!round.archived_board_list);
     }
 

--- a/crates/kanban-mcp/src/tools/column.rs
+++ b/crates/kanban-mcp/src/tools/column.rs
@@ -218,7 +218,6 @@ mod tests {
         };
         let round = named_board.scope().next_round(&Model::default());
         assert!(round.board_list);
-        assert!(!round.column_list);
         assert!(round.columns_by_board.is_empty());
         assert!(!named_board.scope().wants_board_columns);
 
@@ -240,7 +239,6 @@ mod tests {
         };
         let round = named_list.scope().next_round(&Model::default());
         assert!(round.board_list);
-        assert!(!round.column_list);
         assert!(!named_list.scope().wants_board_columns);
 
         let named_get = GetColumnRequest {

--- a/crates/kanban-server/src/scope.rs
+++ b/crates/kanban-server/src/scope.rs
@@ -237,9 +237,7 @@ mod tests {
         assert_eq!(round.boards, vec![board_id]);
         assert_eq!(round.columns_by_board, vec![board_id]);
         assert!(round.archived_cards_by_board.is_empty());
-        assert!(!round.card_list);
         assert!(!round.board_list);
-        assert!(!round.column_list);
         assert!(round.cards_by_column.is_empty());
     }
 
@@ -328,7 +326,6 @@ mod tests {
         assert!(round.archived_cards_by_board.is_empty());
         assert!(!round.archived_card_list);
         assert!(round.cards.is_empty());
-        assert!(!round.card_list);
         assert!(!round.board_list);
     }
 
@@ -445,7 +442,6 @@ mod tests {
         .next_round(&Model::default());
 
         assert!(round.sprints_by_board.is_empty());
-        assert!(!round.sprint_list);
     }
 
     #[test]
@@ -515,7 +511,6 @@ mod tests {
         let card_round = RouteScope::Card(card_id).next_round(&Model::default());
         assert_eq!(card_round.cards, vec![card_id]);
         assert!(!card_round.is_empty());
-        assert!(!card_round.card_list);
         assert!(!card_round.board_list);
         assert!(card_round.boards.is_empty());
         assert!(card_round.columns_by_board.is_empty());
@@ -532,7 +527,6 @@ mod tests {
 
         assert!(round.graph);
         assert_eq!(round.cards, vec![card_id]);
-        assert!(!round.card_list);
     }
 
     #[test]

--- a/crates/kanban-service/src/context/sync/tests.rs
+++ b/crates/kanban-service/src/context/sync/tests.rs
@@ -7,6 +7,7 @@ use kanban_domain::{Board, CardUpdate, KanbanOperations, NoProjections};
 
 use super::*;
 use crate::fetch_plan::{requestable, FetchRound, LoadedEntities};
+use uuid::Uuid;
 
 struct BoardListPlan;
 impl FetchPlan for BoardListPlan {
@@ -38,11 +39,17 @@ impl FetchPlan for ForceArchivedBoardListPlan {
     }
 }
 
-struct CardListPlan;
-impl FetchPlan for CardListPlan {
+struct CardByIdPlan {
+    id: Uuid,
+}
+impl FetchPlan for CardByIdPlan {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         FetchRound {
-            card_list: requestable(loaded.card_list()),
+            cards: if requestable(loaded.card(self.id)) {
+                vec![self.id]
+            } else {
+                Vec::new()
+            },
             ..Default::default()
         }
     }
@@ -121,7 +128,11 @@ fn test_sync_invalidated_refetches_the_invalidated_card_before_planning() {
         .unwrap();
 
     let mut model_a = Model::default();
-    ctx_a.sync(&CardListPlan, &mut model_a, &mut NoProjections);
+    ctx_a.sync(
+        &CardByIdPlan { id: card.id },
+        &mut model_a,
+        &mut NoProjections,
+    );
     assert_eq!(
         model_a.card_by_id_state(card.id).loaded().unwrap().title,
         "before"
@@ -137,7 +148,12 @@ fn test_sync_invalidated_refetches_the_invalidated_card_before_planning() {
         )
         .unwrap();
 
-    ctx_a.sync_invalidated(inv, &CardListPlan, &mut model_a, &mut NoProjections);
+    ctx_a.sync_invalidated(
+        inv,
+        &CardByIdPlan { id: card.id },
+        &mut model_a,
+        &mut NoProjections,
+    );
     assert_eq!(
         model_a.card_by_id_state(card.id).loaded().unwrap().title,
         "after"
@@ -159,7 +175,11 @@ fn test_sync_invalidated_refetches_the_invalidated_card_before_planning() {
         .unwrap();
 
     let mut model_b = Model::default();
-    ctx_b.sync(&CardListPlan, &mut model_b, &mut NoProjections);
+    ctx_b.sync(
+        &CardByIdPlan { id: card_b.id },
+        &mut model_b,
+        &mut NoProjections,
+    );
     assert_eq!(
         model_b.card_by_id_state(card_b.id).loaded().unwrap().title,
         "before"
@@ -176,7 +196,11 @@ fn test_sync_invalidated_refetches_the_invalidated_card_before_planning() {
         .unwrap();
     let _ = inv_b;
 
-    ctx_b.sync(&CardListPlan, &mut model_b, &mut NoProjections);
+    ctx_b.sync(
+        &CardByIdPlan { id: card_b.id },
+        &mut model_b,
+        &mut NoProjections,
+    );
     assert_eq!(
         model_b.card_by_id_state(card_b.id).loaded().unwrap().title,
         "before"
@@ -336,7 +360,11 @@ fn test_resync_invalidated_refetches_a_mutated_card_the_caller_plan_never_names(
     let card = seed_card(&mut ctx);
 
     let mut model = Model::default();
-    ctx.sync(&CardListPlan, &mut model, &mut NoProjections);
+    ctx.sync(
+        &CardByIdPlan { id: card.id },
+        &mut model,
+        &mut NoProjections,
+    );
     assert_eq!(
         model.card_by_id_state(card.id).loaded().unwrap().title,
         "before"
@@ -357,14 +385,18 @@ fn test_resync_invalidated_refetches_a_mutated_card_the_caller_plan_never_names(
         model.card_by_id_state(card.id).loaded().unwrap().title,
         "after"
     );
-    assert!(model.cards_state().is_loaded());
-
     let mut ctx_control =
         KanbanContext::open_deferred(Arc::new(InMemoryStore::new()), AppConfig::default());
     let card_control = seed_card(&mut ctx_control);
 
     let mut model_control = Model::default();
-    ctx_control.sync(&CardListPlan, &mut model_control, &mut NoProjections);
+    ctx_control.sync(
+        &CardByIdPlan {
+            id: card_control.id,
+        },
+        &mut model_control,
+        &mut NoProjections,
+    );
 
     let (_card_control, inv_control) = ctx_control
         .update_card_impl(
@@ -481,7 +513,11 @@ fn test_resync_invalidated_does_not_refetch_what_the_repair_pass_already_read() 
         .unwrap();
 
     let mut model = Model::default();
-    ctx.sync(&CardListPlan, &mut model, &mut NoProjections);
+    ctx.sync(
+        &CardByIdPlan { id: card.id },
+        &mut model,
+        &mut NoProjections,
+    );
 
     let (_card, inv) = ctx
         .update_card_impl(
@@ -494,9 +530,14 @@ fn test_resync_invalidated_does_not_refetch_what_the_repair_pass_already_read() 
         .unwrap();
 
     backend.clear_ops();
-    ctx.resync_invalidated(inv, &CardListPlan, &mut model, &mut NoProjections);
+    ctx.resync_invalidated(
+        inv,
+        &CardByIdPlan { id: card.id },
+        &mut model,
+        &mut NoProjections,
+    );
 
-    assert_eq!(backend.op_count("list_all_cards"), 1);
+    assert_eq!(backend.op_count("get_card"), 1);
 }
 
 #[cfg(feature = "test-helpers")]
@@ -527,7 +568,11 @@ fn test_resync_invalidated_records_a_failed_repair_read_as_failed_not_empty() {
         .unwrap();
 
     let mut model = Model::default();
-    ctx.sync(&CardListPlan, &mut model, &mut NoProjections);
+    ctx.sync(
+        &CardByIdPlan { id: card.id },
+        &mut model,
+        &mut NoProjections,
+    );
 
     let (_card, inv) = ctx
         .update_card_impl(
@@ -539,9 +584,9 @@ fn test_resync_invalidated_records_a_failed_repair_read_as_failed_not_empty() {
         )
         .unwrap();
 
-    backend.fail("list_all_cards");
+    backend.fail("get_card");
     ctx.resync_invalidated(inv, &NothingPlan, &mut model, &mut NoProjections);
 
-    assert!(model.cards_state().is_failed());
-    assert!(!model.cards_state().is_loaded());
+    assert!(model.card_by_id_state(card.id).is_failed());
+    assert!(!model.card_by_id_state(card.id).is_loaded());
 }

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -30,7 +30,7 @@ pub fn requestable(status: FetchStatus) -> bool {
 }
 
 /// Whole-collection accessors, parent-scoped accessors, and per-id accessors
-/// are independent tiers: a `card_list()` of `NotLoaded` alongside a
+/// are independent tiers: a `board_list()` of `NotLoaded` alongside a
 /// `cards_of_column(c)` of `Loaded` alongside a `card(id)` of `Missing` is a
 /// coherent state, not a contradiction.
 ///
@@ -45,9 +45,6 @@ pub fn requestable(status: FetchStatus) -> bool {
 /// served by `DataStore::list_archived_cards_by_board`.
 pub trait LoadedState {
     fn board_list(&self) -> FetchStatus;
-    fn column_list(&self) -> FetchStatus;
-    fn card_list(&self) -> FetchStatus;
-    fn sprint_list(&self) -> FetchStatus;
     fn graph(&self) -> FetchStatus;
     fn board(&self, id: Uuid) -> FetchStatus;
     fn column(&self, id: Uuid) -> FetchStatus;
@@ -68,9 +65,6 @@ pub trait LoadedState {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FetchRound {
     pub board_list: bool,
-    pub column_list: bool,
-    pub card_list: bool,
-    pub sprint_list: bool,
     pub graph: bool,
     pub boards: Vec<Uuid>,
     pub columns: Vec<Uuid>,
@@ -91,9 +85,6 @@ pub struct FetchRound {
 impl FetchRound {
     pub fn is_empty(&self) -> bool {
         !self.board_list
-            && !self.column_list
-            && !self.card_list
-            && !self.sprint_list
             && !self.graph
             && self.boards.is_empty()
             && self.columns.is_empty()
@@ -139,7 +130,6 @@ mod tests {
 
     struct StubLoaded {
         board_list: FetchStatus,
-        card_list: FetchStatus,
         card: FetchStatus,
         cards_of_column: FetchStatus,
         columns_by_board: HashMap<Uuid, Vec<Column>>,
@@ -149,7 +139,6 @@ mod tests {
         fn default() -> Self {
             StubLoaded {
                 board_list: FetchStatus::NotLoaded,
-                card_list: FetchStatus::NotLoaded,
                 card: FetchStatus::NotLoaded,
                 cards_of_column: FetchStatus::NotLoaded,
                 columns_by_board: HashMap::new(),
@@ -160,15 +149,6 @@ mod tests {
     impl LoadedState for StubLoaded {
         fn board_list(&self) -> FetchStatus {
             self.board_list
-        }
-        fn column_list(&self) -> FetchStatus {
-            FetchStatus::NotLoaded
-        }
-        fn card_list(&self) -> FetchStatus {
-            self.card_list
-        }
-        fn sprint_list(&self) -> FetchStatus {
-            FetchStatus::NotLoaded
         }
         fn graph(&self) -> FetchStatus {
             FetchStatus::NotLoaded
@@ -287,21 +267,6 @@ mod tests {
         }
         .is_empty());
         assert!(!FetchRound {
-            column_list: true,
-            ..Default::default()
-        }
-        .is_empty());
-        assert!(!FetchRound {
-            card_list: true,
-            ..Default::default()
-        }
-        .is_empty());
-        assert!(!FetchRound {
-            sprint_list: true,
-            ..Default::default()
-        }
-        .is_empty());
-        assert!(!FetchRound {
             graph: true,
             ..Default::default()
         }
@@ -387,13 +352,13 @@ mod tests {
         let column_id = Uuid::new_v4();
         let card_id = Uuid::new_v4();
         let loaded = StubLoaded {
-            card_list: FetchStatus::NotLoaded,
+            board_list: FetchStatus::NotLoaded,
             cards_of_column: FetchStatus::Loaded,
             card: FetchStatus::Missing,
             ..Default::default()
         };
 
-        assert!(requestable(loaded.card_list()));
+        assert!(requestable(loaded.board_list()));
         assert!(!requestable(loaded.cards_of_column(column_id)));
         assert!(!requestable(loaded.card(card_id)));
     }
@@ -427,11 +392,12 @@ mod tests {
     #[test]
     fn test_loaded_state_distinguishes_whole_collection_status_from_per_id_status() {
         let loaded = StubLoaded {
+            board_list: FetchStatus::NotLoaded,
             card: FetchStatus::Loaded,
             ..Default::default()
         };
 
-        assert!(requestable(loaded.card_list()));
+        assert!(requestable(loaded.board_list()));
         assert!(!requestable(loaded.card(Uuid::new_v4())));
     }
 

--- a/crates/kanban-service/src/invalidation_plan.rs
+++ b/crates/kanban-service/src/invalidation_plan.rs
@@ -55,9 +55,6 @@ impl InvalidationPlan {
         let round = match invalidation {
             Invalidation::All => FetchRound {
                 board_list: was_read(loaded.board_list()),
-                column_list: was_read(loaded.column_list()),
-                card_list: was_read(loaded.card_list()),
-                sprint_list: was_read(loaded.sprint_list()),
                 graph: was_read(loaded.graph()),
                 boards: Vec::new(),
                 columns: Vec::new(),
@@ -85,9 +82,6 @@ impl InvalidationPlan {
 fn build_entities_round(ids: &EntityIds, loaded: &dyn LoadedState) -> FetchRound {
     FetchRound {
         board_list: (!ids.boards.is_empty() || ids.prefixes) && was_read(loaded.board_list()),
-        column_list: !ids.columns.is_empty() && was_read(loaded.column_list()),
-        card_list: !ids.cards.is_empty() && was_read(loaded.card_list()),
-        sprint_list: !ids.sprints.is_empty() && was_read(loaded.sprint_list()),
         graph: ids.graph && was_read(loaded.graph()),
         boards: already_read(&ids.boards, |id| loaded.board(id)),
         columns: already_read(&ids.columns, |id| loaded.column(id)),
@@ -110,13 +104,12 @@ impl FetchPlan for InvalidationPlan {
     /// defect this type exists to close, so a new tier must break the build
     /// here. Never repair such a break with `..Default::default()`; that
     /// trades the compile error for the silent gap. Add the field by name
-    /// and decide it.
+    /// and decide it. The same holds in reverse: retiring a tier removes its
+    /// named field from all three literals rather than leaving it to
+    /// `..Default::default()`.
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         FetchRound {
             board_list: self.round.board_list && requestable(loaded.board_list()),
-            column_list: self.round.column_list && requestable(loaded.column_list()),
-            card_list: self.round.card_list && requestable(loaded.card_list()),
-            sprint_list: self.round.sprint_list && requestable(loaded.sprint_list()),
             graph: self.round.graph && requestable(loaded.graph()),
             boards: outstanding(&self.round.boards, |id| loaded.board(id)),
             columns: outstanding(&self.round.columns, |id| loaded.column(id)),

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -11,9 +11,6 @@ use super::*;
 
 struct StubWorld {
     board_list: FetchStatus,
-    column_list: FetchStatus,
-    card_list: FetchStatus,
-    sprint_list: FetchStatus,
     graph: FetchStatus,
     boards: HashMap<Uuid, FetchStatus>,
     columns: HashMap<Uuid, FetchStatus>,
@@ -31,9 +28,6 @@ impl Default for StubWorld {
     fn default() -> Self {
         StubWorld {
             board_list: FetchStatus::NotLoaded,
-            column_list: FetchStatus::NotLoaded,
-            card_list: FetchStatus::NotLoaded,
-            sprint_list: FetchStatus::NotLoaded,
             graph: FetchStatus::NotLoaded,
             boards: HashMap::new(),
             columns: HashMap::new(),
@@ -52,15 +46,6 @@ impl Default for StubWorld {
 impl LoadedState for StubWorld {
     fn board_list(&self) -> FetchStatus {
         self.board_list
-    }
-    fn column_list(&self) -> FetchStatus {
-        self.column_list
-    }
-    fn card_list(&self) -> FetchStatus {
-        self.card_list
-    }
-    fn sprint_list(&self) -> FetchStatus {
-        self.sprint_list
     }
     fn graph(&self) -> FetchStatus {
         self.graph
@@ -145,9 +130,6 @@ impl LoadedEntities for StubWorld {
 fn all_loaded() -> StubWorld {
     StubWorld {
         board_list: FetchStatus::Loaded,
-        column_list: FetchStatus::Loaded,
-        card_list: FetchStatus::Loaded,
-        sprint_list: FetchStatus::Loaded,
         graph: FetchStatus::Loaded,
         boards: HashMap::new(),
         columns: HashMap::new(),
@@ -189,26 +171,7 @@ fn test_an_invalidated_card_that_was_loaded_is_requested_by_id() {
     assert!(plan.round().columns.is_empty());
     assert!(plan.round().sprints.is_empty());
     assert!(!plan.round().board_list);
-    assert!(!plan.round().column_list);
-    assert!(!plan.round().card_list);
-    assert!(!plan.round().sprint_list);
     assert!(!plan.round().graph);
-}
-
-#[test]
-fn test_a_loaded_card_list_is_re_requested_when_any_card_is_invalidated() {
-    let a = Uuid::new_v4();
-    let world = StubWorld {
-        card_list: FetchStatus::Loaded,
-        ..Default::default()
-    };
-
-    let plan =
-        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
-            .expect("card_list was loaded");
-
-    assert!(plan.round().card_list);
-    assert!(plan.round().cards.is_empty());
 }
 
 #[test]
@@ -248,9 +211,6 @@ fn test_a_prefix_only_invalidation_re_requests_a_loaded_board_list() {
     assert!(plan.round().cards.is_empty());
     assert!(plan.round().sprints.is_empty());
     assert!(!plan.round().graph);
-    assert!(!plan.round().column_list);
-    assert!(!plan.round().card_list);
-    assert!(!plan.round().sprint_list);
 }
 
 #[test]
@@ -306,18 +266,18 @@ fn test_only_the_loaded_ids_of_a_mixed_invalidation_are_requested() {
 }
 
 #[test]
-fn test_a_failed_card_list_is_still_re_requested_because_it_was_read() {
-    let a = Uuid::new_v4();
+fn test_a_failed_board_list_is_still_re_requested_because_it_was_read() {
+    let b = Uuid::new_v4();
     let world = StubWorld {
-        card_list: FetchStatus::Failed,
+        board_list: FetchStatus::Failed,
         ..Default::default()
     };
 
     let plan =
-        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::cards([a])), &world)
-            .expect("card_list was read, even though it failed");
+        InvalidationPlan::for_invalidation(&Invalidation::Entities(EntityIds::boards([b])), &world)
+            .expect("board_list was read, even though it failed");
 
-    assert!(plan.round().card_list);
+    assert!(plan.round().board_list);
 }
 
 #[test]
@@ -434,20 +394,17 @@ fn test_empty_entities_invalidation_plans_nothing_and_wipes_nothing() {
     let _ = model.invalidate(inv);
 
     assert_eq!(LoadedState::board_list(&model), FetchStatus::Loaded);
-    assert_eq!(LoadedState::column_list(&model), FetchStatus::Loaded);
-    assert_eq!(LoadedState::card_list(&model), FetchStatus::Loaded);
-    assert_eq!(LoadedState::sprint_list(&model), FetchStatus::Loaded);
+    assert!(model.columns_state().is_loaded());
+    assert!(model.cards_state().is_loaded());
+    assert!(model.sprints_state().is_loaded());
     assert_eq!(LoadedState::graph(&model), FetchStatus::Loaded);
     assert_eq!(LoadedState::column(&model, column.id), FetchStatus::Loaded);
 }
 
 #[test]
-fn test_all_repairs_every_read_tier_including_the_archival_markers() {
+fn test_invalidation_plan_for_all_re_requests_every_surviving_tier_that_was_read() {
     let world = StubWorld {
         board_list: FetchStatus::Loaded,
-        column_list: FetchStatus::Loaded,
-        card_list: FetchStatus::Loaded,
-        sprint_list: FetchStatus::Loaded,
         graph: FetchStatus::Loaded,
         archived_card_list: FetchStatus::Loaded,
         archived_board_list: FetchStatus::Loaded,
@@ -459,9 +416,6 @@ fn test_all_repairs_every_read_tier_including_the_archival_markers() {
 
     let round = plan.round();
     assert!(round.board_list);
-    assert!(round.column_list);
-    assert!(round.card_list);
-    assert!(round.sprint_list);
     assert!(round.graph);
     assert!(round.archived_card_list);
     assert!(round.archived_board_list);
@@ -611,4 +565,56 @@ fn all_loaded_with_cards(ids: &[Uuid]) -> StubWorld {
         cards: ids.iter().map(|id| (*id, FetchStatus::Loaded)).collect(),
         ..all_loaded()
     }
+}
+
+#[test]
+fn test_invalidate_all_over_seeded_flat_collections_issues_no_flat_list_read() {
+    let board = Board::new("B", None::<String>);
+    let column = Column::new(board.id, "A", 0);
+    let card = Card::new(board.id, column.id, "task", 0);
+    let sprint = Sprint::new(board.id, 1, None, None::<String>);
+
+    let mut model = Model::default();
+    let changed = model.apply_resolved(Resolved {
+        boards: Collection {
+            all: LoadState::Loaded(vec![board.clone()]),
+            ..Default::default()
+        },
+        columns: Collection {
+            all: LoadState::Loaded(vec![]),
+            ..Default::default()
+        },
+        cards: Collection {
+            all: LoadState::Loaded(vec![card.clone()]),
+            ..Default::default()
+        },
+        sprints: Collection {
+            all: LoadState::Loaded(vec![]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    NoProjections.resync(&model, changed);
+
+    let plan = InvalidationPlan::for_invalidation(&Invalidation::All, &model)
+        .expect("board_list and flat collections were loaded");
+    let _ = model.invalidate(Invalidation::All);
+
+    let store = crate::read_recorder::RecordingStore::new();
+    kanban_domain::DataStore::upsert_board(&store, board.clone()).unwrap();
+    kanban_domain::DataStore::upsert_column(&store, column.clone()).unwrap();
+    kanban_domain::DataStore::upsert_card(&store, card.clone()).unwrap();
+    kanban_domain::DataStore::upsert_sprint(&store, sprint.clone()).unwrap();
+
+    crate::resolve::resolve(&plan, &model, &store);
+
+    let ops = store.ops();
+    let ops = ops.lock().unwrap();
+    assert!(
+        !ops.iter().any(|op| matches!(
+            op.method,
+            "list_all_columns" | "list_all_cards" | "list_all_sprints"
+        )),
+        "no plan may drive a whole-workspace list read; ops were: {ops:?}"
+    );
 }

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -14,18 +14,6 @@ impl LoadedState for Model {
         self.boards_state().into()
     }
 
-    fn column_list(&self) -> FetchStatus {
-        self.columns_state().into()
-    }
-
-    fn card_list(&self) -> FetchStatus {
-        self.cards_state().into()
-    }
-
-    fn sprint_list(&self) -> FetchStatus {
-        self.sprints_state().into()
-    }
-
     fn graph(&self) -> FetchStatus {
         self.graph_state().into()
     }
@@ -146,7 +134,7 @@ mod tests {
         let mut model = Model::default();
         model.set_cards_of_column(column_id, LoadState::Loaded(vec![card]));
 
-        assert_eq!(LoadedState::card_list(&model), FetchStatus::NotLoaded);
+        assert_eq!(LoadedState::board_list(&model), FetchStatus::NotLoaded);
         assert_eq!(
             LoadedState::cards_of_column(&model, column_id),
             FetchStatus::Loaded

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -22,15 +22,6 @@ impl LoadedState for Overlay<'_> {
     fn board_list(&self) -> FetchStatus {
         overlay_status(&self.pass.boards.all, self.base.board_list())
     }
-    fn column_list(&self) -> FetchStatus {
-        overlay_status(&self.pass.columns.all, self.base.column_list())
-    }
-    fn card_list(&self) -> FetchStatus {
-        overlay_status(&self.pass.cards.all, self.base.card_list())
-    }
-    fn sprint_list(&self) -> FetchStatus {
-        overlay_status(&self.pass.sprints.all, self.base.sprint_list())
-    }
     fn graph(&self) -> FetchStatus {
         overlay_status(&self.pass.graph, self.base.graph())
     }
@@ -143,9 +134,6 @@ impl LoadedEntities for Overlay<'_> {
 #[derive(Default)]
 struct Fetched {
     board_list: bool,
-    column_list: bool,
-    card_list: bool,
-    sprint_list: bool,
     graph: bool,
     boards: HashSet<Uuid>,
     columns: HashSet<Uuid>,
@@ -162,9 +150,6 @@ struct Fetched {
 impl Fetched {
     fn record(&mut self, round: &FetchRound) {
         self.board_list |= round.board_list;
-        self.column_list |= round.column_list;
-        self.card_list |= round.card_list;
-        self.sprint_list |= round.sprint_list;
         self.graph |= round.graph;
         self.boards.extend(round.boards.iter().copied());
         self.columns.extend(round.columns.iter().copied());
@@ -207,9 +192,6 @@ fn narrow_to_outstanding(
 ) -> FetchRound {
     FetchRound {
         board_list: round.board_list && !fetched.board_list,
-        column_list: round.column_list && !fetched.column_list,
-        card_list: round.card_list && !fetched.card_list,
-        sprint_list: round.sprint_list && !fetched.sprint_list,
         graph: round.graph && !fetched.graph,
         boards: outstanding(round.boards, &fetched.boards, |id| loaded.board(id)),
         columns: outstanding(round.columns, &fetched.columns, |id| loaded.column(id)),
@@ -230,24 +212,6 @@ fn narrow_to_outstanding(
 fn fetch_round(round: &FetchRound, store: &dyn DataStore, resolved: &mut Resolved) {
     if round.board_list {
         resolved.boards.all = match store.list_boards() {
-            Ok(v) => LoadState::Loaded(v),
-            Err(e) => LoadState::Failed(Arc::new(e)),
-        };
-    }
-    if round.column_list {
-        resolved.columns.all = match store.list_all_columns() {
-            Ok(v) => LoadState::Loaded(v),
-            Err(e) => LoadState::Failed(Arc::new(e)),
-        };
-    }
-    if round.card_list {
-        resolved.cards.all = match store.list_all_cards() {
-            Ok(v) => LoadState::Loaded(v),
-            Err(e) => LoadState::Failed(Arc::new(e)),
-        };
-    }
-    if round.sprint_list {
-        resolved.sprints.all = match store.list_all_sprints() {
             Ok(v) => LoadState::Loaded(v),
             Err(e) => LoadState::Failed(Arc::new(e)),
         };

--- a/crates/kanban-service/src/resolve/tests/archived.rs
+++ b/crates/kanban-service/src/resolve/tests/archived.rs
@@ -107,19 +107,19 @@ fn test_an_unrequested_archived_tier_stays_not_loaded() {
 
     let loaded = StubLoaded::default();
     let plan = FixedPlan(FetchRound {
-        card_list: true,
+        cards_by_column: vec![column.id],
         ..Default::default()
     });
 
     let resolved = resolve(&plan, &loaded, &store);
 
-    assert!(resolved.cards.all.is_loaded());
+    assert!(resolved.cards.by_parent[&column.id].is_loaded());
     assert!(resolved.archived_cards.is_untouched());
     assert_ops(
         &store.ops(),
         &[ReadOp {
-            method: "list_all_cards",
-            ids: vec![],
+            method: "list_cards_by_column",
+            ids: vec![column.id],
         }],
     );
 }

--- a/crates/kanban-service/src/resolve/tests/mod.rs
+++ b/crates/kanban-service/src/resolve/tests/mod.rs
@@ -38,15 +38,6 @@ impl LoadedStateTrait for StubLoaded {
     fn board_list(&self) -> FetchStatus {
         (&self.boards.all).into()
     }
-    fn column_list(&self) -> FetchStatus {
-        (&self.columns.all).into()
-    }
-    fn card_list(&self) -> FetchStatus {
-        (&self.cards.all).into()
-    }
-    fn sprint_list(&self) -> FetchStatus {
-        (&self.sprints.all).into()
-    }
     fn graph(&self) -> FetchStatus {
         (&self.graph).into()
     }
@@ -372,15 +363,16 @@ impl FetchPlan for StickyThenNextPlan {
     }
 }
 
-pub(super) struct CardListThenCardPlan {
+pub(super) struct CardsByColumnThenCardPlan {
+    pub column_id: Uuid,
     pub card_id: Uuid,
 }
 
-impl FetchPlan for CardListThenCardPlan {
+impl FetchPlan for CardsByColumnThenCardPlan {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
-        if requestable(loaded.card_list()) {
+        if requestable(loaded.cards_of_column(self.column_id)) {
             FetchRound {
-                card_list: true,
+                cards_by_column: vec![self.column_id],
                 ..Default::default()
             }
         } else if requestable(loaded.card(self.card_id)) {
@@ -467,9 +459,6 @@ impl FetchPlan for ArchivedByBoardPlan {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct Observed {
     pub board_list: FetchStatus,
-    pub column_list: FetchStatus,
-    pub card_list: FetchStatus,
-    pub sprint_list: FetchStatus,
     pub graph: FetchStatus,
     pub column: FetchStatus,
     pub card: FetchStatus,
@@ -515,9 +504,6 @@ impl FetchPlan for ProbePlan {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         self.seen.borrow_mut().push(Observed {
             board_list: loaded.board_list(),
-            column_list: loaded.column_list(),
-            card_list: loaded.card_list(),
-            sprint_list: loaded.sprint_list(),
             graph: loaded.graph(),
             column: loaded.column(self.column_id),
             card: loaded.card(self.card_id),

--- a/crates/kanban-service/src/resolve/tests/multi_round.rs
+++ b/crates/kanban-service/src/resolve/tests/multi_round.rs
@@ -2,7 +2,7 @@ use crate::fetch_plan::FetchRound;
 use uuid::Uuid;
 
 use super::{
-    seed_board_with_column, seed_card, store, CardListThenCardPlan, CardsByIdPlan, ChainPlan,
+    seed_board_with_column, seed_card, store, CardsByColumnThenCardPlan, CardsByIdPlan, ChainPlan,
     FixedPlan, GraphThenCardPlan, StickyThenNextPlan, StubLoaded,
 };
 use crate::read_recorder::{assert_ops, ReadOp};
@@ -176,7 +176,10 @@ fn test_a_later_round_does_not_clobber_a_collection_loaded_by_an_earlier_round()
     let (board, column) = seed_board_with_column(&store);
     let card = seed_card(&store, &board, &column, "a");
     let loaded = StubLoaded::default();
-    let plan = CardListThenCardPlan { card_id: card.id };
+    let plan = CardsByColumnThenCardPlan {
+        column_id: column.id,
+        card_id: card.id,
+    };
 
     let resolved = resolve(&plan, &loaded, &store);
 
@@ -184,8 +187,8 @@ fn test_a_later_round_does_not_clobber_a_collection_loaded_by_an_earlier_round()
         &store.ops(),
         &[
             ReadOp {
-                method: "list_all_cards",
-                ids: vec![],
+                method: "list_cards_by_column",
+                ids: vec![column.id],
             },
             ReadOp {
                 method: "get_card",
@@ -193,8 +196,11 @@ fn test_a_later_round_does_not_clobber_a_collection_loaded_by_an_earlier_round()
             },
         ],
     );
-    assert!(resolved.cards.all.is_loaded());
-    assert_eq!(resolved.cards.all.loaded().unwrap().len(), 1);
+    assert!(resolved.cards.by_parent[&column.id].is_loaded());
+    assert_eq!(
+        resolved.cards.by_parent[&column.id].loaded().unwrap().len(),
+        1
+    );
     assert!(resolved.cards.by_id[&card.id].is_loaded());
 }
 

--- a/crates/kanban-service/src/resolve/tests/overlay.rs
+++ b/crates/kanban-service/src/resolve/tests/overlay.rs
@@ -63,13 +63,13 @@ fn test_a_scope_discovered_from_an_earlier_round_resolves_in_the_same_call() {
 fn test_the_overlay_reports_the_pass_over_the_base() {
     let base = StubLoaded::default();
     let mut resolved = Resolved::default();
-    resolved.cards.all = LoadState::Loaded(vec![]);
+    resolved.boards.all = LoadState::Loaded(vec![]);
     let overlay = Overlay {
         base: &base,
         pass: &resolved,
     };
 
-    assert_eq!(overlay.card_list(), FetchStatus::Loaded);
+    assert_eq!(overlay.board_list(), FetchStatus::Loaded);
 }
 
 #[test]
@@ -139,9 +139,6 @@ fn test_an_empty_base_and_empty_pass_project_every_dimension_as_not_loaded() {
 
     let observed = plan.last();
     assert_eq!(observed.board_list, FetchStatus::NotLoaded);
-    assert_eq!(observed.column_list, FetchStatus::NotLoaded);
-    assert_eq!(observed.card_list, FetchStatus::NotLoaded);
-    assert_eq!(observed.sprint_list, FetchStatus::NotLoaded);
     assert_eq!(observed.graph, FetchStatus::NotLoaded);
     assert_eq!(observed.column, FetchStatus::NotLoaded);
     assert_eq!(observed.card, FetchStatus::NotLoaded);

--- a/crates/kanban-service/src/resolve/tests/resolve.rs
+++ b/crates/kanban-service/src/resolve/tests/resolve.rs
@@ -33,32 +33,14 @@ fn test_resolve_for_a_board_list_need_issues_exactly_one_list_boards_read() {
 }
 
 #[test]
-fn test_resolve_of_a_whole_collection_need_populates_all_not_just_by_id() {
-    let store = store();
-    let (board, column) = seed_board_with_column(&store);
-    seed_card(&store, &board, &column, "a");
-    let loaded = StubLoaded::default();
-    let plan = FixedPlan(FetchRound {
-        card_list: true,
-        ..Default::default()
-    });
-
-    let resolved = resolve(&plan, &loaded, &store);
-
-    assert!(resolved.cards.all.is_loaded());
-    assert_eq!(resolved.cards.all.loaded().unwrap().len(), 1);
-    assert!(resolved.cards.by_id.is_empty());
-}
-
-#[test]
-fn test_resolve_of_column_sprint_and_graph_list_needs_populates_the_returned_all_tier() {
+fn test_resolve_of_columns_sprints_and_graph_scoped_needs_populates_the_returned_scoped_tier() {
     let store = store();
     let (board, column) = seed_board_with_column(&store);
     let sprint = seed_sprint(&store, &board);
     let loaded = StubLoaded::default();
     let plan = FixedPlan(FetchRound {
-        column_list: true,
-        sprint_list: true,
+        columns_by_board: vec![board.id],
+        sprints_by_board: vec![board.id],
         graph: true,
         ..Default::default()
     });
@@ -68,37 +50,22 @@ fn test_resolve_of_column_sprint_and_graph_list_needs_populates_the_returned_all
     assert_eq!(
         resolved
             .columns
-            .all
-            .loaded()
+            .by_parent
+            .get(&board.id)
+            .and_then(|s| s.loaded())
             .map(|c| c.iter().map(|c| c.id).collect::<Vec<_>>()),
         Some(vec![column.id])
     );
     assert_eq!(
         resolved
             .sprints
-            .all
-            .loaded()
+            .by_parent
+            .get(&board.id)
+            .and_then(|s| s.loaded())
             .map(|s| s.iter().map(|s| s.id).collect::<Vec<_>>()),
         Some(vec![sprint.id])
     );
     assert!(resolved.graph.is_loaded());
-}
-
-#[test]
-fn test_resolve_of_a_genuinely_empty_card_list_is_loaded_not_not_loaded() {
-    let store = store();
-    let loaded = StubLoaded::default();
-    let plan = FixedPlan(FetchRound {
-        card_list: true,
-        ..Default::default()
-    });
-
-    let resolved = resolve(&plan, &loaded, &store);
-
-    assert!(resolved.cards.all.is_loaded());
-    assert!(resolved.cards.all.loaded().unwrap().is_empty());
-    assert!(!resolved.cards.all.is_not_loaded());
-    assert!(!resolved.cards.is_untouched());
 }
 
 #[test]
@@ -256,14 +223,14 @@ fn test_a_loaded_card_collection_does_not_report_an_unfetched_card_id_as_loaded(
     let a = seed_card(&store, &board, &column, "a");
     let mut loaded = StubLoaded::default();
     let plan = FixedPlan(FetchRound {
-        card_list: true,
+        cards_by_column: vec![column.id],
         ..Default::default()
     });
 
     let resolved = resolve(&plan, &loaded, &store);
     loaded.apply(resolved);
 
-    assert!(loaded.card_list_state().is_loaded());
+    assert!(loaded.cards.by_parent[&column.id].is_loaded());
     assert!(loaded.card_state(a.id).is_not_loaded());
 }
 

--- a/crates/kanban-service/src/resolve/tests/result_mapping.rs
+++ b/crates/kanban-service/src/resolve/tests/result_mapping.rs
@@ -6,55 +6,68 @@ use crate::resolve::resolve;
 
 #[test]
 fn test_a_failing_list_read_is_failed_not_a_loaded_empty_collection() {
-    for (method, round) in [
-        (
-            "list_boards",
-            FetchRound {
-                board_list: true,
-                ..Default::default()
-            },
-        ),
-        (
-            "list_all_columns",
-            FetchRound {
-                column_list: true,
-                ..Default::default()
-            },
-        ),
-        (
-            "list_all_cards",
-            FetchRound {
-                card_list: true,
-                ..Default::default()
-            },
-        ),
-        (
-            "list_all_sprints",
-            FetchRound {
-                sprint_list: true,
-                ..Default::default()
-            },
-        ),
-    ] {
-        let store = store();
-        seed_board_with_column(&store);
-        store.fail_method(method);
-        let loaded = StubLoaded::default();
+    let store = store();
+    let (board, column) = seed_board_with_column(&store);
+    let loaded = StubLoaded::default();
 
-        let resolved = resolve(&FixedPlan(round), &loaded, &store);
+    store.fail_method("list_boards");
+    let resolved = resolve(
+        &FixedPlan(FetchRound {
+            board_list: true,
+            ..Default::default()
+        }),
+        &loaded,
+        &store,
+    );
+    assert!(
+        resolved.boards.all.is_failed(),
+        "list_boards: returned tier must be Failed, not Loaded(empty)"
+    );
+    store.clear_failures();
 
-        let returned = match method {
-            "list_boards" => resolved.boards.all.is_failed(),
-            "list_all_columns" => resolved.columns.all.is_failed(),
-            "list_all_cards" => resolved.cards.all.is_failed(),
-            _ => resolved.sprints.all.is_failed(),
-        };
+    store.fail_method("list_columns_by_board");
+    let resolved = resolve(
+        &FixedPlan(FetchRound {
+            columns_by_board: vec![board.id],
+            ..Default::default()
+        }),
+        &loaded,
+        &store,
+    );
+    assert!(
+        resolved.columns.by_parent[&board.id].is_failed(),
+        "list_columns_by_board: returned tier must be Failed, not Loaded(empty)"
+    );
+    store.clear_failures();
 
-        assert!(
-            returned,
-            "{method}: returned tier must be Failed, not Loaded(empty)"
-        );
-    }
+    store.fail_method("list_cards_by_column");
+    let resolved = resolve(
+        &FixedPlan(FetchRound {
+            cards_by_column: vec![column.id],
+            ..Default::default()
+        }),
+        &loaded,
+        &store,
+    );
+    assert!(
+        resolved.cards.by_parent[&column.id].is_failed(),
+        "list_cards_by_column: returned tier must be Failed, not Loaded(empty)"
+    );
+    store.clear_failures();
+
+    store.fail_method("list_sprints_by_board");
+    let resolved = resolve(
+        &FixedPlan(FetchRound {
+            sprints_by_board: vec![board.id],
+            ..Default::default()
+        }),
+        &loaded,
+        &store,
+    );
+    assert!(
+        resolved.sprints.by_parent[&board.id].is_failed(),
+        "list_sprints_by_board: returned tier must be Failed, not Loaded(empty)"
+    );
 }
 
 #[test]

--- a/crates/kanban-service/src/resolve/tests/scoped.rs
+++ b/crates/kanban-service/src/resolve/tests/scoped.rs
@@ -190,23 +190,6 @@ fn test_a_scoped_fetch_leaves_the_list_and_id_tiers_untouched() {
 }
 
 #[test]
-fn test_a_whole_list_fetch_leaves_the_scoped_tier_untouched() {
-    let store = store();
-    let (board, column) = seed_board_with_column(&store);
-    seed_card(&store, &board, &column, "a");
-    let loaded = StubLoaded::default();
-    let plan = FixedPlan(FetchRound {
-        card_list: true,
-        ..Default::default()
-    });
-
-    let resolved = resolve(&plan, &loaded, &store);
-
-    assert!(resolved.cards.all.is_loaded());
-    assert!(resolved.cards.by_parent.is_empty());
-}
-
-#[test]
 fn test_a_loaded_scope_is_refetched_by_a_later_resolve_call() {
     let store = store();
     let (board, column) = seed_board_with_column(&store);

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -138,7 +138,7 @@ pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &
         .unwrap();
 
     let plan_with_list = StaticPlan(FetchRound {
-        card_list: true,
+        cards_by_column: vec![column.id],
         cards: vec![card.id],
         ..Default::default()
     });
@@ -152,17 +152,19 @@ pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &
         .is_loaded());
     apply(&mut model, resolved);
     assert!(model.card_by_id_state(card.id).is_loaded());
-    let cards = model.cards_state().loaded().expect("card list loaded");
+    let scope = model.column_cards_state(column.id);
+    let cards = scope.loaded().expect("column's card scope loaded");
     assert!(cards.iter().any(|c| c.id == card.id));
 
     let _invalidation = ctx.delete_card_impl(card.id).unwrap();
 
-    let plan_by_id_only = StaticPlan(FetchRound {
+    let plan_after_delete = StaticPlan(FetchRound {
+        cards_by_column: vec![column.id],
         cards: vec![card.id],
         ..Default::default()
     });
 
-    let resolved2 = ctx.resolve(&plan_by_id_only, &model);
+    let resolved2 = ctx.resolve(&plan_after_delete, &model);
     assert!(resolved2
         .cards
         .by_id
@@ -171,10 +173,10 @@ pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &
         .is_missing());
     apply(&mut model, resolved2);
     assert!(model.card_by_id_state(card.id).is_missing());
-    let cards = model
-        .cards_state()
+    let scope = model.column_cards_state(column.id);
+    let cards = scope
         .loaded()
-        .expect("card list still loaded after the delete");
+        .expect("column's card scope still loaded after the delete");
     assert!(!cards.iter().any(|c| c.id == card.id));
 }
 
@@ -217,32 +219,7 @@ pub async fn test_a_backend_read_error_resolves_failed_not_missing(factory: Back
     assert!(!state.is_missing());
 }
 
-pub async fn test_a_backend_list_error_resolves_the_list_failed_not_empty(factory: BackendFactory) {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("test.store");
-    let (factory, handles) = faultable(factory);
-    let backend = factory(&path);
-    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
-    let ctx = KanbanContext::open(backend, AppConfig::default())
-        .await
-        .unwrap();
-    let model = Model::default();
-
-    handle.fail("list_all_cards");
-
-    let resolved = ctx.resolve(
-        &StaticPlan(FetchRound {
-            card_list: true,
-            ..Default::default()
-        }),
-        &model,
-    );
-
-    assert!(resolved.cards.all.is_failed());
-    assert!(!resolved.cards.all.is_loaded());
-}
-
-pub async fn test_a_backend_list_error_resolves_the_column_list_failed_not_empty(
+pub async fn test_a_backend_scoped_card_list_error_resolves_failed_not_empty(
     factory: BackendFactory,
 ) {
     let dir = TempDir::new().unwrap();
@@ -250,26 +227,36 @@ pub async fn test_a_backend_list_error_resolves_the_column_list_failed_not_empty
     let (factory, handles) = faultable(factory);
     let backend = factory(&path);
     let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
-    let ctx = KanbanContext::open(backend, AppConfig::default())
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
         .await
         .unwrap();
     let model = Model::default();
 
-    handle.fail("list_all_columns");
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let column = ctx.create_column(board.id, "Col".into(), None).unwrap();
+
+    handle.fail("list_cards_by_column");
 
     let resolved = ctx.resolve(
         &StaticPlan(FetchRound {
-            column_list: true,
+            cards_by_column: vec![column.id],
             ..Default::default()
         }),
         &model,
     );
 
-    assert!(resolved.columns.all.is_failed());
-    assert!(!resolved.columns.all.is_loaded());
+    let state = resolved
+        .cards
+        .by_parent
+        .get(&column.id)
+        .expect("column scope requested");
+    assert!(state.is_failed());
+    assert!(!state.is_loaded());
 }
 
-pub async fn test_a_backend_list_error_resolves_the_sprint_list_failed_not_empty(
+pub async fn test_a_backend_scoped_column_list_error_resolves_failed_not_empty(
     factory: BackendFactory,
 ) {
     let dir = TempDir::new().unwrap();
@@ -277,23 +264,68 @@ pub async fn test_a_backend_list_error_resolves_the_sprint_list_failed_not_empty
     let (factory, handles) = faultable(factory);
     let backend = factory(&path);
     let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
-    let ctx = KanbanContext::open(backend, AppConfig::default())
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
         .await
         .unwrap();
     let model = Model::default();
 
-    handle.fail("list_all_sprints");
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+
+    handle.fail("list_columns_by_board");
 
     let resolved = ctx.resolve(
         &StaticPlan(FetchRound {
-            sprint_list: true,
+            columns_by_board: vec![board.id],
             ..Default::default()
         }),
         &model,
     );
 
-    assert!(resolved.sprints.all.is_failed());
-    assert!(!resolved.sprints.all.is_loaded());
+    let state = resolved
+        .columns
+        .by_parent
+        .get(&board.id)
+        .expect("board scope requested");
+    assert!(state.is_failed());
+    assert!(!state.is_loaded());
+}
+
+pub async fn test_a_backend_scoped_sprint_list_error_resolves_failed_not_empty(
+    factory: BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let (factory, handles) = faultable(factory);
+    let backend = factory(&path);
+    let handle = handles.lock().unwrap()[&path].last().unwrap().clone();
+    let mut ctx = KanbanContext::open(backend, AppConfig::default())
+        .await
+        .unwrap();
+    let model = Model::default();
+
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+
+    handle.fail("list_sprints_by_board");
+
+    let resolved = ctx.resolve(
+        &StaticPlan(FetchRound {
+            sprints_by_board: vec![board.id],
+            ..Default::default()
+        }),
+        &model,
+    );
+
+    let state = resolved
+        .sprints
+        .by_parent
+        .get(&board.id)
+        .expect("board scope requested");
+    assert!(state.is_failed());
+    assert!(!state.is_loaded());
 }
 
 pub async fn test_a_failed_read_is_retried_on_the_next_resolve(factory: BackendFactory) {
@@ -797,7 +829,7 @@ pub async fn test_a_failed_scoped_read_is_failed_not_empty_on_every_backend(
     assert!(!state.is_loaded());
 }
 
-pub async fn test_a_card_resolved_by_id_matches_the_same_card_in_the_card_list(
+pub async fn test_a_card_resolved_by_id_matches_the_same_card_in_the_column_scope(
     factory: &BackendFactory,
 ) {
     let dir = TempDir::new().unwrap();
@@ -826,7 +858,7 @@ pub async fn test_a_card_resolved_by_id_matches_the_same_card_in_the_card_list(
 
     let resolved = ctx.resolve(
         &StaticPlan(FetchRound {
-            card_list: true,
+            cards_by_column: vec![column.id],
             cards: vec![card.id],
             ..Default::default()
         }),
@@ -840,18 +872,20 @@ pub async fn test_a_card_resolved_by_id_matches_the_same_card_in_the_card_list(
         .expect("card requested")
         .loaded()
         .expect("card loaded");
-    let in_list = resolved
+    let in_scope = resolved
         .cards
-        .all
+        .by_parent
+        .get(&column.id)
+        .expect("column scope requested")
         .loaded()
-        .expect("card list loaded")
+        .expect("column scope loaded")
         .iter()
         .find(|c| c.id == card.id)
-        .expect("card present in the resolved list");
-    assert_card_eq(by_id, in_list);
+        .expect("card present in the resolved column scope");
+    assert_card_eq(by_id, in_scope);
 }
 
-pub async fn test_a_column_resolved_by_id_matches_the_same_column_in_the_column_list(
+pub async fn test_a_column_resolved_by_id_matches_the_same_column_in_the_board_scope(
     factory: &BackendFactory,
 ) {
     let dir = TempDir::new().unwrap();
@@ -867,7 +901,7 @@ pub async fn test_a_column_resolved_by_id_matches_the_same_column_in_the_column_
 
     let resolved = ctx.resolve(
         &StaticPlan(FetchRound {
-            column_list: true,
+            columns_by_board: vec![board.id],
             columns: vec![column.id],
             ..Default::default()
         }),
@@ -881,26 +915,28 @@ pub async fn test_a_column_resolved_by_id_matches_the_same_column_in_the_column_
         .expect("column requested")
         .loaded()
         .expect("column loaded");
-    let in_list = resolved
+    let in_scope = resolved
         .columns
-        .all
+        .by_parent
+        .get(&board.id)
+        .expect("board scope requested")
         .loaded()
-        .expect("column list loaded")
+        .expect("board scope loaded")
         .iter()
         .find(|c| c.id == column.id)
-        .expect("column present in the resolved list");
-    assert_eq!(by_id.id, in_list.id, "column id");
-    assert_eq!(by_id.board_id, in_list.board_id, "column board_id");
-    assert_eq!(by_id.name, in_list.name, "column name");
-    assert_eq!(by_id.position, in_list.position, "column position");
-    assert_eq!(by_id.wip_limit, in_list.wip_limit, "column wip_limit");
+        .expect("column present in the resolved board scope");
+    assert_eq!(by_id.id, in_scope.id, "column id");
+    assert_eq!(by_id.board_id, in_scope.board_id, "column board_id");
+    assert_eq!(by_id.name, in_scope.name, "column name");
+    assert_eq!(by_id.position, in_scope.position, "column position");
+    assert_eq!(by_id.wip_limit, in_scope.wip_limit, "column wip_limit");
     assert_eq!(
-        by_id.default_status, in_list.default_status,
+        by_id.default_status, in_scope.default_status,
         "column default_status"
     );
 }
 
-pub async fn test_a_sprint_resolved_by_id_matches_the_same_sprint_in_the_sprint_list(
+pub async fn test_a_sprint_resolved_by_id_matches_the_same_sprint_in_the_board_scope(
     factory: &BackendFactory,
 ) {
     let dir = TempDir::new().unwrap();
@@ -918,7 +954,7 @@ pub async fn test_a_sprint_resolved_by_id_matches_the_same_sprint_in_the_sprint_
 
     let resolved = ctx.resolve(
         &StaticPlan(FetchRound {
-            sprint_list: true,
+            sprints_by_board: vec![board.id],
             sprints: vec![sprint.id],
             ..Default::default()
         }),
@@ -932,19 +968,21 @@ pub async fn test_a_sprint_resolved_by_id_matches_the_same_sprint_in_the_sprint_
         .expect("sprint requested")
         .loaded()
         .expect("sprint loaded");
-    let in_list = resolved
+    let in_scope = resolved
         .sprints
-        .all
+        .by_parent
+        .get(&board.id)
+        .expect("board scope requested")
         .loaded()
-        .expect("sprint list loaded")
+        .expect("board scope loaded")
         .iter()
         .find(|s| s.id == sprint.id)
-        .expect("sprint present in the resolved list");
-    assert_eq!(by_id.id, in_list.id, "sprint id");
-    assert_eq!(by_id.board_id, in_list.board_id, "sprint board_id");
-    assert_eq!(by_id.status, in_list.status, "sprint status");
-    assert_eq!(by_id.start_date, in_list.start_date, "sprint start_date");
-    assert_eq!(by_id.end_date, in_list.end_date, "sprint end_date");
+        .expect("sprint present in the resolved board scope");
+    assert_eq!(by_id.id, in_scope.id, "sprint id");
+    assert_eq!(by_id.board_id, in_scope.board_id, "sprint board_id");
+    assert_eq!(by_id.status, in_scope.status, "sprint status");
+    assert_eq!(by_id.start_date, in_scope.start_date, "sprint start_date");
+    assert_eq!(by_id.end_date, in_scope.end_date, "sprint end_date");
 }
 
 pub async fn test_an_archived_card_resolves_loaded_by_id_on_every_backend(
@@ -982,7 +1020,7 @@ pub async fn test_an_archived_card_resolves_loaded_by_id_on_every_backend(
     assert!(state.is_loaded());
 }
 
-pub async fn test_an_archived_card_is_absent_from_the_resolved_card_list_on_every_backend(
+pub async fn test_an_archived_card_is_absent_from_the_resolved_column_scope_on_every_backend(
     factory: &BackendFactory,
 ) {
     let dir = TempDir::new().unwrap();
@@ -1007,17 +1045,23 @@ pub async fn test_an_archived_card_is_absent_from_the_resolved_card_list_on_ever
 
     let resolved = ctx.resolve(
         &StaticPlan(FetchRound {
-            card_list: true,
+            cards_by_column: vec![column.id],
             ..Default::default()
         }),
         &Model::default(),
     );
 
-    let cards = resolved.cards.all.loaded().expect("card list loaded");
+    let cards = resolved
+        .cards
+        .by_parent
+        .get(&column.id)
+        .expect("column scope requested")
+        .loaded()
+        .expect("column scope loaded");
     assert!(!cards.iter().any(|c| c.id == card.id));
 }
 
-pub async fn test_a_restored_card_reappears_in_the_resolved_card_list(factory: &BackendFactory) {
+pub async fn test_a_restored_card_reappears_in_the_resolved_column_scope(factory: &BackendFactory) {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.store");
     let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
@@ -1054,7 +1098,7 @@ pub async fn test_a_restored_card_reappears_in_the_resolved_card_list(factory: &
     NoProjections.resync(&model, changed);
 
     let plan = StaticPlan(FetchRound {
-        card_list: true,
+        cards_by_column: vec![column.id],
         cards: vec![card.id],
         graph: true,
         ..Default::default()
@@ -1079,7 +1123,8 @@ pub async fn test_a_restored_card_reappears_in_the_resolved_card_list(factory: &
     let resolved = ctx.resolve(&plan, &model);
     apply(&mut model, resolved);
 
-    let after_list = model.cards_state().loaded().expect("card list loaded");
+    let scope = model.column_cards_state(column.id);
+    let after_list = scope.loaded().expect("column scope loaded");
     assert!(after_list.iter().any(|c| c.id == card.id));
     let after_state = model.card_by_id_state(card.id);
     let after = after_state.loaded().expect("card loaded after restore");
@@ -1117,7 +1162,7 @@ pub async fn test_a_deleted_then_undone_card_is_resolvable_again_on_every_backen
         .unwrap();
 
     let plan = StaticPlan(FetchRound {
-        card_list: true,
+        cards_by_column: vec![column.id],
         cards: vec![card.id],
         ..Default::default()
     });
@@ -1146,7 +1191,8 @@ pub async fn test_a_deleted_then_undone_card_is_resolvable_again_on_every_backen
         .copied()
         .expect("card resolvable again after undo");
     assert_card_eq(&before, after);
-    let list = model.cards_state().loaded().expect("card list loaded");
+    let scope = model.column_cards_state(column.id);
+    let list = scope.loaded().expect("column scope loaded");
     assert!(list.iter().any(|c| c.id == card.id));
 }
 
@@ -1473,26 +1519,29 @@ pub async fn test_invalidate_all_clears_every_collection_on_every_backend(
     let _ = ctx.block_impl(a.id, b.id, Severity::Low).unwrap();
 
     let plan = StaticPlan(FetchRound {
-        card_list: true,
-        column_list: true,
-        sprint_list: true,
+        board_list: true,
+        columns_by_board: vec![board.id],
+        cards_by_column: vec![column.id],
+        sprints_by_board: vec![board.id],
         cards: vec![a.id, b.id],
         graph: true,
         ..Default::default()
     });
     let resolved = ctx.resolve(&plan, &model);
     apply(&mut model, resolved);
-    assert!(model.cards_state().is_loaded());
-    assert!(model.columns_state().is_loaded());
-    assert!(model.sprints_state().is_loaded());
+    assert!(model.boards_state().is_loaded());
+    assert!(model.column_cards_state(column.id).is_loaded());
+    assert!(model.board_columns_state(board.id).is_loaded());
+    assert!(model.board_sprints_state(board.id).is_loaded());
     assert!(model.graph_state().is_loaded());
 
     let changed = model.invalidate(Invalidation::All);
     NoProjections.resync(&model, changed);
 
-    assert!(model.cards_state().is_not_loaded());
-    assert!(model.columns_state().is_not_loaded());
-    assert!(model.sprints_state().is_not_loaded());
+    assert!(model.boards_state().is_not_loaded());
+    assert!(model.column_cards_state(column.id).is_not_loaded());
+    assert!(model.board_columns_state(board.id).is_not_loaded());
+    assert!(model.board_sprints_state(board.id).is_not_loaded());
     assert!(model.graph_state().is_not_loaded());
 }
 

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -486,16 +486,16 @@ macro_rules! cache_contract_tests {
             $crate::test_helpers::contract::cache::test_a_backend_read_error_resolves_failed_not_missing($factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_a_backend_list_error_resolves_the_list_failed_not_empty() {
-            $crate::test_helpers::contract::cache::test_a_backend_list_error_resolves_the_list_failed_not_empty($factory_fn()).await;
+        async fn test_a_backend_scoped_card_list_error_resolves_failed_not_empty() {
+            $crate::test_helpers::contract::cache::test_a_backend_scoped_card_list_error_resolves_failed_not_empty($factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_a_backend_list_error_resolves_the_column_list_failed_not_empty() {
-            $crate::test_helpers::contract::cache::test_a_backend_list_error_resolves_the_column_list_failed_not_empty($factory_fn()).await;
+        async fn test_a_backend_scoped_column_list_error_resolves_failed_not_empty() {
+            $crate::test_helpers::contract::cache::test_a_backend_scoped_column_list_error_resolves_failed_not_empty($factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_a_backend_list_error_resolves_the_sprint_list_failed_not_empty() {
-            $crate::test_helpers::contract::cache::test_a_backend_list_error_resolves_the_sprint_list_failed_not_empty($factory_fn()).await;
+        async fn test_a_backend_scoped_sprint_list_error_resolves_failed_not_empty() {
+            $crate::test_helpers::contract::cache::test_a_backend_scoped_sprint_list_error_resolves_failed_not_empty($factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
         async fn test_a_failed_read_is_retried_on_the_next_resolve() {
@@ -530,28 +530,28 @@ macro_rules! cache_contract_tests {
             $crate::test_helpers::contract::cache::test_a_failed_scoped_read_is_failed_not_empty_on_every_backend($factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_a_card_resolved_by_id_matches_the_same_card_in_the_card_list() {
-            $crate::test_helpers::contract::cache::test_a_card_resolved_by_id_matches_the_same_card_in_the_card_list(&$factory_fn()).await;
+        async fn test_a_card_resolved_by_id_matches_the_same_card_in_the_column_scope() {
+            $crate::test_helpers::contract::cache::test_a_card_resolved_by_id_matches_the_same_card_in_the_column_scope(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_a_column_resolved_by_id_matches_the_same_column_in_the_column_list() {
-            $crate::test_helpers::contract::cache::test_a_column_resolved_by_id_matches_the_same_column_in_the_column_list(&$factory_fn()).await;
+        async fn test_a_column_resolved_by_id_matches_the_same_column_in_the_board_scope() {
+            $crate::test_helpers::contract::cache::test_a_column_resolved_by_id_matches_the_same_column_in_the_board_scope(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_a_sprint_resolved_by_id_matches_the_same_sprint_in_the_sprint_list() {
-            $crate::test_helpers::contract::cache::test_a_sprint_resolved_by_id_matches_the_same_sprint_in_the_sprint_list(&$factory_fn()).await;
+        async fn test_a_sprint_resolved_by_id_matches_the_same_sprint_in_the_board_scope() {
+            $crate::test_helpers::contract::cache::test_a_sprint_resolved_by_id_matches_the_same_sprint_in_the_board_scope(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
         async fn test_an_archived_card_resolves_loaded_by_id_on_every_backend() {
             $crate::test_helpers::contract::cache::test_an_archived_card_resolves_loaded_by_id_on_every_backend(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_an_archived_card_is_absent_from_the_resolved_card_list_on_every_backend() {
-            $crate::test_helpers::contract::cache::test_an_archived_card_is_absent_from_the_resolved_card_list_on_every_backend(&$factory_fn()).await;
+        async fn test_an_archived_card_is_absent_from_the_resolved_column_scope_on_every_backend() {
+            $crate::test_helpers::contract::cache::test_an_archived_card_is_absent_from_the_resolved_column_scope_on_every_backend(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
-        async fn test_a_restored_card_reappears_in_the_resolved_card_list() {
-            $crate::test_helpers::contract::cache::test_a_restored_card_reappears_in_the_resolved_card_list(&$factory_fn()).await;
+        async fn test_a_restored_card_reappears_in_the_resolved_column_scope() {
+            $crate::test_helpers::contract::cache::test_a_restored_card_reappears_in_the_resolved_column_scope(&$factory_fn()).await;
         }
         #[tokio::test(flavor = "multi_thread")]
         async fn test_a_deleted_then_undone_card_is_resolvable_again_on_every_backend() {

--- a/crates/kanban-service/tests/archived_bodies_fetch_parity.rs
+++ b/crates/kanban-service/tests/archived_bodies_fetch_parity.rs
@@ -18,7 +18,6 @@ struct ArchivedBodiesPlan {
 impl FetchPlan for ArchivedBodiesPlan {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         let mut round = FetchRound {
-            card_list: self.card_bodies && requestable(loaded.card_list()),
             board_list: self.board_bodies && requestable(loaded.board_list()),
             ..Default::default()
         };
@@ -115,11 +114,7 @@ fn assert_an_archived_card_body_is_fetchable_without_a_snapshot(ctx: &mut Kanban
     ctx.sync(&cards_plan(), &mut model, &mut NoProjections);
     ctx.sync(&cards_plan(), &mut model, &mut NoProjections);
 
-    assert!(model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .any(|c| c.id == card.id));
+    assert!(model.card_by_id_state(card.id).loaded().is_some());
     assert!(model.archived_card_ids().contains(&card.id));
 }
 
@@ -200,14 +195,8 @@ fn assert_a_card_mutation_keeps_every_other_archived_body_present(ctx: &mut Kanb
     ctx.resync_invalidated(inv, &cards_plan(), &mut model, &mut NoProjections);
     ctx.sync(&cards_plan(), &mut model, &mut NoProjections);
 
-    let present: Vec<Uuid> = model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .map(|c| c.id)
-        .collect();
-    assert!(present.contains(&a.id));
-    assert!(present.contains(&b.id));
+    assert!(model.card_by_id_state(a.id).loaded().is_some());
+    assert!(model.card_by_id_state(b.id).loaded().is_some());
 }
 
 fn assert_archive_then_restore_is_the_identity_over_the_card_and_its_partition(
@@ -229,24 +218,18 @@ fn assert_archive_then_restore_is_the_identity_over_the_card_and_its_partition(
     ctx.resync_invalidated(inv, &cards_plan(), &mut model, &mut NoProjections);
     ctx.sync(&cards_plan(), &mut model, &mut NoProjections);
 
-    assert!(model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .any(|c| c.id == card.id));
+    assert!(model.card_by_id_state(card.id).loaded().is_some());
     assert!(model.archived_card_ids().contains(&card.id));
 
     let (_card, inv) = ctx.restore_card_impl(card.id, None).unwrap();
     ctx.resync_invalidated(inv, &cards_plan(), &mut model, &mut NoProjections);
     ctx.sync(&cards_plan(), &mut model, &mut NoProjections);
 
-    let restored = model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .find(|c| c.id == card.id)
-        .unwrap()
-        .clone();
+    let restored = (*model
+        .card_by_id_state(card.id)
+        .loaded()
+        .expect("card resolvable again after restore"))
+    .clone();
     assert_eq!(restored.title, "task");
     assert_eq!(restored.column_id, column.id);
     assert!(!model.archived_card_ids().contains(&card.id));

--- a/crates/kanban-service/tests/resync_invalidated_backend_parity.rs
+++ b/crates/kanban-service/tests/resync_invalidated_backend_parity.rs
@@ -10,6 +10,8 @@ use tempfile::tempdir;
 use uuid::Uuid;
 
 struct WarmPlan {
+    board_id: Uuid,
+    column_id: Uuid,
     card_id: Uuid,
     sprint_id: Uuid,
 }
@@ -18,9 +20,21 @@ impl FetchPlan for WarmPlan {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         FetchRound {
             board_list: requestable(loaded.board_list()),
-            column_list: requestable(loaded.column_list()),
-            card_list: requestable(loaded.card_list()),
-            sprint_list: requestable(loaded.sprint_list()),
+            columns_by_board: if requestable(loaded.columns_of_board(self.board_id)) {
+                vec![self.board_id]
+            } else {
+                vec![]
+            },
+            cards_by_column: if requestable(loaded.cards_of_column(self.column_id)) {
+                vec![self.column_id]
+            } else {
+                vec![]
+            },
+            sprints_by_board: if requestable(loaded.sprints_of_board(self.board_id)) {
+                vec![self.board_id]
+            } else {
+                vec![]
+            },
             graph: requestable(loaded.graph()),
             cards: if requestable(loaded.card(self.card_id)) {
                 vec![self.card_id]
@@ -71,6 +85,8 @@ fn assert_resync_invalidated_returns_the_updated_graph(ctx: &mut KanbanContext) 
     let mut model = kanban_domain::Model::default();
     ctx.sync(
         &WarmPlan {
+            board_id: board.id,
+            column_id: column.id,
             card_id: card.id,
             sprint_id: sprint.id,
         },
@@ -78,9 +94,9 @@ fn assert_resync_invalidated_returns_the_updated_graph(ctx: &mut KanbanContext) 
         &mut NoProjections,
     );
     assert!(model.boards_state().is_loaded());
-    assert!(model.columns_state().is_loaded());
-    assert!(model.cards_state().is_loaded());
-    assert!(model.sprints_state().is_loaded());
+    assert!(model.board_columns_state(board.id).is_loaded());
+    assert!(model.column_cards_state(column.id).is_loaded());
+    assert!(model.board_sprints_state(board.id).is_loaded());
     assert!(model.graph_state().is_loaded());
     assert!(model.card_by_id_state(card.id).loaded().is_some());
     assert!(model.sprint_by_id_state(sprint.id).loaded().is_some());
@@ -121,32 +137,25 @@ fn assert_resync_invalidated_returns_the_updated_graph(ctx: &mut KanbanContext) 
         model.sprint_by_id_state(sprint.id).loaded().unwrap().prefix,
         Some("REN".into())
     );
-    assert!(model.cards_state().is_loaded());
-    assert!(model.sprints_state().is_loaded());
-
     assert!(model.boards_state().is_loaded());
     assert!(model
         .boards_state()
         .loaded_or_empty()
         .iter()
         .any(|b| b.id == board.id));
-    assert!(model.columns_state().is_loaded());
-    assert!(model
-        .columns_state()
-        .loaded_or_empty()
-        .iter()
-        .any(|c| c.id == column.id));
     assert!(model.graph_state().is_loaded());
 }
 
 fn assert_resync_invalidated_classifies_a_restored_card_as_live(ctx: &mut KanbanContext) {
-    let (_board, _column, card, sprint) = seed(ctx);
+    let (board, column, card, sprint) = seed(ctx);
 
     let _ = ctx.archive_card_impl(card.id).unwrap();
 
     let mut model = kanban_domain::Model::default();
     ctx.sync(
         &WarmPlan {
+            board_id: board.id,
+            column_id: column.id,
             card_id: card.id,
             sprint_id: sprint.id,
         },
@@ -166,11 +175,13 @@ fn assert_resync_invalidated_classifies_a_restored_card_as_live(ctx: &mut Kanban
 }
 
 fn assert_resync_invalidated_classifies_an_archived_board_as_archived(ctx: &mut KanbanContext) {
-    let (board, _column, card, sprint) = seed(ctx);
+    let (board, column, card, sprint) = seed(ctx);
 
     let mut model = kanban_domain::Model::default();
     ctx.sync(
         &WarmPlan {
+            board_id: board.id,
+            column_id: column.id,
             card_id: card.id,
             sprint_id: sprint.id,
         },

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -189,9 +189,6 @@ mod tests {
 
     struct StubLoaded {
         board_list: FetchStatus,
-        column_list: FetchStatus,
-        card_list: FetchStatus,
-        sprint_list: FetchStatus,
         graph: FetchStatus,
         card: FetchStatus,
         sprint: FetchStatus,
@@ -213,9 +210,6 @@ mod tests {
         fn default() -> Self {
             StubLoaded {
                 board_list: FetchStatus::NotLoaded,
-                column_list: FetchStatus::NotLoaded,
-                card_list: FetchStatus::NotLoaded,
-                sprint_list: FetchStatus::NotLoaded,
                 graph: FetchStatus::NotLoaded,
                 card: FetchStatus::NotLoaded,
                 sprint: FetchStatus::NotLoaded,
@@ -238,15 +232,6 @@ mod tests {
     impl kanban_service::LoadedState for StubLoaded {
         fn board_list(&self) -> FetchStatus {
             self.board_list
-        }
-        fn column_list(&self) -> FetchStatus {
-            self.column_list
-        }
-        fn card_list(&self) -> FetchStatus {
-            self.card_list
-        }
-        fn sprint_list(&self) -> FetchStatus {
-            self.sprint_list
         }
         fn graph(&self) -> FetchStatus {
             self.graph
@@ -387,9 +372,6 @@ mod tests {
         let c1 = Uuid::new_v4();
         let stub = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: FetchStatus::Failed,
-            card_list: FetchStatus::Failed,
-            sprint_list: FetchStatus::Failed,
             columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
             sprints_of_board: FetchStatus::Loaded,
             loaded_columns: HashMap::from([(board, vec![column(c1)])]),
@@ -414,9 +396,6 @@ mod tests {
         let board = Uuid::new_v4();
         let stub = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: FetchStatus::Loaded,
-            card_list: FetchStatus::Loaded,
-            sprint_list: FetchStatus::Loaded,
             graph: FetchStatus::Loaded,
             card: FetchStatus::Loaded,
             sprint: FetchStatus::Loaded,
@@ -451,9 +430,6 @@ mod tests {
         let board = Uuid::new_v4();
         let stub = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: FetchStatus::Loaded,
-            card_list: FetchStatus::Loaded,
-            sprint_list: FetchStatus::Loaded,
             columns_of_board: HashMap::from([(board, FetchStatus::Failed)]),
             ..StubLoaded::default()
         };
@@ -490,9 +466,6 @@ mod tests {
         let board = Uuid::new_v4();
         let stub = StubLoaded {
             board_list: FetchStatus::Loaded,
-            column_list: FetchStatus::Loaded,
-            card_list: FetchStatus::Loaded,
-            sprint_list: FetchStatus::Loaded,
             columns_of_board: HashMap::from([(board, FetchStatus::Loaded)]),
             sprints_of_board: FetchStatus::Loaded,
             loaded_columns: HashMap::from([(board, vec![])]),
@@ -525,9 +498,6 @@ mod tests {
 
         let round = scope.next_round(&stub);
         assert!(round.board_list);
-        assert!(!round.column_list);
-        assert!(!round.card_list);
-        assert!(!round.sprint_list);
         assert!(round.columns_by_board.is_empty());
         assert!(round.cards_by_column.is_empty());
         assert!(round.sprints_by_board.is_empty());
@@ -562,9 +532,6 @@ mod tests {
 
         let round = scope.next_round(&stub);
         assert!(round.board_list);
-        assert!(!round.column_list);
-        assert!(!round.card_list);
-        assert!(!round.sprint_list);
         assert!(round.columns_by_board.is_empty());
         assert!(round.cards_by_column.is_empty());
         assert!(round.sprints_by_board.is_empty());
@@ -642,7 +609,6 @@ mod tests {
         let round = scope.next_round(&stub);
         assert_eq!(round.cards, vec![m1]);
         assert!(!round.archived_card_list);
-        assert!(!round.card_list);
     }
 
     #[test]

--- a/crates/kanban-tui/tests/archived_board_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_board_parity_tests.rs
@@ -144,20 +144,15 @@ fn test_archived_board_sprints_view_reachable() {
     // The active board's sprints resolve archival-agnostically.
     let board = app.active_board().expect("archived board resolves");
     assert_eq!(board.id, board_id);
-    let sprint_count = app
-        .model
-        .sprints_state()
-        .loaded_or_empty()
-        .iter()
-        .filter(|s| s.board_id == board_id)
-        .count();
+    let sprints = app.model.board_sprints_state(board_id);
+    let sprint_count = sprints
+        .loaded()
+        .map(|s| s.iter().filter(|s| s.board_id == board_id).count())
+        .unwrap_or(0);
     assert_eq!(sprint_count, 1, "archived board's sprint is visible");
-    assert!(app
-        .model
-        .sprints_state()
-        .loaded_or_empty()
-        .iter()
-        .any(|s| s.id == sprint_id));
+    assert!(sprints
+        .loaded()
+        .is_some_and(|s| s.iter().any(|s| s.id == sprint_id)));
 }
 
 #[test]
@@ -176,11 +171,10 @@ fn test_archived_board_columns_resolve() {
     assert_eq!(board.id, board_id);
     let column_count = app
         .model
-        .columns_state()
-        .loaded_or_empty()
-        .iter()
-        .filter(|c| c.board_id == board_id)
-        .count();
+        .board_columns_state(board_id)
+        .loaded()
+        .map(|c| c.iter().filter(|c| c.board_id == board_id).count())
+        .unwrap_or(0);
     assert_eq!(column_count, 2, "archived board's columns are visible");
 }
 

--- a/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
@@ -482,10 +482,8 @@ fn test_move_selected_card_column_still_moves_when_the_column_tier_is_loaded() {
     app.reload_model();
     let moved_column = app
         .model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .find(|c| c.id == card_id)
+        .card_by_id_state(card_id)
+        .loaded()
         .map(|c| c.column_id)
         .expect("card still present");
     assert_eq!(moved_column, right_id);

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -416,6 +416,34 @@ async fn test_toggle_card_completion_refetches_the_card_tiers_and_repairs_the_vi
 }
 
 #[tokio::test]
+async fn test_a_card_mutation_repairs_the_column_scope_without_reading_the_whole_card_list() {
+    let mut app = App::test_default();
+    let seed = seed_two_columns_two_cards(&mut app);
+    let ops = prime(&mut app).await;
+
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        cards: kanban_domain::resolved::Collection {
+            all: kanban_domain::LoadState::Loaded(vec![]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    app.selection.active_board_id = Some(seed.board);
+    app.focus.active = Focus::Cards;
+    app.selection.active_card_id = Some(seed.k1);
+    app.handle_toggle_card_completion();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", seed.c1),
+        "got {refetch:?}"
+    );
+    assert!(app.model.column_cards_state(seed.c1).is_loaded());
+}
+
+#[tokio::test]
 async fn test_move_card_refetches_the_card_tiers_and_leaves_the_column_tier_untouched() {
     let mut app = App::test_default();
     let board = app.ctx.create_board("Board".to_string(), None).unwrap();

--- a/crates/kanban-tui/tests/tui_context_sync.rs
+++ b/crates/kanban-tui/tests/tui_context_sync.rs
@@ -8,6 +8,7 @@ use kanban_service::{
 use kanban_tui::tui_context::TuiContext;
 use std::sync::Arc;
 use tempfile::TempDir;
+use uuid::Uuid;
 
 struct BoardListPlan;
 impl FetchPlan for BoardListPlan {
@@ -19,11 +20,17 @@ impl FetchPlan for BoardListPlan {
     }
 }
 
-struct CardListPlan;
-impl FetchPlan for CardListPlan {
+struct CardByIdPlan {
+    id: Uuid,
+}
+impl FetchPlan for CardByIdPlan {
     fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
         FetchRound {
-            card_list: requestable(loaded.card_list()),
+            cards: if requestable(loaded.card(self.id)) {
+                vec![self.id]
+            } else {
+                Vec::new()
+            },
             ..Default::default()
         }
     }
@@ -103,7 +110,11 @@ fn test_tui_context_sync_invalidated_refetches_before_planning() {
         .unwrap();
 
     let mut model = Model::default();
-    tui_ctx.sync(&CardListPlan, &mut model, &mut NoProjections);
+    tui_ctx.sync(
+        &CardByIdPlan { id: card.id },
+        &mut model,
+        &mut NoProjections,
+    );
     assert_eq!(
         model.card_by_id_state(card.id).loaded().unwrap().title,
         "before"
@@ -121,7 +132,7 @@ fn test_tui_context_sync_invalidated_refetches_before_planning() {
 
     tui_ctx.sync_invalidated(
         kanban_domain::Invalidation::All,
-        &CardListPlan,
+        &CardByIdPlan { id: card.id },
         &mut model,
         &mut NoProjections,
     );


### PR DESCRIPTION
Deletes the three workspace-flat fetch tiers so a whole-workspace column, card, or sprint fetch is inexpressible at the type level:

- `FetchRound.column_list/card_list/sprint_list`
- the matching `LoadedState` trait methods and all six impls (`Overlay`, `Model`, and the in-file and cross-crate test stubs)
- the `Overlay`/`Fetched`/`narrow_to_outstanding`/`fetch_round` plumbing in `resolve.rs`
- the flat arms in all three exhaustive `InvalidationPlan` literals

`Model.cards/columns/sprints` and the flat fallback in `card_by_id_state` are left untouched. They were already unreachable in production once KAN-1585 stopped requesting these tiers, and removing them is the follow-up card's slice.

Test changes:

- three new/rewritten pinning tests: a whole-round equality on `Invalidation::All`, an invalidate-all repair over a model with a previously-loaded flat card tier that must not issue `list_all_cards`, and a card-mutation repair that must not re-read the flat card list
- the kanban-service contract suite (`test_helpers/contract/cache.rs`), run against in-memory, json and sqlite, retargeted from the flat tiers onto the surviving per-parent-scope and per-id tiers
- the mcp/server/tui negative-round assertions and the sync/invalidation-plan unit tests updated to match the surviving `FetchRound` shape
- one previously-undiscovered victim (`kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs`) retargeted from `cards_state()` to `card_by_id_state()`, since `apply_collection` only merges into the flat vec when it is already `Loaded`

Verification: `cargo check --workspace --all-targets`, `cargo test --workspace --all-features` (302 test binaries, 0 failed), `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check` all green. Confirmed by grep that no flat column_list/card_list/sprint_list field, method, or literal remains outside the unrelated `card_list_component.rs`/`archived_card_list` matches.
