### PR TITLE
KAN-1569 fix(cli): startup errors emit the same envelope as command errors

### DIFF
--- a/.changeset/kan-1569-startup-errors-emit-the-cli-response-envelope.md
+++ b/.changeset/kan-1569-startup-errors-emit-the-cli-response-envelope.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+cli: every non-zero exit now writes exactly one CliResponse error envelope to stderr, whether the failure happened during startup (unreachable remote locator, unsupported future on-disk version, missing data file, unregistered backend) or inside a command handler

--- a/.changeset/kan-1569-startup-errors-emit-the-cli-response-envelope.md
+++ b/.changeset/kan-1569-startup-errors-emit-the-cli-response-envelope.md
@@ -2,4 +2,4 @@
 bump: patch
 ---
 
-cli: every non-zero exit now writes exactly one CliResponse error envelope to stderr, whether the failure happened during startup (unreachable remote locator, unsupported future on-disk version, missing data file, unregistered backend) or inside a command handler
+cli: every failure after argument parsing now writes exactly one CliResponse error envelope to stderr, whether it happened during startup (unreachable remote locator, unsupported future on-disk version, missing data file, unregistered backend) or inside a command handler. Argument-parsing errors keep clap's plain-text output and exit code 2.

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -17,7 +17,7 @@ kanban init boards.json --board "Project"  # Create file + first board, exit
 2. `KANBAN_FILE` environment variable
 3. Config file `storage_location`
 
-All commands output JSON to stdout. Errors are written to stderr.
+Successful commands write a `CliResponse` JSON envelope to stdout. Every failure, whatever stage it occurred at, writes exactly one `CliResponse` envelope with `success: false` to stderr.
 
 ---
 

--- a/crates/kanban-cli/README.md
+++ b/crates/kanban-cli/README.md
@@ -17,7 +17,7 @@ kanban init boards.json --board "Project"  # Create file + first board, exit
 2. `KANBAN_FILE` environment variable
 3. Config file `storage_location`
 
-Successful commands write a `CliResponse` JSON envelope to stdout. Every failure, whatever stage it occurred at, writes exactly one `CliResponse` envelope with `success: false` to stderr.
+Successful commands write a `CliResponse` JSON envelope to stdout. Every failure after argument parsing, whether it happened during startup or inside a command handler, writes exactly one `CliResponse` envelope with `success: false` to stderr. Argument-parsing errors are reported by clap as plain text with exit code 2, and `--help` / `--version` print to stdout with exit code 0.
 
 ---
 

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -99,9 +99,8 @@ where
     // per-kind internally — DisplayHelp / DisplayVersion go to stdout
     // with exit code 0; real argument errors go to stderr with exit
     // code 2. No `match e.kind()` needed here. Without it the error
-    // propagates through main's generic eprintln!("Error: {e}") path,
-    // sending the version / help text to stderr with exit 1 and a
-    // doubled trailing newline.
+    // would reach the envelope seam, rendering the version / help text
+    // as a CliResponse failure on stderr with exit code 1.
     let matches = cmd
         .try_get_matches_from_mut(args)
         .unwrap_or_else(|e| e.exit());

