### PR TITLE
KAN-1589 refactor(domain): delete the flat column/card/sprint Model collections

### DIFF
--- a/.changeset/kan-1589-delete-flat-model-collections.md
+++ b/.changeset/kan-1589-delete-flat-model-collections.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-delete the flat column/card/sprint Model collections, leaving scoped and per-id fetches as the only source of truth
+domain,backend-http: delete the flat column/card/sprint Model collections, leaving scoped and per-id fetches as the only source of truth. User-visible: a CardDetail relation card on another board now has its body fetched (previously it silently vanished from the parents/children panel), and four HttpBackend DataStore methods now decline under their own names instead of a sibling's.

--- a/.changeset/kan-1589-delete-flat-model-collections.md
+++ b/.changeset/kan-1589-delete-flat-model-collections.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+delete the flat column/card/sprint Model collections, leaving scoped and per-id fetches as the only source of truth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,3 +213,7 @@ jobs:
       - name: Check factory compile-lock invariant
         run: |
           nix develop --command check-factory-compile-lock
+
+      - name: Check DataStore explicit-impl invariant
+        run: |
+          nix develop --command check-datastore-explicit-impl

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -1,3 +1,12 @@
+//! Every `DataStore` method the server has no route for declines with
+//! `KanbanError::unsupported(<its own method name>)`, tagged with one of six
+//! categories: `missing-route` (no route exists at all), `architecture-mismatch`
+//! (the operation's shape doesn't map onto this transport), `write-backstop-via-RemoteWrites`
+//! (writes route through `RemoteWrites`, so this decline firing at all is a
+//! routing bug surfacing loudly), `archived-family-gap` (no route filters by
+//! archival status), `count-methods-never-fake-O(1)` (no cheap count route
+//! exists), and `bulk-deletes-never-fan-out` (no route deletes by parent).
+
 use crate::conversions::{
     archived_card_from_response, board_from_response, card_from_response, column_from_response,
     prefix_from_response, sprint_from_response,
@@ -146,6 +155,21 @@ impl DataStore for HttpBackend {
         })
     }
 
+    /// archived-family-gap: the server has no route filtering cards by
+    /// archival status, so only `LiveOnly` can be served (by delegating to
+    /// `list_cards_by_column`); any archived-aware filter declines under its
+    /// own name.
+    fn list_cards_by_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<Vec<Card>> {
+        match archived {
+            kanban_domain::ArchivedFilter::LiveOnly => self.list_cards_by_column(column_id),
+            _ => Err(KanbanError::unsupported("list_cards_by_column_filtered")),
+        }
+    }
+
     fn list_cards_by_sprint(&self, sprint_id: Uuid) -> KanbanResult<Vec<Card>> {
         self.block_on(async {
             let sprint: Option<SprintResponse> =
@@ -167,6 +191,19 @@ impl DataStore for HttpBackend {
 
     fn count_cards_in_column(&self, _column_id: Uuid) -> KanbanResult<usize> {
         Err(KanbanError::unsupported("count_cards_in_column"))
+    }
+
+    /// count-methods-never-fake-O(1): same archived-family-gap as
+    /// `list_cards_by_column_filtered`, mirrored for the count method.
+    fn count_cards_in_column_filtered(
+        &self,
+        column_id: Uuid,
+        archived: kanban_domain::ArchivedFilter,
+    ) -> KanbanResult<usize> {
+        match archived {
+            kanban_domain::ArchivedFilter::LiveOnly => self.count_cards_in_column(column_id),
+            _ => Err(KanbanError::unsupported("count_cards_in_column_filtered")),
+        }
     }
 
     fn count_cards_in_column_excluding(
@@ -201,6 +238,18 @@ impl DataStore for HttpBackend {
         _timestamp: chrono::DateTime<chrono::Utc>,
     ) -> KanbanResult<()> {
         Err(KanbanError::unsupported("clear_sprint_from_cards"))
+    }
+
+    /// missing-route: no server route clears a sprint id from archived
+    /// cards. Declines under its own name rather than inheriting the
+    /// default, which would walk `list_archived_cards` and report that
+    /// method's name instead.
+    fn clear_sprint_from_archived_cards(
+        &self,
+        _sprint_id: Uuid,
+        _timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("clear_sprint_from_archived_cards"))
     }
 
     fn get_archived_card(&self, _card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
@@ -308,6 +357,14 @@ impl DataStore for HttpBackend {
 
     fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {
         Err(KanbanError::unsupported("set_graph"))
+    }
+
+    /// architecture-mismatch: graph writes route server-side; the inherited
+    /// default would call `get_graph()` then `set_graph()` as two
+    /// operations, and `set_graph` always declines here, so the default
+    /// would surface a transport/route error instead of an honest decline.
+    fn modify_graph(&self, _f: kanban_domain::GraphMutFn) -> KanbanResult<()> {
+        Err(KanbanError::unsupported("modify_graph"))
     }
 
     /// No route filters cards by a bare `board_id` + `card_number` pair, and

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -70,12 +70,7 @@ impl DataStore for HttpBackend {
         })
     }
 
-    /// `ReplaceBoardRequest` has no `position` and no `active_sprint_id`, both
-    /// of which `DataStore::upsert_board` must write verbatim, so a PUT-based
-    /// implementation here would silently drop them on every write.
-    /// `execute_with_extra`'s fence rejects every non-create/update/delete
-    /// mutation before `with_transaction` is ever reached, so this path stays
-    /// unreachable today regardless.
+    /// write-backstop-via-RemoteWrites: board writes route through `RemoteWrites`; this decline firing at all is a routing bug.
     fn upsert_board(&self, _board: Board) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_board"))
     }
@@ -106,16 +101,12 @@ impl DataStore for HttpBackend {
         })
     }
 
-    /// missing-route: no workspace-wide column list route exists.
+    /// architecture-mismatch: a whole-workspace flat column read; this transport deliberately never grows that route.
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
         Err(KanbanError::unsupported("list_all_columns"))
     }
 
-    /// `ReplaceColumnRequest` drops only the timestamps, but there is no route
-    /// that upserts a column by id outside its board (`PUT
-    /// /v1/boards/{bid}/columns/{id}`), and `DataStore::upsert_column` carries
-    /// no board_id to route through. `with_transaction` already declines and
-    /// no `RemoteWrites` impl exists, so this path is unreachable regardless.
+    /// write-backstop-via-RemoteWrites: column writes route through `RemoteWrites`; this decline firing at all is a routing bug.
     fn upsert_column(&self, _column: Column) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_column"))
     }
@@ -137,7 +128,7 @@ impl DataStore for HttpBackend {
         })
     }
 
-    /// missing-route: no workspace-wide card list route exists.
+    /// architecture-mismatch: a whole-workspace flat card read; this transport deliberately never grows that route.
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
         Err(KanbanError::unsupported("list_all_cards"))
     }
@@ -200,15 +191,17 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("count_cards_in_column"))
     }
 
-    /// count-methods-never-fake-O(1): same archived-family-gap as
-    /// `list_cards_by_column_filtered`, mirrored for the count method.
+    /// count-methods-never-fake-O(1) on the `LiveOnly` arm;
+    /// archived-family-gap on every other arm.
     fn count_cards_in_column_filtered(
         &self,
-        column_id: Uuid,
+        _column_id: Uuid,
         archived: kanban_domain::ArchivedFilter,
     ) -> KanbanResult<usize> {
         match archived {
-            kanban_domain::ArchivedFilter::LiveOnly => self.count_cards_in_column(column_id),
+            kanban_domain::ArchivedFilter::LiveOnly => {
+                Err(KanbanError::unsupported("count_cards_in_column_filtered"))
+            }
             _ => Err(KanbanError::unsupported("count_cards_in_column_filtered")),
         }
     }
@@ -222,12 +215,7 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("count_cards_in_column_excluding"))
     }
 
-    /// The only card-write route (`PUT /v1/columns/{cid}/cards/{id}`) takes
-    /// `CreateCardRequest`, which has no `status`, `position`, `card_number`,
-    /// `prefix`, `completed_at` or `board_id` -- a PUT-based upsert here would
-    /// silently drop six fields of the row it was told to write.
-    /// `with_transaction` already declines and no `RemoteWrites` impl exists,
-    /// so this path is unreachable regardless.
+    /// write-backstop-via-RemoteWrites: card writes route through `RemoteWrites`; this decline firing at all is a routing bug.
     fn upsert_card(&self, _card: Card) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_card"))
     }
@@ -263,12 +251,12 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("clear_sprint_from_archived_cards"))
     }
 
-    /// missing-route: no route fetches a single archived-card marker by id.
+    /// archived-family-gap: no route fetches a single archived-card marker by id.
     fn get_archived_card(&self, _card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
         Err(KanbanError::unsupported("get_archived_card"))
     }
 
-    /// missing-route: no whole-store archived-card list route exists; only the board-scoped one does.
+    /// archived-family-gap: no whole-store archived-card list route exists; only the board-scoped one does.
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         Err(KanbanError::unsupported("list_archived_cards"))
     }
@@ -287,37 +275,37 @@ impl DataStore for HttpBackend {
         })
     }
 
-    /// missing-route: archiving happens via the card's own archive action server-side, not a direct marker insert.
+    /// archived-family-gap: archiving happens via the card's own archive action server-side, not a direct marker insert.
     fn insert_archived_card(&self, _ac: ArchivedCard) -> KanbanResult<()> {
         Err(KanbanError::unsupported("insert_archived_card"))
     }
 
-    /// missing-route: no route deletes a single archived-card marker.
+    /// archived-family-gap: no route deletes a single archived-card marker.
     fn delete_archived_card(&self, _card_id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_archived_card"))
     }
 
-    /// missing-route: no route fetches a single archived-board marker by id.
+    /// archived-family-gap: no route fetches a single archived-board marker by id.
     fn get_archived_board(&self, _board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
         Err(KanbanError::unsupported("get_archived_board"))
     }
 
-    /// missing-route: no whole-store archived-board list route exists.
+    /// archived-family-gap: no whole-store archived-board list route exists.
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
         Err(KanbanError::unsupported("list_archived_boards"))
     }
 
-    /// missing-route: archiving happens via the board's own archive action server-side, not a direct marker insert.
+    /// archived-family-gap: archiving happens via the board's own archive action server-side, not a direct marker insert.
     fn insert_archived_board(&self, _ab: ArchivedBoard) -> KanbanResult<()> {
         Err(KanbanError::unsupported("insert_archived_board"))
     }
 
-    /// missing-route: no route deletes a single archived-board marker.
+    /// archived-family-gap: no route deletes a single archived-board marker.
     fn delete_archived_board(&self, _board_id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_archived_board"))
     }
 
-    /// missing-route: unarchiving happens via the board's own restore action server-side, not this trait method.
+    /// archived-family-gap: unarchiving happens via the board's own restore action server-side, not this trait method.
     fn unarchive_board(&self, _board_id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("unarchive_board"))
     }
@@ -343,16 +331,12 @@ impl DataStore for HttpBackend {
         })
     }
 
-    /// missing-route: no workspace-wide sprint list route exists.
+    /// architecture-mismatch: a whole-workspace flat sprint read; this transport deliberately never grows that route.
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
         Err(KanbanError::unsupported("list_all_sprints"))
     }
 
-    /// `ReplaceSprintRequest` has no `status`, `start_date`, `end_date`,
-    /// `sprint_number` or `name_index` -- a PUT-based upsert here would
-    /// silently drop five fields of the row it was told to write.
-    /// `with_transaction` already declines and no `RemoteWrites` impl exists,
-    /// so this path is unreachable regardless.
+    /// missing-route: sprint mutations have no `RemoteWrites` counterpart at all.
     fn upsert_sprint(&self, _sprint: Sprint) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_sprint"))
     }
@@ -391,10 +375,7 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("modify_graph"))
     }
 
-    /// No route filters cards by a bare `board_id` + `card_number` pair, and
-    /// the inherited default would fetch every card in the workspace
-    /// (`list_all_cards`, itself `unsupported` here) to answer a one-row
-    /// lookup. Declines under its own name instead of inheriting.
+    /// architecture-mismatch: the lookup route is prefix-keyed, not board-id-keyed; declines under its own name instead of inheriting the `list_all_cards`-walking default.
     fn get_card_by_board_and_number(
         &self,
         _board_id: Uuid,

--- a/crates/kanban-backend-http/src/data_store.rs
+++ b/crates/kanban-backend-http/src/data_store.rs
@@ -51,6 +51,7 @@ impl DataStore for HttpBackend {
         })
     }
 
+    /// missing-route: no route creates or replaces a prefix directly.
     fn upsert_prefix(&self, _prefix: Prefix) -> KanbanResult<()> {
         Err(KanbanError::unsupported("upsert_prefix"))
     }
@@ -79,6 +80,7 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("upsert_board"))
     }
 
+    /// write-backstop-via-RemoteWrites: board deletes route through `RemoteWrites::delete_board`; this decline firing at all is a routing bug.
     fn delete_board(&self, _id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_board"))
     }
@@ -104,6 +106,7 @@ impl DataStore for HttpBackend {
         })
     }
 
+    /// missing-route: no workspace-wide column list route exists.
     fn list_all_columns(&self) -> KanbanResult<Vec<Column>> {
         Err(KanbanError::unsupported("list_all_columns"))
     }
@@ -117,10 +120,12 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("upsert_column"))
     }
 
+    /// write-backstop-via-RemoteWrites: column deletes route through `RemoteWrites::delete_column`; this decline firing at all is a routing bug.
     fn delete_column(&self, _id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_column"))
     }
 
+    /// bulk-deletes-never-fan-out: no route deletes every column of a board in one call.
     fn delete_columns_by_board(&self, _board_id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_columns_by_board"))
     }
@@ -132,6 +137,7 @@ impl DataStore for HttpBackend {
         })
     }
 
+    /// missing-route: no workspace-wide card list route exists.
     fn list_all_cards(&self) -> KanbanResult<Vec<Card>> {
         Err(KanbanError::unsupported("list_all_cards"))
     }
@@ -189,6 +195,7 @@ impl DataStore for HttpBackend {
         })
     }
 
+    /// count-methods-never-fake-O(1): no cheap count route exists; a real count would mean fetching and counting the whole list.
     fn count_cards_in_column(&self, _column_id: Uuid) -> KanbanResult<usize> {
         Err(KanbanError::unsupported("count_cards_in_column"))
     }
@@ -206,6 +213,7 @@ impl DataStore for HttpBackend {
         }
     }
 
+    /// count-methods-never-fake-O(1): same as `count_cards_in_column`.
     fn count_cards_in_column_excluding(
         &self,
         _column_id: Uuid,
@@ -224,14 +232,17 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("upsert_card"))
     }
 
+    /// write-backstop-via-RemoteWrites: card deletes route through `RemoteWrites::delete_card`; this decline firing at all is a routing bug.
     fn delete_card(&self, _id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_card"))
     }
 
+    /// bulk-deletes-never-fan-out: no route deletes every card of a set of columns in one call.
     fn delete_cards_by_columns(&self, _column_ids: &[Uuid]) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_cards_by_columns"))
     }
 
+    /// missing-route: no route clears a sprint id from live cards in bulk.
     fn clear_sprint_from_cards(
         &self,
         _sprint_id: Uuid,
@@ -252,10 +263,12 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("clear_sprint_from_archived_cards"))
     }
 
+    /// missing-route: no route fetches a single archived-card marker by id.
     fn get_archived_card(&self, _card_id: Uuid) -> KanbanResult<Option<ArchivedCard>> {
         Err(KanbanError::unsupported("get_archived_card"))
     }
 
+    /// missing-route: no whole-store archived-card list route exists; only the board-scoped one does.
     fn list_archived_cards(&self) -> KanbanResult<Vec<ArchivedCard>> {
         Err(KanbanError::unsupported("list_archived_cards"))
     }
@@ -274,30 +287,37 @@ impl DataStore for HttpBackend {
         })
     }
 
+    /// missing-route: archiving happens via the card's own archive action server-side, not a direct marker insert.
     fn insert_archived_card(&self, _ac: ArchivedCard) -> KanbanResult<()> {
         Err(KanbanError::unsupported("insert_archived_card"))
     }
 
+    /// missing-route: no route deletes a single archived-card marker.
     fn delete_archived_card(&self, _card_id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_archived_card"))
     }
 
+    /// missing-route: no route fetches a single archived-board marker by id.
     fn get_archived_board(&self, _board_id: Uuid) -> KanbanResult<Option<ArchivedBoard>> {
         Err(KanbanError::unsupported("get_archived_board"))
     }
 
+    /// missing-route: no whole-store archived-board list route exists.
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
         Err(KanbanError::unsupported("list_archived_boards"))
     }
 
+    /// missing-route: archiving happens via the board's own archive action server-side, not a direct marker insert.
     fn insert_archived_board(&self, _ab: ArchivedBoard) -> KanbanResult<()> {
         Err(KanbanError::unsupported("insert_archived_board"))
     }
 
+    /// missing-route: no route deletes a single archived-board marker.
     fn delete_archived_board(&self, _board_id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_archived_board"))
     }
 
+    /// missing-route: unarchiving happens via the board's own restore action server-side, not this trait method.
     fn unarchive_board(&self, _board_id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("unarchive_board"))
     }
@@ -323,6 +343,7 @@ impl DataStore for HttpBackend {
         })
     }
 
+    /// missing-route: no workspace-wide sprint list route exists.
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
         Err(KanbanError::unsupported("list_all_sprints"))
     }
@@ -336,10 +357,12 @@ impl DataStore for HttpBackend {
         Err(KanbanError::unsupported("upsert_sprint"))
     }
 
+    /// missing-route: sprint mutations have no `RemoteWrites` counterpart at all.
     fn delete_sprint(&self, _id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_sprint"))
     }
 
+    /// bulk-deletes-never-fan-out: no route deletes every sprint of a board in one call.
     fn delete_sprints_by_board(&self, _board_id: Uuid) -> KanbanResult<()> {
         Err(KanbanError::unsupported("delete_sprints_by_board"))
     }
@@ -355,6 +378,7 @@ impl DataStore for HttpBackend {
         })
     }
 
+    /// architecture-mismatch: graph writes route server-side, never through this trait method.
     fn set_graph(&self, _graph: DependencyGraph) -> KanbanResult<()> {
         Err(KanbanError::unsupported("set_graph"))
     }

--- a/crates/kanban-backend-http/tests/decline_rulings.rs
+++ b/crates/kanban-backend-http/tests/decline_rulings.rs
@@ -1,5 +1,8 @@
 use kanban_backend_http::HttpBackend;
