### PR TITLE
KAN-1580 fix(domain): DeleteCard enumerates the card and the graph it touches

### DIFF
--- a/.changeset/kan-1580-delete-card-touched-entities.md
+++ b/.changeset/kan-1580-delete-card-touched-entities.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+domain: DeleteCard::touched_entities now names the card it deletes and the dependency graph instead of returning None. Every card create derives its invalidation from its captured DeleteCard inverse, so creates stop broadening to Invalidation::All and name the created card; the prefix-counter bump they also perform is still declared through execute_with_extra. Card deletes are unaffected on the forward path (their invalidation comes from the ImportEntities inverse) but a redo of a delete is now scoped too.

--- a/crates/kanban-backend-http/tests/remote_writes.rs
+++ b/crates/kanban-backend-http/tests/remote_writes.rs
@@ -224,13 +224,10 @@ async fn test_create_card_over_http_hits_the_card_route_and_returns_server_state
     assert_eq!(card.priority, CardPriority::High);
     assert_eq!(card.points, Some(3));
     assert!(card.card_number > 0, "server should have minted a number");
-    assert_eq!(
-        invalidation,
-        Invalidation::All,
-        "a fresh CreateCard's inverse is captured against pre-create store state, \
-         so invalidation_from_inverse falls back to All -- pinned by \
-         kanban-service's test_create_card_from_spec_returns_an_invalidation_naming_the_card"
-    );
+    match invalidation {
+        Invalidation::Entities(ids) => assert!(ids.cards.contains(&card.id)),
+        Invalidation::All => panic!("expected a scoped invalidation"),
+    }
 
     server.shutdown().await;
 }