--- a/crates/kanban-cli/src/app.rs
+++ b/crates/kanban-cli/src/app.rs
@@ -317,7 +317,23 @@ impl CliApp {
     /// Like [`run`], but accepts an explicit argument list instead of reading
     /// from `std::env::args_os()`. Useful for testing without spawning a
     /// subprocess.
+    ///
+    /// On failure, writes the `CliResponse` error envelope to stderr before
+    /// returning, so every non-zero exit emits exactly one envelope regardless
+    /// of whether the failure happened during startup or inside a handler.
     pub async fn run_with_args<I, T>(self, args: I) -> anyhow::Result<()>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<std::ffi::OsString> + Clone,
+    {
+        let result = self.run_inner(args).await;
+        if let Err(ref e) = result {
+            output::emit_error(&e.to_string());
+        }
+        result
+    }
+
+    async fn run_inner<I, T>(self, args: I) -> anyhow::Result<()>
     where
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -5,8 +5,7 @@ use kanban_cli::CliApp;
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = CliApp::with_defaults().run().await {
-        eprintln!("Error: {e}");
+    if CliApp::with_defaults().run().await.is_err() {
         std::process::exit(1);
     }
 }

--- a/crates/kanban-cli/src/output.rs
+++ b/crates/kanban-cli/src/output.rs
@@ -20,17 +20,23 @@ pub fn output_success<T: Serialize>(data: T) {
     println!("{}", serde_json::to_string(&response).unwrap());
 }
 
-/// Outputs an error response to stderr and returns an error for proper propagation.
-///
-/// Returns an `anyhow::Error` to allow callers to handle the error appropriately
-/// and enable proper cleanup. The CLI's main function handles the exit code.
-pub fn output_error(message: &str) -> anyhow::Result<()> {
+fn error_envelope(message: &str) -> String {
     let response: CliResponse<()> = CliResponse {
         success: false,
         api_version: env!("CARGO_PKG_VERSION"),
         data: None,
         error: Some(message.to_string()),
     };
-    eprintln!("{}", serde_json::to_string(&response).unwrap());
+    serde_json::to_string(&response).unwrap()
+}
+
+/// Writes the `CliResponse` failure envelope to stderr.
+pub fn emit_error(message: &str) {
+    eprintln!("{}", error_envelope(message));
+}
+
+/// Returns the CLI-boundary error for a handler to propagate. The envelope
+/// itself is written once, by `CliApp::run_with_args`.
+pub fn output_error(message: &str) -> anyhow::Result<()> {
     anyhow::bail!("{}", message)
 }

--- a/crates/kanban-cli/tests/error_envelope.rs
+++ b/crates/kanban-cli/tests/error_envelope.rs
@@ -1,0 +1,193 @@
+use assert_cmd::{cargo_bin_cmd, Command};
+use serde_json::Value;
+use std::time::Duration;
+use tempfile::tempdir;
+
+fn kanban() -> Command {
+    cargo_bin_cmd!("kanban")
+}
+
+fn kanban_no_config(dir: &std::path::Path) -> Command {
+    let mut cmd = kanban();
+    cmd.current_dir(dir)
+        .env_remove("KANBAN_FILE")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("HOME", dir)
+        .env("KANBAN_CONFIG", dir.join("config.toml"));
+    cmd
+}
+
+fn error_envelopes(stderr: &str) -> Vec<Value> {
+    stderr
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|v| v.get("success").and_then(Value::as_bool) == Some(false))
+        .collect()
+}
+
+fn plain_error_lines(stderr: &str) -> Vec<&str> {
+    stderr
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter(|line| line.starts_with("Error: "))
+        .collect()
+}
+
+#[cfg(feature = "http")]
+#[test]
+fn test_cli_startup_probe_failure_emits_the_cli_response_error_envelope() {
+    let dir = tempdir().unwrap();
+    let assert = kanban_no_config(dir.path())
+        .args(["http://127.0.0.1:1", "board", "list"])
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .code(1);
+
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        plain_error_lines(&stderr).is_empty(),
+        "expected no plain 'Error: ' line, got stderr: {stderr}"
+    );
+
+    let envelopes = error_envelopes(&stderr);
+    assert_eq!(
+        envelopes.len(),
+        1,
+        "expected exactly one CliResponse error envelope, got stderr: {stderr}"
+    );
+
+    let env = &envelopes[0];
+    assert_eq!(env["success"], Value::Bool(false));
+    let api_version = env["api_version"].as_str();
+    assert!(
+        api_version.is_some_and(|v| !v.is_empty()),
+        "expected non-empty api_version, got {env:?}"
+    );
+    let error = env["error"].as_str().unwrap();
+    assert!(error.contains("transport error"), "error was: {error}");
+    assert!(error.contains("health probe"), "error was: {error}");
+}
+
+#[test]
+fn test_cli_command_error_stderr_holds_exactly_one_envelope_and_no_plain_error_line() {
+    let dir = tempdir().unwrap();
+    let missing = dir.path().join("missing.json");
+    let assert = kanban_no_config(dir.path())
+        .args([missing.to_str().unwrap(), "board", "list"])
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .code(1);
+
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        plain_error_lines(&stderr).is_empty(),
+        "expected no plain 'Error: ' line, got stderr: {stderr}"
+    );
+
+    let envelopes = error_envelopes(&stderr);
+    assert_eq!(
+        envelopes.len(),
+        1,
+        "expected exactly one CliResponse error envelope, got stderr: {stderr}"
+    );
+
+    let error = envelopes[0]["error"].as_str().unwrap();
+    assert!(error.contains("Board file not found"), "error was: {error}");
+}
+
+#[test]
+fn test_cli_json_future_version_refusal_emits_the_cli_response_error_envelope() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("future.json");
+    let contents = serde_json::json!({
+        "version": 99,
+        "metadata": {
+            "instance_id": "550e8400-e29b-41d4-a716-446655440000",
+            "saved_at": "2030-01-01T00:00:00Z"
+        },
+        "data": {}
+    });
+    std::fs::write(&file, serde_json::to_string(&contents).unwrap()).unwrap();
+    let before = std::fs::read(&file).unwrap();
+
+    let assert = kanban_no_config(dir.path())
+        .args([file.to_str().unwrap(), "board", "list"])
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .code(1);
+
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        plain_error_lines(&stderr).is_empty(),
+        "expected no plain 'Error: ' line, got stderr: {stderr}"
+    );
+
+    let envelopes = error_envelopes(&stderr);
+    assert_eq!(
+        envelopes.len(),
+        1,
+        "expected exactly one CliResponse error envelope, got stderr: {stderr}"
+    );
+
+    let error = envelopes[0]["error"].as_str().unwrap();
+    assert!(error.contains("v99"), "error was: {error}");
+    assert!(error.contains("upgrade kanban"), "error was: {error}");
+
+    let after = std::fs::read(&file).unwrap();
+    assert_eq!(before, after, "refusal must not modify the file on disk");
+}
+
+#[test]
+fn test_cli_sqlite_future_version_refusal_emits_the_cli_response_error_envelope() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("future.db");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        kanban_persistence_sqlite::write_test_metadata_with_schema_version(&file, 99)
+            .await
+            .unwrap();
+    });
+
+    let assert = kanban_no_config(dir.path())
+        .args([file.to_str().unwrap(), "board", "list"])
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .code(1);
+
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        plain_error_lines(&stderr).is_empty(),
+        "expected no plain 'Error: ' line, got stderr: {stderr}"
+    );
+
+    let envelopes = error_envelopes(&stderr);
+    assert_eq!(
+        envelopes.len(),
+        1,
+        "expected exactly one CliResponse error envelope, got stderr: {stderr}"
+    );
+
+    let error = envelopes[0]["error"].as_str().unwrap();
+    assert!(error.contains("v99"), "error was: {error}");
+    assert!(error.contains("upgrade kanban"), "error was: {error}");
+
+    rt.block_on(async {
+        let schema_version = kanban_persistence_sqlite::read_test_schema_version(&file)
+            .await
+            .unwrap();
+        assert_eq!(schema_version, Some(99));
+    });
+}