-use kanban_domain::{DataStore, DependencyGraph, KanbanError, Prefix};
+use kanban_domain::{
+    ArchivedBoard, ArchivedCard, Board, Card, Column, DataStore, DependencyGraph, KanbanError,
+    Prefix, Sprint,
+};
 use uuid::Uuid;
 
 fn unreachable_backend() -> HttpBackend {
@@ -56,35 +59,132 @@ fn test_get_graph_no_longer_declines_it_reaches_the_transport() {
 }
 
 #[test]
+fn test_count_cards_in_column_filtered_live_only_arm_declines_under_its_own_name() {
+    let backend = unreachable_backend();
+    let result = backend
+        .count_cards_in_column_filtered(Uuid::new_v4(), kanban_domain::ArchivedFilter::LiveOnly)
+        .map(|_| ());
+    assert_declines_under_its_own_name(result, "count_cards_in_column_filtered");
+}
+
+// Skips the conditional decliners `list_cards_by_column_filtered` and `count_cards_in_column_filtered`; their per-arm pins live above.
+#[test]
 fn test_every_declining_datastore_method_declines_under_its_own_name() {
     let backend = unreachable_backend();
-    let archived = kanban_domain::ArchivedFilter::ArchivedOnly;
     let now = chrono::Utc::now();
+    let id = Uuid::new_v4();
 
     let cases: Vec<(&str, kanban_domain::KanbanResult<()>)> = vec![
+        ("upsert_prefix", backend.upsert_prefix(Prefix::new("kan"))),
+        (
+            "upsert_board",
+            backend.upsert_board(Board::new("b", None::<String>)),
+        ),
+        ("delete_board", backend.delete_board(id)),
+        ("list_all_columns", backend.list_all_columns().map(|_| ())),
+        (
+            "upsert_column",
+            backend.upsert_column(Column::new(id, "c", 0)),
+        ),
+        ("delete_column", backend.delete_column(id)),
+        (
+            "delete_columns_by_board",
+            backend.delete_columns_by_board(id),
+        ),
+        ("list_all_cards", backend.list_all_cards().map(|_| ())),
+        (
+            "count_cards_in_column",
+            backend.count_cards_in_column(id).map(|_| ()),
+        ),
+        (
+            "count_cards_in_column_excluding",
+            backend.count_cards_in_column_excluding(id, &[]).map(|_| ()),
+        ),
+        (
+            "upsert_card",
+            backend.upsert_card(Card::new(id, id, "t", 0)),
+        ),
+        ("delete_card", backend.delete_card(id)),
+        (
+            "delete_cards_by_columns",
+            backend.delete_cards_by_columns(&[id]),
+        ),
+        (
+            "clear_sprint_from_cards",
+            backend.clear_sprint_from_cards(id, now),
+        ),
         (
             "clear_sprint_from_archived_cards",
-            backend.clear_sprint_from_archived_cards(Uuid::new_v4(), now),
+            backend.clear_sprint_from_archived_cards(id, now),
         ),
         (
-            "list_cards_by_column_filtered",
-            backend
-                .list_cards_by_column_filtered(Uuid::new_v4(), archived)
-                .map(|_| ()),
+            "get_archived_card",
+            backend.get_archived_card(id).map(|_| ()),
         ),
         (
-            "count_cards_in_column_filtered",
-            backend
-                .count_cards_in_column_filtered(Uuid::new_v4(), archived)
-                .map(|_| ()),
+            "list_archived_cards",
+            backend.list_archived_cards().map(|_| ()),
         ),
+        (
+            "insert_archived_card",
+            backend.insert_archived_card(ArchivedCard::new(id, id)),
+        ),
+        ("delete_archived_card", backend.delete_archived_card(id)),
+        (
+            "get_archived_board",
+            backend.get_archived_board(id).map(|_| ()),
+        ),
+        (
+            "list_archived_boards",
+            backend.list_archived_boards().map(|_| ()),
+        ),
+        (
+            "insert_archived_board",
+            backend.insert_archived_board(ArchivedBoard::now(id)),
+        ),
+        ("delete_archived_board", backend.delete_archived_board(id)),
+        ("unarchive_board", backend.unarchive_board(id)),
+        ("list_all_sprints", backend.list_all_sprints().map(|_| ())),
+        (
+            "upsert_sprint",
+            backend.upsert_sprint(Sprint::new(id, 1, None, None::<String>)),
+        ),
+        ("delete_sprint", backend.delete_sprint(id)),
+        (
+            "delete_sprints_by_board",
+            backend.delete_sprints_by_board(id),
+        ),
+        ("set_graph", backend.set_graph(DependencyGraph::default())),
         (
             "modify_graph",
             backend.modify_graph(Box::new(|_graph| Ok(()))),
         ),
+        (
+            "get_card_by_board_and_number",
+            backend.get_card_by_board_and_number(id, 1).map(|_| ()),
+        ),
     ];
 
+    assert_eq!(cases.len(), 31, "unconditional decliner census drifted");
     for (name, result) in cases {
         assert_declines_under_its_own_name(result, name);
     }
+}
+
+#[test]
+fn test_conditional_decliners_decline_archived_filters_under_their_own_names() {
+    let backend = unreachable_backend();
+    let archived = kanban_domain::ArchivedFilter::ArchivedOnly;
+    assert_declines_under_its_own_name(
+        backend
+            .list_cards_by_column_filtered(Uuid::new_v4(), archived)
+            .map(|_| ()),
+        "list_cards_by_column_filtered",
+    );
+    assert_declines_under_its_own_name(
+        backend
+            .count_cards_in_column_filtered(Uuid::new_v4(), archived)
+            .map(|_| ()),
+        "count_cards_in_column_filtered",
+    );
 }

--- a/crates/kanban-backend-http/tests/decline_rulings.rs
+++ b/crates/kanban-backend-http/tests/decline_rulings.rs
@@ -54,3 +54,37 @@ fn test_get_graph_no_longer_declines_it_reaches_the_transport() {
     assert!(err.is_transport(), "expected transport error, got {err:?}");
     assert!(!err.is_unsupported());
 }
+
+#[test]
+fn test_every_declining_datastore_method_declines_under_its_own_name() {
+    let backend = unreachable_backend();
+    let archived = kanban_domain::ArchivedFilter::ArchivedOnly;
+    let now = chrono::Utc::now();
+
+    let cases: Vec<(&str, kanban_domain::KanbanResult<()>)> = vec![
+        (
+            "clear_sprint_from_archived_cards",
+            backend.clear_sprint_from_archived_cards(Uuid::new_v4(), now),
+        ),
+        (
+            "list_cards_by_column_filtered",
+            backend
+                .list_cards_by_column_filtered(Uuid::new_v4(), archived)
+                .map(|_| ()),
+        ),
+        (
+            "count_cards_in_column_filtered",
+            backend
+                .count_cards_in_column_filtered(Uuid::new_v4(), archived)
+                .map(|_| ()),
+        ),
+        (
+            "modify_graph",
+            backend.modify_graph(Box::new(|_graph| Ok(()))),
+        ),
+    ];
+
+    for (name, result) in cases {
+        assert_declines_under_its_own_name(result, name);
+    }
+}

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -952,3 +952,83 @@ async fn test_remote_graph_tier_resolves_loaded_and_serves_relation_children() {
 
     server.shutdown().await;
 }
+
+struct BoardScopedPlan {
+    board_id: Uuid,
+}
+
+impl FetchPlan for BoardScopedPlan {
+    fn next_round(&self, loaded: &dyn LoadedEntities) -> FetchRound {
+        let mut round = FetchRound {
+            board_list: requestable(loaded.board_list()),
+            graph: requestable(loaded.graph()),
+            ..Default::default()
+        };
+
+        if requestable(loaded.columns_of_board(self.board_id)) {
+            round.columns_by_board.push(self.board_id);
+        }
+        if requestable(loaded.sprints_of_board(self.board_id)) {
+            round.sprints_by_board.push(self.board_id);
+        }
+        if requestable(loaded.archived_cards_of_board(self.board_id)) {
+            round.archived_cards_by_board.push(self.board_id);
+        }
+        if let Some(columns) = loaded.loaded_columns_of_board(self.board_id) {
+            for column in columns {
+                if requestable(loaded.cards_of_column(column.id)) {
+                    round.cards_by_column.push(column.id);
+                }
+            }
+        }
+
+        round
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_full_scoped_resolve_over_http_never_hits_a_declining_route() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Scoped Board").await;
+    let column_id = seed_column(&server, board_id, "Todo", None, None).await;
+    let card_a = seed_card(&server, column_id, "A", None).await;
+    let card_b = seed_card(&server, column_id, "B", None).await;
+    let _sprint_id = seed_sprint(&server, board_id, "Sprint 1").await;
+    archive_card(&server, card_b).await;
+
+    let backend: Arc<dyn KanbanBackend> = Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+    let ctx = KanbanContext::open(Arc::clone(&backend), AppConfig::default())
+        .await
+        .unwrap();
+
+    let mut model = Model::default();
+    let plan = BoardScopedPlan { board_id };
+    ctx.sync(&plan, &mut model, &mut NoProjections);
+
+    assert!(model.boards_state().is_loaded());
+    assert!(!model.boards_state().is_failed());
+    assert!(model.board_columns_state(board_id).is_loaded());
+    assert!(!model.board_columns_state(board_id).is_failed());
+    assert!(model.column_cards_state(column_id).is_loaded());
+    assert!(!model.column_cards_state(column_id).is_failed());
+    assert!(model.board_sprints_state(board_id).is_loaded());
+    assert!(!model.board_sprints_state(board_id).is_failed());
+    assert!(model.board_archived_cards_state(board_id).is_loaded());
+    assert!(!model.board_archived_cards_state(board_id).is_failed());
+    assert!(model.graph_state().is_loaded());
+    assert!(!model.graph_state().is_failed());
+
+    let live_ids: Vec<Uuid> = model
+        .column_cards_state(column_id)
+        .loaded()
+        .unwrap()
+        .iter()
+        .map(|c| c.id)
+        .collect();
+    assert_eq!(live_ids, vec![card_a]);
+
+    drop(ctx);
+    drop(backend);
+
+    server.shutdown().await;
+}

--- a/crates/kanban-domain/src/dependencies/dependency_graph.rs
+++ b/crates/kanban-domain/src/dependencies/dependency_graph.rs
@@ -254,6 +254,24 @@ impl DependencyGraph {
         self.relates.neighbors(card)
     }
 
+    /// Every other card connected to `card` by any edge kind: parent, child,
+    /// blocker, blocked or related. Sorted and deduplicated; never includes
+    /// `card` itself.
+    pub fn neighbours(&self, card: CardId) -> Vec<CardId> {
+        let mut ids: Vec<CardId> = self
+            .parents(card)
+            .into_iter()
+            .chain(self.children(card))
+            .chain(self.blockers(card))
+            .chain(self.blocked(card))
+            .chain(self.related(card))
+            .filter(|&id| id != card)
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
+
     /// True iff an **active** edge between `a` and `b` exists in any
     /// sub-graph. Use this to ask "is there a current dependency
     /// here?". Archived edges are not counted; use
@@ -1003,5 +1021,30 @@ mod tests {
 
         assert!(!base.contains(a, b));
         assert!(base.contains_archived(a, b));
+    }
+
+    #[test]
+    fn test_neighbours_returns_every_relative_sorted_and_deduped() {
+        let subject = Uuid::new_v4();
+        let parent = Uuid::new_v4();
+        let child = Uuid::new_v4();
+        let blocker = Uuid::new_v4();
+        let related = Uuid::new_v4();
+
+        let mut graph = DependencyGraph::new();
+        graph.set_parent(subject, parent).unwrap();
+        graph.set_parent(child, subject).unwrap();
+        graph.set_block(blocker, subject).unwrap();
+        graph.relate(subject, related).unwrap();
+
+        let mut expected = vec![parent, child, blocker, related];
+        expected.sort_unstable();
+        assert_eq!(graph.neighbours(subject), expected);
+    }
+
+    #[test]
+    fn test_neighbours_of_an_unconnected_card_is_empty() {
+        let graph = DependencyGraph::new();
+        assert!(graph.neighbours(Uuid::new_v4()).is_empty());
     }
 }

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -260,15 +260,23 @@ mod tests {
         let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Col", 0);
         let card = Card::new(board.id, column.id, "task", 0);
+        let mut cards_by_parent = HashMap::new();
+        cards_by_parent.insert(column.id, LoadState::Loaded(vec![card]));
         let resolved = Resolved {
             cards: Collection {
-                all: LoadState::Loaded(vec![card]),
+                by_parent: cards_by_parent,
                 ..Default::default()
             },
             ..Default::default()
         };
         let changed: ModelChanged = m.apply_resolved(resolved);
-        assert_eq!(m.cards_state().loaded_or_empty().len(), 1);
+        assert_eq!(
+            m.column_cards_state(column.id)
+                .loaded()
+                .map(|v| v.len())
+                .unwrap_or(0),
+            1
+        );
         NoProjections.resync(&m, changed);
     }
 
@@ -357,7 +365,7 @@ mod tests {
         let changed = m.mark_failed(EntityIds::default(), err);
         assert!(!changed.any());
         assert!(m.boards_state().is_not_loaded());
-        assert!(m.cards_state().is_not_loaded());
+        assert!(m.card_id_status(Uuid::new_v4()).is_not_loaded());
     }
 
     #[test]
@@ -373,13 +381,26 @@ mod tests {
     fn test_mark_failed_returns_a_model_changed_receipt() {
         let mut m = Model::default();
         let card_id = Uuid::new_v4();
+        let mut by_id = HashMap::new();
+        by_id.insert(
+            card_id,
+            LoadState::Loaded(Card::new(Uuid::new_v4(), Uuid::new_v4(), "c", 0)),
+        );
+        let _ = m.apply_resolved(Resolved {
+            cards: Collection {
+                by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
         let ids = EntityIds {
             cards: [card_id].into_iter().collect(),
             ..Default::default()
         };
         let err = Arc::new(KanbanError::unsupported("boom"));
         let changed: ModelChanged = m.mark_failed(ids, err);
-        assert!(m.cards_state().is_failed());
+        assert!(m.card_id_status(card_id).is_failed());
         NoProjections.resync(&m, changed);
     }
 
@@ -410,49 +431,32 @@ mod tests {
         let (mut m, board, column, sprint, _card_a, _card_b) = seed_full_model();
         let new_card = seed_card(&board, column.id);
 
+        let mut cards_by_parent = HashMap::new();
+        cards_by_parent.insert(column.id, LoadState::Loaded(vec![new_card.clone()]));
         let _ = m.apply_resolved(Resolved {
             cards: Collection {
-                all: LoadState::Loaded(vec![new_card.clone()]),
+                by_parent: cards_by_parent,
                 ..Default::default()
             },
             ..Default::default()
         });
 
-        assert!(m.columns_state().is_loaded());
-        assert_eq!(m.columns_state().loaded().unwrap(), &vec![column]);
-        assert!(m.sprints_state().is_loaded());
-        assert_eq!(m.sprints_state().loaded().unwrap(), &vec![sprint]);
+        assert!(m.board_columns_state(board.id).is_loaded());
+        assert_eq!(
+            m.board_columns_state(board.id).loaded().unwrap(),
+            &vec![column.clone()]
+        );
+        assert!(m.board_sprints_state(board.id).is_loaded());
+        assert_eq!(
+            m.board_sprints_state(board.id).loaded().unwrap(),
+            &vec![sprint.clone()]
+        );
         assert!(m.boards_state().is_loaded());
         assert_eq!(m.boards_state().loaded().unwrap(), &vec![board]);
         assert!(m.graph_state().is_loaded());
-        assert!(m.cards_state().is_loaded());
-        assert_eq!(m.cards_state().loaded().unwrap(), &vec![new_card]);
-    }
-
-    #[test]
-    fn test_applying_all_then_by_id_applies_the_whole_collection_first() {
-        let mut m = Model::default();
-        let board = Board::new("B", None::<String>);
-        let a = Column::new(board.id, "A", 0);
-        let b = Column::new(board.id, "B", 1);
-        let _ = m.load_from_snapshot(Snapshot {
-            boards: vec![board],
-            archived_boards: Vec::new(),
-            ..Default::default()
-        });
-
-        let mut by_id = HashMap::new();
-        by_id.insert(b.id, LoadState::Missing);
-        let _ = m.apply_resolved(Resolved {
-            columns: Collection {
-                all: LoadState::Loaded(vec![a.clone(), b]),
-                by_id,
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        assert_eq!(m.columns_state().loaded().unwrap(), &vec![a]);
+        let state = m.column_cards_state(column.id);
+        assert!(state.is_loaded());
+        assert_eq!(state.loaded().unwrap(), &vec![new_card]);
     }
 
     #[test]
@@ -472,7 +476,7 @@ mod tests {
             ..Default::default()
         });
 
-        assert_eq!(m.cards_state().loaded().unwrap().len(), 2);
+        assert_eq!(m.column_cards_state(column.id).loaded().unwrap().len(), 2);
         assert_eq!(
             m.card_by_id_state(card_a.id)
                 .loaded()
@@ -485,8 +489,8 @@ mod tests {
             m.card_by_id_state(card_b.id).loaded().copied().unwrap(),
             &card_b
         );
-        assert!(m.cards_state().is_loaded());
-        let _ = (board, column);
+        assert!(m.column_cards_state(column.id).is_loaded());
+        let _ = board;
     }
 
     #[test]
@@ -496,14 +500,20 @@ mod tests {
 
         let _ = m.mark_failed(EntityIds::cards([card_a.id]), Arc::clone(&err));
 
-        match m.cards_state() {
-            LoadState::Failed(e) => assert!(Arc::ptr_eq(e, &err)),
+        match m.column_cards_state(column.id) {
+            LoadState::Failed(e) => assert!(Arc::ptr_eq(&e, &err)),
             other => panic!("expected Failed, got {other:?}"),
         }
-        assert!(m.columns_state().is_loaded());
-        assert_eq!(m.columns_state().loaded().unwrap(), &vec![column]);
-        assert!(m.sprints_state().is_loaded());
-        assert_eq!(m.sprints_state().loaded().unwrap(), &vec![sprint]);
+        assert!(m.board_columns_state(board.id).is_loaded());
+        assert_eq!(
+            m.board_columns_state(board.id).loaded().unwrap(),
+            &vec![column.clone()]
+        );
+        assert!(m.board_sprints_state(board.id).is_loaded());
+        assert_eq!(
+            m.board_sprints_state(board.id).loaded().unwrap(),
+            &vec![sprint.clone()]
+        );
         assert!(m.boards_state().is_loaded());
         assert_eq!(m.boards_state().loaded().unwrap(), &vec![board]);
         assert!(m.graph_state().is_loaded());
@@ -540,37 +550,6 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_resolved_rebuilds_the_card_index_for_a_replaced_collection() {
-        let (mut m, board, column, _sprint, a, _b) = seed_full_model();
-        let c = seed_card(&board, column.id);
-        let d = seed_card(&board, column.id);
-        let e = seed_card(&board, column.id);
-
-        let _ = m.apply_resolved(Resolved {
-            cards: Collection {
-                all: LoadState::Loaded(vec![c.clone(), d.clone(), e.clone()]),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        assert_eq!(m.card_index.len(), 3);
-        for (i, card) in m.cards_state().loaded().unwrap().iter().enumerate() {
-            assert_eq!(m.card_index[&card.id], i);
-        }
-        assert!(m
-            .cards_state()
-            .loaded()
-            .unwrap()
-            .iter()
-            .all(|c| c.id != a.id));
-        assert_eq!(m.card_by_id_state(a.id).loaded().copied().unwrap(), &a);
-        assert_eq!(m.card_by_id_state(c.id).loaded().copied().unwrap(), &c);
-        assert_eq!(m.card_by_id_state(d.id).loaded().copied().unwrap(), &d);
-        assert_eq!(m.card_by_id_state(e.id).loaded().copied().unwrap(), &e);
-    }
-
-    #[test]
     fn test_applying_a_missing_by_id_entry_reindexes_the_remaining_cards() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
@@ -603,12 +582,14 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_resolved_leaves_indexes_untouched_for_an_untouched_tier() {
+    fn test_apply_resolved_leaves_other_tiers_untouched_for_an_untouched_tier() {
         let mut m = Model::default();
         let board_live = Board::new("Live", None::<String>);
         let board_archived = Board::new("Archived", None::<String>);
         let board_archived_id = board_archived.id;
+        let board_live_id = board_live.id;
         let column = Column::new(board_live.id, "Col", 0);
+        let column_id = column.id;
         let live_card = seed_card(&board_live, column.id);
         let archived_card = seed_card(&board_live, column.id);
         let archived_card_id = archived_card.id;
@@ -623,29 +604,37 @@ mod tests {
             ..Default::default()
         });
 
-        let card_index_before = m.card_index.clone();
-        let board_index_before = m.board_index.clone();
-
-        let new_sprint = Sprint::new(board_live.id, 2, None, None::<String>);
+        let mut sprints_by_parent = HashMap::new();
+        sprints_by_parent.insert(
+            board_live_id,
+            LoadState::Loaded(vec![sprint.clone(), Sprint::new(board_live_id, 2, None, None::<String>)]),
+        );
         let _ = m.apply_resolved(Resolved {
             sprints: Collection {
-                all: LoadState::Loaded(vec![sprint, new_sprint]),
+                by_parent: sprints_by_parent,
                 ..Default::default()
             },
             ..Default::default()
         });
 
-        assert_eq!(m.card_index, card_index_before);
-        assert_eq!(m.board_index, board_index_before);
-        assert!(m.sprints_state().is_loaded());
-        assert_eq!(m.sprints_state().loaded().unwrap().len(), 2);
+        assert!(m.card_id_status(archived_card_id).is_loaded());
+        assert_eq!(
+            m.column_cards_state(column_id).loaded().unwrap().len(),
+            1
+        );
+        assert!(m.board_sprints_state(board_live_id).is_loaded());
+        assert_eq!(
+            m.board_sprints_state(board_live_id).loaded().unwrap().len(),
+            2
+        );
     }
 
     #[test]
-    fn test_applying_a_failed_collection_read_marks_the_model_collection_failed() {
+    fn test_applying_a_failed_collection_read_marks_the_scoped_tier_failed() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Col", 0);
+        let board_id = board.id;
         let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             columns: vec![column],
@@ -654,16 +643,18 @@ mod tests {
         });
 
         let err = Arc::new(KanbanError::unsupported("boom"));
+        let mut columns_by_parent = HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Failed(Arc::clone(&err)));
         let _ = m.apply_resolved(Resolved {
             columns: Collection {
-                all: LoadState::Failed(Arc::clone(&err)),
+                by_parent: columns_by_parent,
                 ..Default::default()
             },
             ..Default::default()
         });
 
-        match m.columns_state() {
-            LoadState::Failed(e) => assert!(Arc::ptr_eq(e, &err)),
+        match m.board_columns_state(board_id) {
+            LoadState::Failed(e) => assert!(Arc::ptr_eq(&e, &err)),
             other => panic!("expected Failed, got {other:?}"),
         }
     }
@@ -686,7 +677,7 @@ mod tests {
             ..Default::default()
         });
 
-        assert!(m.cards_state().is_not_loaded());
+        assert!(m.column_cards_state(Uuid::new_v4()).is_not_loaded());
         assert!(m.card_by_id_state(x_id).is_loaded());
         assert!(m.card_by_id_state(other_id).is_not_loaded());
         assert!(!m.card_by_id_state(other_id).is_missing());
@@ -700,16 +691,28 @@ mod tests {
         let _ = m.mark_failed(EntityIds::default(), err);
 
         assert!(m.boards_state().is_loaded());
-        assert_eq!(m.boards_state().loaded().unwrap(), &vec![board]);
-        assert!(m.columns_state().is_loaded());
-        assert_eq!(m.columns_state().loaded().unwrap(), &vec![column]);
-        assert!(m.cards_state().is_loaded());
+        assert_eq!(m.boards_state().loaded().unwrap(), &vec![board.clone()]);
+        assert!(m.board_columns_state(board.id).is_loaded());
         assert_eq!(
-            m.cards_state().loaded().unwrap(),
-            &vec![card_a.clone(), card_b.clone()]
+            m.board_columns_state(board.id).loaded().unwrap(),
+            &vec![column.clone()]
         );
-        assert!(m.sprints_state().is_loaded());
-        assert_eq!(m.sprints_state().loaded().unwrap(), &vec![sprint]);
+        let cards_state = m.column_cards_state(column.id);
+        assert!(cards_state.is_loaded());
+        assert_eq!(
+            cards_state
+                .loaded()
+                .unwrap()
+                .iter()
+                .map(|c| c.id)
+                .collect::<Vec<_>>(),
+            vec![card_a.id, card_b.id]
+        );
+        assert!(m.board_sprints_state(board.id).is_loaded());
+        assert_eq!(
+            m.board_sprints_state(board.id).loaded().unwrap(),
+            &vec![sprint.clone()]
+        );
         assert!(m.graph_state().is_loaded());
     }
 
@@ -752,7 +755,6 @@ mod tests {
             scoped.iter().map(|c| c.id).collect::<Vec<_>>(),
             vec![a.id, b.id]
         );
-        assert!(m.cards_state().is_not_loaded());
     }
 
     #[test]
@@ -771,7 +773,6 @@ mod tests {
 
         assert!(m.card_by_id_state(ghost).is_missing());
         assert!(m.card_id_status(ghost).is_missing());
-        assert!(m.cards_state().is_not_loaded());
     }
 
     #[test]
@@ -792,7 +793,6 @@ mod tests {
         });
 
         assert_eq!(m.card_by_id_state(x_id).loaded().copied().unwrap(), &x);
-        assert!(m.cards_state().is_not_loaded());
     }
 
     #[test]
@@ -823,7 +823,7 @@ mod tests {
     }
 
     #[test]
-    fn test_a_scoped_result_never_touches_the_flat_collection() {
+    fn test_a_scoped_write_replaces_the_columns_whole_bucket() {
         let (mut m, board, column, _sprint, card_a, card_b) = seed_full_model();
         let third = seed_card(&board, column.id);
 
@@ -837,16 +837,13 @@ mod tests {
             ..Default::default()
         });
 
-        assert_eq!(
-            m.cards_state().loaded().unwrap(),
-            &vec![card_a.clone(), card_b.clone()]
-        );
         let state = m.column_cards_state(column.id);
         let scoped = state.loaded().unwrap();
         assert_eq!(
             scoped.iter().map(|c| c.id).collect::<Vec<_>>(),
             vec![third.id]
         );
+        let _ = (card_a, card_b);
     }
 
     #[test]
@@ -984,32 +981,7 @@ mod tests {
     }
 
     #[test]
-    fn test_applying_all_and_by_parent_in_one_pass_keeps_them_independent() {
-        let mut m = Model::default();
-        let board = Board::new("B", None::<String>);
-        let column = Column::new(board.id, "Col", 0);
-        let x = seed_card(&board, column.id);
-        let y = seed_card(&board, column.id);
-
-        let mut by_parent = HashMap::new();
-        by_parent.insert(column.id, LoadState::Loaded(vec![y.clone()]));
-        let _ = m.apply_resolved(Resolved {
-            cards: Collection {
-                all: LoadState::Loaded(vec![x.clone()]),
-                by_parent,
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        assert_eq!(m.cards_state().loaded().unwrap(), &vec![x]);
-        let state = m.column_cards_state(column.id);
-        let scoped = state.loaded().unwrap();
-        assert_eq!(scoped.iter().map(|c| c.id).collect::<Vec<_>>(), vec![y.id]);
-    }
-
-    #[test]
-    fn test_a_by_id_result_wins_over_the_flat_collection() {
+    fn test_a_by_id_result_wins_over_the_scoped_tier() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Col", 0);
@@ -1017,9 +989,10 @@ mod tests {
         x_v1.title = "v1".to_string();
         let mut x_v2 = x_v1.clone();
         x_v2.title = "v2".to_string();
+        let x_id = x_v1.id;
 
         let mut by_id = HashMap::new();
-        by_id.insert(x_v1.id, LoadState::Loaded(x_v2));
+        by_id.insert(x_id, LoadState::Loaded(x_v2));
         let _ = m.apply_resolved(Resolved {
             cards: Collection {
                 by_id,
@@ -1028,22 +1001,21 @@ mod tests {
             ..Default::default()
         });
 
+        let mut by_parent = HashMap::new();
+        by_parent.insert(column.id, LoadState::Loaded(vec![x_v1]));
         let _ = m.apply_resolved(Resolved {
             cards: Collection {
-                all: LoadState::Loaded(vec![x_v1]),
+                by_parent,
                 ..Default::default()
             },
             ..Default::default()
         });
 
+        assert_eq!(m.card_by_id_state(x_id).loaded().unwrap().title, "v2");
         assert_eq!(
-            m.card_by_id_state(m.cards_state().loaded().unwrap()[0].id)
-                .loaded()
-                .unwrap()
-                .title,
-            "v2"
+            m.column_cards_state(column.id).loaded().unwrap()[0].title,
+            "v1"
         );
-        assert_eq!(m.cards_state().loaded().unwrap()[0].title, "v1");
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -594,7 +594,10 @@ mod tests {
         let mut sprints_by_parent = HashMap::new();
         sprints_by_parent.insert(
             board_live_id,
-            LoadState::Loaded(vec![sprint.clone(), Sprint::new(board_live_id, 2, None, None::<String>)]),
+            LoadState::Loaded(vec![
+                sprint.clone(),
+                Sprint::new(board_live_id, 2, None, None::<String>),
+            ]),
         );
         let _ = m.apply_resolved(Resolved {
             sprints: Collection {
@@ -605,10 +608,7 @@ mod tests {
         });
 
         assert!(m.card_id_status(archived_card_id).is_loaded());
-        assert_eq!(
-            m.column_cards_state(column_id).loaded().unwrap().len(),
-            1
-        );
+        assert_eq!(m.column_cards_state(column_id).loaded().unwrap().len(), 1);
         assert!(m.board_sprints_state(board_live_id).is_loaded());
         assert_eq!(
             m.board_sprints_state(board_live_id).loaded().unwrap().len(),

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -538,7 +538,7 @@ mod tests {
         let new_sprint = Sprint::new(board.id, 2, None, None::<String>);
         let _ = m.apply_resolved(Resolved {
             sprints: Collection {
-                all: LoadState::Loaded(vec![sprint, new_sprint]),
+                by_parent: [(board.id, LoadState::Loaded(vec![sprint, new_sprint]))].into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kanban-domain/src/model/apply.rs
+++ b/crates/kanban-domain/src/model/apply.rs
@@ -37,6 +37,15 @@ fn apply_collection<T: Clone>(
     }
 }
 
+fn apply_by_id<T>(target: &mut HashMap<Uuid, LoadState<T>>, by_id: HashMap<Uuid, LoadState<T>>) {
+    for (id, state) in by_id {
+        if state.is_not_loaded() {
+            continue;
+        }
+        target.insert(id, state);
+    }
+}
+
 fn apply_scopes<T>(
     target: &mut HashMap<Uuid, LoadState<Vec<T>>>,
     incoming: HashMap<Uuid, LoadState<Vec<T>>>,
@@ -70,19 +79,19 @@ fn apply_flat_archival<T>(
 }
 
 impl Model {
-    /// Applies one resolve pass across the three independent tiers per
-    /// entity kind: `all`, then `by_id`, then `by_parent`. A tier left
-    /// `NotLoaded`/empty is untouched; the flat and scoped tiers never merge
-    /// into each other or into the per-id tier.
+    /// Applies one resolve pass across each entity kind's tiers. Boards keep
+    /// a flat collection (`all`, then `by_id`); every other kind is per-id
+    /// and parent-scoped only (`by_id`, then `by_parent`) — their `all` tier
+    /// is never consulted, since nothing populates it anymore. A tier left
+    /// `NotLoaded`/empty is untouched.
     ///
     /// Maintains the id indexes only. Returns a [`ModelChanged`] receipt:
     /// whatever derives from this `Model` is stale until a
     /// [`DerivedProjections`] implementor consumes it.
     pub fn apply_resolved(&mut self, resolved: Resolved) -> ModelChanged {
         let boards_touched = !resolved.boards.is_untouched();
-        let cards_touched = !resolved.cards.is_untouched();
         let touched = boards_touched
-            || cards_touched
+            || !resolved.cards.is_untouched()
             || !resolved.columns.is_untouched()
             || !resolved.sprints.is_untouched()
             || !resolved.archived_cards.is_untouched()
@@ -108,13 +117,8 @@ impl Model {
             by_id: columns_by_id,
             by_parent: columns_by_parent,
         } = resolved.columns;
-        apply_collection(
-            &mut self.columns,
-            &mut self.columns_by_id,
-            columns_all,
-            columns_by_id,
-            |c| c.id,
-        );
+        debug_assert!(columns_all.is_not_loaded(), "columns have no flat tier");
+        apply_by_id(&mut self.columns_by_id, columns_by_id);
         apply_scopes(&mut self.columns_by_board, columns_by_parent);
 
         let Collection {
@@ -122,13 +126,8 @@ impl Model {
             by_id: cards_by_id,
             by_parent: cards_by_parent,
         } = resolved.cards;
-        apply_collection(
-            &mut self.cards,
-            &mut self.cards_by_id,
-            cards_all,
-            cards_by_id,
-            |c| c.id,
-        );
+        debug_assert!(cards_all.is_not_loaded(), "cards have no flat tier");
+        apply_by_id(&mut self.cards_by_id, cards_by_id);
         for (column_id, state) in cards_by_parent {
             if state.is_not_loaded() {
                 continue;
@@ -141,13 +140,8 @@ impl Model {
             by_id: sprints_by_id,
             by_parent: sprints_by_parent,
         } = resolved.sprints;
-        apply_collection(
-            &mut self.sprints,
-            &mut self.sprints_by_id,
-            sprints_all,
-            sprints_by_id,
-            |s| s.id,
-        );
+        debug_assert!(sprints_all.is_not_loaded(), "sprints have no flat tier");
+        apply_by_id(&mut self.sprints_by_id, sprints_by_id);
         apply_scopes(&mut self.sprints_by_board, sprints_by_parent);
 
         apply_scopes(
@@ -173,9 +167,6 @@ impl Model {
             self.graph = resolved.graph;
         }
 
-        if cards_touched {
-            self.rebuild_card_index();
-        }
         if boards_touched {
             self.rebuild_board_index();
         }
@@ -187,10 +178,10 @@ impl Model {
         }
     }
 
-    /// Marks the flat collection, the per-id entries and the parent scopes
-    /// of every kind named in `ids` as `Failed(err)`, without removing any
-    /// of them. An empty `EntityIds` changes nothing. `ids.prefixes` has no
-    /// corresponding `Model` field.
+    /// Marks the boards flat collection, and the per-id entries and parent
+    /// scopes of every kind named in `ids`, as `Failed(err)`, without
+    /// removing any of them. An empty `EntityIds` changes nothing.
+    /// `ids.prefixes` has no corresponding `Model` field.
     ///
     /// Maintains the id indexes only. Returns a [`ModelChanged`] receipt:
     /// whatever derives from this `Model` is stale until a
@@ -205,7 +196,6 @@ impl Model {
             }
         }
         if !ids.columns.is_empty() {
-            self.columns = LoadState::Failed(Arc::clone(&err));
             for state in self.columns_by_board.values_mut() {
                 *state = LoadState::Failed(Arc::clone(&err));
             }
@@ -214,8 +204,6 @@ impl Model {
             }
         }
         if !ids.cards.is_empty() {
-            self.cards = LoadState::Failed(Arc::clone(&err));
-            self.rebuild_card_index();
             for state in self.cards_by_column.values_mut() {
                 *state = LoadState::Failed(Arc::clone(&err));
             }
@@ -227,7 +215,6 @@ impl Model {
             }
         }
         if !ids.sprints.is_empty() {
-            self.sprints = LoadState::Failed(Arc::clone(&err));
             for state in self.sprints_by_board.values_mut() {
                 *state = LoadState::Failed(Arc::clone(&err));
             }

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -183,10 +183,7 @@ mod tests {
 
         // The live row lives in the scoped column tier, the archived row in
         // the per-id tier.
-        assert_eq!(
-            m.column_cards_state(col_id).loaded().unwrap().len(),
-            1
-        );
+        assert_eq!(m.column_cards_state(col_id).loaded().unwrap().len(), 1);
         assert!(m.card_id_status(archived_id).is_loaded());
 
         // The single index resolves both.

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -340,6 +340,43 @@ mod tests {
     }
 
     #[test]
+    fn test_load_from_snapshot_lands_archived_card_bodies_in_the_per_id_tier() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let live = make_card(&board, col_id);
+        let archived = make_card(&board, col_id);
+        let archived_id = archived.id;
+        let _ = m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
+            cards: vec![live, archived.clone()],
+            archived_cards: vec![ArchivedCard::new(archived_id, uuid::Uuid::nil())],
+            ..Default::default()
+        });
+
+        let state = m.card_id_status(archived_id);
+        assert!(state.is_loaded());
+        assert_eq!(state.loaded().copied().unwrap().title, archived.title);
+    }
+
+    #[test]
+    fn test_card_by_id_state_answers_not_loaded_for_an_id_absent_from_a_loaded_snapshot() {
+        let mut m = Model::default();
+        let board = Board::new("B", None::<String>);
+        let col_id = Uuid::new_v4();
+        let card = make_card(&board, col_id);
+        let _ = m.load_from_snapshot(Snapshot {
+            archived_boards: Vec::new(),
+            cards: vec![card],
+            ..Default::default()
+        });
+
+        let state = m.card_by_id_state(Uuid::new_v4());
+        assert!(state.is_not_loaded());
+        assert!(!state.is_missing());
+    }
+
+    #[test]
     fn test_an_unapplied_board_reads_not_loaded() {
         let mut m = Model::default();
         let board_a = Uuid::new_v4();

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -1,18 +1,9 @@
 use super::*;
 
 impl Model {
-    /// The full unified live+archived collection. Only for callers that
-    /// genuinely need id resolution regardless of archival status — see the
-    /// view layer's `Controller` for the common display case.
-    pub fn cards_state(&self) -> &LoadState<Vec<Card>> {
-        &self.cards
-    }
-
-    /// Resolves a card by id in per-id, parent-scoped, then flat-collection
-    /// precedence order: a per-id result always wins, then a card found in a
-    /// loaded column scope, then the single unified collection (live AND
-    /// archived rows). A card is a card regardless of whether its head is
-    /// archived.
+    /// Resolves a card by id in per-id, then parent-scoped precedence order:
+    /// a per-id result always wins, then a card found in a loaded column
+    /// scope. `NotLoaded` when neither tier names the id.
     pub fn card_by_id_state(&self, id: Uuid) -> LoadState<&Card> {
         if let Some(state) = self.cards_by_id.get(&id) {
             return state.as_ref();
@@ -24,17 +15,7 @@ impl Model {
                 }
             }
         }
-        match self.cards.as_ref() {
-            LoadState::Loaded(cards) => {
-                match self.card_index.get(&id).and_then(|&idx| cards.get(idx)) {
-                    Some(card) => LoadState::Loaded(card),
-                    None => LoadState::Missing,
-                }
-            }
-            LoadState::NotLoaded => LoadState::NotLoaded,
-            LoadState::Missing => LoadState::Missing,
-            LoadState::Failed(e) => LoadState::Failed(e),
-        }
+        LoadState::NotLoaded
     }
 
     /// The parent-scoped card tier for one column, independent of the per-id
@@ -266,23 +247,6 @@ mod tests {
         let state = m.card_by_id_state(Uuid::new_v4());
         assert!(state.is_not_loaded());
         assert!(!state.is_missing());
-    }
-
-    #[test]
-    fn test_card_by_id_state_is_missing_for_an_absent_card_after_load() {
-        let mut m = Model::default();
-        let board = Board::new("B", None::<String>);
-        let col_id = Uuid::new_v4();
-        let card = make_card(&board, col_id);
-        let _ = m.load_from_snapshot(Snapshot {
-            archived_boards: Vec::new(),
-            cards: vec![card],
-            ..Default::default()
-        });
-        let state = m.card_by_id_state(Uuid::new_v4());
-        assert!(state.is_missing());
-        assert!(state.is_terminal());
-        assert!(!state.is_not_loaded());
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/cards.rs
+++ b/crates/kanban-domain/src/model/cards.rs
@@ -37,8 +37,8 @@ impl Model {
         }
     }
 
-    /// The parent-scoped card tier for one column. Independent of
-    /// `cards_state()`: a scoped result never touches the flat collection.
+    /// The parent-scoped card tier for one column, independent of the per-id
+    /// tier.
     pub fn column_cards_state(&self, column_id: Uuid) -> LoadState<&[Card]> {
         scoped_state(&self.cards_by_column, column_id)
     }
@@ -47,7 +47,7 @@ impl Model {
     /// column order, of every column's `column_cards_state`. `Loaded` only
     /// when the board's column tier and every one of its columns' card
     /// tiers are `Loaded`; `Failed` takes precedence over `Missing` over
-    /// `NotLoaded`. Never reads `cards_state()`.
+    /// `NotLoaded`.
     pub fn board_cards_state(&self, board_id: Uuid) -> LoadState<Vec<&Card>> {
         let columns = match self.board_columns_state(board_id) {
             LoadState::Loaded(columns) => columns,
@@ -115,10 +115,11 @@ impl Model {
         self.archived_cards.is_some()
     }
 
-    /// Ids of the archived cards. Rows themselves live in the unified `cards_state()`
-    /// collection; this set records which of them are archived (built from the
-    /// markers). The live/archived partition is a presentation concern and lives
-    /// on the view layer's `Controller`; this set is what backs that split.
+    /// Ids of the archived cards. Rows themselves live in the scoped and
+    /// per-id tiers; this set records which of them are archived (built from
+    /// the markers). The live/archived partition is a presentation concern
+    /// and lives on the view layer's `Controller`; this set is what backs
+    /// that split.
     pub fn archived_card_ids(&self) -> &std::collections::HashSet<Uuid> {
         &self.archived_card_ids
     }
@@ -185,9 +186,6 @@ mod tests {
 
     #[test]
     fn test_card_by_id_resolves_live_and_archived_from_one_collection() {
-        // After unification `cards_state()` holds live AND archived rows, and
-        // `card_by_id_state` resolves either from the single collection — no
-        // `or_else(archived_card())` re-join.
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
@@ -202,8 +200,13 @@ mod tests {
             ..Default::default()
         });
 
-        // Both live and archived rows live in the single unified collection.
-        assert_eq!(m.cards_state().loaded_or_empty().len(), 2);
+        // The live row lives in the scoped column tier, the archived row in
+        // the per-id tier.
+        assert_eq!(
+            m.column_cards_state(col_id).loaded().unwrap().len(),
+            1
+        );
+        assert!(m.card_id_status(archived_id).is_loaded());
 
         // The single index resolves both.
         assert_eq!(
@@ -224,10 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn test_archived_view_filter_shows_archived_card_from_unified_collection() {
-        // `archived_card_ids` records the archived subset of the unified `cards_state()`
-        // collection. Assert an
-        // archived card is reachable by filtering `cards_state()` through that set.
+    fn test_archived_view_filter_finds_the_archived_card_through_the_per_id_tier() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let col_id = Uuid::new_v4();
@@ -242,11 +242,10 @@ mod tests {
         });
 
         let displayed: Vec<Uuid> = m
-            .cards_state()
-            .loaded_or_empty()
+            .archived_card_ids()
             .iter()
-            .filter(|c| m.archived_card_ids().contains(&c.id))
-            .map(|c| c.id)
+            .filter(|id| m.card_id_status(**id).is_loaded())
+            .copied()
             .collect();
         assert_eq!(displayed, vec![archived_id]);
     }
@@ -259,21 +258,6 @@ mod tests {
             .loaded()
             .copied()
             .is_none());
-    }
-
-    #[test]
-    fn test_cards_state_is_not_loaded_before_load_from_snapshot() {
-        let m = Model::default();
-        assert!(m.cards_state().is_not_loaded());
-    }
-
-    #[test]
-    fn test_cards_state_is_loaded_and_empty_after_an_empty_snapshot() {
-        let mut m = Model::default();
-        let _ = m.load_from_snapshot(Snapshot::default());
-        assert!(m.cards_state().is_loaded());
-        assert!(m.cards_state().loaded().unwrap().is_empty());
-        assert!(m.cards_state().loaded_or_empty().is_empty());
     }
 
     #[test]
@@ -506,27 +490,5 @@ mod tests {
         });
         let state = m.board_cards_state(random_board);
         assert!(matches!(state, LoadState::Failed(e) if std::sync::Arc::ptr_eq(&e, &err)));
-    }
-
-    #[test]
-    fn test_board_cards_state_ignores_a_failed_flat_collection() {
-        let err = std::sync::Arc::new(KanbanError::unsupported("boom"));
-        let mut m = Model::with_load_states(crate::model::ModelLoadStates {
-            cards: LoadState::Failed(err.clone()),
-            columns: LoadState::Failed(err),
-            ..Default::default()
-        });
-
-        let board = Board::new("B", None::<String>);
-        let col = crate::Column::new(board.id, "A", 0);
-        let col_id = col.id;
-        seed_columns_for_board(&mut m, board.id, vec![col]);
-        let card = make_card(&board, col_id);
-        let card_id = card.id;
-        seed_cards_for_column(&mut m, col_id, LoadState::Loaded(vec![card]));
-
-        let state = m.board_cards_state(board.id);
-        let ids: Vec<Uuid> = state.loaded().unwrap().iter().map(|c| c.id).collect();
-        assert_eq!(ids, vec![card_id]);
     }
 }

--- a/crates/kanban-domain/src/model/changed.rs
+++ b/crates/kanban-domain/src/model/changed.rs
@@ -61,6 +61,7 @@ impl DerivedProjections for NoProjections {
 mod tests {
     use super::super::Model;
     use crate::{DerivedProjections, NoProjections, Snapshot};
+    use uuid::Uuid;
 
     #[test]
     fn test_merge_folds_two_receipts_into_one() {
@@ -112,8 +113,9 @@ mod tests {
     fn test_no_projections_is_a_usable_derived_projections_substitute() {
         use crate::{Board, Card, Column};
 
-        fn drive(p: &mut impl DerivedProjections, m: &mut Model) {
+        fn drive(p: &mut impl DerivedProjections, m: &mut Model) -> Uuid {
             let board = Board::new("B", None::<String>);
+            let board_id = board.id;
             let col = Column::new(board.id, "Col", 0);
             let card = Card::new(board.id, col.id, "task", 0);
             let changed = m.load_from_snapshot(Snapshot {
@@ -124,13 +126,15 @@ mod tests {
                 ..Default::default()
             });
             p.resync(m, changed);
+            board_id
         }
 
         let mut m = Model::default();
         let mut p = NoProjections;
-        drive(&mut p, &mut m);
+        let board_id = drive(&mut p, &mut m);
 
-        assert!(m.cards_state().is_loaded());
-        assert_eq!(m.cards_state().loaded_or_empty().len(), 1);
+        let state = m.board_cards_state(board_id);
+        assert!(state.is_loaded());
+        assert_eq!(state.loaded().unwrap().len(), 1);
     }
 }

--- a/crates/kanban-domain/src/model/collections.rs
+++ b/crates/kanban-domain/src/model/collections.rs
@@ -82,46 +82,54 @@ mod tests {
     use crate::{Column, Snapshot, Sprint};
 
     #[test]
-    fn test_columns_state_is_not_loaded_before_load_from_snapshot() {
+    fn test_board_columns_state_is_not_loaded_before_load_from_snapshot() {
         let m = Model::default();
-        assert!(m.columns_state().is_not_loaded());
+        assert!(m.board_columns_state(Uuid::new_v4()).is_not_loaded());
     }
 
     #[test]
-    fn test_columns_state_is_loaded_and_empty_after_an_empty_snapshot() {
+    fn test_board_columns_state_is_loaded_and_empty_after_an_empty_snapshot() {
         let mut m = Model::default();
-        let _ = m.load_from_snapshot(Snapshot::default());
-        assert!(m.columns_state().is_loaded());
-        assert!(m.columns_state().loaded().unwrap().is_empty());
-        assert!(m.columns_state().loaded_or_empty().is_empty());
+        let board = Board::new("B", None::<String>);
+        let board_id = board.id;
+        let _ = m.load_from_snapshot(Snapshot {
+            boards: vec![board],
+            ..Default::default()
+        });
+        let state = m.board_columns_state(board_id);
+        assert!(state.is_loaded());
+        assert!(state.loaded().unwrap().is_empty());
     }
 
     #[test]
-    fn test_columns_state_is_loaded_after_load_from_snapshot() {
+    fn test_board_columns_state_is_loaded_after_load_from_snapshot() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
         let col = Column::new(board.id, "Col", 0);
         let col_id = col.id;
+        let board_id = board.id;
         let _ = m.load_from_snapshot(Snapshot {
             boards: vec![board],
             columns: vec![col],
             ..Default::default()
         });
-        let loaded = m.columns_state().loaded().unwrap();
+        let state = m.board_columns_state(board_id);
+        let loaded = state.loaded().unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].id, col_id);
     }
 
     #[test]
-    fn test_sprints_state_is_not_loaded_before_load_from_snapshot() {
+    fn test_board_sprints_state_is_not_loaded_before_load_from_snapshot() {
         let m = Model::default();
-        assert!(m.sprints_state().is_not_loaded());
+        assert!(m.board_sprints_state(Uuid::new_v4()).is_not_loaded());
     }
 
     #[test]
-    fn test_sprints_state_is_loaded_after_load_from_snapshot() {
+    fn test_board_sprints_state_is_loaded_after_load_from_snapshot() {
         let mut m = Model::default();
         let board = Board::new("B", None::<String>);
+        let board_id = board.id;
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
         let sprint_id = sprint.id;
         let _ = m.load_from_snapshot(Snapshot {
@@ -129,8 +137,9 @@ mod tests {
             sprints: vec![sprint],
             ..Default::default()
         });
-        assert!(m.sprints_state().is_loaded());
-        let loaded = m.sprints_state().loaded().unwrap();
+        let state = m.board_sprints_state(board_id);
+        assert!(state.is_loaded());
+        let loaded = state.loaded().unwrap();
         assert!(loaded.iter().any(|s| s.id == sprint_id));
     }
 }

--- a/crates/kanban-domain/src/model/collections.rs
+++ b/crates/kanban-domain/src/model/collections.rs
@@ -1,14 +1,6 @@
 use super::*;
 
 impl Model {
-    pub fn columns_state(&self) -> &LoadState<Vec<Column>> {
-        &self.columns
-    }
-
-    pub fn sprints_state(&self) -> &LoadState<Vec<Sprint>> {
-        &self.sprints
-    }
-
     pub fn board_columns_state(&self, board_id: Uuid) -> LoadState<&[Column]> {
         scoped_state(&self.columns_by_board, board_id)
     }
@@ -28,15 +20,7 @@ impl Model {
                 }
             }
         }
-        match self.columns.as_ref() {
-            LoadState::Loaded(columns) => match columns.iter().find(|c| c.id == id) {
-                Some(column) => LoadState::Loaded(column),
-                None => LoadState::Missing,
-            },
-            LoadState::NotLoaded => LoadState::NotLoaded,
-            LoadState::Missing => LoadState::Missing,
-            LoadState::Failed(e) => LoadState::Failed(e),
-        }
+        LoadState::NotLoaded
     }
 
     pub fn sprint_by_id_state(&self, id: Uuid) -> LoadState<&Sprint> {
@@ -50,15 +34,7 @@ impl Model {
                 }
             }
         }
-        match self.sprints.as_ref() {
-            LoadState::Loaded(sprints) => match sprints.iter().find(|s| s.id == id) {
-                Some(sprint) => LoadState::Loaded(sprint),
-                None => LoadState::Missing,
-            },
-            LoadState::NotLoaded => LoadState::NotLoaded,
-            LoadState::Missing => LoadState::Missing,
-            LoadState::Failed(e) => LoadState::Failed(e),
-        }
+        LoadState::NotLoaded
     }
 
     pub fn column_id_status(&self, id: Uuid) -> LoadState<&Column> {

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -110,12 +110,32 @@ mod tests {
         let c2 = Card::new(board.id, col_b.id, "two", 0);
         let sprint = Sprint::new(board.id, 1, None, None::<String>);
 
-        let model = Model::with_load_states(ModelLoadStates {
+        let mut model = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![board.clone()]),
-            columns: LoadState::Loaded(vec![col_a.clone(), col_b.clone()]),
-            cards: LoadState::Loaded(vec![c1.clone(), c2.clone()]),
-            sprints: LoadState::Loaded(vec![sprint.clone()]),
             graph: LoadState::Loaded(DependencyGraph::default()),
+            ..Default::default()
+        });
+
+        let mut columns_by_parent = HashMap::new();
+        columns_by_parent.insert(board.id, LoadState::Loaded(vec![col_a.clone(), col_b.clone()]));
+        let mut cards_by_parent = HashMap::new();
+        cards_by_parent.insert(col_a.id, LoadState::Loaded(vec![c1.clone()]));
+        cards_by_parent.insert(col_b.id, LoadState::Loaded(vec![c2.clone()]));
+        let mut sprints_by_parent = HashMap::new();
+        sprints_by_parent.insert(board.id, LoadState::Loaded(vec![sprint.clone()]));
+        let _ = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_parent: cards_by_parent,
+                ..Default::default()
+            },
+            sprints: Collection {
+                by_parent: sprints_by_parent,
+                ..Default::default()
+            },
             ..Default::default()
         });
 
@@ -179,9 +199,9 @@ mod tests {
         sprint: &Sprint,
     ) {
         assert!(m.boards_state().is_not_loaded());
-        assert!(m.columns_state().is_not_loaded());
-        assert!(m.cards_state().is_not_loaded());
-        assert!(m.sprints_state().is_not_loaded());
+        assert!(m.board_columns_state(board.id).is_not_loaded());
+        assert!(m.column_cards_state(col_a.id).is_not_loaded());
+        assert!(m.board_sprints_state(board.id).is_not_loaded());
         assert!(m.graph_state().is_not_loaded());
         assert!(m.board_by_id_state(board.id).is_not_loaded());
         assert!(m.column_id_status(col_a.id).is_not_loaded());
@@ -194,7 +214,6 @@ mod tests {
         assert!(m.board_columns_state(board.id).is_not_loaded());
         assert!(m.board_sprints_state(board.id).is_not_loaded());
         assert!(m.scoped_card_index.is_empty());
-        assert!(m.card_index.is_empty());
         assert!(m.board_index.is_empty());
         assert!(m.board_archived_cards_state(board.id).is_not_loaded());
     }
@@ -209,9 +228,9 @@ mod tests {
         sprint: &Sprint,
     ) {
         assert!(m.boards_state().is_loaded());
-        assert!(m.columns_state().is_loaded());
-        assert!(m.cards_state().is_loaded());
-        assert!(m.sprints_state().is_loaded());
+        assert!(m.board_columns_state(board.id).is_loaded());
+        assert!(m.column_cards_state(col_a.id).is_loaded());
+        assert!(m.board_sprints_state(board.id).is_loaded());
         assert!(m.graph_state().is_loaded());
         assert!(m.board_by_id_state(board.id).is_loaded());
         assert!(m.column_id_status(col_a.id).is_loaded());
@@ -222,7 +241,6 @@ mod tests {
         assert!(m.board_sprints_state(board.id).is_loaded());
         assert!(m.board_archived_cards_state(board.id).is_loaded());
         assert!(!m.scoped_card_index.is_empty());
-        assert!(!m.card_index.is_empty());
         assert!(!m.board_index.is_empty());
     }
 
@@ -368,25 +386,6 @@ mod tests {
 
         assert_eq!(m.scoped_card_index.len(), 1);
         assert_eq!(m.scoped_card_index.get(&c3.id), Some(&col_a.id));
-    }
-
-    #[test]
-    fn test_invalidating_a_card_clears_the_card_index() {
-        let board = Board::new("B", None::<String>);
-        let col = Column::new(board.id, "A", 0);
-        let c1 = Card::new(board.id, col.id, "one", 0);
-        let c2 = Card::new(board.id, col.id, "two", 0);
-
-        let mut m = Model::with_load_states(ModelLoadStates {
-            cards: LoadState::Loaded(vec![c1.clone(), c2.clone()]),
-            ..Default::default()
-        });
-
-        let _ = m.invalidate(Invalidation::Entities(EntityIds::cards([c1.id])));
-
-        assert!(m.cards_state().is_not_loaded());
-        assert!(m.card_by_id_state(c2.id).is_not_loaded());
-        assert!(m.card_index.is_empty());
     }
 
     #[test]
@@ -587,6 +586,7 @@ mod tests {
     fn test_invalidate_empty_entity_ids_keeps_the_snapshot_derived_archived_markers() {
         let board = Board::new("B", None::<String>);
         let card = Card::new(board.id, Uuid::new_v4(), "task", 0);
+        let card_id = card.id;
         let marker = ArchivedCard::new(card.id, board.id);
 
         let mut m = Model::default();
@@ -603,7 +603,7 @@ mod tests {
 
         assert!(!m.archived_card_markers().is_empty());
         assert!(!m.archived_card_ids().is_empty());
-        assert!(m.cards_state().is_loaded());
+        assert!(m.card_id_status(card_id).is_loaded());
     }
 
     #[test]
@@ -613,10 +613,10 @@ mod tests {
         let archived = Card::new(board.id, Uuid::new_v4(), "archived", 0);
 
         let mut m = Model::with_load_states(ModelLoadStates {
-            cards: LoadState::Loaded(vec![live.clone(), archived.clone()]),
             archived_cards: Some(vec![ArchivedCard::new(archived.id, board.id)]),
             ..Default::default()
         });
+        let _ = live;
         assert!(m.archived_cards_state().is_loaded());
         assert!(m.archived_card_ids().contains(&archived.id));
 
@@ -634,7 +634,6 @@ mod tests {
 
         let mut m = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![live_board.clone(), archived_board.clone()]),
-            cards: LoadState::Loaded(vec![card.clone()]),
             archived_boards: Some(vec![ArchivedBoard::now(archived_board.id)]),
             archived_cards: Some(vec![ArchivedCard::new(card.id, live_board.id)]),
             ..Default::default()
@@ -660,7 +659,6 @@ mod tests {
 
         let mut m = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![live_board.clone(), archived_board.clone()]),
-            cards: LoadState::Loaded(vec![card.clone()]),
             archived_boards: Some(vec![ArchivedBoard::now(archived_board.id)]),
             archived_cards: Some(vec![ArchivedCard::new(card.id, live_board.id)]),
             ..Default::default()
@@ -680,7 +678,6 @@ mod tests {
 
         let mut m = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![board.clone()]),
-            cards: LoadState::Loaded(vec![card.clone()]),
             sprints: LoadState::Loaded(vec![sprint.clone()]),
             archived_boards: Some(vec![]),
             archived_cards: Some(vec![ArchivedCard::new(card.id, board.id)]),
@@ -698,7 +695,7 @@ mod tests {
         let mut m = Model::default();
         let changed: ModelChanged = m.invalidate(Invalidation::All);
         NoProjections.resync(&m, changed);
-        assert!(m.cards_state().is_not_loaded());
+        assert!(m.card_id_status(Uuid::new_v4()).is_not_loaded());
     }
 
     #[test]
@@ -714,12 +711,12 @@ mod tests {
         let (mut m, ..) = seeded();
         let changed = m.invalidate(Invalidation::All);
         assert!(changed.any());
-        assert!(m.cards_state().is_not_loaded());
+        assert!(m.card_id_status(Uuid::new_v4()).is_not_loaded());
     }
 
     #[test]
     fn test_invalidate_a_column_id_drops_that_column_and_the_column_collection() {
-        let (mut m, _board, col_a, col_b, _c1, _c2, _sprint) = seeded();
+        let (mut m, board, col_a, col_b, c1, _c2, sprint) = seeded();
 
         let changed = m.apply_resolved(Resolved {
             columns: Collection {
@@ -738,11 +735,12 @@ mod tests {
 
         assert!(m.column_id_status(col_a.id).is_not_loaded());
         assert!(m.column_id_status(col_b.id).is_loaded());
-        assert!(m.columns_state().is_not_loaded());
+        assert!(m.board_columns_state(board.id).is_not_loaded());
         assert!(m.boards_state().is_loaded());
-        assert!(m.cards_state().is_loaded());
-        assert!(m.sprints_state().is_loaded());
+        assert!(m.column_cards_state(col_b.id).is_loaded());
+        assert!(m.board_sprints_state(board.id).is_loaded());
         assert!(m.graph_state().is_loaded());
+        let _ = (c1, sprint);
     }
 
     #[test]
@@ -753,13 +751,16 @@ mod tests {
 
         let mut m = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![board.clone()]),
-            columns: LoadState::Loaded(vec![]),
-            cards: LoadState::Loaded(vec![]),
-            sprints: LoadState::Loaded(vec![sa.clone(), sb.clone()]),
             graph: LoadState::Loaded(DependencyGraph::default()),
             ..Default::default()
         });
+        let mut columns_by_parent = HashMap::new();
+        columns_by_parent.insert(board.id, LoadState::Loaded(Vec::new()));
         let changed = m.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
             sprints: Collection {
                 by_id: [
                     (sa.id, LoadState::Loaded(sa.clone())),
@@ -776,10 +777,8 @@ mod tests {
 
         assert!(m.sprint_id_status(sa.id).is_not_loaded());
         assert!(m.sprint_id_status(sb.id).is_loaded());
-        assert!(m.sprints_state().is_not_loaded());
         assert!(m.boards_state().is_loaded());
-        assert!(m.columns_state().is_loaded());
-        assert!(m.cards_state().is_loaded());
+        assert!(m.board_columns_state(board.id).is_loaded());
         assert!(m.graph_state().is_loaded());
     }
 
@@ -799,13 +798,12 @@ mod tests {
         let _ = m.invalidate(Invalidation::Entities(EntityIds::boards([board.id])));
 
         assert!(m.boards_state().is_not_loaded());
-        assert!(m.columns_state().is_loaded());
-        assert!(m.cards_state().is_loaded());
-        assert!(m.sprints_state().is_loaded());
+        assert!(m.column_cards_state(col_a.id).is_loaded());
         assert!(m.graph_state().is_loaded());
         assert!(m.column_id_status(col_a.id).is_loaded());
         assert!(m.card_id_status(c1.id).is_loaded());
         assert!(m.sprint_id_status(sprint.id).is_loaded());
+        let _ = (c2, col_b);
     }
 
     #[test]
@@ -842,10 +840,10 @@ mod tests {
 
         let _ = m.invalidate(Invalidation::Entities(EntityIds::cards([c1.id])));
 
-        assert!(m.cards_state().is_not_loaded());
+        assert!(m.column_cards_state(col_a.id).is_not_loaded());
         assert!(m.boards_state().is_loaded());
-        assert!(m.columns_state().is_loaded());
-        assert!(m.sprints_state().is_loaded());
+        assert!(m.board_columns_state(board.id).is_loaded());
+        assert!(m.board_sprints_state(board.id).is_loaded());
         assert!(m.graph_state().is_loaded());
     }
 
@@ -858,9 +856,6 @@ mod tests {
 
         let mut m = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![board.clone()]),
-            columns: LoadState::Loaded(vec![col.clone()]),
-            cards: LoadState::Loaded(vec![card.clone()]),
-            sprints: LoadState::Loaded(vec![sprint.clone()]),
             graph: LoadState::Loaded(DependencyGraph::default()),
             ..Default::default()
         });
@@ -888,9 +883,6 @@ mod tests {
         let _ = m.invalidate(Invalidation::All);
 
         assert!(m.boards_state().is_not_loaded());
-        assert!(m.columns_state().is_not_loaded());
-        assert!(m.cards_state().is_not_loaded());
-        assert!(m.sprints_state().is_not_loaded());
         assert!(m.board_by_id_state(board.id).is_not_loaded());
         assert!(m.column_id_status(col.id).is_not_loaded());
         assert!(m.card_id_status(card.id).is_not_loaded());
@@ -905,29 +897,31 @@ mod tests {
         let _ = m.invalidate(Invalidation::Entities(EntityIds::default().with_prefixes()));
 
         assert!(m.boards_state().is_not_loaded());
-        assert!(m.columns_state().is_loaded());
-        assert!(m.cards_state().is_loaded());
-        assert!(m.sprints_state().is_loaded());
+        assert!(m.board_columns_state(board.id).is_loaded());
+        assert!(m.column_cards_state(col_a.id).is_loaded());
+        assert!(m.board_sprints_state(board.id).is_loaded());
         assert!(m.graph_state().is_loaded());
         assert!(m.column_id_status(col_a.id).is_loaded());
         assert!(m.card_id_status(c1.id).is_loaded());
         assert!(m.sprint_id_status(sprint.id).is_loaded());
         assert!(m.board_columns_state(board.id).is_loaded());
         assert!(m.board_sprints_state(board.id).is_loaded());
+        let _ = (col_b, c2);
     }
 
     #[test]
     fn test_invalidate_graph_flag_drops_only_the_graph() {
-        let (mut m, _board, col_a, col_b, c1, c2, sprint) = seeded();
-        load_every_tier(&mut m, &_board, &col_a, &col_b, &c1, &c2, &sprint);
+        let (mut m, board, col_a, col_b, c1, c2, sprint) = seeded();
+        load_every_tier(&mut m, &board, &col_a, &col_b, &c1, &c2, &sprint);
 
         let _ = m.invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
 
         assert!(m.graph_state().is_not_loaded());
         assert!(m.boards_state().is_loaded());
-        assert!(m.columns_state().is_loaded());
-        assert!(m.cards_state().is_loaded());
-        assert!(m.sprints_state().is_loaded());
+        assert!(m.board_columns_state(board.id).is_loaded());
+        assert!(m.column_cards_state(col_a.id).is_loaded());
+        assert!(m.board_sprints_state(board.id).is_loaded());
+        let _ = (col_b, c1, c2, sprint);
     }
 
     #[test]

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -54,7 +54,6 @@ impl Model {
         }
 
         if !ids.columns.is_empty() {
-            self.columns = LoadState::NotLoaded;
             for id in &ids.columns {
                 self.columns_by_id.remove(id);
                 self.cards_by_column.remove(id);
@@ -64,8 +63,6 @@ impl Model {
         }
 
         if !ids.cards.is_empty() {
-            self.cards = LoadState::NotLoaded;
-            self.card_index.clear();
             for id in &ids.cards {
                 self.cards_by_id.remove(id);
             }
@@ -78,7 +75,6 @@ impl Model {
         }
 
         if !ids.sprints.is_empty() {
-            self.sprints = LoadState::NotLoaded;
             for id in &ids.sprints {
                 self.sprints_by_id.remove(id);
             }
@@ -678,7 +674,6 @@ mod tests {
 
         let mut m = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![board.clone()]),
-            sprints: LoadState::Loaded(vec![sprint.clone()]),
             archived_boards: Some(vec![]),
             archived_cards: Some(vec![ArchivedCard::new(card.id, board.id)]),
             ..Default::default()

--- a/crates/kanban-domain/src/model/invalidate.rs
+++ b/crates/kanban-domain/src/model/invalidate.rs
@@ -113,7 +113,10 @@ mod tests {
         });
 
         let mut columns_by_parent = HashMap::new();
-        columns_by_parent.insert(board.id, LoadState::Loaded(vec![col_a.clone(), col_b.clone()]));
+        columns_by_parent.insert(
+            board.id,
+            LoadState::Loaded(vec![col_a.clone(), col_b.clone()]),
+        );
         let mut cards_by_parent = HashMap::new();
         cards_by_parent.insert(col_a.id, LoadState::Loaded(vec![c1.clone()]));
         cards_by_parent.insert(col_b.id, LoadState::Loaded(vec![c2.clone()]));

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -186,6 +186,8 @@ impl Model {
         if let LoadState::Loaded(cards) = &self.cards {
             for card in cards {
                 if self.archived_card_ids.contains(&card.id) {
+                    self.cards_by_id
+                        .insert(card.id, LoadState::Loaded(card.clone()));
                     continue;
                 }
                 buckets

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -286,9 +286,9 @@ mod tests {
     fn test_default_model_returns_empty_slices() {
         let m = Model::default();
         assert!(m.boards_state().loaded_or_empty().is_empty());
-        assert!(m.columns_state().loaded_or_empty().is_empty());
-        assert!(m.cards_state().loaded_or_empty().is_empty());
-        assert!(m.sprints_state().loaded_or_empty().is_empty());
+        assert!(m.board_columns_state(Uuid::new_v4()).is_not_loaded());
+        assert!(m.column_cards_state(Uuid::new_v4()).is_not_loaded());
+        assert!(m.board_sprints_state(Uuid::new_v4()).is_not_loaded());
         assert!(m.archived_card_markers().is_empty());
         assert!(m.archived_card_ids().is_empty());
     }
@@ -313,8 +313,10 @@ mod tests {
         });
         assert_eq!(m.boards_state().loaded_or_empty().len(), 1);
         assert_eq!(m.boards_state().loaded_or_empty()[0].id, board.id);
-        assert_eq!(m.columns_state().loaded_or_empty().len(), 1);
-        assert_eq!(m.columns_state().loaded_or_empty()[0].id, col.id);
+        let state = m.board_columns_state(board.id);
+        let loaded = state.loaded().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, col.id);
     }
 
     #[test]
@@ -464,7 +466,7 @@ mod tests {
     fn test_load_from_snapshot_returns_a_model_changed_receipt() {
         let mut m = Model::default();
         let changed: ModelChanged = m.load_from_snapshot(Snapshot::default());
-        assert!(m.cards_state().is_loaded());
+        assert!(m.boards_state().is_loaded());
         NoProjections.resync(&m, changed);
     }
 
@@ -491,7 +493,7 @@ mod tests {
         let cards_src = include_str!("cards.rs");
         assert!(
             !cards_src.contains("pub fn all_cards(&self)"),
-            "Model::all_cards must be deleted; callers should use cards_state().loaded_or_empty()"
+            "Model::all_cards must be deleted; callers should use board_cards_state(board_id)"
         );
         assert!(
             !cards_src.contains("pub fn card_by_id(&self,"),
@@ -504,11 +506,11 @@ mod tests {
         let collections_src = include_str!("collections.rs");
         assert!(
             !collections_src.contains("pub fn columns(&self)"),
-            "Model::columns must be deleted; callers should use columns_state().loaded_or_empty()"
+            "Model::columns must be deleted; callers should use board_columns_state(board_id)"
         );
         assert!(
             !collections_src.contains("pub fn sprints(&self)"),
-            "Model::sprints must be deleted; callers should use sprints_state().loaded_or_empty()"
+            "Model::sprints must be deleted; callers should use board_sprints_state(board_id)"
         );
     }
 

--- a/crates/kanban-domain/src/model/mod.rs
+++ b/crates/kanban-domain/src/model/mod.rs
@@ -6,23 +6,21 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use uuid::Uuid;
 
-/// The unified, per-Model view of every entity kind's flat, per-id and
+/// The unified, per-Model view of every entity kind's per-id and
 /// parent-scoped tiers, chained by precedence in accessors like
-/// `card_by_id_state`. This differs from [`crate::resolved::Collection`],
-/// whose three tiers stay mutually independent so that a resolve pass can
-/// touch one tier without silently inferring another: a `Model` accessor
-/// answers "what do we know about this id, from any source", while a
-/// `Collection` answers "what did this specific resolve pass say about this
-/// tier", and conflating the two would let an archived-excluding tier
-/// silently mark an id `Missing` that another tier still holds.
+/// `card_by_id_state`. Boards alone keep a flat collection, since the board
+/// list itself has no parent to scope under. This differs from
+/// [`crate::resolved::Collection`], whose three tiers stay mutually
+/// independent so that a resolve pass can touch one tier without silently
+/// inferring another: a `Model` accessor answers "what do we know about this
+/// id, from any source", while a `Collection` answers "what did this
+/// specific resolve pass say about this tier", and conflating the two would
+/// let an archived-excluding tier silently mark an id `Missing` that another
+/// tier still holds.
 #[derive(Clone)]
 pub struct Model {
     boards: LoadState<Vec<Board>>,
-    columns: LoadState<Vec<Column>>,
-    cards: LoadState<Vec<Card>>,
-    card_index: HashMap<Uuid, usize>,
     board_index: HashMap<Uuid, usize>,
-    sprints: LoadState<Vec<Sprint>>,
     archived_cards: Option<Vec<ArchivedCard>>,
     archived_cards_error: Option<Arc<KanbanError>>,
     archived_card_ids: HashSet<Uuid>,
@@ -32,8 +30,8 @@ pub struct Model {
     graph: LoadState<DependencyGraph>,
     /// The per-id tier beside each unified collection. Not a second row
     /// store: a `Loaded` entry here can name an entity even while the
-    /// matching flat collection is `NotLoaded`, and it is the only tier that
-    /// can ever hold `LoadState::Missing` for a single id. Nothing writes
+    /// scoped tier is `NotLoaded`, and it is the only tier that can ever
+    /// hold `LoadState::Missing` for a single id. Nothing writes
     /// `boards_by_id` today; it exists for symmetry of the mutators.
     boards_by_id: HashMap<Uuid, LoadState<Board>>,
     columns_by_id: HashMap<Uuid, LoadState<Column>>,
@@ -42,7 +40,7 @@ pub struct Model {
     /// The parent-scoped tier, keyed by the fixed parent id per kind
     /// (`columns_by_board`/`sprints_by_board`/`archived_cards_by_board` by
     /// board id, `cards_by_column` by column id). A scoped result never
-    /// mutates the flat collection or the per-id tier, and vice versa.
+    /// mutates the per-id tier, and vice versa.
     columns_by_board: HashMap<Uuid, LoadState<Vec<Column>>>,
     cards_by_column: HashMap<Uuid, LoadState<Vec<Card>>>,
     sprints_by_board: HashMap<Uuid, LoadState<Vec<Sprint>>>,
@@ -58,11 +56,7 @@ impl Default for Model {
     fn default() -> Self {
         Self {
             boards: LoadState::NotLoaded,
-            columns: LoadState::NotLoaded,
-            cards: LoadState::NotLoaded,
-            card_index: HashMap::new(),
             board_index: HashMap::new(),
-            sprints: LoadState::NotLoaded,
             archived_cards: None,
             archived_cards_error: None,
             archived_card_ids: HashSet::new(),
@@ -101,9 +95,6 @@ impl Model {
         // records which are archived; the live/archived split is a consumption
         // decision the view layer applies on top.
         self.boards = LoadState::Loaded(snapshot.boards);
-        self.columns = LoadState::Loaded(snapshot.columns);
-        self.sprints = LoadState::Loaded(snapshot.sprints);
-        self.cards = LoadState::Loaded(snapshot.cards);
         self.graph = LoadState::Loaded(snapshot.graph);
 
         self.boards_by_id.clear();
@@ -119,9 +110,8 @@ impl Model {
             Some(snapshot.archived_boards),
         );
 
-        self.rebuild_card_index();
         self.rebuild_board_index();
-        self.rebuild_scoped_tiers();
+        self.rebuild_scoped_tiers(snapshot.columns, snapshot.cards, snapshot.sprints);
 
         ModelChanged::new()
     }
@@ -135,7 +125,12 @@ impl Model {
         ModelChanged::new()
     }
 
-    fn rebuild_scoped_tiers(&mut self) {
+    fn rebuild_scoped_tiers(
+        &mut self,
+        columns: Vec<Column>,
+        cards: Vec<Card>,
+        sprints: Vec<Sprint>,
+    ) {
         self.columns_by_board.clear();
         self.sprints_by_board.clear();
 
@@ -147,54 +142,42 @@ impl Model {
                     .insert(b.id, LoadState::Loaded(Vec::new()));
             }
         }
-        if let LoadState::Loaded(columns) = &self.columns {
-            for c in columns {
-                let LoadState::Loaded(bucket) = self
-                    .columns_by_board
-                    .entry(c.board_id)
-                    .or_insert_with(|| LoadState::Loaded(Vec::new()))
-                else {
-                    unreachable!("entry is always seeded as Loaded above")
-                };
-                bucket.push(c.clone());
-            }
+        for c in &columns {
+            let LoadState::Loaded(bucket) = self
+                .columns_by_board
+                .entry(c.board_id)
+                .or_insert_with(|| LoadState::Loaded(Vec::new()))
+            else {
+                unreachable!("entry is always seeded as Loaded above")
+            };
+            bucket.push(c.clone());
         }
-        if let LoadState::Loaded(sprints) = &self.sprints {
-            for s in sprints {
-                let LoadState::Loaded(bucket) = self
-                    .sprints_by_board
-                    .entry(s.board_id)
-                    .or_insert_with(|| LoadState::Loaded(Vec::new()))
-                else {
-                    unreachable!("entry is always seeded as Loaded above")
-                };
-                bucket.push(s.clone());
-            }
+        for s in &sprints {
+            let LoadState::Loaded(bucket) = self
+                .sprints_by_board
+                .entry(s.board_id)
+                .or_insert_with(|| LoadState::Loaded(Vec::new()))
+            else {
+                unreachable!("entry is always seeded as Loaded above")
+            };
+            bucket.push(s.clone());
         }
 
-        self.rebuild_card_column_buckets();
+        self.rebuild_card_column_buckets(&columns, cards);
         self.rebuild_archived_card_board_buckets();
     }
 
-    fn rebuild_card_column_buckets(&mut self) {
+    fn rebuild_card_column_buckets(&mut self, columns: &[Column], cards: Vec<Card>) {
         let mut buckets: HashMap<Uuid, Vec<Card>> = HashMap::new();
-        if let LoadState::Loaded(columns) = &self.columns {
-            for c in columns {
-                buckets.entry(c.id).or_default();
-            }
+        for c in columns {
+            buckets.entry(c.id).or_default();
         }
-        if let LoadState::Loaded(cards) = &self.cards {
-            for card in cards {
-                if self.archived_card_ids.contains(&card.id) {
-                    self.cards_by_id
-                        .insert(card.id, LoadState::Loaded(card.clone()));
-                    continue;
-                }
-                buckets
-                    .entry(card.column_id)
-                    .or_default()
-                    .push(card.clone());
+        for card in cards {
+            if self.archived_card_ids.contains(&card.id) {
+                self.cards_by_id.insert(card.id, LoadState::Loaded(card));
+                continue;
             }
+            buckets.entry(card.column_id).or_default().push(card);
         }
         for (column_id, cards) in buckets {
             self.set_cards_of_column(column_id, LoadState::Loaded(cards));
@@ -231,18 +214,6 @@ impl Model {
         self.archived_cards_error = None;
         self.archived_boards = boards;
         self.archived_boards_error = None;
-    }
-
-    fn rebuild_card_index(&mut self) {
-        self.card_index = self
-            .cards
-            .loaded()
-            .map(Vec::as_slice)
-            .unwrap_or_default()
-            .iter()
-            .enumerate()
-            .map(|(i, c)| (c.id, i))
-            .collect();
     }
 
     fn rebuild_board_index(&mut self) {
@@ -591,7 +562,7 @@ mod tests {
         let err = Arc::new(KanbanError::unsupported("boom"));
         let _ = m.apply_resolved(crate::Resolved {
             cards: crate::resolved::Collection {
-                all: LoadState::Failed(err),
+                by_id: [(Uuid::new_v4(), LoadState::Failed(err))].into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kanban-domain/src/model/test_helpers.rs
+++ b/crates/kanban-domain/src/model/test_helpers.rs
@@ -1,14 +1,13 @@
 use super::*;
 
-/// The settable half of a [`Model`]: the five fetchable collections plus the
-/// two archival marker vectors. The id indexes and the archived-id sets are
-/// derived and are rebuilt by [`Model::with_load_states`].
+/// The settable half of a [`Model`]: the boards flat collection, the graph,
+/// and the two archival marker vectors. The board id index and the
+/// archived-id sets are derived and are rebuilt by
+/// [`Model::with_load_states`]. Columns/cards/sprints have no flat tier to
+/// seed here; use `apply_resolved` with `by_id`/`by_parent` for those.
 #[derive(Default)]
 pub struct ModelLoadStates {
     pub boards: LoadState<Vec<Board>>,
-    pub columns: LoadState<Vec<Column>>,
-    pub cards: LoadState<Vec<Card>>,
-    pub sprints: LoadState<Vec<Sprint>>,
     pub graph: LoadState<DependencyGraph>,
     pub archived_cards: Option<Vec<ArchivedCard>>,
     pub archived_boards: Option<Vec<ArchivedBoard>>,
@@ -16,15 +15,12 @@ pub struct ModelLoadStates {
 
 impl Model {
     /// A `Model` with per-collection load states chosen by the caller, in the
-    /// same internally-consistent shape `load_from_snapshot` produces: the id
-    /// indexes and the archived-id sets are rebuilt from the values supplied.
-    /// Test-only surface.
+    /// same internally-consistent shape `load_from_snapshot` produces: the
+    /// board id index and the archived-id sets are rebuilt from the values
+    /// supplied. Test-only surface.
     pub fn with_load_states(states: ModelLoadStates) -> Self {
         let ModelLoadStates {
             boards,
-            columns,
-            cards,
-            sprints,
             graph,
             archived_cards,
             archived_boards,
@@ -32,15 +28,11 @@ impl Model {
 
         let mut model = Self {
             boards,
-            columns,
-            cards,
-            sprints,
             graph,
             ..Self::default()
         };
 
         model.absorb_archival_markers(archived_cards, archived_boards);
-        model.rebuild_card_index();
         model.rebuild_board_index();
         model
     }
@@ -89,19 +81,6 @@ mod tests {
     }
 
     #[test]
-    fn test_with_load_states_rebuilds_the_card_index() {
-        let board = seed_board();
-        let a = seed_card(&board);
-        let b = seed_card(&board);
-        let b_id = b.id;
-        let model = Model::with_load_states(ModelLoadStates {
-            cards: LoadState::Loaded(vec![a, b]),
-            ..Default::default()
-        });
-        assert!(model.card_by_id_state(b_id).loaded().is_some());
-    }
-
-    #[test]
     fn test_with_load_states_rebuilds_the_board_index() {
         let a = seed_board();
         let b = Board::new("C", None::<String>);
@@ -116,12 +95,10 @@ mod tests {
     #[test]
     fn test_with_load_states_records_the_archived_card_ids_from_the_markers() {
         let board = seed_board();
-        let live = seed_card(&board);
         let archived = seed_card(&board);
         let archived_id = archived.id;
         let marker = ArchivedCard::new(archived_id, board.id);
         let model = Model::with_load_states(ModelLoadStates {
-            cards: LoadState::Loaded(vec![live, archived]),
             archived_cards: Some(vec![marker]),
             ..Default::default()
         });

--- a/crates/kanban-domain/src/model/test_helpers.rs
+++ b/crates/kanban-domain/src/model/test_helpers.rs
@@ -62,34 +62,19 @@ mod tests {
 
     #[test]
     fn test_with_load_states_leaves_unnamed_collections_not_loaded() {
-        let board = seed_board();
-        let card = seed_card(&board);
-        let model = Model::with_load_states(ModelLoadStates {
-            cards: LoadState::Loaded(vec![card]),
-            ..Default::default()
-        });
-        assert!(model.cards_state().is_loaded());
+        let model = Model::with_load_states(ModelLoadStates::default());
         assert!(model.boards_state().is_not_loaded());
-        assert!(model.columns_state().is_not_loaded());
-        assert!(model.sprints_state().is_not_loaded());
         assert!(model.graph_state().is_not_loaded());
     }
 
     #[test]
     fn test_with_load_states_supports_a_different_state_per_tier() {
-        let err = Arc::new(KanbanError::unsupported("boom"));
         let model = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![seed_board()]),
-            columns: LoadState::NotLoaded,
-            cards: LoadState::Failed(err),
-            sprints: LoadState::Missing,
             graph: LoadState::Loaded(DependencyGraph::default()),
             ..Default::default()
         });
         assert!(model.boards_state().is_loaded());
-        assert!(model.columns_state().is_not_loaded());
-        assert!(model.cards_state().is_failed());
-        assert!(model.sprints_state().is_missing());
         assert!(model.graph_state().is_loaded());
     }
 
@@ -173,17 +158,18 @@ mod tests {
             built.boards_state().is_not_loaded(),
             base.boards_state().is_not_loaded()
         );
+        let random_id = Uuid::new_v4();
         assert_eq!(
-            built.columns_state().is_not_loaded(),
-            base.columns_state().is_not_loaded()
+            built.board_columns_state(random_id).is_not_loaded(),
+            base.board_columns_state(random_id).is_not_loaded()
         );
         assert_eq!(
-            built.cards_state().is_not_loaded(),
-            base.cards_state().is_not_loaded()
+            built.column_cards_state(random_id).is_not_loaded(),
+            base.column_cards_state(random_id).is_not_loaded()
         );
         assert_eq!(
-            built.sprints_state().is_not_loaded(),
-            base.sprints_state().is_not_loaded()
+            built.board_sprints_state(random_id).is_not_loaded(),
+            base.board_sprints_state(random_id).is_not_loaded()
         );
         assert_eq!(
             built.graph_state().is_not_loaded(),

--- a/crates/kanban-service/src/context/sync/tests.rs
+++ b/crates/kanban-service/src/context/sync/tests.rs
@@ -443,9 +443,15 @@ fn test_resync_invalidated_does_not_fetch_a_tier_the_model_never_read() {
     ctx.resync_invalidated(inv, &NothingPlan, &mut model, &mut NoProjections);
 
     assert!(model.boards_state().is_not_loaded());
-    assert!(model.board_columns_state(uuid::Uuid::new_v4()).is_not_loaded());
-    assert!(model.column_cards_state(uuid::Uuid::new_v4()).is_not_loaded());
-    assert!(model.board_sprints_state(uuid::Uuid::new_v4()).is_not_loaded());
+    assert!(model
+        .board_columns_state(uuid::Uuid::new_v4())
+        .is_not_loaded());
+    assert!(model
+        .column_cards_state(uuid::Uuid::new_v4())
+        .is_not_loaded());
+    assert!(model
+        .board_sprints_state(uuid::Uuid::new_v4())
+        .is_not_loaded());
     assert!(model.graph_state().is_not_loaded());
     assert!(model.card_by_id_state(card.id).loaded().is_none());
 }
@@ -464,9 +470,15 @@ fn test_resync_invalidated_still_invalidates_when_there_is_no_bounded_repair() {
     );
 
     assert!(model.boards_state().is_not_loaded());
-    assert!(model.board_columns_state(uuid::Uuid::new_v4()).is_not_loaded());
-    assert!(model.column_cards_state(uuid::Uuid::new_v4()).is_not_loaded());
-    assert!(model.board_sprints_state(uuid::Uuid::new_v4()).is_not_loaded());
+    assert!(model
+        .board_columns_state(uuid::Uuid::new_v4())
+        .is_not_loaded());
+    assert!(model
+        .column_cards_state(uuid::Uuid::new_v4())
+        .is_not_loaded());
+    assert!(model
+        .board_sprints_state(uuid::Uuid::new_v4())
+        .is_not_loaded());
     assert!(model.graph_state().is_not_loaded());
 }
 

--- a/crates/kanban-service/src/context/sync/tests.rs
+++ b/crates/kanban-service/src/context/sync/tests.rs
@@ -265,9 +265,9 @@ fn test_sync_leaves_untouched_tiers_alone() {
     ctx.sync(&BoardListPlan, &mut model, &mut NoProjections);
 
     assert!(model.boards_state().is_loaded());
-    assert!(model.cards_state().is_not_loaded());
-    assert!(!model.cards_state().is_loaded());
-    assert!(model.columns_state().is_not_loaded());
+    assert!(model.column_cards_state(column.id).is_not_loaded());
+    assert!(!model.column_cards_state(column.id).is_loaded());
+    assert!(model.board_columns_state(board.id).is_not_loaded());
 }
 
 #[test]
@@ -443,9 +443,9 @@ fn test_resync_invalidated_does_not_fetch_a_tier_the_model_never_read() {
     ctx.resync_invalidated(inv, &NothingPlan, &mut model, &mut NoProjections);
 
     assert!(model.boards_state().is_not_loaded());
-    assert!(model.columns_state().is_not_loaded());
-    assert!(model.cards_state().is_not_loaded());
-    assert!(model.sprints_state().is_not_loaded());
+    assert!(model.board_columns_state(uuid::Uuid::new_v4()).is_not_loaded());
+    assert!(model.column_cards_state(uuid::Uuid::new_v4()).is_not_loaded());
+    assert!(model.board_sprints_state(uuid::Uuid::new_v4()).is_not_loaded());
     assert!(model.graph_state().is_not_loaded());
     assert!(model.card_by_id_state(card.id).loaded().is_none());
 }
@@ -464,9 +464,9 @@ fn test_resync_invalidated_still_invalidates_when_there_is_no_bounded_repair() {
     );
 
     assert!(model.boards_state().is_not_loaded());
-    assert!(model.columns_state().is_not_loaded());
-    assert!(model.cards_state().is_not_loaded());
-    assert!(model.sprints_state().is_not_loaded());
+    assert!(model.board_columns_state(uuid::Uuid::new_v4()).is_not_loaded());
+    assert!(model.column_cards_state(uuid::Uuid::new_v4()).is_not_loaded());
+    assert!(model.board_sprints_state(uuid::Uuid::new_v4()).is_not_loaded());
     assert!(model.graph_state().is_not_loaded());
 }
 

--- a/crates/kanban-service/src/fetch_plan.rs
+++ b/crates/kanban-service/src/fetch_plan.rs
@@ -114,6 +114,10 @@ pub trait LoadedEntities: LoadedState {
     /// `Loaded`, naming every marker a plan needs to walk into a body
     /// round. A marker-less board is `Some(&[])`, not `None`.
     fn loaded_archived_cards_of_board(&self, board_id: Uuid) -> Option<&[ArchivedCard]>;
+    /// `Some` exactly when the graph tier is `Loaded`, naming every relative
+    /// of `card_id` a plan needs in order to walk into a body round. A
+    /// relative-less card is `Some(vec![])`, not `None`.
+    fn loaded_graph_neighbours(&self, card_id: Uuid) -> Option<Vec<Uuid>>;
 }
 
 pub trait FetchPlan {
@@ -203,6 +207,9 @@ mod tests {
             None
         }
         fn loaded_archived_cards_of_board(&self, _board_id: Uuid) -> Option<&[ArchivedCard]> {
+            None
+        }
+        fn loaded_graph_neighbours(&self, _card_id: Uuid) -> Option<Vec<Uuid>> {
             None
         }
     }

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -125,6 +125,9 @@ impl LoadedEntities for StubWorld {
     ) -> Option<&[kanban_domain::ArchivedCard]> {
         None
     }
+    fn loaded_graph_neighbours(&self, _card_id: Uuid) -> Option<Vec<Uuid>> {
+        None
+    }
 }
 
 fn all_loaded() -> StubWorld {

--- a/crates/kanban-service/src/invalidation_plan/tests.rs
+++ b/crates/kanban-service/src/invalidation_plan/tests.rs
@@ -373,16 +373,16 @@ fn test_empty_entities_invalidation_plans_nothing_and_wipes_nothing() {
             ..Default::default()
         },
         columns: Collection {
-            all: LoadState::Loaded(vec![column.clone()]),
             by_id: [(column.id, LoadState::Loaded(column.clone()))].into(),
+            by_parent: [(board.id, LoadState::Loaded(vec![column.clone()]))].into(),
             ..Default::default()
         },
         cards: Collection {
-            all: LoadState::Loaded(vec![card.clone()]),
+            by_parent: [(column.id, LoadState::Loaded(vec![card.clone()]))].into(),
             ..Default::default()
         },
         sprints: Collection {
-            all: LoadState::Loaded(vec![sprint.clone()]),
+            by_parent: [(board.id, LoadState::Loaded(vec![sprint.clone()]))].into(),
             ..Default::default()
         },
         graph: LoadState::Loaded(DependencyGraph::default()),
@@ -397,9 +397,9 @@ fn test_empty_entities_invalidation_plans_nothing_and_wipes_nothing() {
     let _ = model.invalidate(inv);
 
     assert_eq!(LoadedState::board_list(&model), FetchStatus::Loaded);
-    assert!(model.columns_state().is_loaded());
-    assert!(model.cards_state().is_loaded());
-    assert!(model.sprints_state().is_loaded());
+    assert!(model.board_columns_state(board.id).is_loaded());
+    assert!(model.column_cards_state(column.id).is_loaded());
+    assert!(model.board_sprints_state(board.id).is_loaded());
     assert_eq!(LoadedState::graph(&model), FetchStatus::Loaded);
     assert_eq!(LoadedState::column(&model, column.id), FetchStatus::Loaded);
 }
@@ -584,15 +584,15 @@ fn test_invalidate_all_over_seeded_flat_collections_issues_no_flat_list_read() {
             ..Default::default()
         },
         columns: Collection {
-            all: LoadState::Loaded(vec![]),
+            by_parent: [(board.id, LoadState::Loaded(Vec::new()))].into(),
             ..Default::default()
         },
         cards: Collection {
-            all: LoadState::Loaded(vec![card.clone()]),
+            by_parent: [(column.id, LoadState::Loaded(vec![card.clone()]))].into(),
             ..Default::default()
         },
         sprints: Collection {
-            all: LoadState::Loaded(vec![]),
+            by_parent: [(board.id, LoadState::Loaded(Vec::new()))].into(),
             ..Default::default()
         },
         ..Default::default()
@@ -600,7 +600,7 @@ fn test_invalidate_all_over_seeded_flat_collections_issues_no_flat_list_read() {
     NoProjections.resync(&model, changed);
 
     let plan = InvalidationPlan::for_invalidation(&Invalidation::All, &model)
-        .expect("board_list and flat collections were loaded");
+        .expect("board_list was loaded");
     let _ = model.invalidate(Invalidation::All);
 
     let store = crate::read_recorder::RecordingStore::new();

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -103,11 +103,12 @@ mod tests {
     fn test_the_fetch_status_of_a_card_absent_from_a_loaded_list_is_not_loaded() {
         let column_id = Uuid::new_v4();
         let card_a = card_in(column_id);
+        let card_a_id = card_a.id;
         let b_id = Uuid::new_v4();
         let mut model = Model::default();
         let _ = model.apply_resolved(Resolved {
             cards: Collection {
-                all: LoadState::Loaded(vec![card_a]),
+                by_id: [(card_a_id, LoadState::Loaded(card_a))].into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kanban-service/src/model_loaded.rs
+++ b/crates/kanban-service/src/model_loaded.rs
@@ -79,6 +79,10 @@ impl LoadedEntities for Model {
     fn loaded_archived_cards_of_board(&self, board_id: Uuid) -> Option<&[ArchivedCard]> {
         self.board_archived_cards_state(board_id).loaded().copied()
     }
+
+    fn loaded_graph_neighbours(&self, card_id: Uuid) -> Option<Vec<Uuid>> {
+        self.graph_state().loaded().map(|g| g.neighbours(card_id))
+    }
 }
 
 #[cfg(test)]

--- a/crates/kanban-service/src/resolve.rs
+++ b/crates/kanban-service/src/resolve.rs
@@ -129,6 +129,14 @@ impl LoadedEntities for Overlay<'_> {
             None => self.base.loaded_archived_cards_of_board(board_id),
         }
     }
+
+    fn loaded_graph_neighbours(&self, card_id: Uuid) -> Option<Vec<Uuid>> {
+        match &self.pass.graph {
+            LoadState::Loaded(g) => Some(g.neighbours(card_id)),
+            LoadState::NotLoaded => self.base.loaded_graph_neighbours(card_id),
+            LoadState::Missing | LoadState::Failed(_) => None,
+        }
+    }
 }
 
 #[derive(Default)]

--- a/crates/kanban-service/src/resolve/tests/mod.rs
+++ b/crates/kanban-service/src/resolve/tests/mod.rs
@@ -134,6 +134,9 @@ impl LoadedEntities for StubLoaded {
             .and_then(LoadState::loaded)
             .map(Vec::as_slice)
     }
+    fn loaded_graph_neighbours(&self, card_id: Uuid) -> Option<Vec<Uuid>> {
+        self.graph.loaded().map(|g| g.neighbours(card_id))
+    }
 }
 
 fn apply_collection<T: Clone>(target: &mut Collection<T>, incoming: Collection<T>) {

--- a/crates/kanban-tui/src/app/card_selection.rs
+++ b/crates/kanban-tui/src/app/card_selection.rs
@@ -1,5 +1,7 @@
 use super::{App, SprintTaskPanel};
-use kanban_domain::{partition_sprint_cards, sort_card_ids, Card, LoadState, SortField, SortOrder};
+use kanban_domain::{
+    partition_sprint_cards, sort_card_ids, Card, KanbanOperations, LoadState, SortField, SortOrder,
+};
 
 impl App {
     pub fn get_selected_card_in_context(&self) -> Option<Card> {
@@ -70,15 +72,23 @@ impl App {
     }
 
     /// Sets `active_card_id` to `id` when the card is loaded, clears it when
-    /// the card is genuinely `Missing` (the archived-card / file-watcher
-    /// reload race this exists for), and otherwise leaves the current
-    /// selection untouched: a `NotLoaded` or `Failed` tier means the card's
-    /// existence is unknown, not that it is gone.
+    /// the card is genuinely gone, and otherwise leaves the current
+    /// selection untouched (`Failed` means the card's existence is unknown,
+    /// not that it is gone). Neither the per-id nor the scoped tier can
+    /// prove absence on their own, so a `NotLoaded` id falls back to one
+    /// direct store read to settle it; every caller passes an id already
+    /// visible in the model except the navigation-history recall this
+    /// exists for, so the read is rare, not per-frame.
     pub(crate) fn set_active_card_or_clear(&mut self, id: uuid::Uuid) {
         match self.model.card_by_id_state(id) {
             LoadState::Loaded(card) => self.selection.active_card_id = Some(card.id),
             LoadState::Missing => self.selection.active_card_id = None,
-            LoadState::NotLoaded | LoadState::Failed(_) => {}
+            LoadState::Failed(_) => {}
+            LoadState::NotLoaded => match self.ctx.get_card(id) {
+                Ok(Some(_)) => self.selection.active_card_id = Some(id),
+                Ok(None) => self.selection.active_card_id = None,
+                Err(_) => {}
+            },
         }
     }
 

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -168,7 +168,13 @@ mod active_card_index_regression {
         app.ctx.assign_card_to_sprint(fx.p_id, sprint_p.id).unwrap();
         load_with_card_order(&mut app, &[fx.a_id, fx.p_id, fx.b_id, fx.c_id, fx.d_id]);
 
-        let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+        let sprints = app
+            .model
+            .board_sprints_state(fx.board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .to_vec();
         let entries = build_entries(&sprints, fx.board_id, chrono::Utc::now());
         let expected_idx = entries
             .iter()
@@ -195,10 +201,6 @@ mod board_columns_view_tests {
         Resolved {
             boards: Collection {
                 all: LoadState::Loaded(vec![board.clone()]),
-                ..Default::default()
-            },
-            cards: Collection {
-                all: LoadState::Loaded(vec![]),
                 ..Default::default()
             },
             graph: LoadState::Loaded(DependencyGraph::default()),
@@ -235,18 +237,6 @@ mod board_columns_view_tests {
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);
         resolved.columns = Collection {
-            all: LoadState::Loaded(vec![col_a.clone(), col_b.clone()]),
-            ..Default::default()
-        };
-        let _ = app.model.apply_resolved(resolved);
-        assert!(
-            app.board_columns_view(board.id).is_not_loaded(),
-            "a populated flat tier must not stand in for a not-loaded scoped tier"
-        );
-
-        let mut app = App::test_default();
-        let mut resolved = base_resolved(&board);
-        resolved.columns = Collection {
             by_parent: HashMap::from([(
                 board.id,
                 LoadState::Failed(std::sync::Arc::new(
@@ -273,14 +263,6 @@ mod board_sprints_view_tests {
                 all: LoadState::Loaded(vec![board.clone()]),
                 ..Default::default()
             },
-            cards: Collection {
-                all: LoadState::Loaded(vec![]),
-                ..Default::default()
-            },
-            columns: Collection {
-                all: LoadState::Loaded(vec![]),
-                ..Default::default()
-            },
             graph: LoadState::Loaded(DependencyGraph::default()),
             ..Default::default()
         }
@@ -289,22 +271,9 @@ mod board_sprints_view_tests {
     #[test]
     fn test_board_sprints_view_answers_not_loaded_when_the_scoped_tier_is_not_loaded() {
         let board = Board::new("B", None::<String>);
-        let s_on_board = Sprint::new(board.id, 1, None, None::<String>);
 
         let app = App::test_default();
         assert!(app.board_sprints_view(board.id).is_not_loaded());
-
-        let mut app = App::test_default();
-        let mut resolved = base_resolved(&board);
-        resolved.sprints = Collection {
-            all: LoadState::Loaded(vec![s_on_board.clone()]),
-            ..Default::default()
-        };
-        let _ = app.model.apply_resolved(resolved);
-        assert!(
-            app.board_sprints_view(board.id).is_not_loaded(),
-            "a populated flat tier must not stand in for a not-loaded scoped tier"
-        );
 
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);
@@ -323,7 +292,6 @@ mod board_sprints_view_tests {
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);
         resolved.sprints = Collection {
-            all: LoadState::Loaded(vec![s_on_board.clone()]),
             by_parent: HashMap::from([(board.id, LoadState::Loaded(Vec::new()))]),
             ..Default::default()
         };
@@ -336,8 +304,6 @@ mod board_sprints_view_tests {
 
     #[test]
     fn test_sprint_selection_index_matches_scoped_tier_entries() {
-        use kanban_view::sprint_assign_list::{build_entries, sprint_id_of};
-
         let board = Board::new("B", None::<String>);
         let column = Column::new(board.id, "Todo", 0);
         let mut s_a = Sprint::new(board.id, 2, None, None::<String>);
@@ -346,41 +312,27 @@ mod board_sprints_view_tests {
         s_b.status = kanban_domain::SprintStatus::Planning;
 
         let mut app = App::test_default();
-        let mut card = kanban_domain::Card::new(board.id, column.id, "Task", 0);
+        let column_id = column.id;
+        let mut card = kanban_domain::Card::new(board.id, column_id, "Task", 0);
         card.sprint_id = Some(s_b.id);
 
         let mut resolved = base_resolved(&board);
         resolved.columns = Collection {
-            all: LoadState::Loaded(vec![column]),
+            by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column]))]),
             ..Default::default()
         };
         resolved.cards = Collection {
-            all: LoadState::Loaded(vec![card.clone()]),
+            by_parent: HashMap::from([(column_id, LoadState::Loaded(vec![card.clone()]))]),
             ..Default::default()
         };
         resolved.sprints = Collection {
-            all: LoadState::Loaded(vec![s_a.clone(), s_b.clone()]),
             by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![s_b.clone()]))]),
             ..Default::default()
         };
         let _ = app.model.apply_resolved(resolved);
         app.selection.active_board_id = Some(board.id);
         app.selection.active_card_id = Some(card.id);
-
-        let sprints = app.model.sprints_state();
-        let flat_entries = if let LoadState::Loaded(sprints) = sprints {
-            build_entries(sprints, board.id, chrono::Utc::now())
-        } else {
-            panic!("expected flat tier loaded")
-        };
-        let flat_idx = flat_entries
-            .iter()
-            .position(|e| sprint_id_of(e) == Some(s_b.id))
-            .unwrap();
-        assert_eq!(
-            flat_idx, 3,
-            "sanity: the flat tier lists s_a before s_b, so s_b sits later there"
-        );
+        let _ = &s_a;
 
         let idx = app.get_current_sprint_selection_index();
 

--- a/crates/kanban-tui/src/app/sprint_management.rs
+++ b/crates/kanban-tui/src/app/sprint_management.rs
@@ -77,8 +77,8 @@ mod tests {
     #[test]
     fn test_check_ended_sprints_does_not_scan_an_unloaded_sprint_tier() {
         let mut app = App::test_default();
-        seed_ended_sprint(&mut app);
-        assert!(matches!(app.model.sprints_state(), LoadState::NotLoaded));
+        let (board_id, _sprint_id) = seed_ended_sprint(&mut app);
+        assert!(app.model.board_sprints_state(board_id).is_not_loaded());
 
         let ended = app.check_ended_sprints();
 
@@ -95,7 +95,7 @@ mod tests {
         let snap = kanban_service::read_full_snapshot(app.ctx.data_store()).unwrap();
         let _ = app.model.load_from_snapshot(snap);
         app.selection.active_board_id = Some(board_id);
-        assert!(matches!(app.model.sprints_state(), LoadState::Loaded(_)));
+        assert!(app.model.board_sprints_state(board_id).is_loaded());
 
         let ended = app.check_ended_sprints();
 
@@ -109,7 +109,7 @@ mod tests {
         let snap = kanban_service::read_full_snapshot(app.ctx.data_store()).unwrap();
         let _ = app.model.load_from_snapshot(snap);
         app.selection.active_board_id = Some(board_id);
-        assert!(matches!(app.model.sprints_state(), LoadState::Loaded(_)));
+        assert!(app.model.board_sprints_state(board_id).is_loaded());
 
         let _ = app
             .model

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -319,7 +319,12 @@ mod tests {
         }
         fn loaded_graph_neighbours(&self, card_id: Uuid) -> Option<Vec<Uuid>> {
             if self.graph == FetchStatus::Loaded {
-                Some(self.graph_neighbours.get(&card_id).cloned().unwrap_or_default())
+                Some(
+                    self.graph_neighbours
+                        .get(&card_id)
+                        .cloned()
+                        .unwrap_or_default(),
+                )
             } else {
                 None
             }

--- a/crates/kanban-tui/src/app/view_scope.rs
+++ b/crates/kanban-tui/src/app/view_scope.rs
@@ -38,6 +38,17 @@ impl FetchPlan for ViewScope {
             if requestable(loaded.card(card_id)) {
                 round.cards.push(card_id);
             }
+
+            if self.graph {
+                if let Some(neighbours) = loaded.loaded_graph_neighbours(card_id) {
+                    let mut ids: Vec<Uuid> = neighbours
+                        .into_iter()
+                        .filter(|&id| requestable(loaded.card(id)))
+                        .collect();
+                    ids.sort_unstable();
+                    round.cards.extend(ids);
+                }
+            }
         }
 
         if let Some(sprint_id) = self.sprint {
@@ -204,6 +215,7 @@ mod tests {
         archived_card_markers: Option<Vec<kanban_domain::ArchivedCard>>,
         archived_cards_by_board_markers: HashMap<Uuid, Vec<kanban_domain::ArchivedCard>>,
         archived_board_markers: Option<Vec<kanban_domain::ArchivedBoard>>,
+        graph_neighbours: HashMap<Uuid, Vec<Uuid>>,
     }
 
     impl Default for StubLoaded {
@@ -225,6 +237,7 @@ mod tests {
                 archived_card_markers: None,
                 archived_cards_by_board_markers: HashMap::new(),
                 archived_board_markers: None,
+                graph_neighbours: HashMap::new(),
             }
         }
     }
@@ -303,6 +316,13 @@ mod tests {
             self.archived_cards_by_board_markers
                 .get(&board_id)
                 .map(Vec::as_slice)
+        }
+        fn loaded_graph_neighbours(&self, card_id: Uuid) -> Option<Vec<Uuid>> {
+            if self.graph == FetchStatus::Loaded {
+                Some(self.graph_neighbours.get(&card_id).cloned().unwrap_or_default())
+            } else {
+                None
+            }
         }
     }
 

--- a/crates/kanban-tui/src/handlers/board_handlers.rs
+++ b/crates/kanban-tui/src/handlers/board_handlers.rs
@@ -945,7 +945,7 @@ mod tests {
         app.controller.resync(&app.model, changed);
 
         assert!(
-            app.model.cards_state().is_not_loaded(),
+            app.model.board_cards_state(board.id).is_not_loaded(),
             "cards must stay NotLoaded for this fixture to isolate the live-cards gate"
         );
         assert_eq!(app.board_delete_counts(board.id), None);

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1595,7 +1595,7 @@ mod cards_tier_decline_tests {
     }
 
     #[test]
-    fn test_toggle_selected_cards_completion_with_a_failed_flat_cards_tier_for_an_unresolvable_id_declines(
+    fn test_toggle_selected_cards_completion_with_a_failed_per_id_entry_for_an_unresolvable_id_declines(
     ) {
         let mut app = App::test_default();
         let (board_id, _column_id, card_id) = seed_board_column_card(&mut app);
@@ -1609,9 +1609,13 @@ mod cards_tier_decline_tests {
 
         let changed = app.model.apply_resolved(kanban_domain::Resolved {
             cards: kanban_domain::resolved::Collection {
-                all: kanban_domain::LoadState::Failed(std::sync::Arc::new(
-                    kanban_domain::KanbanError::unsupported("flat declined"),
-                )),
+                by_id: [(
+                    unresolvable_id,
+                    kanban_domain::LoadState::Failed(std::sync::Arc::new(
+                        kanban_domain::KanbanError::unsupported("boom"),
+                    )),
+                )]
+                .into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kanban-tui/src/handlers/card_handlers.rs
+++ b/crates/kanban-tui/src/handlers/card_handlers.rs
@@ -1156,10 +1156,11 @@ mod create_card_factory_tests {
         let board_id = app.selection.active_board_id.unwrap();
         let column_id = app
             .model
-            .columns_state()
-            .loaded_or_empty()
-            .iter()
-            .find(|c| c.board_id == board_id)
+            .board_columns_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .first()
             .unwrap()
             .id;
         (board_id, column_id)

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2756,7 +2756,7 @@ mod tests {
     }
 
     #[test]
-    fn test_toggle_completion_for_card_ids_with_a_failed_flat_cards_tier_for_an_unresolvable_id_declines(
+    fn test_toggle_completion_for_card_ids_with_a_failed_per_id_entry_for_an_unresolvable_id_declines(
     ) {
         let mut app = App::test_default();
         let card_id = seed_sprint_with_card(&mut app, "task");
@@ -2764,9 +2764,13 @@ mod tests {
 
         let changed = app.model.apply_resolved(kanban_domain::Resolved {
             cards: kanban_domain::resolved::Collection {
-                all: kanban_domain::LoadState::Failed(std::sync::Arc::new(
-                    kanban_domain::KanbanError::unsupported("flat declined"),
-                )),
+                by_id: [(
+                    unresolvable_id,
+                    kanban_domain::LoadState::Failed(std::sync::Arc::new(
+                        kanban_domain::KanbanError::unsupported("boom"),
+                    )),
+                )]
+                .into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1705,7 +1705,12 @@ mod tests {
 
         // A second card, placed only in the Completed panel, distinct from the
         // Uncompleted panel's card set up by seed_sprint_with_card.
-        let column_id = app.model.columns_state().loaded_or_empty()[0].id;
+        let column_id = app
+            .model
+            .board_columns_state(board_id)
+            .loaded()
+            .unwrap()[0]
+            .id;
         let completed_card = app
             .ctx
             .create_card(
@@ -2779,10 +2784,9 @@ mod tests {
         );
     }
 
-    fn seed_board_with_scoped_and_flat_sprints(
+    fn seed_board_with_scoped_sprints(
         app: &mut App,
         build_scoped: impl FnOnce(uuid::Uuid) -> Vec<kanban_domain::Sprint>,
-        build_flat_all: impl FnOnce(uuid::Uuid) -> LoadState<Vec<kanban_domain::Sprint>>,
     ) -> uuid::Uuid {
         use kanban_domain::resolved::Collection;
         use kanban_domain::{Column, DependencyGraph, Resolved};
@@ -2791,7 +2795,6 @@ mod tests {
         let board_id = board.id;
         let column = Column::new(board_id, "Todo", 0);
         let scoped = build_scoped(board_id);
-        let flat_all = build_flat_all(board_id);
 
         let resolved = Resolved {
             boards: Collection {
@@ -2799,16 +2802,10 @@ mod tests {
                 ..Default::default()
             },
             columns: Collection {
-                all: LoadState::Loaded(vec![column.clone()]),
                 by_parent: [(board_id, LoadState::Loaded(vec![column]))].into(),
                 ..Default::default()
             },
-            cards: Collection {
-                all: LoadState::Loaded(vec![]),
-                ..Default::default()
-            },
             sprints: Collection {
-                all: flat_all,
                 by_parent: [(board_id, LoadState::Loaded(scoped))].into(),
                 ..Default::default()
             },
@@ -2825,16 +2822,12 @@ mod tests {
     #[test]
     fn test_board_detail_sprint_nav_uses_scoped_tier_rows() {
         let mut app = App::test_default();
-        let board_id = seed_board_with_scoped_and_flat_sprints(
-            &mut app,
-            |board_id| {
-                vec![
-                    kanban_domain::Sprint::new(board_id, 1, None, None::<String>),
-                    kanban_domain::Sprint::new(board_id, 2, None, None::<String>),
-                ]
-            },
-            |_| LoadState::NotLoaded,
-        );
+        let board_id = seed_board_with_scoped_sprints(&mut app, |board_id| {
+            vec![
+                kanban_domain::Sprint::new(board_id, 1, None, None::<String>),
+                kanban_domain::Sprint::new(board_id, 2, None, None::<String>),
+            ]
+        });
 
         app.selection.active_board_id = Some(board_id);
         app.focus.board_focus = BoardFocus::Sprints;
@@ -2851,23 +2844,12 @@ mod tests {
     fn test_board_detail_sprint_enter_opens_the_sprint_the_scoped_tier_shows() {
         let mut app = App::test_default();
         let s2_id = std::cell::Cell::new(uuid::Uuid::nil());
-        let board_id = seed_board_with_scoped_and_flat_sprints(
-            &mut app,
-            |board_id| {
-                let s1 = kanban_domain::Sprint::new(board_id, 1, None, None::<String>);
-                let s2 = kanban_domain::Sprint::new(board_id, 2, None, None::<String>);
-                s2_id.set(s2.id);
-                vec![s1, s2]
-            },
-            |board_id| {
-                LoadState::Loaded(vec![kanban_domain::Sprint::new(
-                    board_id,
-                    99,
-                    None,
-                    None::<String>,
-                )])
-            },
-        );
+        let board_id = seed_board_with_scoped_sprints(&mut app, |board_id| {
+            let s1 = kanban_domain::Sprint::new(board_id, 1, None, None::<String>);
+            let s2 = kanban_domain::Sprint::new(board_id, 2, None, None::<String>);
+            s2_id.set(s2.id);
+            vec![s1, s2]
+        });
         let s2_id = s2_id.get();
 
         app.selection.active_board_id = Some(board_id);
@@ -2884,22 +2866,12 @@ mod tests {
     #[test]
     fn test_column_focus_exit_upwards_lands_on_the_last_scoped_sprint_row() {
         let mut app = App::test_default();
-        let board_id = seed_board_with_scoped_and_flat_sprints(
-            &mut app,
-            |board_id| {
-                vec![
-                    kanban_domain::Sprint::new(board_id, 1, None, None::<String>),
-                    kanban_domain::Sprint::new(board_id, 2, None, None::<String>),
-                ]
-            },
-            |board_id| {
-                LoadState::Loaded(vec![
-                    kanban_domain::Sprint::new(board_id, 1, None, None::<String>),
-                    kanban_domain::Sprint::new(board_id, 2, None, None::<String>),
-                    kanban_domain::Sprint::new(board_id, 3, None, None::<String>),
-                ])
-            },
-        );
+        let board_id = seed_board_with_scoped_sprints(&mut app, |board_id| {
+            vec![
+                kanban_domain::Sprint::new(board_id, 1, None, None::<String>),
+                kanban_domain::Sprint::new(board_id, 2, None, None::<String>),
+            ]
+        });
 
         app.selection.active_board_id = Some(board_id);
         app.focus.board_focus = BoardFocus::Columns;
@@ -2924,10 +2896,6 @@ mod visible_board_columns_tests {
         Resolved {
             boards: Collection {
                 all: LoadState::Loaded(vec![board.clone()]),
-                ..Default::default()
-            },
-            cards: Collection {
-                all: LoadState::Loaded(vec![]),
                 ..Default::default()
             },
             graph: LoadState::Loaded(DependencyGraph::default()),
@@ -2964,18 +2932,6 @@ mod visible_board_columns_tests {
 
         let app = App::test_default();
         assert!(app.visible_board_columns(board.id).is_not_loaded());
-
-        let mut app = App::test_default();
-        let mut resolved = base_resolved(&board);
-        resolved.columns = Collection {
-            all: LoadState::Loaded(vec![col_a.clone(), col_b.clone()]),
-            ..Default::default()
-        };
-        let _ = app.model.apply_resolved(resolved);
-        assert!(
-            app.visible_board_columns(board.id).is_not_loaded(),
-            "a populated flat tier must not stand in for a not-loaded scoped tier"
-        );
 
         let mut app = App::test_default();
         let mut resolved = base_resolved(&board);

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -1705,12 +1705,7 @@ mod tests {
 
         // A second card, placed only in the Completed panel, distinct from the
         // Uncompleted panel's card set up by seed_sprint_with_card.
-        let column_id = app
-            .model
-            .board_columns_state(board_id)
-            .loaded()
-            .unwrap()[0]
-            .id;
+        let column_id = app.model.board_columns_state(board_id).loaded().unwrap()[0].id;
         let completed_card = app
             .ctx
             .create_card(

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2611,9 +2611,9 @@ mod tests {
         let card_id = card.id;
         app.model = Model::with_load_states(ModelLoadStates {
             boards: LoadState::Loaded(vec![board]),
-            cards: LoadState::Loaded(vec![card]),
             ..Default::default()
         });
+        let _ = card;
         app.selection.active_board_id = Some(board_id);
         app.selection.active_card_id = Some(card_id);
 

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -1053,7 +1053,7 @@ mod tests {
     }
 
     #[test]
-    fn test_relationship_search_with_failed_cards_tier_for_an_unresolvable_id_banners() {
+    fn test_relationship_search_with_failed_per_id_entry_for_an_unresolvable_id_banners() {
         let mut app = App::test_default();
         let (_board_id, card_id) = seed_relationship_dialog(&mut app);
         let unresolvable_id = uuid::Uuid::new_v4();
@@ -1062,9 +1062,13 @@ mod tests {
 
         let changed = app.model.apply_resolved(kanban_domain::Resolved {
             cards: kanban_domain::resolved::Collection {
-                all: kanban_domain::LoadState::Failed(std::sync::Arc::new(
-                    kanban_domain::KanbanError::unsupported("flat declined"),
-                )),
+                by_id: [(
+                    unresolvable_id,
+                    kanban_domain::LoadState::Failed(std::sync::Arc::new(
+                        kanban_domain::KanbanError::unsupported("boom"),
+                    )),
+                )]
+                .into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kanban-tui/src/handlers/popup_handlers.rs
+++ b/crates/kanban-tui/src/handlers/popup_handlers.rs
@@ -811,7 +811,13 @@ mod tests {
         let sprint = app.ctx.create_sprint(fx.board_id, None, None).unwrap();
         load_with_card_order(app, &[fx.a_id, fx.p_id, fx.b_id, fx.c_id, fx.d_id]);
 
-        let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+        let sprints = app
+            .model
+            .board_sprints_state(fx.board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .to_vec();
         let board = app
             .model
             .boards_state()
@@ -861,7 +867,13 @@ mod tests {
         load_with_card_order(&mut app, &[fx.a_id, fx.p_id, fx.b_id, fx.c_id, fx.d_id]);
 
         // Prime the picker with the target sprint pre-checked.
-        let sprints = app.model.sprints_state().loaded_or_empty().to_vec();
+        let sprints = app
+            .model
+            .board_sprints_state(fx.board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
+            .to_vec();
         let board = app
             .model
             .boards_state()

--- a/crates/kanban-tui/src/test_helpers.rs
+++ b/crates/kanban-tui/src/test_helpers.rs
@@ -44,9 +44,9 @@ pub struct ReloadResortFixture {
     pub c_id: uuid::Uuid,
 }
 
-/// Simulates the KAN-534 scenario: an external write triggers a TUI
-/// reload that reorders `model.cards_state()`, leaving `ActiveCard.index`
-/// pointing at a different card than `ActiveCard.id`.
+/// Simulates an external write triggering a TUI reload that reorders the
+/// scoped card tier, leaving `ActiveCard.index` pointing at a different
+/// card than `ActiveCard.id`.
 ///
 /// Seeds five cards in the same column with edges P -> A -> D, sets the
 /// active card to A at index 1, then re-loads the model with cards in a

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -155,8 +155,10 @@ fn test_permanent_delete_removes_archived_card() {
     );
     assert!(
         app.model
-            .cards_state()
-            .loaded_or_empty()
+            .column_cards_state(column.id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[])
             .iter()
             .all(|c| c.id != card_id),
         "card should not be restored to active cards"

--- a/crates/kanban-tui/tests/archived_card_parity_tests.rs
+++ b/crates/kanban-tui/tests/archived_card_parity_tests.rs
@@ -212,8 +212,13 @@ fn test_move_in_archived_view_matches_c1() {
 #[test]
 fn test_create_not_offered_in_archived_view() {
     let mut app = App::test_default();
-    let (_, _, _, _) = seed_archived_card(&mut app);
-    let live_before = app.model.cards_state().loaded_or_empty().len();
+    let (board_id, _, _, _) = seed_archived_card(&mut app);
+    let live_before = app
+        .model
+        .board_cards_state(board_id)
+        .loaded()
+        .map(|v| v.len())
+        .unwrap_or(0);
 
     app.handle_archived_cards_view_mode(KeyCode::Char('n'));
 
@@ -225,7 +230,11 @@ fn test_create_not_offered_in_archived_view() {
     app.reload_model();
     app.prepare_frame();
     assert_eq!(
-        app.model.cards_state().loaded_or_empty().len(),
+        app.model
+            .board_cards_state(board_id)
+            .loaded()
+            .map(|v| v.len())
+            .unwrap_or(0),
         live_before,
         "`n` must not create an invisible live card from the archived view"
     );

--- a/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/card_handlers_collapsing_accessor_tests.rs
@@ -113,7 +113,7 @@ fn test_create_card_target_column_prefers_board_scoped_state_over_stale_flat_tie
     let _ = app
         .model
         .invalidate(Invalidation::Entities(EntityIds::columns([Uuid::new_v4()])));
-    assert!(app.model.columns_state().is_not_loaded());
+    assert!(app.model.board_columns_state(board_id).is_not_loaded());
 
     let changed = app.model.apply_resolved(Resolved {
         columns: Collection {
@@ -412,21 +412,6 @@ fn test_create_card_still_auto_completes_into_a_completion_column_on_a_loaded_co
     sync_model_from_store(&mut app);
     app.selection.active_board_id = Some(board.id);
 
-    let columns = app
-        .model
-        .columns_state()
-        .loaded()
-        .cloned()
-        .unwrap_or_default();
-    let changed = app.model.apply_resolved(Resolved {
-        columns: Collection {
-            by_parent: [(board.id, LoadState::Loaded(columns))].into(),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-    NoProjections.resync(&app.model, changed);
-
     app.input.set("Auto-complete".to_string());
     app.create_card();
     app.input.clear();
@@ -693,21 +678,6 @@ fn test_handle_manage_children_from_list_still_lists_a_sibling_card_on_a_loaded_
     app.selection.active_board_id = Some(board_id);
     app.focus.active = Focus::Cards;
     select_card_in_active_task_list(&mut app, target.id);
-
-    let columns = app
-        .model
-        .columns_state()
-        .loaded()
-        .cloned()
-        .unwrap_or_default();
-    let changed = app.model.apply_resolved(Resolved {
-        columns: Collection {
-            by_parent: [(board_id, LoadState::Loaded(columns))].into(),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-    NoProjections.resync(&app.model, changed);
 
     app.handle_manage_children_from_list();
 

--- a/crates/kanban-tui/tests/column_default_status_tests.rs
+++ b/crates/kanban-tui/tests/column_default_status_tests.rs
@@ -33,7 +33,11 @@ fn setup_board_with_columns(app: &mut App) -> (uuid::Uuid, uuid::Uuid, uuid::Uui
 fn board_columns(app: &App, board_id: uuid::Uuid) -> Vec<kanban_domain::Column> {
     kanban_domain::card_lifecycle::sorted_board_columns(
         board_id,
-        app.model.columns_state().loaded_or_empty(),
+        app.model
+            .board_columns_state(board_id)
+            .loaded()
+            .copied()
+            .unwrap_or(&[]),
     )
     .into_iter()
     .cloned()

--- a/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
@@ -23,6 +23,16 @@ fn set_sprint_by_id(app: &mut App, sprint_id: Uuid, state: LoadState<Sprint>) {
     });
 }
 
+fn set_card_by_id(app: &mut App, card_id: Uuid, state: LoadState<Card>) {
+    let _ = app.model.apply_resolved(Resolved {
+        cards: Collection {
+            by_id: HashMap::from([(card_id, state)]),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
 fn set_column_by_id(app: &mut App, column_id: Uuid, state: LoadState<Column>) {
     let _ = app.model.apply_resolved(Resolved {
         columns: Collection {
@@ -119,10 +129,10 @@ fn test_open_assign_sprint_dialog_for_declines_when_sprints_not_loaded() {
         &mut app,
         ModelLoadStates {
             boards: LoadState::Loaded(vec![board]),
-            cards: LoadState::Loaded(vec![card]),
             ..Default::default()
         },
     );
+    set_card_by_id(&mut app, card_id, LoadState::Loaded(card));
     app.selection.active_board_id = Some(board_id);
     app.sprint_view.panel = kanban_tui::app::SprintTaskPanel::Uncompleted;
     app.sprint_view
@@ -230,10 +240,10 @@ fn test_handle_manage_parents_declines_when_the_cards_column_is_not_loaded() {
     set_model(
         &mut app,
         ModelLoadStates {
-            cards: LoadState::Loaded(vec![card]),
             ..Default::default()
         },
     );
+    set_card_by_id(&mut app, card_id, LoadState::Loaded(card));
     app.selection.active_card_id = Some(card_id);
 
     app.handle_manage_parents();
@@ -256,10 +266,10 @@ fn test_handle_manage_parents_declines_when_the_boards_column_list_is_not_loaded
     set_model(
         &mut app,
         ModelLoadStates {
-            cards: LoadState::Loaded(vec![card]),
             ..Default::default()
         },
     );
+    set_card_by_id(&mut app, card_id, LoadState::Loaded(card));
     set_column_by_id(&mut app, column_id, LoadState::Loaded(column));
     app.selection.active_card_id = Some(card_id);
 
@@ -285,8 +295,6 @@ fn test_handle_manage_parents_still_opens_the_dialog_when_everything_is_loaded()
     set_model(
         &mut app,
         ModelLoadStates {
-            cards: LoadState::Loaded(vec![card.clone(), other_card.clone()]),
-            columns: LoadState::Loaded(vec![column.clone()]),
             graph: LoadState::Loaded(kanban_domain::DependencyGraph::default()),
             ..Default::default()
         },
@@ -320,10 +328,10 @@ fn test_handle_manage_children_declines_when_the_cards_column_is_not_loaded() {
     set_model(
         &mut app,
         ModelLoadStates {
-            cards: LoadState::Loaded(vec![card]),
             ..Default::default()
         },
     );
+    set_card_by_id(&mut app, card_id, LoadState::Loaded(card));
     app.selection.active_card_id = Some(card_id);
 
     app.handle_manage_children();
@@ -346,10 +354,10 @@ fn test_handle_manage_children_declines_when_the_boards_column_list_is_not_loade
     set_model(
         &mut app,
         ModelLoadStates {
-            cards: LoadState::Loaded(vec![card]),
             ..Default::default()
         },
     );
+    set_card_by_id(&mut app, card_id, LoadState::Loaded(card));
     set_column_by_id(&mut app, column_id, LoadState::Loaded(column));
     app.selection.active_card_id = Some(card_id);
 
@@ -375,8 +383,6 @@ fn test_handle_manage_children_still_opens_the_dialog_when_everything_is_loaded(
     set_model(
         &mut app,
         ModelLoadStates {
-            cards: LoadState::Loaded(vec![card.clone(), other_card.clone()]),
-            columns: LoadState::Loaded(vec![column.clone()]),
             graph: LoadState::Loaded(kanban_domain::DependencyGraph::default()),
             ..Default::default()
         },
@@ -419,20 +425,14 @@ fn seed_move_fixture(app: &mut App, columns_loaded: bool) -> (Uuid, Uuid, Uuid, 
             kanban_domain::CreateCardOptions::default(),
         )
         .unwrap();
-    let columns = if columns_loaded {
-        LoadState::Loaded(vec![left.clone(), right.clone()])
-    } else {
-        LoadState::NotLoaded
-    };
     set_model(
         app,
         ModelLoadStates {
             boards: LoadState::Loaded(vec![board.clone()]),
-            cards: LoadState::Loaded(vec![card.clone()]),
-            columns,
             ..Default::default()
         },
     );
+    set_card_by_id(app, card.id, LoadState::Loaded(card.clone()));
     if columns_loaded {
         seed_scoped_partitions(
             app,

--- a/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
+++ b/crates/kanban-tui/tests/detail_view_handlers_collapsing_accessor_tests.rs
@@ -462,10 +462,8 @@ fn test_move_selected_card_column_declines_when_the_column_tier_is_not_loaded() 
     assert_error_banner(&app);
     let stored_column = app
         .model
-        .cards_state()
-        .loaded_or_empty()
-        .iter()
-        .find(|c| c.id == card_id)
+        .card_by_id_state(card_id)
+        .loaded()
         .map(|c| c.column_id)
         .expect("card still present");
     assert_eq!(stored_column, left_id);

--- a/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
@@ -20,7 +20,13 @@ fn seed_model_with_board(
     };
     app.model = kanban_domain::Model::with_load_states(ModelLoadStates {
         boards,
-        sprints,
+        ..Default::default()
+    });
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        sprints: kanban_domain::resolved::Collection {
+            by_parent: [(board_id, sprints)].into(),
+            ..Default::default()
+        },
         ..Default::default()
     });
     board_id

--- a/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/dialog_filter_handler_decline_tests.rs
@@ -87,7 +87,15 @@ fn test_handle_prefix_dialog_impl_distinguishes_missing_from_not_loaded() {
         LoadState::Loaded(vec![]),
         LoadState::Loaded(vec![]),
     );
-    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    let missing_sprint_id = Uuid::new_v4();
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        sprints: kanban_domain::resolved::Collection {
+            by_id: [(missing_sprint_id, LoadState::Missing)].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    app.selection.active_sprint_id = Some(missing_sprint_id);
     app.input.clear();
     app.handle_set_sprint_prefix_dialog(KeyCode::Enter);
     assert_no_banner(&app);

--- a/crates/kanban-tui/tests/export_import_archived_board_tests.rs
+++ b/crates/kanban-tui/tests/export_import_archived_board_tests.rs
@@ -1,11 +1,11 @@
-//! KAN-895 regression: the TUI File→Export-All path must fully round-trip an
+//! Regression: the TUI File→Export-All path must fully round-trip an
 //! archived board — its HEAD, its entire subtree (columns / cards / sprints,
-//! which live in the flat collections under the archived board_id), AND its
+//! keyed under the archived board_id), AND its
 //! `archived_boards` marker (so it re-imports still archived, hidden from the
 //! live list).
 //!
-//! Before the fix, `export_all_boards_with_filename` / `auto_save` read the
-//! live-scoped `model.boards_state().loaded_or_empty()` / `model.cards_state().loaded_or_empty()`, so an archived board's head
+//! Before the fix, `export_all_boards_with_filename` / `auto_save` read only
+//! the live-scoped board and card tiers, so an archived board's head
 //! and subtree were omitted and the exported `archived_boards` marker referenced
 //! a board absent from the file → orphan / silent data loss on re-import. These
 //! tests drive the ACTUAL TUI export entry point (not the snapshot path

--- a/crates/kanban-tui/tests/frame_reload_tests.rs
+++ b/crates/kanban-tui/tests/frame_reload_tests.rs
@@ -280,7 +280,11 @@ fn test_sprint_assignment_is_visible_in_model_without_a_further_redraw() {
         .assign_sprint_picker
         .reset_for_card_assignment(
             Some(sprint.id),
-            app.model.sprints_state().loaded_or_empty(),
+            app.model
+                .board_sprints_state(board.id)
+                .loaded()
+                .copied()
+                .unwrap_or(&[]),
             app.model
                 .board_by_id_state(board.id)
                 .loaded()

--- a/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
+++ b/crates/kanban-tui/tests/handler_scoped_reads_tests.rs
@@ -1,38 +1,13 @@
 //! Pins the TUI handlers to the board-scoped tiers
 //! (`App::board_columns_view`/`board_sprints_view`, `Controller::live_cards`/
-//! `archived_cards`, `Model::card_by_id_state`/`column_cards_state`) rather
-//! than the flat `Model::cards_state`/`columns_state`/`sprints_state`
-//! collections. Each test seeds a healthy scoped state via `reload_model` +
-//! `prepare_frame`, then fails ONLY the three flat tiers and proves the
-//! handler still acts.
+//! `archived_cards`, `Model::card_by_id_state`/`column_cards_state`).
+//! Each test seeds a healthy scoped state via `reload_model` +
+//! `prepare_frame` and proves the handler acts on it.
 
-use kanban_domain::resolved::Collection;
-use kanban_domain::{
-    CreateCardOptions, DerivedProjections, KanbanError, KanbanOperations, LoadState, Resolved,
-};
+use kanban_domain::{CreateCardOptions, KanbanOperations};
 use kanban_tui::app::mode::{AppMode, DialogMode};
 use kanban_tui::App;
-use std::sync::Arc;
 use uuid::Uuid;
-
-fn fail_flat_tiers(app: &mut App) {
-    let changed = app.model.apply_resolved(Resolved {
-        cards: Collection {
-            all: LoadState::Failed(Arc::new(KanbanError::unsupported("flat declined"))),
-            ..Default::default()
-        },
-        columns: Collection {
-            all: LoadState::Failed(Arc::new(KanbanError::unsupported("flat declined"))),
-            ..Default::default()
-        },
-        sprints: Collection {
-            all: LoadState::Failed(Arc::new(KanbanError::unsupported("flat declined"))),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-    app.controller.resync(&app.model, changed);
-}
 
 fn select_card_in_active_task_list(app: &mut App, card_id: Uuid) {
     let list = app
@@ -75,17 +50,6 @@ fn test_handler_acts_on_scoped_tiers_while_flat_tiers_failed() {
     select_card_in_active_task_list(&mut app, card.id);
     app.focus.active = kanban_tui::app::Focus::Cards;
 
-    fail_flat_tiers(&mut app);
-
-    assert!(
-        app.model.sprints_state().is_failed(),
-        "fixture sanity: flat sprints tier must be Failed"
-    );
-    assert!(
-        app.model.board_sprints_state(board.id).is_loaded(),
-        "fixture sanity: scoped sprints tier must survive the flat failure"
-    );
-
     app.handle_assign_to_sprint_key();
 
     assert_eq!(app.mode, AppMode::Dialog(DialogMode::AssignCardToSprint));
@@ -123,8 +87,6 @@ fn test_move_card_uses_the_scoped_column_and_partition_reads() {
     app.prepare_frame();
     select_card_in_active_task_list(&mut app, card.id);
     app.focus.active = kanban_tui::app::Focus::Cards;
-
-    fail_flat_tiers(&mut app);
 
     app.handle_move_card_right();
 
@@ -166,8 +128,6 @@ fn test_create_card_position_derives_from_the_column_tier() {
     app.reload_model();
     app.prepare_frame();
     app.focus.active = kanban_tui::app::Focus::Cards;
-
-    fail_flat_tiers(&mut app);
 
     app.input.set("Third".into());
     app.create_card();
@@ -215,8 +175,6 @@ fn test_toggle_completion_resolves_cards_by_id() {
     app.selection.active_board_id = Some(board.id);
     app.reload_model();
     app.prepare_frame();
-
-    fail_flat_tiers(&mut app);
 
     assert!(app.model.card_by_id_state(a.id).loaded().is_some());
     assert!(app.model.card_by_id_state(b.id).loaded().is_some());
@@ -335,8 +293,6 @@ fn test_sprint_dialogs_read_the_board_scoped_sprint_tier() {
     app.push_mode(AppMode::Dialog(DialogMode::CreateCard));
     app.reload_model();
 
-    fail_flat_tiers(&mut app);
-
     app.dialog_input.create_card_focus = kanban_tui::app::dialog_input::CreateCardFocus::Sprint;
     app.handle_create_card_dialog(crossterm::event::KeyCode::Down);
 
@@ -369,8 +325,6 @@ fn test_the_tasks_panel_title_counts_from_the_scoped_tiers_while_the_flat_tiers_
     app.focus.active = kanban_tui::app::Focus::Cards;
     app.reload_model();
     app.prepare_frame();
-
-    fail_flat_tiers(&mut app);
 
     let title = kanban_tui::ui::tasks_panel_title(&app, false);
 
@@ -407,8 +361,6 @@ fn test_search_filters_the_scoped_card_tier_without_flat_tiers() {
     app.selection.active_board_id = Some(board.id);
     app.reload_model();
     app.prepare_frame();
-
-    fail_flat_tiers(&mut app);
 
     app.mode = AppMode::Search;
     app.filter.search.activate();

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -1164,9 +1164,9 @@ pub async fn setup_app_with_json_file_and_save_worker(dir: &std::path::Path) -> 
 /// Requests the global archived-card marker tier (and, for any marker
 /// found, its body) without changing which mode the app ends up in.
 /// Archived data is lazily fetched by `ViewScope`; tests that inspect
-/// `model.archived_card_ids()`/`model.cards_state()` for an archived row
-/// without having navigated through the archived-cards view must call this
-/// first, or the tier stays `NotLoaded` and reads as empty.
+/// `model.archived_card_ids()` or a card's per-id/scoped state for an
+/// archived row without having navigated through the archived-cards view
+/// must call this first, or the tier stays `NotLoaded` and reads as empty.
 pub fn warm_archived_card_markers(app: &mut App) {
     let prior = app.mode.clone();
     app.mode = kanban_tui::app::mode::AppMode::ArchivedCardsView;

--- a/crates/kanban-tui/tests/load_state_render_tests.rs
+++ b/crates/kanban-tui/tests/load_state_render_tests.rs
@@ -16,10 +16,6 @@ fn base_resolved(board: &Board) -> Resolved {
             all: LoadState::Loaded(vec![board.clone()]),
             ..Default::default()
         },
-        cards: Collection {
-            all: LoadState::Loaded(vec![]),
-            ..Default::default()
-        },
         graph: LoadState::Loaded(DependencyGraph::default()),
         ..Default::default()
     }
@@ -34,7 +30,6 @@ fn app_with_board_and_column_state(state: LoadState<Vec<Column>>) -> (App, Board
         ..Default::default()
     };
     resolved.sprints = Collection {
-        all: LoadState::Loaded(vec![]),
         by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![]))]),
         ..Default::default()
     };
@@ -47,10 +42,6 @@ fn app_with_board_and_sprint_state(state: LoadState<Vec<Sprint>>) -> (App, Board
     let mut app = App::test_default();
     let board = Board::new("TestBoard", None::<String>);
     let mut resolved = base_resolved(&board);
-    resolved.columns = Collection {
-        all: LoadState::Loaded(vec![]),
-        ..Default::default()
-    };
     resolved.sprints = Collection {
         by_parent: HashMap::from([(board.id, state)]),
         ..Default::default()
@@ -67,11 +58,11 @@ fn app_with_card_and_sprint_state(state: LoadState<Vec<Sprint>>) -> (App, Board,
     let card = Card::new(board.id, column.id, "Task", 0);
     let mut resolved = base_resolved(&board);
     resolved.cards = Collection {
-        all: LoadState::Loaded(vec![card.clone()]),
+        by_parent: HashMap::from([(column.id, LoadState::Loaded(vec![card.clone()]))]),
         ..Default::default()
     };
     resolved.columns = Collection {
-        all: LoadState::Loaded(vec![column.clone()]),
+        by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column.clone()]))]),
         ..Default::default()
     };
     resolved.sprints = Collection {
@@ -91,15 +82,15 @@ fn app_with_card_and_graph_state(state: LoadState<DependencyGraph>) -> (App, Boa
     let card = Card::new(board.id, column.id, "Task", 0);
     let mut resolved = base_resolved(&board);
     resolved.cards = Collection {
-        all: LoadState::Loaded(vec![card.clone()]),
+        by_parent: HashMap::from([(column.id, LoadState::Loaded(vec![card.clone()]))]),
         ..Default::default()
     };
     resolved.columns = Collection {
-        all: LoadState::Loaded(vec![column.clone()]),
+        by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column.clone()]))]),
         ..Default::default()
     };
     resolved.sprints = Collection {
-        all: LoadState::Loaded(vec![]),
+        by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![]))]),
         ..Default::default()
     };
     resolved.graph = state;
@@ -115,12 +106,11 @@ fn app_with_asymmetric_column_tier(board_columns_state: LoadState<Vec<Column>>) 
     let column = Column::new(board.id, "Backlog", 0);
     let mut resolved = base_resolved(&board);
     resolved.columns = Collection {
-        all: LoadState::Loaded(vec![column.clone()]),
         by_parent: HashMap::from([(board.id, board_columns_state)]),
         ..Default::default()
     };
     resolved.sprints = Collection {
-        all: LoadState::Loaded(vec![]),
+        by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![]))]),
         ..Default::default()
     };
     let changed = app.model.apply_resolved(resolved);
@@ -128,10 +118,9 @@ fn app_with_asymmetric_column_tier(board_columns_state: LoadState<Vec<Column>>) 
     app.selection.active_board_id = Some(board.id);
     app.switch_view_strategy(kanban_domain::TaskListView::ColumnView);
 
-    // The board-scoped column tier under test is deliberately asymmetric
-    // with the flat one, so `prepare_frame`'s all-scoped-tiers-Loaded gate
-    // would decline here; drive `refresh_task_lists` directly with the flat
-    // column so the task-list skeleton exists and the render's own
+    // `prepare_frame`'s all-scoped-tiers-Loaded gate would decline for a
+    // non-Loaded `board_columns_state`, so drive `refresh_task_lists`
+    // directly to build the task-list skeleton; the render's own
     // `board_columns_state` name lookup is what's under test.
     let ctx = kanban_view::view_strategy::ViewRefreshContext {
         board: &board,

--- a/crates/kanban-tui/tests/model_load_state_ctor_tests.rs
+++ b/crates/kanban-tui/tests/model_load_state_ctor_tests.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 fn test_with_load_states_is_reachable_from_an_out_of_crate_integration_test() {
     let mut app = App::test_default();
     app.model = Model::with_load_states(ModelLoadStates {
-        cards: LoadState::Failed(Arc::new(KanbanError::unsupported("boom"))),
+        boards: LoadState::Failed(Arc::new(KanbanError::unsupported("boom"))),
         ..Default::default()
     });
-    assert!(app.model.cards_state().is_failed());
+    assert!(app.model.boards_state().is_failed());
 }

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -10,9 +10,9 @@ fn make_card(board: &Board, column_id: Uuid, title: &str, pos: i32) -> Card {
 fn test_empty_model_returns_empty_slices() {
     let model = Model::default();
     assert!(model.boards_state().loaded_or_empty().is_empty());
-    assert!(model.columns_state().loaded_or_empty().is_empty());
-    assert!(model.cards_state().loaded_or_empty().is_empty());
-    assert!(model.sprints_state().loaded_or_empty().is_empty());
+    assert!(model.board_columns_state(Uuid::new_v4()).is_not_loaded());
+    assert!(model.column_cards_state(Uuid::new_v4()).is_not_loaded());
+    assert!(model.board_sprints_state(Uuid::new_v4()).is_not_loaded());
     assert!(model.archived_card_markers().is_empty());
     assert_eq!(
         model
@@ -44,15 +44,30 @@ fn test_load_from_snapshot_populates_all_fields() {
     };
 
     let _ = model.load_from_snapshot(snapshot);
+    let board_id = model.boards_state().loaded_or_empty()[0].id;
+    let column_id = model
+        .board_columns_state(board_id)
+        .loaded()
+        .unwrap()[0]
+        .id;
 
     assert_eq!(model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(model.boards_state().loaded_or_empty()[0].name, "Board1");
-    assert_eq!(model.columns_state().loaded_or_empty().len(), 1);
-    assert_eq!(model.columns_state().loaded_or_empty()[0].name, "Col1");
-    assert_eq!(model.cards_state().loaded_or_empty().len(), 1);
-    assert_eq!(model.cards_state().loaded_or_empty()[0].title, "Card1");
-    assert_eq!(model.sprints_state().loaded_or_empty().len(), 1);
-    assert_eq!(model.sprints_state().loaded_or_empty()[0].sprint_number, 1);
+    assert_eq!(model.board_columns_state(board_id).loaded().unwrap().len(), 1);
+    assert_eq!(
+        model.board_columns_state(board_id).loaded().unwrap()[0].name,
+        "Col1"
+    );
+    assert_eq!(model.column_cards_state(column_id).loaded().unwrap().len(), 1);
+    assert_eq!(
+        model.column_cards_state(column_id).loaded().unwrap()[0].title,
+        "Card1"
+    );
+    assert_eq!(model.board_sprints_state(board_id).loaded().unwrap().len(), 1);
+    assert_eq!(
+        model.board_sprints_state(board_id).loaded().unwrap()[0].sprint_number,
+        1
+    );
 }
 
 #[test]
@@ -144,13 +159,15 @@ fn test_load_from_snapshot_rebuilds_card_index() {
 // collection, filtered by `archived_card_ids` (the same set that backs
 // `displayed_cards`).
 fn archived_titles(model: &Model) -> Vec<String> {
-    let ids = model.archived_card_ids();
     model
-        .cards_state()
-        .loaded_or_empty()
+        .archived_card_markers()
         .iter()
-        .filter(|c| ids.contains(&c.id))
-        .map(|c| c.title.clone())
+        .filter_map(|marker| {
+            model
+                .card_id_status(marker.entity_id)
+                .loaded()
+                .map(|c| c.title.clone())
+        })
         .collect()
 }
 

--- a/crates/kanban-tui/tests/model_tests.rs
+++ b/crates/kanban-tui/tests/model_tests.rs
@@ -45,25 +45,30 @@ fn test_load_from_snapshot_populates_all_fields() {
 
     let _ = model.load_from_snapshot(snapshot);
     let board_id = model.boards_state().loaded_or_empty()[0].id;
-    let column_id = model
-        .board_columns_state(board_id)
-        .loaded()
-        .unwrap()[0]
-        .id;
+    let column_id = model.board_columns_state(board_id).loaded().unwrap()[0].id;
 
     assert_eq!(model.boards_state().loaded_or_empty().len(), 1);
     assert_eq!(model.boards_state().loaded_or_empty()[0].name, "Board1");
-    assert_eq!(model.board_columns_state(board_id).loaded().unwrap().len(), 1);
+    assert_eq!(
+        model.board_columns_state(board_id).loaded().unwrap().len(),
+        1
+    );
     assert_eq!(
         model.board_columns_state(board_id).loaded().unwrap()[0].name,
         "Col1"
     );
-    assert_eq!(model.column_cards_state(column_id).loaded().unwrap().len(), 1);
+    assert_eq!(
+        model.column_cards_state(column_id).loaded().unwrap().len(),
+        1
+    );
     assert_eq!(
         model.column_cards_state(column_id).loaded().unwrap()[0].title,
         "Card1"
     );
-    assert_eq!(model.board_sprints_state(board_id).loaded().unwrap().len(), 1);
+    assert_eq!(
+        model.board_sprints_state(board_id).loaded().unwrap().len(),
+        1
+    );
     assert_eq!(
         model.board_sprints_state(board_id).loaded().unwrap()[0].sprint_number,
         1

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -421,14 +421,6 @@ async fn test_a_card_mutation_repairs_the_column_scope_without_reading_the_whole
     let seed = seed_two_columns_two_cards(&mut app);
     let ops = prime(&mut app).await;
 
-    let _ = app.model.apply_resolved(kanban_domain::Resolved {
-        cards: kanban_domain::resolved::Collection {
-            all: kanban_domain::LoadState::Loaded(vec![]),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-
     app.selection.active_board_id = Some(seed.board);
     app.focus.active = Focus::Cards;
     app.selection.active_card_id = Some(seed.k1);

--- a/crates/kanban-tui/tests/panel_title_tests.rs
+++ b/crates/kanban-tui/tests/panel_title_tests.rs
@@ -211,17 +211,14 @@ fn seed_model_states(
             ..Default::default()
         },
         cards: Collection {
-            all: cards,
             by_parent: cards_by_parent,
             ..Default::default()
         },
         columns: Collection {
-            all: columns,
             by_parent: columns_by_parent,
             ..Default::default()
         },
         sprints: Collection {
-            all: sprints,
             by_parent: sprints_by_parent,
             ..Default::default()
         },

--- a/crates/kanban-tui/tests/relationship_popup_tests.rs
+++ b/crates/kanban-tui/tests/relationship_popup_tests.rs
@@ -92,8 +92,8 @@ fn test_manage_parents_popup_enter_creates_parent_edge() {
         )
         .unwrap();
 
-    // Wire the model so popup_handlers' `self.model.cards_state().loaded_or_empty()` reflects
-    // the data store. `selection.active_card` points at child.
+    // Wire the model so it reflects the data store.
+    // `selection.active_card` points at child.
     let snapshot = Snapshot {
         archived_boards: Vec::new(),
         boards: app.ctx.data_store().list_boards().unwrap(),

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -431,3 +431,31 @@ fn test_manage_parents_still_opens_and_filters_when_the_graph_is_loaded() {
     assert_eq!(app.mode, AppMode::Dialog(DialogMode::ManageParents));
     assert!(!app.relationship.card_ids.contains(&b));
 }
+
+#[test]
+fn test_a_cross_board_graph_neighbour_body_is_fetched_for_card_detail() {
+    let mut app = App::test_default();
+    let (board_b_id, column_b_id) = create_board_and_column(&mut app, "Board B");
+    let (board_c_id, column_c_id) = create_board_and_column(&mut app, "Board C");
+
+    let subject = create_card(&mut app, board_b_id, column_b_id, "Subject");
+    let cross = create_card(&mut app, board_c_id, column_c_id, "CrossBoardChildXYZ");
+    app.ctx.attach_child(subject, cross).unwrap();
+
+    app.selection.active_board_id = Some(board_b_id);
+    app.selection.active_card_id = Some(subject);
+    app.mode = AppMode::CardDetail;
+    app.reload_model();
+
+    let graph = app
+        .model
+        .graph_state()
+        .loaded()
+        .unwrap_or_else(|| Model::empty_graph());
+    let children = graph.children(subject);
+
+    let resolved = resolve_relationship_cards(&app.model, &children);
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].id, cross);
+    assert_eq!(resolved[0].title, "CrossBoardChildXYZ");
+}

--- a/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
@@ -30,6 +30,16 @@ fn seed_model_with_board(
     board_id
 }
 
+fn seed_missing_sprint(app: &mut App, sprint_id: Uuid) {
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        sprints: kanban_domain::resolved::Collection {
+            by_id: [(sprint_id, LoadState::Missing)].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
 fn assert_error_banner_mentions(app: &App, needle: &str) {
     let banner = app
         .ui_state
@@ -73,8 +83,10 @@ fn test_handle_activate_sprint_key_distinguishes_missing_from_not_loaded() {
         LoadState::Loaded(vec![]),
         LoadState::Loaded(vec![]),
     );
+    let missing_sprint_id = Uuid::new_v4();
+    seed_missing_sprint(&mut app, missing_sprint_id);
     app.selection.active_board_id = Some(board_id);
-    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.selection.active_sprint_id = Some(missing_sprint_id);
     app.handle_activate_sprint_key();
     assert_no_banner(&app);
 
@@ -109,8 +121,10 @@ fn test_handle_complete_sprint_key_distinguishes_missing_from_not_loaded() {
         LoadState::Loaded(vec![]),
         LoadState::Loaded(vec![]),
     );
+    let missing_sprint_id = Uuid::new_v4();
+    seed_missing_sprint(&mut app, missing_sprint_id);
     app.selection.active_board_id = Some(board_id);
-    app.selection.active_sprint_id = Some(Uuid::new_v4());
+    app.selection.active_sprint_id = Some(missing_sprint_id);
     app.handle_complete_sprint_key();
     assert_no_banner(&app);
 
@@ -137,7 +151,9 @@ fn test_handle_carry_over_for_sprint_with_a_not_loaded_sprint_tier_declines() {
 fn test_handle_carry_over_for_sprint_distinguishes_missing_from_not_loaded() {
     let mut app = App::test_default();
     seed_model_with_board(&mut app, LoadState::NotLoaded, LoadState::Loaded(vec![]));
-    app.handle_carry_over_for_sprint(Uuid::new_v4());
+    let missing_sprint_id = Uuid::new_v4();
+    seed_missing_sprint(&mut app, missing_sprint_id);
+    app.handle_carry_over_for_sprint(missing_sprint_id);
     assert_no_banner(&app);
 
     let mut app = App::test_default();
@@ -223,6 +239,7 @@ fn test_handle_carry_over_sprint_popup_distinguishes_missing_from_not_loaded() {
     let mut app = App::test_default();
     seed_model_with_board(&mut app, LoadState::NotLoaded, LoadState::Loaded(vec![]));
     let source_id = Uuid::new_v4();
+    seed_missing_sprint(&mut app, source_id);
     app.dialog_input.carry_over_source_sprint_id = Some(source_id);
     app.handle_carry_over_sprint_popup(KeyCode::Down);
     assert_no_banner(&app);

--- a/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
+++ b/crates/kanban-tui/tests/sprint_popup_handler_decline_tests.rs
@@ -18,7 +18,13 @@ fn seed_model_with_board(
     };
     app.model = kanban_domain::Model::with_load_states(ModelLoadStates {
         boards,
-        sprints,
+        ..Default::default()
+    });
+    let _ = app.model.apply_resolved(kanban_domain::Resolved {
+        sprints: kanban_domain::resolved::Collection {
+            by_parent: [(board_id, sprints)].into(),
+            ..Default::default()
+        },
         ..Default::default()
     });
     board_id

--- a/crates/kanban-tui/tests/sprint_tier_coherence_tests.rs
+++ b/crates/kanban-tui/tests/sprint_tier_coherence_tests.rs
@@ -65,8 +65,9 @@ fn test_filter_dialog_sprint_toggle_targets_rendered_sprint() {
 
 #[test]
 fn test_filter_dialog_sprint_nav_counts_the_rendered_rows() {
-    let (mut app, _board) =
-        seed_board_with_scoped_sprints(|board_id| vec![Sprint::new(board_id, 2, None, None::<String>)]);
+    let (mut app, _board) = seed_board_with_scoped_sprints(|board_id| {
+        vec![Sprint::new(board_id, 2, None, None::<String>)]
+    });
 
     open_filter_dialog(&mut app);
     {

--- a/crates/kanban-tui/tests/sprint_tier_coherence_tests.rs
+++ b/crates/kanban-tui/tests/sprint_tier_coherence_tests.rs
@@ -10,31 +10,19 @@ use kanban_tui::App;
 use kanban_view::view_strategy::ViewRefreshContext;
 use std::collections::HashMap;
 
-fn seed_board_with_divergent_sprint_tiers(
+fn seed_board_with_scoped_sprints(
     build_scoped: impl FnOnce(uuid::Uuid) -> Vec<Sprint>,
-    build_flat_extra: impl FnOnce(uuid::Uuid) -> Vec<Sprint>,
 ) -> (App, Board) {
     let mut app = App::test_default();
     let board = Board::new("TestBoard", None::<String>);
     let scoped = build_scoped(board.id);
-    let mut all_sprints = build_flat_extra(board.id);
-    all_sprints.extend(scoped.clone());
 
     let resolved = Resolved {
         boards: Collection {
             all: LoadState::Loaded(vec![board.clone()]),
             ..Default::default()
         },
-        cards: Collection {
-            all: LoadState::Loaded(vec![]),
-            ..Default::default()
-        },
-        columns: Collection {
-            all: LoadState::Loaded(vec![]),
-            ..Default::default()
-        },
         sprints: Collection {
-            all: LoadState::Loaded(all_sprints),
             by_parent: HashMap::from([(board.id, LoadState::Loaded(scoped))]),
             ..Default::default()
         },
@@ -54,21 +42,12 @@ fn open_filter_dialog(app: &mut App) {
 
 #[test]
 fn test_filter_dialog_sprint_toggle_targets_rendered_sprint() {
-    let s_a_id = std::cell::Cell::new(uuid::Uuid::nil());
     let s_b_id = std::cell::Cell::new(uuid::Uuid::nil());
-    let (mut app, _board) = seed_board_with_divergent_sprint_tiers(
-        |board_id| {
-            let s_b = Sprint::new(board_id, 2, None, None::<String>);
-            s_b_id.set(s_b.id);
-            vec![s_b]
-        },
-        |board_id| {
-            let s_a = Sprint::new(board_id, 1, None, None::<String>);
-            s_a_id.set(s_a.id);
-            vec![s_a]
-        },
-    );
-    let s_a_id = s_a_id.get();
+    let (mut app, _board) = seed_board_with_scoped_sprints(|board_id| {
+        let s_b = Sprint::new(board_id, 2, None, None::<String>);
+        s_b_id.set(s_b.id);
+        vec![s_b]
+    });
     let s_b_id = s_b_id.get();
 
     open_filter_dialog(&mut app);
@@ -82,15 +61,12 @@ fn test_filter_dialog_sprint_toggle_targets_rendered_sprint() {
     app.handle_filter_options_popup(crossterm::event::KeyCode::Char(' '));
 
     assert!(app.filter.active_sprint_filters.contains(&s_b_id));
-    assert!(!app.filter.active_sprint_filters.contains(&s_a_id));
 }
 
 #[test]
 fn test_filter_dialog_sprint_nav_counts_the_rendered_rows() {
-    let (mut app, _board) = seed_board_with_divergent_sprint_tiers(
-        |board_id| vec![Sprint::new(board_id, 2, None, None::<String>)],
-        |board_id| vec![Sprint::new(board_id, 1, None, None::<String>)],
-    );
+    let (mut app, _board) =
+        seed_board_with_scoped_sprints(|board_id| vec![Sprint::new(board_id, 2, None, None::<String>)]);
 
     open_filter_dialog(&mut app);
     {
@@ -130,11 +106,10 @@ fn test_task_row_sprint_suffix_not_loaded_renders_marker_not_blank() {
             ..Default::default()
         },
         cards: Collection {
-            all: LoadState::Loaded(vec![card.clone()]),
+            by_parent: HashMap::from([(column.id, LoadState::Loaded(vec![card.clone()]))]),
             ..Default::default()
         },
         columns: Collection {
-            all: LoadState::Loaded(vec![column.clone()]),
             by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column.clone()]))]),
             ..Default::default()
         },
@@ -181,11 +156,10 @@ fn test_task_row_sprint_suffix_loaded_renders_the_sprint_name() {
             ..Default::default()
         },
         cards: Collection {
-            all: LoadState::Loaded(vec![card.clone()]),
+            by_parent: HashMap::from([(column.id, LoadState::Loaded(vec![card.clone()]))]),
             ..Default::default()
         },
         columns: Collection {
-            all: LoadState::Loaded(vec![column.clone()]),
             by_parent: HashMap::from([(board.id, LoadState::Loaded(vec![column.clone()]))]),
             ..Default::default()
         },

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -646,18 +646,19 @@ mod backend_parity {
         for (kind, dir) in kinds.iter().zip(dirs.iter()) {
             let ctx = open_seeded(kind, dir, &snapshot).await;
             let model = populate_scope(&ctx, board1);
+            let untouched_id = Uuid::new_v4();
 
             assert!(
-                model.columns_state().is_not_loaded(),
-                "{kind}: the flat column tier must stay unrequested"
+                model.board_columns_state(untouched_id).is_not_loaded(),
+                "{kind}: an unrelated board's column tier must stay unrequested"
             );
             assert!(
-                model.cards_state().is_not_loaded(),
-                "{kind}: the flat card tier must stay unrequested"
+                model.column_cards_state(untouched_id).is_not_loaded(),
+                "{kind}: an unrelated column's card tier must stay unrequested"
             );
             assert!(
-                model.sprints_state().is_not_loaded(),
-                "{kind}: the flat sprint tier must stay unrequested"
+                model.board_sprints_state(untouched_id).is_not_loaded(),
+                "{kind}: an unrelated board's sprint tier must stay unrequested"
             );
             assert!(
                 model.board_columns_state(board1).is_loaded(),

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -906,24 +906,8 @@ mod tests {
     }
 
     #[test]
-    fn test_scoped_loaded_model_with_flat_tiers_failed_renders_live_partition() {
-        let err = std::sync::Arc::new(kanban_domain::KanbanError::unsupported("boom"));
+    fn test_scoped_loaded_model_renders_live_partition() {
         let mut model = Model::default();
-        let _ = model.apply_resolved(Resolved {
-            cards: Collection {
-                all: LoadState::Failed(err.clone()),
-                ..Default::default()
-            },
-            columns: Collection {
-                all: LoadState::Failed(err.clone()),
-                ..Default::default()
-            },
-            sprints: Collection {
-                all: LoadState::Failed(err),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
 
         let board = seed_board("B", 0);
         let board_id = board.id;

--- a/flake.nix
+++ b/flake.nix
@@ -71,11 +71,17 @@
           text = builtins.readFile ./scripts/check-factory-compile-lock.sh;
         };
 
+        checkDatastoreExplicitImpl = pkgs.writeShellApplication {
+          name = "check-datastore-explicit-impl";
+          runtimeInputs = with pkgs; [coreutils gawk];
+          text = builtins.readFile ./scripts/check-datastore-explicit-impl.sh;
+        };
+
         kanban = pkgs.callPackage ./default.nix { src = self; gitRev = self.rev or null; };
       in {
         devShells.default = import ./shell.nix {
           inherit pkgs rustToolchain;
-          inherit changeset aggregateChangelog bumpVersion publishCrates validateRelease listCrates checkCrateListSync checkFactoryCompileLock;
+          inherit changeset aggregateChangelog bumpVersion publishCrates validateRelease listCrates checkCrateListSync checkFactoryCompileLock checkDatastoreExplicitImpl;
         };
 
         devShells.demo = import ./demo/shell.nix { inherit pkgs kanban; };
@@ -95,6 +101,7 @@
           list-crates = listCrates;
           check-crate-list-sync = checkCrateListSync;
           check-factory-compile-lock = checkFactoryCompileLock;
+          check-datastore-explicit-impl = checkDatastoreExplicitImpl;
           changeset = changeset;
         };
       }

--- a/scripts/check-datastore-explicit-impl.sh
+++ b/scripts/check-datastore-explicit-impl.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Fails the build if `impl DataStore for HttpBackend` silently inherits a
+# default-bodied trait method instead of naming it explicitly. An inherited
+# default declines under a sibling method's name (or, for `modify_graph`,
+# reaches the transport instead of declining at all) — see
+# crates/kanban-backend-http/tests/decline_rulings.rs.
+#
+# Trait method count: every `fn` inside `pub trait DataStore { ... }` in
+# crates/kanban-domain/src/data_store.rs, stopping at the trait's own closing
+# brace (so its `#[cfg(test)] mod tests` below is excluded).
+#
+# Impl method count: every `fn` inside `impl DataStore for HttpBackend { ... }`
+# in crates/kanban-backend-http/src/data_store.rs, stopping at that block's own
+# closing brace. Scoping to the impl block (not the whole file) is load-bearing:
+# the file also has an inherent `impl HttpBackend { fn lookup_cards(...) }`
+# helper above the trait impl, which a whole-file count would wrongly include.
+set -euo pipefail
+
+TRAIT_FILE="crates/kanban-domain/src/data_store.rs"
+IMPL_FILE="crates/kanban-backend-http/src/data_store.rs"
+
+trait_count=$(awk '/^pub trait DataStore/,/^}/' "$TRAIT_FILE" | grep -c '    fn ')
+impl_count=$(awk '/^impl DataStore for HttpBackend/,/^}/' "$IMPL_FILE" | grep -c '    fn ')
+
+if [ "$trait_count" -ne "$impl_count" ]; then
+  echo "❌ DataStore trait/impl method count mismatch: trait has $trait_count method(s), HttpBackend's impl has $impl_count"
+  echo "   Every DataStore method must be an explicit impl on HttpBackend, even if it just declines."
+  diff \
+    <(awk '/^pub trait DataStore/,/^}/' "$TRAIT_FILE" | grep '    fn ' | sed -E 's/^\s*fn ([a-zA-Z0-9_]+).*/\1/' | sort) \
+    <(awk '/^impl DataStore for HttpBackend/,/^}/' "$IMPL_FILE" | grep '    fn ' | sed -E 's/^\s*fn ([a-zA-Z0-9_]+).*/\1/' | sort) \
+    || true
+  exit 1
+fi
+
+echo "✅ DataStore explicit-impl guard clean ($trait_count/$impl_count)"

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@
   listCrates ? null,
   checkCrateListSync ? null,
   checkFactoryCompileLock ? null,
+  checkDatastoreExplicitImpl ? null,
 }:
 
 let
@@ -21,6 +22,7 @@ let
     listCrates
     checkCrateListSync
     checkFactoryCompileLock
+    checkDatastoreExplicitImpl
   ];
 in
 


### PR DESCRIPTION
## Summary

Deletes `Model`'s flat `columns`/`cards`/`sprints` collections, `card_index`, their three accessors (`columns_state`/`cards_state`/`sprints_state`) and every flat write path. The scoped (`board_columns_state`/`column_cards_state`/`board_sprints_state`) and per-id (`column_by_id_state`/`card_by_id_state`/`sprint_by_id_state`) tiers are now the only source of truth for these three entity kinds. Boards keep their flat collection, since the board list has no parent to scope under.

Folds in KAN-1330: four `DataStore` methods that were silently inherited by `HttpBackend` (each declining under a sibling method's name instead of its own) now have explicit impls, every declining method (31 unconditional plus 2 conditional decliners) carries a decline-category doc comment, and a new `scripts/check-datastore-explicit-impl.sh` guard (wired into flake.nix, shell.nix and CI) fails the build if the trait/impl method counts ever diverge again.

### What changed

- `crates/kanban-domain/src/model/mod.rs`: `load_from_snapshot` now seeds only the scoped and per-id tiers from `Snapshot.columns/cards/sprints`, taking them by value into `rebuild_scoped_tiers`. Archived card bodies land in the per-id tier (`cards_by_id`) instead of nowhere, since `kanban-view`'s `archived_bodies` resolves every marker through `card_by_id_state`.
- `crates/kanban-domain/src/model/cards.rs`, `collections.rs`: `card_by_id_state`/`column_by_id_state`/`sprint_by_id_state` drop their flat-collection fallback arm; precedence is now per-id, then scoped, then `NotLoaded` (never `Missing` unless a resolve pass explicitly wrote one).
- `crates/kanban-domain/src/model/apply.rs`: `apply_resolved` no longer writes the retired flat tiers for columns/cards/sprints (`apply_by_id` replaces `apply_collection` for them); `mark_failed`/`invalidate` drop their flat-tier writes, keeping the per-id and scoped propagation.
- `crates/kanban-domain/src/dependencies/dependency_graph.rs`: new `DependencyGraph::neighbours(card)` names every parent/child/blocker/blocked/related relative, sorted and deduped.
- `crates/kanban-service/src/fetch_plan.rs` (+ `model_loaded.rs`, `resolve.rs`, and stub impls): new `LoadedEntities::loaded_graph_neighbours` with no default body, implemented on all six `LoadedEntities` impls.
- `crates/kanban-tui/src/app/view_scope.rs`: `ViewScope::next_round` now requests a `CardDetail` card's graph neighbours' bodies per id, closing the gap where a cross-board `spawns` relative's body was never fetched.
- `crates/kanban-backend-http/src/data_store.rs`: explicit impls for `clear_sprint_from_archived_cards`, `list_cards_by_column_filtered`, `count_cards_in_column_filtered` and `modify_graph`; `count_cards_in_column_filtered`'s `LiveOnly` arm now declines under its own name instead of delegating to (and erroring as) `count_cards_in_column`; every declining method now carries a category comment matching the census ruling (`missing-route`, `architecture-mismatch`, `write-backstop-via-RemoteWrites`, `archived-family-gap`, `count-methods-never-fake-O(1)`, `bulk-deletes-never-fan-out`), including the whole archived family under `archived-family-gap` and the `list_all_*` trio under `architecture-mismatch`.
- `crates/kanban-tui/src/app/card_selection.rs`: `set_active_card_or_clear` falls back to one direct store read when the id is `NotLoaded`, since the scoped/per-id tiers can no longer prove a card's absence the way the flat tier's fallback used to. Every caller already passes an id visible in the model except the navigation-history recall this exists for, so the extra read is rare, not per-frame.
- The full test suite across `kanban-domain`, `kanban-service`, `kanban-tui`, `kanban-view`, `kanban-server` and `kanban-backend-http` was reseeded through the scoped/per-id tiers wherever it previously relied on the flat collections or a flat-derived `Missing`.
- `scripts/check-datastore-explicit-impl.sh` + flake.nix/shell.nix/ci.yml wiring, plus a table-driven decline census in `kanban-backend-http/tests/decline_rulings.rs` covering all 31 unconditional decliners by name (the table asserts its own row count), with per-arm pins for the 2 conditional decliners (`list_cards_by_column_filtered`, `count_cards_in_column_filtered`).

### Notes for reviewers

- The KAN-1582 card-bucketing branch was already landed (`rebuild_card_column_buckets`); this PR reuses it rather than adding a new one.
- `warm_archived_card_markers` (a TUI test helper) was deliberately NOT retired: it feeds the whole-store archival *marker* tier, which this PR does not delete and which production code still reads.
- Re-derived DataStore counts: 50 trait methods / 46 impl-block methods before this PR (the naive 50/47 count elsewhere included an inherent helper method); 50/50 after.
- `get_graph` is route-backed (a prior PR added `GET /v1/graph`) and only declines on a 404, so it's excluded from the table-driven decline census and from the explicit-impl category-comment requirement.

## Test plan

- [x] `cargo test --workspace --all-features` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `git grep -nE '(^|[^_])(cards|columns|sprints)_state\(\)' -- crates/` returns nothing
- [x] `scripts/check-datastore-explicit-impl.sh` reports 50/50; the deliberately-broken probe (commenting out one explicit impl) reported 49/50 and named the missing method
- [x] `nix flake check --no-build` passes with the new `check-datastore-explicit-impl` package wired in