--- a/crates/kanban-domain/src/commands/card/lifecycle.rs
+++ b/crates/kanban-domain/src/commands/card/lifecycle.rs
@@ -307,7 +307,7 @@ impl DeleteCard {
     }
 
     pub fn touched_entities(&self) -> Option<crate::EntityIds> {
-        None
+        Some(crate::EntityIds::cards([self.card_id]).with_graph())
     }
 
     /// Inverse: re-insert whichever state the card was in (live,

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -95,9 +95,9 @@ pub enum Invalidation {
 /// any command in the batch returns `None`, or when the batch (or its
 /// accumulated ids) is empty.
 ///
-/// A forward batch and its own inverse are different commands and can imply
-/// different results: `CreateCard` names its card and board, while its
-/// inverse `DeleteCard` is unenumerable and yields `All`.
+/// A forward batch and its own inverse are different commands and can name
+/// different sets: `CreateCard` names its card, its board and the prefixes,
+/// while its inverse `DeleteCard` names only the card and the graph.
 pub fn invalidation_from_inverse(inverse: &[crate::commands::Command]) -> Invalidation {
     if inverse.is_empty() {
         return Invalidation::All;

--- a/crates/kanban-domain/src/invalidation.rs
+++ b/crates/kanban-domain/src/invalidation.rs
@@ -279,11 +279,26 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_card_touched_entities_is_unenumerable() {
-        let cmd = Command::Card(CardCommand::Delete(DeleteCard {
-            card_id: Uuid::new_v4(),
-        }));
-        assert!(cmd.touched_entities().is_none());
+    fn test_delete_card_touched_entities_names_the_card_and_the_graph() {
+        let card_id = Uuid::new_v4();
+        let cmd = Command::Card(CardCommand::Delete(DeleteCard { card_id }));
+        let ids = cmd.touched_entities().expect("enumerable");
+        assert_eq!(ids.cards, HashSet::from([card_id]));
+        assert!(ids.graph);
+        assert!(ids.boards.is_empty());
+        assert!(ids.columns.is_empty());
+        assert!(ids.sprints.is_empty());
+        assert!(!ids.prefixes);
+    }
+
+    #[test]
+    fn test_a_card_creates_inverse_names_the_card_and_the_graph() {
+        let card_id = Uuid::new_v4();
+        let batch = vec![Command::Card(CardCommand::Delete(DeleteCard { card_id }))];
+        assert_eq!(
+            invalidation_from_inverse(&batch),
+            Invalidation::Entities(EntityIds::cards([card_id]).with_graph())
+        );
     }
 
     #[test]
@@ -458,8 +473,11 @@ mod tests {
                 card_id: Uuid::new_v4(),
                 updates: CardUpdate::default(),
             })),
-            Command::Card(CardCommand::Delete(DeleteCard {
+            Command::Card(CardCommand::Restore(RestoreCard {
                 card_id: Uuid::new_v4(),
+                column_id: Uuid::new_v4(),
+                position: 0,
+                timestamp: Utc::now(),
             })),
         ];
         assert_eq!(invalidation_from_inverse(&batch), Invalidation::All);

--- a/crates/kanban-server/tests/cards_write.rs
+++ b/crates/kanban-server/tests/cards_write.rs
@@ -78,7 +78,7 @@ async fn test_post_card_creates_with_append_position_and_returns_201() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_post_card_response_carries_a_parseable_invalidation() {
+async fn test_post_card_response_carries_an_invalidation_naming_the_card() {
     let dir = tempdir().unwrap();
     let state = make_state(&dir.path().join("s.json"));
 
@@ -96,9 +96,11 @@ async fn test_post_card_response_carries_a_parseable_invalidation() {
     let body = json_of(response).await;
     let entity: kanban_service::api::CardResponse = serde_json::from_value(body.clone()).unwrap();
     assert_eq!(entity.title, "A card");
-    let _invalidation: kanban_service::api::InvalidationDto =
-        serde_json::from_value(body["invalidation"].clone())
-            .expect("body must carry a parseable invalidation");
+    let card_id = body["id"].as_str().unwrap();
+    let invalidated_cards = body["invalidation"]["entities"]["cards"]
+        .as_array()
+        .expect("entities invalidation must name cards");
+    assert!(invalidated_cards.iter().any(|v| v == card_id));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -215,6 +215,7 @@ pub async fn test_a_created_cards_invalidation_names_the_card_on_every_backend(
         Invalidation::All => panic!("expected a scoped invalidation"),
     };
     assert!(ids.cards.contains(&card.id));
+    assert!(ids.prefixes);
 
     let plan = StaticPlan(FetchRound {
         cards_by_column: vec![column.id],
@@ -222,9 +223,13 @@ pub async fn test_a_created_cards_invalidation_names_the_card_on_every_backend(
     });
     let resolved = ctx.resolve(&plan, &model);
     apply(&mut model, resolved);
+    assert!(model.column_cards_state(column.id).loaded().is_some());
 
-    let changed = model.invalidate(Invalidation::Entities(ids));
-    let _ = changed;
+    let _ = model.invalidate(Invalidation::Entities(ids));
+    assert!(
+        model.column_cards_state(column.id).loaded().is_none(),
+        "a card-named invalidation must drop the column's card scope"
+    );
 
     let resolved = ctx.resolve(&plan, &model);
     apply(&mut model, resolved);

--- a/crates/kanban-service/src/test_helpers/contract/cache.rs
+++ b/crates/kanban-service/src/test_helpers/contract/cache.rs
@@ -180,6 +180,60 @@ pub async fn test_a_deleted_card_resolves_missing_on_a_second_resolve(factory: &
     assert!(!cards.iter().any(|c| c.id == card.id));
 }
 
+pub async fn test_a_created_cards_invalidation_names_the_card_on_every_backend(
+    factory: &BackendFactory,
+) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.store");
+    let mut ctx = KanbanContext::open(factory(&path), AppConfig::default())
+        .await
+        .unwrap();
+    let mut model = Model::default();
+
+    let board = ctx
+        .create_board("Board".into(), Some("BRD".into()))
+        .unwrap();
+    let column = ctx.create_column(board.id, "Col".into(), None).unwrap();
+
+    let (card, inv) = ctx
+        .create_card_from_spec(
+            None,
+            kanban_domain::NewCard {
+                column_id: column.id,
+                title: "A".into(),
+                description: None,
+                priority: kanban_domain::CardPriority::Medium,
+                due_date: None,
+                points: None,
+                sprint_id: None,
+            },
+        )
+        .unwrap();
+
+    let ids = match inv {
+        Invalidation::Entities(ids) => ids,
+        Invalidation::All => panic!("expected a scoped invalidation"),
+    };
+    assert!(ids.cards.contains(&card.id));
+
+    let plan = StaticPlan(FetchRound {
+        cards_by_column: vec![column.id],
+        ..Default::default()
+    });
+    let resolved = ctx.resolve(&plan, &model);
+    apply(&mut model, resolved);
+
+    let changed = model.invalidate(Invalidation::Entities(ids));
+    let _ = changed;
+
+    let resolved = ctx.resolve(&plan, &model);
+    apply(&mut model, resolved);
+
+    let scope = model.column_cards_state(column.id);
+    let cards = scope.loaded().expect("column's card scope loaded");
+    assert!(cards.iter().any(|c| c.id == card.id));
+}
+
 pub async fn test_a_backend_read_error_resolves_failed_not_missing(factory: BackendFactory) {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("test.store");

--- a/crates/kanban-service/src/test_helpers/mod.rs
+++ b/crates/kanban-service/src/test_helpers/mod.rs
@@ -589,5 +589,9 @@ macro_rules! cache_contract_tests {
         async fn test_the_flat_archived_board_tier_round_trips_markers_on_every_backend() {
             $crate::test_helpers::contract::cache::test_the_flat_archived_board_tier_round_trips_markers_on_every_backend(&$factory_fn()).await;
         }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_a_created_cards_invalidation_names_the_card_on_every_backend() {
+            $crate::test_helpers::contract::cache::test_a_created_cards_invalidation_names_the_card_on_every_backend(&$factory_fn()).await;
+        }
     };
 }

--- a/crates/kanban-service/tests/execute_with_extra.rs
+++ b/crates/kanban-service/tests/execute_with_extra.rs
@@ -1,12 +1,9 @@
 use kanban_backend_memory::InMemoryStore;
-use kanban_domain::commands::{CardCommand, Command, CreateCard, UpdateCard};
-use kanban_domain::{
-    CardUpdate, CreateCardOptions, EntityIds, Invalidation, KanbanOperations, KanbanResult,
-};
+use kanban_domain::commands::{CardCommand, Command, UpdateCard};
+use kanban_domain::{CardUpdate, EntityIds, Invalidation, KanbanOperations, KanbanResult};
 use kanban_service::KanbanContext;
 use std::collections::HashSet;
 use std::sync::Arc;
-use uuid::Uuid;
 
 async fn make_ctx() -> KanbanContext {
     KanbanContext::open(
@@ -52,19 +49,14 @@ async fn test_execute_with_extra_does_not_downgrade_all_to_entities() -> KanbanR
     let mut ctx = make_ctx().await;
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
+    let card = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
 
     let inv = ctx.execute_with_extra(EntityIds::default().with_prefixes(), |_| {
-        Ok(vec![Command::Card(CardCommand::Create(CreateCard {
-            id: Uuid::new_v4(),
-            card_number: 1,
-            board_id: board.id,
-            column_id: col.id,
-            title: "c".into(),
-            position: 0,
-            options: CreateCardOptions::default(),
-            timestamp: chrono::Utc::now(),
-            default_card_prefix: "task".into(),
-        }))])
+        Ok(vec![Command::Card(CardCommand::Archive(
+            kanban_domain::commands::ArchiveCards {
+                ids: vec![card.id],
+            },
+        ))])
     })?;
 
     assert_eq!(inv, Invalidation::All);

--- a/crates/kanban-service/tests/execute_with_extra.rs
+++ b/crates/kanban-service/tests/execute_with_extra.rs
@@ -53,9 +53,7 @@ async fn test_execute_with_extra_does_not_downgrade_all_to_entities() -> KanbanR
 
     let inv = ctx.execute_with_extra(EntityIds::default().with_prefixes(), |_| {
         Ok(vec![Command::Card(CardCommand::Archive(
-            kanban_domain::commands::ArchiveCards {
-                ids: vec![card.id],
-            },
+            kanban_domain::commands::ArchiveCards { ids: vec![card.id] },
         ))])
     })?;
 

--- a/crates/kanban-service/tests/mutation_invalidation.rs
+++ b/crates/kanban-service/tests/mutation_invalidation.rs
@@ -500,7 +500,7 @@ async fn test_create_card_from_spec_returns_an_invalidation_naming_the_card() ->
     let board = ctx.create_board("B".into(), Some("KAN".into()))?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
 
-    let (_card, inv) = ctx.create_card_from_spec(
+    let (card, inv) = ctx.create_card_from_spec(
         None,
         NewCard {
             column_id: col.id,
@@ -513,7 +513,15 @@ async fn test_create_card_from_spec_returns_an_invalidation_naming_the_card() ->
         },
     )?;
 
-    assert_eq!(inv, Invalidation::All);
+    match inv {
+        Invalidation::Entities(ids) => {
+            assert!(ids.cards.contains(&card.id));
+            assert!(ids.prefixes);
+            assert!(ids.graph);
+            assert!(ids.boards.is_empty());
+        }
+        Invalidation::All => panic!("expected a scoped invalidation"),
+    }
     Ok(())
 }
 
@@ -539,7 +547,10 @@ async fn test_create_or_replace_card_returns_the_create_invalidation_on_the_crea
     )?;
 
     assert!(outcome.created);
-    assert_eq!(inv, Invalidation::All);
+    match inv {
+        Invalidation::Entities(ids) => assert!(ids.cards.contains(&id)),
+        Invalidation::All => panic!("expected a scoped invalidation"),
+    }
     Ok(())
 }
 

--- a/crates/kanban-service/tests/undo_invalidation.rs
+++ b/crates/kanban-service/tests/undo_invalidation.rs
@@ -83,11 +83,7 @@ async fn test_redo_records_the_invalidation_of_the_forward_batch() -> KanbanResu
     let (card, create_inv) =
         ctx.create_card_impl(board.id, col.id, "A".into(), Default::default())?;
 
-    assert_eq!(
-        create_inv,
-        Invalidation::All,
-        "create's inverse is DeleteCard, which is unenumerable"
-    );
+    assert_eq!(entities(create_inv).cards, HashSet::from([card.id]));
 
     let _ = ctx.undo()?.expect("undo applied");
     let inv = ctx.redo()?.expect("redo applied");
@@ -105,7 +101,8 @@ async fn test_undo_of_a_batch_whose_inverse_is_unenumerable_records_all() -> Kan
     let board = ctx.create_board("B".into(), None)?;
     let col = ctx.create_column(board.id, "C".into(), None)?;
     let card_a = ctx.create_card(board.id, col.id, "A".into(), Default::default())?;
-    let _card_c = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
+    let card_c = ctx.create_card(board.id, col.id, "C".into(), Default::default())?;
+    ctx.archive_card(card_c.id)?;
 
     let (_card, update_inv) = ctx.update_card_impl(
         card_a.id,

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -5,7 +5,7 @@ use helpers::{CountingBackend, ReadOp, ReadOpLog};
 use kanban_core::Editable;
 use kanban_domain::{
     commands::{CardCommand, Command, DeleteCard},
-    BoardSettingsDto, CardMetadataDto, CreateCardOptions, KanbanOperations,
+    BoardSettingsDto, CardMetadataDto, CreateCardOptions, EntityIds, KanbanOperations,
 };
 use kanban_tui::app::focus::Focus;
 use kanban_tui::app::mode::AppMode;
@@ -593,11 +593,13 @@ async fn test_toggle_completion_for_card_ids_with_no_resolvable_cards_issues_no_
 }
 
 #[tokio::test]
-async fn test_create_card_falls_back_to_a_whole_model_reset_because_its_inverse_is_unenumerable() {
-    let delete = Command::Card(CardCommand::Delete(DeleteCard {
-        card_id: Uuid::new_v4(),
-    }));
-    assert_eq!(delete.touched_entities(), None);
+async fn test_create_card_refetches_the_card_tiers_named_by_its_inverse() {
+    let card_id = Uuid::new_v4();
+    let delete = Command::Card(CardCommand::Delete(DeleteCard { card_id }));
+    assert_eq!(
+        delete.touched_entities(),
+        Some(EntityIds::cards([card_id]).with_graph())
+    );
 
     let mut app = App::test_default();
     let seed = seed_two_columns_two_cards(&mut app);
@@ -613,11 +615,11 @@ async fn test_create_card_falls_back_to_a_whole_model_reset_because_its_inverse_
     assert!(has_op(&refetch, "list_boards"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
     assert!(
-        has_op_with_id(&refetch, "list_columns_by_board", seed.board),
+        !has_op_with_id(&refetch, "list_columns_by_board", seed.board),
         "got {refetch:?}"
     );
     assert!(
-        has_op_with_id(&refetch, "list_sprints_by_board", seed.board),
+        !has_op_with_id(&refetch, "list_sprints_by_board", seed.board),
         "got {refetch:?}"
     );
 


### PR DESCRIPTION
## Summary

- `DeleteCard::touched_entities` now names the card it deletes and the dependency graph, instead of returning `None`.
- Every card create derives its invalidation from its captured `DeleteCard` inverse, so a create stops broadening to `Invalidation::All` and names the created card instead. The prefix-counter bump a create also performs is still declared separately through `execute_with_extra`.
- The forward delete path is unaffected: its invalidation still comes from the `ImportEntities` inverse captured by `DeleteCard::capture_inverse`, not from `DeleteCard::touched_entities`.
- A redo of a delete is now scoped too, since `UndoOperations::redo` derives its invalidation from the forward `DeleteCard`.
- Corrected the doc comment on `invalidation_from_inverse` that stated `DeleteCard` was unenumerable.
- Rewrote the seven existing tests across five crates that asserted the `All` fallback for card creates, and retargeted two tests that used `DeleteCard` as their stand-in for an unenumerable command.
- Added a cross-backend contract test proving the create invalidation is scoped and still repopulates the column's card scope, run on in-memory, JSON, and SQLite.

## Test plan

- [x] `cargo test -p kanban-domain`
- [x] `cargo test -p kanban-service --features test-helpers`
- [x] `cargo test -p kanban-server --features test-helpers`
- [x] `cargo test -p kanban-backend-http`
- [x] `cargo test -p kanban-tui`
- [x] `cargo test -p kanban-persistence-json`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