### PR DESCRIPTION
## Summary

- Every non-zero `kanban` exit now writes exactly one `CliResponse` failure envelope to stderr, whether the failure happened during startup (unreachable remote locator, unsupported future on-disk version, missing data file, unregistered backend) or inside a command handler.
- `CliApp::run_with_args` is the single seam that emits the envelope. The old body moved into a private `run_inner`, and the public wrapper writes `output::emit_error(...)` on `Err` before returning it.
- `output::output_error` no longer prints to stderr itself; it just returns the `anyhow` error for the new seam to render, removing the previous double stderr line (envelope + plain `Error: ...`) on every command failure.
- `main.rs` no longer has its own `eprintln!("Error: {e}")` path; it only sets the exit code.
- README updated to describe the envelope contract on both stdout and stderr.

## Test plan

- [x] `cargo test -p kanban-cli --all-features` green, including four new tests in `crates/kanban-cli/tests/error_envelope.rs` covering: an unreachable remote locator probe failure, a missing-file command error, a future-version JSON refusal, and a future-version SQLite refusal.
- [x] Confirmed each new test fails before the fix (see red proof in the task record).
- [x] Mutation check: reverted `output_error` to print again, confirmed the "exactly one envelope" assertion catches the regression, then restored the fix.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test --all-features --workspace` green.
- [x] `-V` / `--version` / `--help` empty-stderr tests still pass, proving clap's own exit path was not touched.
