### PR TITLE
KAN-1590 fix(tui): a backend swap rewires the freshness source

### DIFF
--- a/.changeset/kan-1590-backend-swap-rewires-freshness.md
+++ b/.changeset/kan-1590-backend-swap-rewires-freshness.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-a backend swap rewires the freshness source through one helper
+Switching storage location mid-session, or adopting a new storage file, now re-points live change detection at the new location instead of leaving it on the old one, so a switch to a remote server starts receiving other clients' changes without a restart.

--- a/.changeset/kan-1590-backend-swap-rewires-freshness.md
+++ b/.changeset/kan-1590-backend-swap-rewires-freshness.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+a backend swap rewires the freshness source through one helper

--- a/crates/kanban-tui/src/app/freshness.rs
+++ b/crates/kanban-tui/src/app/freshness.rs
@@ -1,0 +1,8 @@
+use super::App;
+
+impl App {
+    #[doc(hidden)]
+    pub async fn rewire_freshness(&mut self) -> Option<std::path::PathBuf> {
+        None
+    }
+}

--- a/crates/kanban-tui/src/app/freshness.rs
+++ b/crates/kanban-tui/src/app/freshness.rs
@@ -1,8 +1,84 @@
 use super::App;
+use crate::app::FreshnessSource;
+use kanban_persistence::ChangeDetector;
+use std::path::PathBuf;
 
 impl App {
     #[doc(hidden)]
-    pub async fn rewire_freshness(&mut self) -> Option<std::path::PathBuf> {
-        None
+    pub async fn rewire_freshness(&mut self) -> Option<PathBuf> {
+        self.clear_freshness().await;
+        match self
+            .persistence
+            .save_file
+            .clone()
+            .as_deref()
+            .and_then(super::types::watcher_target)
+        {
+            Some(local) => self.wire_file_watcher(local).await,
+            None => {
+                self.wire_remote_subscription();
+                None
+            }
+        }
+    }
+
+    async fn clear_freshness(&mut self) {
+        if let Some(watcher) = self.persistence.file_watcher.take() {
+            let _ = watcher.stop_watching().await;
+        }
+        self.persistence.file_change_rx = None;
+        self.persistence.remote_change_rx = None;
+        self.persistence.freshness = FreshnessSource::Off;
+    }
+
+    async fn wire_file_watcher(&mut self, local: &str) -> Option<PathBuf> {
+        tracing::info!("Initializing file watcher for: {}", local);
+        let watcher = kanban_persistence::FileWatcher::new();
+        watcher.set_own_instance_id(self.ctx.backend().instance_id());
+        let rx = watcher.subscribe();
+        self.persistence.file_change_rx = Some(rx);
+        tracing::debug!("File change broadcast receiver subscribed");
+
+        let path = PathBuf::from(local);
+        let deferred_watch_path = if path.exists() {
+            if let Err(e) = watcher.start_watching(path.clone()).await {
+                tracing::warn!(
+                    "Failed to start file watching for {}: {}",
+                    path.display(),
+                    e
+                );
+            } else {
+                tracing::info!("File watcher started for: {}", path.display());
+            }
+            None
+        } else {
+            tracing::debug!(
+                "File does not exist yet, deferring file watching until first save: {}",
+                path.display()
+            );
+            Some(path.clone())
+        };
+
+        self.persistence.file_watcher = Some(watcher.clone());
+        let watcher_arc = std::sync::Arc::new(watcher);
+        self.ctx.save_coordinator.set_file_watcher(watcher_arc);
+        self.persistence.freshness = FreshnessSource::File(path);
+
+        deferred_watch_path
+    }
+
+    fn wire_remote_subscription(&mut self) {
+        if let Some(ref f) = self.persistence.save_file {
+            tracing::info!("Remote storage location; skipping file watcher: {f}");
+        }
+        let backend = self.ctx.backend();
+        if let Some(http) = backend
+            .as_any()
+            .and_then(|a| a.downcast_ref::<kanban_backend_http::HttpBackend>())
+        {
+            tracing::info!("Remote storage location; subscribing to SSE change events");
+            self.persistence.remote_change_rx = Some(http.subscribe());
+            self.persistence.freshness = FreshnessSource::Remote;
+        }
     }
 }

--- a/crates/kanban-tui/src/app/lifecycle.rs
+++ b/crates/kanban-tui/src/app/lifecycle.rs
@@ -299,7 +299,9 @@ impl App {
                 let mut config = self.app_config.clone();
                 config.storage_location = Some(path);
                 self.set_app_config(config);
-                self.spawn_save_worker(save_rx, None);
+                let deferred_watch_path =
+                    tokio::task::block_in_place(|| handle.block_on(self.rewire_freshness()));
+                self.spawn_save_worker(save_rx, deferred_watch_path);
                 self.ctx.save_coordinator.queue_flush();
                 true
             }

--- a/crates/kanban-tui/src/app/lifecycle_tests.rs
+++ b/crates/kanban-tui/src/app/lifecycle_tests.rs
@@ -1116,3 +1116,35 @@ async fn test_adopt_storage_file_still_refuses_an_existing_path() {
         banner.message
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_adopt_storage_file_rewires_freshness_to_the_adopted_file() {
+    use crossterm::event::KeyCode;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let target = dir.path().join("adopted.json");
+
+    let sm = default_store_manager();
+    let (mut app, _save_rx) = App::new_with_store_and_config(sm, None, Default::default())
+        .await
+        .unwrap();
+
+    let (_tx, rx) = tokio::sync::mpsc::channel::<kanban_service::api::ChangeEventFrame>(4);
+    app.persistence.remote_change_rx = Some(rx);
+
+    app.maybe_push_startup_file_dialog();
+    app.input.clear();
+    app.input.set(target.to_str().unwrap().to_string());
+    app.handle_choose_storage_file_dialog(KeyCode::Enter);
+
+    assert!(app.persistence.remote_change_rx.is_none());
+    assert!(app.persistence.file_change_rx.is_some());
+    assert!(
+        matches!(app.persistence.freshness, FreshnessSource::File(ref p) if p.ends_with("adopted.json"))
+    );
+    let watcher = app.persistence.file_watcher.as_ref().unwrap();
+    assert_eq!(
+        watcher.own_instance_id(),
+        Some(app.ctx.backend().instance_id())
+    );
+}

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -46,60 +46,7 @@ impl App {
 
         let mut terminal = setup_terminal()?;
 
-        let save_file = self.persistence.save_file.clone();
-        let deferred_watch_path = match save_file.as_deref().and_then(super::types::watcher_target)
-        {
-            Some(local) => {
-                use kanban_persistence::ChangeDetector;
-                tracing::info!("Initializing file watcher for: {}", local);
-                let watcher = kanban_persistence::FileWatcher::new();
-                watcher.set_own_instance_id(self.ctx.backend().instance_id());
-                let rx = watcher.subscribe();
-                self.persistence.file_change_rx = Some(rx);
-                tracing::debug!("File change broadcast receiver subscribed");
-
-                let path = std::path::PathBuf::from(local);
-                let deferred_watch_path = if path.exists() {
-                    if let Err(e) = watcher.start_watching(path.clone()).await {
-                        tracing::warn!(
-                            "Failed to start file watching for {}: {}",
-                            path.display(),
-                            e
-                        );
-                    } else {
-                        tracing::info!("File watcher started for: {}", path.display());
-                    }
-                    None
-                } else {
-                    tracing::debug!(
-                        "File does not exist yet, deferring file watching until first save: {}",
-                        path.display()
-                    );
-                    Some(path)
-                };
-
-                // Store the watcher to keep the background task alive
-                self.persistence.file_watcher = Some(watcher.clone());
-                let watcher_arc = std::sync::Arc::new(watcher);
-                self.ctx.save_coordinator.set_file_watcher(watcher_arc);
-
-                deferred_watch_path
-            }
-            None => {
-                if let Some(ref f) = save_file {
-                    tracing::info!("Remote storage location; skipping file watcher: {f}");
-                }
-                let backend = self.ctx.backend();
-                if let Some(http) = backend
-                    .as_any()
-                    .and_then(|a| a.downcast_ref::<kanban_backend_http::HttpBackend>())
-                {
-                    tracing::info!("Remote storage location; subscribing to SSE change events");
-                    self.persistence.remote_change_rx = Some(http.subscribe());
-                }
-                None
-            }
-        };
+        let deferred_watch_path = self.rewire_freshness().await;
 
         if let Some(rx) = save_rx {
             self.spawn_save_worker(rx, deferred_watch_path);

--- a/crates/kanban-tui/src/app/mod.rs
+++ b/crates/kanban-tui/src/app/mod.rs
@@ -28,7 +28,7 @@ pub mod view;
 pub use view::ViewState;
 
 pub mod persistence;
-pub use persistence::PersistenceState;
+pub use persistence::{FreshnessSource, PersistenceState};
 
 pub mod ui_state;
 pub use ui_state::UiState;
@@ -48,6 +48,7 @@ mod dialog;
 mod error_log_view;
 mod export_import;
 mod file_io;
+mod freshness;
 mod input_router;
 mod keybindings;
 mod lifecycle;

--- a/crates/kanban-tui/src/app/persistence.rs
+++ b/crates/kanban-tui/src/app/persistence.rs
@@ -1,3 +1,11 @@
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum FreshnessSource {
+    #[default]
+    Off,
+    File(std::path::PathBuf),
+    Remote,
+}
+
 #[derive(Default)]
 pub struct PersistenceState {
     pub save_file: Option<String>,
@@ -8,6 +16,9 @@ pub struct PersistenceState {
     pub save_error_rx: Option<tokio::sync::mpsc::UnboundedReceiver<String>>,
     pub remote_change_rx:
         Option<tokio::sync::mpsc::Receiver<kanban_service::api::ChangeEventFrame>>,
+    /// Written only by `App::rewire_freshness`; mirrors which of
+    /// `file_change_rx`/`file_watcher`/`remote_change_rx` is live.
+    pub freshness: FreshnessSource,
 }
 
 impl PersistenceState {
@@ -23,6 +34,7 @@ impl PersistenceState {
             save_completion_rx,
             save_error_rx: None,
             remote_change_rx: None,
+            freshness: FreshnessSource::default(),
         }
     }
 }

--- a/crates/kanban-tui/src/handlers/settings_handlers.rs
+++ b/crates/kanban-tui/src/handlers/settings_handlers.rs
@@ -270,9 +270,6 @@ impl App {
         }
 
         self.ctx.replace_backend(new_backend);
-        if let Some(watcher) = &self.persistence.file_watcher {
-            watcher.set_own_instance_id(self.ctx.backend().instance_id());
-        }
         let (save_rx, completion_rx) = self.ctx.save_coordinator.reset_save_channels();
         if let Some(board_id) = self.selection.active_board_id {
             if let Ok(Some(board)) = self.ctx.data_store().get_board(board_id) {
@@ -299,7 +296,8 @@ impl App {
 
         self.persistence.save_file = Some(new_storage_location.clone());
         self.persistence.save_completion_rx = Some(completion_rx);
-        self.spawn_save_worker(save_rx, None);
+        let deferred_watch_path = self.rewire_freshness().await;
+        self.spawn_save_worker(save_rx, deferred_watch_path);
         self.cli_file_override = false;
         self.cli_file_provided = false;
         let msg = if file_existed {

--- a/crates/kanban-tui/tests/remote_freshness_tests.rs
+++ b/crates/kanban-tui/tests/remote_freshness_tests.rs
@@ -240,7 +240,8 @@ async fn test_rewire_to_a_local_locator_drops_the_stale_remote_receiver() {
 async fn test_settings_storage_swap_rewires_freshness_to_the_new_file() {
     let dir = tempfile::tempdir().unwrap();
     let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    let other_json = helpers::create_test_json_file(dir.path(), "other.json", &["SecondBoard"]).await;
+    let other_json =
+        helpers::create_test_json_file(dir.path(), "other.json", &["SecondBoard"]).await;
 
     let (_tx, rx) = tokio::sync::mpsc::channel::<ChangeEventFrame>(4);
     app.persistence.remote_change_rx = Some(rx);
@@ -260,28 +261,9 @@ async fn test_settings_storage_swap_rewires_freshness_to_the_new_file() {
         matches!(app.persistence.freshness, FreshnessSource::File(ref p) if p.ends_with("other.json"))
     );
     let watcher = app.persistence.file_watcher.as_ref().unwrap();
-    assert_eq!(watcher.own_instance_id(), Some(app.ctx.backend().instance_id()));
+    assert_eq!(
+        watcher.own_instance_id(),
+        Some(app.ctx.backend().instance_id())
+    );
     assert_ne!(watcher.own_instance_id(), Some(sentinel_id));
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_settings_storage_swap_arms_the_watcher_on_the_new_file() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut app = helpers::setup_app_with_json_file(dir.path()).await;
-    let other_json = helpers::create_test_json_file(dir.path(), "other.json", &["SecondBoard"]).await;
-
-    let old_config = app.app_config.clone();
-    let old_storage_location = app.app_config.effective_storage_location();
-    app.app_config.storage_location = Some(other_json.clone());
-    app.apply_storage_location_change(old_config, &old_storage_location);
-    app.await_migration().await;
-
-    let mut rx = app.persistence.file_change_rx.take().expect("watcher must be armed");
-    std::fs::write(&other_json, br#"{"unrelated":1}"#).unwrap();
-
-    let event = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv())
-        .await
-        .expect("timed out waiting for the watcher to report a change")
-        .expect("watcher channel closed unexpectedly");
-    assert!(event.path.ends_with("other.json"));
 }

--- a/crates/kanban-tui/tests/remote_freshness_tests.rs
+++ b/crates/kanban-tui/tests/remote_freshness_tests.rs
@@ -3,9 +3,12 @@ mod helpers;
 use helpers::{CountingBackend, ReadOpLog};
 use kanban_core::ClientId;
 use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_persistence::ChangeDetector;
 use kanban_service::api::{ChangeEventFrame, EntityIdsDto, InvalidationDto};
 use kanban_tui::app::mode::{AppMode, DialogMode};
+use kanban_tui::app::FreshnessSource;
 use kanban_tui::App;
+use std::sync::Arc;
 use uuid::Uuid;
 
 struct Seed {
@@ -192,4 +195,93 @@ async fn test_dirty_model_frame_opens_external_change_dialog() {
     let board = app.model.board_by_id_state(seed.board).loaded().copied();
     assert_eq!(board.map(|b| b.name.clone()), Some("Board".to_string()));
     assert!(ops.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_rewire_to_a_remote_locator_wires_the_sse_receiver_only() {
+    let mut app = App::test_default();
+    let watcher = kanban_persistence::FileWatcher::new();
+    app.persistence.file_change_rx = Some(watcher.subscribe());
+    app.persistence.file_watcher = Some(watcher);
+
+    let backend = Arc::new(kanban_backend_http::HttpBackend::new("http://127.0.0.1:1").unwrap());
+    app.ctx.replace_backend(backend);
+    app.persistence.save_file = Some("http://127.0.0.1:1".to_string());
+
+    app.rewire_freshness().await;
+
+    assert!(app.persistence.remote_change_rx.is_some());
+    assert!(app.persistence.file_change_rx.is_none());
+    assert!(app.persistence.file_watcher.is_none());
+    assert_eq!(app.persistence.freshness, FreshnessSource::Remote);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_rewire_to_a_local_locator_drops_the_stale_remote_receiver() {
+    let mut app = App::test_default();
+    let (_tx, rx) = tokio::sync::mpsc::channel::<ChangeEventFrame>(4);
+    app.persistence.remote_change_rx = Some(rx);
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = helpers::create_test_json_file(dir.path(), "local.json", &["Board"]).await;
+    app.persistence.save_file = Some(path);
+
+    app.rewire_freshness().await;
+
+    assert!(app.persistence.remote_change_rx.is_none());
+    assert!(app.persistence.file_change_rx.is_some());
+    assert!(app.persistence.file_watcher.is_some());
+    assert!(
+        matches!(app.persistence.freshness, FreshnessSource::File(ref p) if p.ends_with("local.json"))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_settings_storage_swap_rewires_freshness_to_the_new_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut app = helpers::setup_app_with_json_file(dir.path()).await;
+    let other_json = helpers::create_test_json_file(dir.path(), "other.json", &["SecondBoard"]).await;
+
+    let (_tx, rx) = tokio::sync::mpsc::channel::<ChangeEventFrame>(4);
+    app.persistence.remote_change_rx = Some(rx);
+    let sentinel_watcher = kanban_persistence::FileWatcher::new();
+    let sentinel_id = Uuid::new_v4();
+    sentinel_watcher.set_own_instance_id(sentinel_id);
+    app.persistence.file_watcher = Some(sentinel_watcher);
+
+    let old_config = app.app_config.clone();
+    let old_storage_location = app.app_config.effective_storage_location();
+    app.app_config.storage_location = Some(other_json.clone());
+    app.apply_storage_location_change(old_config, &old_storage_location);
+    app.await_migration().await;
+
+    assert!(app.persistence.remote_change_rx.is_none());
+    assert!(
+        matches!(app.persistence.freshness, FreshnessSource::File(ref p) if p.ends_with("other.json"))
+    );
+    let watcher = app.persistence.file_watcher.as_ref().unwrap();
+    assert_eq!(watcher.own_instance_id(), Some(app.ctx.backend().instance_id()));
+    assert_ne!(watcher.own_instance_id(), Some(sentinel_id));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_settings_storage_swap_arms_the_watcher_on_the_new_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut app = helpers::setup_app_with_json_file(dir.path()).await;
+    let other_json = helpers::create_test_json_file(dir.path(), "other.json", &["SecondBoard"]).await;
+
+    let old_config = app.app_config.clone();
+    let old_storage_location = app.app_config.effective_storage_location();
+    app.app_config.storage_location = Some(other_json.clone());
+    app.apply_storage_location_change(old_config, &old_storage_location);
+    app.await_migration().await;
+
+    let mut rx = app.persistence.file_change_rx.take().expect("watcher must be armed");
+    std::fs::write(&other_json, br#"{"unrelated":1}"#).unwrap();
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv())
+        .await
+        .expect("timed out waiting for the watcher to report a change")
+        .expect("watcher channel closed unexpectedly");
+    assert!(event.path.ends_with("other.json"));
 }

--- a/crates/kanban-tui/tests/remote_freshness_tests.rs
+++ b/crates/kanban-tui/tests/remote_freshness_tests.rs
@@ -267,3 +267,32 @@ async fn test_settings_storage_swap_rewires_freshness_to_the_new_file() {
     );
     assert_ne!(watcher.own_instance_id(), Some(sentinel_id));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_settings_storage_swap_arms_the_watcher_on_the_new_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut app = helpers::setup_app_with_json_file(dir.path()).await;
+    let other_json =
+        helpers::create_test_json_file(dir.path(), "other.json", &["SecondBoard"]).await;
+
+    let old_config = app.app_config.clone();
+    let old_storage_location = app.app_config.effective_storage_location();
+    app.app_config.storage_location = Some(other_json.clone());
+    app.apply_storage_location_change(old_config, &old_storage_location);
+    app.await_migration().await;
+
+    let mut rx = app
+        .persistence
+        .file_change_rx
+        .take()
+        .expect("watcher must be armed");
+    let scratch = dir.path().join("scratch.tmp");
+    std::fs::write(&scratch, br#"{"unrelated":1}"#).unwrap();
+    std::fs::rename(&scratch, &other_json).unwrap();
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for the watcher to report a change")
+        .expect("watcher channel closed unexpectedly");
+    assert!(event.path.ends_with("other.json"));
+}


### PR DESCRIPTION
## What

Extracts the TUI's startup freshness wiring (file watcher vs SSE subscription) into one `App::rewire_freshness` helper and calls it from the two runtime backend-swap sites (settings-driven storage switch, `adopt_storage_file`) plus startup, so a swap always ends with exactly one live freshness source pointed at the new locator.

The invariant is made structural: `PersistenceState` gets a `freshness: FreshnessSource` enum (`Off | File(PathBuf) | Remote`) that only `App::rewire_freshness` writes, replacing the implicit "which of these three Option fields is set" reasoning.

## Why

Neither runtime swap site rewired freshness at all before this change:

- The settings-driven swap only called `set_own_instance_id` on the existing watcher; the watcher itself, and any SSE subscription, kept pointing at the old locator.
- `adopt_storage_file` touched no freshness state whatsoever.

Only startup ever built a watcher or an SSE subscription. A user who switched storage location mid-session, or adopted a new file, kept getting change events (or none) for the file they just left.

## How

- `rewire_freshness`: stops and drops any existing watcher (`stop_watching().await`, not just clearing the `Option` -- the old task otherwise leaks and keeps delivering to a channel nobody reads), clears both receivers, then arms exactly one fresh source based on the current `save_file`.
- Both swap sites now call it before `spawn_save_worker`, threading its returned deferred-watch path through (previously always `None`). This is a small behavior change: a swap to a storage location that doesn't exist yet is now watched once the first save creates it, matching what startup already does.
- `main_loop.rs` startup wiring is now a single call to the helper; the duplicated match block is gone.

## Testing

- `cargo test -p kanban-tui`
- `cargo test --all-features --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

New tests cover: rewiring to a remote locator wires only the SSE receiver, rewiring to a local locator drops a stale remote receiver, the settings-driven storage swap ends with the SSE receiver cleared and `freshness` pointing at the new file with the new backend's instance id on the watcher, and that the rewired watcher on the new file is actually armed (an out-of-band atomic write to the new file is observed on `file_change_rx`). A fifth test, driving `adopt_storage_file`, covers the same swap invariant for that site.

## Out of scope, flagged for follow-up

- `SaveCoordinator.file_watcher` is written but never read anywhere in the crate (a keep-alive only). Left alone in this PR; worth a follow-up to confirm it's dead weight and remove it.
