### PR TITLE
KAN-1591 fix(tui,view,persistence): six LoadState lifecycle defects

### DIFF
--- a/.changeset/kan-1591-load-state-lifecycle-defects.md
+++ b/.changeset/kan-1591-load-state-lifecycle-defects.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+fix six LoadState lifecycle defects: relation accessors, archiving animation resolution, save-completion busy-spin guard, archived-body precedence, file watcher restart, and board-detail navigation

--- a/crates/kanban-persistence/src/watch/file_watcher.rs
+++ b/crates/kanban-persistence/src/watch/file_watcher.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
@@ -88,6 +89,8 @@ pub struct FileWatcher {
     own_instance_id: Arc<StdMutex<Option<Uuid>>>,
     suppress_until: Arc<StdMutex<Option<Instant>>>,
     last_content_hash: Arc<StdMutex<Option<u64>>>,
+    armed: Arc<AtomicBool>,
+    stopped: Arc<AtomicBool>,
 }
 
 impl FileWatcher {
@@ -101,6 +104,8 @@ impl FileWatcher {
             own_instance_id: Arc::new(StdMutex::new(None)),
             suppress_until: Arc::new(StdMutex::new(None)),
             last_content_hash: Arc::new(StdMutex::new(None)),
+            armed: Arc::new(AtomicBool::new(false)),
+            stopped: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -152,6 +157,11 @@ impl Default for FileWatcher {
 #[async_trait::async_trait]
 impl ChangeDetector for FileWatcher {
     async fn start_watching(&self, path: PathBuf) -> PersistenceResult<()> {
+        if self.stopped.load(Ordering::Relaxed) {
+            tracing::debug!("start_watching on a stopped watcher; ignoring");
+            return Ok(());
+        }
+
         let tx = self.tx.clone();
         let task_handle = self.task_handle.clone();
         let own_instance_id = self.own_instance_id.clone();
@@ -335,6 +345,8 @@ impl ChangeDetector for FileWatcher {
             ))
         })??;
 
+        self.armed.store(true, Ordering::Relaxed);
+
         Ok(())
     }
 
@@ -344,6 +356,8 @@ impl ChangeDetector for FileWatcher {
             handle.abort();
             tracing::info!("Stopped file watching");
         }
+        self.stopped.store(true, Ordering::Relaxed);
+        self.armed.store(false, Ordering::Relaxed);
         Ok(())
     }
 
@@ -352,7 +366,7 @@ impl ChangeDetector for FileWatcher {
     }
 
     fn is_watching(&self) -> bool {
-        true
+        self.armed.load(Ordering::Relaxed) && !self.stopped.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/kanban-persistence/src/watch/file_watcher.rs
+++ b/crates/kanban-persistence/src/watch/file_watcher.rs
@@ -702,4 +702,26 @@ mod tests {
             result
         );
     }
+
+    #[tokio::test]
+    async fn test_start_watching_after_stop_watching_does_not_rearm_the_watcher() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test.json");
+        tokio::fs::write(&file_path, b"initial content")
+            .await
+            .unwrap();
+
+        let watcher = FileWatcher::new();
+        watcher.start_watching(file_path.clone()).await.unwrap();
+        assert!(watcher.is_watching());
+
+        watcher.stop_watching().await.unwrap();
+        assert!(!watcher.is_watching());
+
+        assert!(watcher.start_watching(file_path).await.is_ok());
+        assert!(
+            !watcher.is_watching(),
+            "start_watching after stop_watching must not rearm the watcher"
+        );
+    }
 }

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -229,4 +229,96 @@ mod tests {
             "the card must not be archived while the cards tier is not loaded, since it was silently skipped"
         );
     }
+
+    #[test]
+    fn test_handle_animation_tick_archives_a_card_whose_board_was_switched_away_from() {
+        let mut app = App::test_default();
+        let board_a = app.ctx.create_board("A".into(), None).unwrap();
+        let column_a = app
+            .ctx
+            .create_column(board_a.id, "Todo".into(), None)
+            .unwrap();
+        let card = app
+            .ctx
+            .create_card(
+                board_a.id,
+                column_a.id,
+                "Card".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+        let board_b = app.ctx.create_board("B".into(), None).unwrap();
+        app.ctx
+            .create_column(board_b.id, "Todo".into(), None)
+            .unwrap();
+
+        app.selection.active_board_id = Some(board_a.id);
+        refresh(&mut app);
+
+        app.animation.animating.insert(
+            card.id,
+            CardAnimation {
+                animation_type: kanban_domain::AnimationType::Archiving,
+                start_time: Instant::now()
+                    - Duration::from_millis(animation::ANIMATION_DURATION_MS as u64 + 50),
+            },
+        );
+
+        app.controller.set_scope_board(Some(board_b.id), &app.model);
+
+        app.handle_animation_tick();
+
+        let archived = app.ctx.data_store().list_archived_cards().unwrap();
+        assert!(
+            archived.iter().any(|a| a.entity_id == card.id),
+            "a card whose board was switched away from during the animation window must still archive"
+        );
+        assert!(app.ui_state.banner.is_none());
+    }
+
+    #[test]
+    fn test_handle_animation_tick_does_not_rearchive_an_already_archived_card() {
+        let mut app = App::test_default();
+        let board = app.ctx.create_board("Board".into(), None).unwrap();
+        let column = app
+            .ctx
+            .create_column(board.id, "Todo".into(), None)
+            .unwrap();
+        let card = app
+            .ctx
+            .create_card(
+                board.id,
+                column.id,
+                "Card".into(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+
+        app.selection.active_board_id = Some(board.id);
+        app.ctx.archive_card(card.id).unwrap();
+        refresh(&mut app);
+
+        app.animation.archive_anchor = Some((column.id, 0));
+        app.animation.animating.insert(
+            card.id,
+            CardAnimation {
+                animation_type: kanban_domain::AnimationType::Archiving,
+                start_time: Instant::now()
+                    - Duration::from_millis(animation::ANIMATION_DURATION_MS as u64 + 50),
+            },
+        );
+
+        app.handle_animation_tick();
+
+        assert_eq!(
+            app.animation.archive_anchor,
+            Some((column.id, 0)),
+            "an already-archived card must not consume the archive anchor"
+        );
+        assert_eq!(
+            app.ctx.data_store().list_archived_cards().unwrap().len(),
+            1,
+            "an already-archived card must not produce a second archived marker"
+        );
+    }
 }

--- a/crates/kanban-tui/src/app/animation_tick.rs
+++ b/crates/kanban-tui/src/app/animation_tick.rs
@@ -24,14 +24,15 @@ impl App {
             self.animation.animating.remove(&card_id);
             match animation_type {
                 AnimationType::Archiving => {
-                    if let LoadState::Loaded(cards) = self.controller.live_cards() {
-                        if let Some(card_pos) = cards.iter().position(|c| c.id == card_id) {
-                            let card = &cards[card_pos];
-                            if !affected_columns.contains(&card.column_id) {
-                                affected_columns.push(card.column_id);
-                            }
-                            archive_cards.push(card_id);
+                    if self.model.archived_card_ids().contains(&card_id) {
+                        continue;
+                    }
+                    if let LoadState::Loaded(card) = self.model.card_by_id_state(card_id) {
+                        let column_id = card.column_id;
+                        if !affected_columns.contains(&column_id) {
+                            affected_columns.push(column_id);
                         }
+                        archive_cards.push(card_id);
                     }
                 }
                 AnimationType::Restoring => {

--- a/crates/kanban-tui/src/app/main_loop.rs
+++ b/crates/kanban-tui/src/app/main_loop.rs
@@ -224,7 +224,7 @@ impl App {
                             }
                         }
                     }
-                    _ = async {
+                    Some(()) = async {
                         if let Some(ref mut rx) = &mut self.persistence.save_completion_rx {
                             rx.recv().await
                         } else {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2286,6 +2286,42 @@ mod tests {
     }
 
     #[test]
+    fn test_board_detail_k_from_columns_counts_the_open_boards_columns_not_the_highlighted_ones()
+    {
+        let mut app = App::test_default();
+        let board_a = app.ctx.create_board("A".into(), None).unwrap();
+        for i in 0..3 {
+            app.ctx
+                .create_column(board_a.id, format!("A{i:02}"), None)
+                .unwrap();
+        }
+        let board_b = app.ctx.create_board("B".into(), None).unwrap();
+        app.ctx
+            .create_column(board_b.id, "B00".into(), None)
+            .unwrap();
+
+        app.selection.active_board_id = Some(board_a.id);
+        load_with_card_order(&mut app, &[]);
+        app.prepare_frame();
+
+        app.board_list.select_board(board_b.id);
+        app.push_mode(AppMode::BoardDetail);
+        app.focus.board_focus = BoardFocus::Columns;
+        app.dialog_input.column_list.update_item_count(3);
+        app.dialog_input.column_list.set_selected_index(Some(2));
+
+        app.handle_board_detail_navigation_key(KeyCode::Char('k'));
+
+        assert_eq!(
+            app.dialog_input.column_list.get_selected_index(),
+            Some(1),
+            "up-navigation must count board A's (the board in context) 3 columns, not board B's highlighted 1"
+        );
+        assert_eq!(app.focus.board_focus, BoardFocus::Columns);
+        assert_no_banner(&app);
+    }
+
+    #[test]
     fn test_column_list_scroll_offset_keeps_selected_column_visible_after_migration() {
         use ratatui::{backend::TestBackend, Terminal};
 

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -492,7 +492,7 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => match self.focus.board_focus {
                 BoardFocus::Sprints => {
-                    if let Some(board_id) = self.active_board().map(|board| board.id) {
+                    if let Some(board_id) = self.board_in_context().map(|board| board.id) {
                         match self.board_sprints_view(board_id) {
                             LoadState::Loaded(sprints) => {
                                 let sprint_count = sprints.len();
@@ -513,7 +513,7 @@ impl App {
                     }
                 }
                 BoardFocus::Columns => {
-                    if let Some(board_id) = self.active_board().map(|board| board.id) {
+                    if let Some(board_id) = self.board_in_context().map(|board| board.id) {
                         if self.visible_board_columns(board_id).is_loaded() {
                             let column_count = self.column_count_for_board(board_id);
                             self.dialog_input
@@ -546,8 +546,8 @@ impl App {
                     if self.focus.board_focus == BoardFocus::Sprints {
                         self.selection.sprint.set(Some(0));
                     } else if self.focus.board_focus == BoardFocus::Columns {
-                        if let Some(board) = self.active_board() {
-                            self.enter_column_focus_at_top(board.id);
+                        if let Some(board_id) = self.board_in_context().map(|b| b.id) {
+                            self.enter_column_focus_at_top(board_id);
                         }
                     }
                 }
@@ -562,7 +562,7 @@ impl App {
                     }
                 }
                 BoardFocus::Columns => {
-                    let board_id = self.board_list.get_selected_board_id();
+                    let board_id = self.board_in_context().map(|b| b.id);
                     let columns_ready = match board_id {
                         None => true,
                         Some(id) => self.visible_board_columns(id).is_loaded(),
@@ -603,8 +603,8 @@ impl App {
                         BoardFocus::Columns => BoardFocus::Sprints,
                     };
                     if self.focus.board_focus == BoardFocus::Columns {
-                        if let Some(board) = self.active_board() {
-                            self.enter_column_focus_at_top(board.id);
+                        if let Some(board_id) = self.board_in_context().map(|b| b.id) {
+                            self.enter_column_focus_at_top(board_id);
                         }
                     }
                 }

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -7,8 +7,8 @@ use crossterm::event::KeyCode;
 use kanban_core::Editable;
 use kanban_domain::card_lifecycle::sorted_board_columns;
 use kanban_domain::{
-    BoardSettingsDto, CardMetadataDto, Column, FieldSearcher, LoadState, MutationOperations,
-    Searcher,
+    BoardSettingsDto, CardMetadataDto, Column, DependencyGraph, FieldSearcher, LoadState,
+    MutationOperations, Searcher,
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
@@ -1271,30 +1271,24 @@ impl App {
         self.open_dialog(DialogMode::ManageChildren);
     }
 
+    fn related_ids(
+        &self,
+        pick: impl FnOnce(&DependencyGraph, uuid::Uuid) -> Vec<uuid::Uuid>,
+    ) -> Option<Vec<uuid::Uuid>> {
+        let Some(active_id) = self.selection.active_card_id else {
+            return Some(Vec::new());
+        };
+        let card = self.model.card_by_id_state(active_id).loaded().copied()?;
+        let graph = self.model.graph_state().loaded()?;
+        Some(pick(graph, card.id))
+    }
+
     pub fn get_current_card_parents(&self) -> Option<Vec<uuid::Uuid>> {
-        if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
-                return self
-                    .model
-                    .graph_state()
-                    .loaded()
-                    .map(|graph| graph.parents(card.id));
-            }
-        }
-        Some(Vec::new())
+        self.related_ids(|graph, id| graph.parents(id))
     }
 
     pub fn get_current_card_children(&self) -> Option<Vec<uuid::Uuid>> {
-        if let Some(active_id) = self.selection.active_card_id {
-            if let Some(card) = self.model.card_by_id_state(active_id).loaded().copied() {
-                return self
-                    .model
-                    .graph_state()
-                    .loaded()
-                    .map(|graph| graph.children(card.id));
-            }
-        }
-        Some(Vec::new())
+        self.related_ids(|graph, id| graph.children(id))
     }
 
     pub(crate) fn refresh_relationship_counts(&mut self) {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2024,9 +2024,9 @@ mod tests {
             cards: kanban_domain::resolved::Collection {
                 by_id: [(
                     fx.a_id,
-                    LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
-                        "boom",
-                    ))),
+                    LoadState::Failed(std::sync::Arc::new(
+                        kanban_domain::KanbanError::unsupported("boom"),
+                    )),
                 )]
                 .into(),
                 ..Default::default()
@@ -2286,8 +2286,7 @@ mod tests {
     }
 
     #[test]
-    fn test_board_detail_k_from_columns_counts_the_open_boards_columns_not_the_highlighted_ones()
-    {
+    fn test_board_detail_k_from_columns_counts_the_open_boards_columns_not_the_highlighted_ones() {
         let mut app = App::test_default();
         let board_a = app.ctx.create_board("A".into(), None).unwrap();
         for i in 0..3 {

--- a/crates/kanban-tui/src/handlers/detail_view_handlers.rs
+++ b/crates/kanban-tui/src/handlers/detail_view_handlers.rs
@@ -2002,6 +2002,89 @@ mod tests {
     }
 
     #[test]
+    fn test_get_current_card_parents_with_a_not_loaded_card_body_returns_none() {
+        let mut app = App::test_default();
+        let fx = setup_reload_resort_fixture(&mut app);
+
+        assert_eq!(app.get_current_card_parents(), Some(vec![fx.p_id]));
+
+        let _ = app
+            .model
+            .invalidate(Invalidation::Entities(EntityIds::cards([fx.a_id])));
+
+        assert_eq!(
+            app.get_current_card_parents(),
+            None,
+            "a NotLoaded card body must be reported as a tier gap, not as zero parents"
+        );
+    }
+
+    #[test]
+    fn test_get_current_card_children_with_a_failed_card_body_returns_none() {
+        let mut app = App::test_default();
+        let fx = setup_reload_resort_fixture(&mut app);
+
+        assert_eq!(app.get_current_card_children(), Some(vec![fx.d_id]));
+
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            cards: kanban_domain::resolved::Collection {
+                by_id: [(
+                    fx.a_id,
+                    LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
+                        "boom",
+                    ))),
+                )]
+                .into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        app.controller.resync(&app.model, changed);
+
+        assert_eq!(
+            app.get_current_card_children(),
+            None,
+            "a Failed card body must be reported as a tier gap, not as zero children"
+        );
+    }
+
+    #[test]
+    fn test_get_current_card_parents_with_a_missing_card_body_returns_none() {
+        let mut app = App::test_default();
+        let fx = setup_reload_resort_fixture(&mut app);
+
+        assert_eq!(app.get_current_card_parents(), Some(vec![fx.p_id]));
+
+        let changed = app.model.apply_resolved(kanban_domain::Resolved {
+            cards: kanban_domain::resolved::Collection {
+                by_id: [(fx.a_id, LoadState::Missing)].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        app.controller.resync(&app.model, changed);
+
+        assert_eq!(
+            app.get_current_card_parents(),
+            None,
+            "a Missing card body is unknowable, not known-empty"
+        );
+    }
+
+    #[test]
+    fn test_get_current_card_parents_with_no_active_card_returns_empty() {
+        let mut app = App::test_default();
+        let _fx = setup_reload_resort_fixture(&mut app);
+        app.selection.active_card_id = None;
+
+        assert_eq!(
+            app.get_current_card_parents(),
+            Some(Vec::new()),
+            "no active card is a real empty state, distinct from a not-loaded tier"
+        );
+    }
+
+    #[test]
     fn test_refresh_relationship_counts_with_a_not_loaded_graph_leaves_the_list_counts_untouched() {
         let mut app = App::test_default();
         let _fx = setup_reload_resort_fixture(&mut app);

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -1196,9 +1196,9 @@ mod tests {
         let mut cards_by_id = std::collections::HashMap::new();
         cards_by_id.insert(
             failed_id,
-            LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
-                "boom",
-            ))),
+            LoadState::Failed(std::sync::Arc::new(
+                kanban_domain::KanbanError::unsupported("boom"),
+            )),
         );
         let changed = model.apply_resolved(Resolved {
             columns: Collection {
@@ -1248,9 +1248,9 @@ mod tests {
         let mut cards_by_id = std::collections::HashMap::new();
         cards_by_id.insert(
             failed_id,
-            LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
-                "boom",
-            ))),
+            LoadState::Failed(std::sync::Arc::new(
+                kanban_domain::KanbanError::unsupported("boom"),
+            )),
         );
         let changed = model.apply_resolved(Resolved {
             columns: Collection {

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -1175,6 +1175,110 @@ mod tests {
     }
 
     #[test]
+    fn test_archived_partition_reports_failed_when_a_failed_body_follows_a_not_loaded_one() {
+        let board = seed_board("B", 0);
+        let board_id = board.id;
+        let column = Column::new(board_id, "Col", 0);
+        let not_loaded_id = Uuid::new_v4();
+        let failed_id = Uuid::new_v4();
+
+        let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(vec![column]));
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(
+            board_id,
+            LoadState::Loaded(vec![
+                ArchivedCard::new(not_loaded_id, board_id),
+                ArchivedCard::new(failed_id, board_id),
+            ]),
+        );
+        let mut cards_by_id = std::collections::HashMap::new();
+        cards_by_id.insert(
+            failed_id,
+            LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
+                "boom",
+            ))),
+        );
+        let changed = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                by_parent: archived_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_id: cards_by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
+        controller.resync(&model, changed);
+
+        assert!(
+            controller.displayed_cards(true).is_failed(),
+            "a Failed body must win over an earlier NotLoaded marker in the walk"
+        );
+    }
+
+    #[test]
+    fn test_archived_partition_reports_failed_when_a_failed_body_precedes_a_not_loaded_one() {
+        let board = seed_board("B", 0);
+        let board_id = board.id;
+        let column = Column::new(board_id, "Col", 0);
+        let not_loaded_id = Uuid::new_v4();
+        let failed_id = Uuid::new_v4();
+
+        let mut model = Model::default();
+        let mut columns_by_parent = std::collections::HashMap::new();
+        columns_by_parent.insert(board_id, LoadState::Loaded(vec![column]));
+        let mut archived_by_parent = std::collections::HashMap::new();
+        archived_by_parent.insert(
+            board_id,
+            LoadState::Loaded(vec![
+                ArchivedCard::new(failed_id, board_id),
+                ArchivedCard::new(not_loaded_id, board_id),
+            ]),
+        );
+        let mut cards_by_id = std::collections::HashMap::new();
+        cards_by_id.insert(
+            failed_id,
+            LoadState::Failed(std::sync::Arc::new(kanban_domain::KanbanError::unsupported(
+                "boom",
+            ))),
+        );
+        let changed = model.apply_resolved(Resolved {
+            columns: Collection {
+                by_parent: columns_by_parent,
+                ..Default::default()
+            },
+            archived_cards: Collection {
+                by_parent: archived_by_parent,
+                ..Default::default()
+            },
+            cards: Collection {
+                by_id: cards_by_id,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut controller = Controller::default();
+        controller.set_scope_board(Some(board_id), &model);
+        controller.resync(&model, changed);
+
+        assert!(
+            controller.displayed_cards(true).is_failed(),
+            "a Failed body must win regardless of marker order"
+        );
+    }
+
+    #[test]
     fn test_board_scoped_live_partition_excludes_another_boards_cards() {
         let board_1 = seed_board("B1", 0);
         let board_1_id = board_1.id;

--- a/crates/kanban-view/src/controller/partitions.rs
+++ b/crates/kanban-view/src/controller/partitions.rs
@@ -15,9 +15,10 @@ fn joined<T, A, B>(flat: LoadState<A>, markers: LoadState<B>) -> LoadState<Vec<T
 
 /// Joins a board's archived-marker tier with the per-id card body tier: for
 /// each Loaded marker, resolves its body through `card_by_id_state`. A
-/// `Missing` body is skipped (a stale marker never wedges the view); any
-/// `Failed` body short-circuits the whole join; any `NotLoaded` body means
-/// the join itself is `NotLoaded`, not partially populated.
+/// `Missing` body is skipped (a stale marker never wedges the view); a
+/// `Failed` body wins over the whole join regardless of where in the marker
+/// order it falls; a `NotLoaded` body means the join is `NotLoaded`, unless a
+/// later marker in the same walk turns out `Failed`.
 fn archived_bodies(model: &Model, board_id: uuid::Uuid) -> LoadState<Vec<Card>> {
     let markers = match model.board_archived_cards_state(board_id) {
         LoadState::Loaded(markers) => markers,
@@ -27,13 +28,17 @@ fn archived_bodies(model: &Model, board_id: uuid::Uuid) -> LoadState<Vec<Card>> 
     };
 
     let mut cards = Vec::with_capacity(markers.len());
+    let mut not_loaded = false;
     for marker in markers {
         match model.card_by_id_state(marker.entity_id) {
             LoadState::Loaded(card) => cards.push(card.clone()),
             LoadState::Missing => continue,
             LoadState::Failed(e) => return LoadState::Failed(e),
-            LoadState::NotLoaded => return LoadState::NotLoaded,
+            LoadState::NotLoaded => not_loaded = true,
         }
+    }
+    if not_loaded {
+        return LoadState::NotLoaded;
     }
     LoadState::Loaded(cards)
 }


### PR DESCRIPTION
Six focused LoadState lifecycle defect fixes across kanban-tui, kanban-view and kanban-persistence.

1. `get_current_card_parents`/`get_current_card_children` (kanban-tui) now report NotLoaded, Missing and Failed card bodies as `None` (a tier gap), not `Some(vec![])`. Both accessors are unified through a new private `related_ids` helper. No call site changed.
2. The `Archiving` animation arm (kanban-tui) now resolves its card through `model.card_by_id_state(card_id)` instead of `controller.live_cards()`, so a board switch during the animation window no longer silently drops the archive. A short-circuit on `model.archived_card_ids()` guards against re-archiving.
3. The save-completion `tokio::select!` arm in `main_loop.rs` now matches `Some(())` instead of `_`, so a drained/closed channel can no longer busy-spin the arm every loop iteration.
4. `archived_bodies` (kanban-view) is now order-independent: a `Failed` body wins over an earlier `NotLoaded` marker in the same walk, instead of returning `NotLoaded` as soon as the first `NotLoaded` marker is seen.
5. `FileWatcher::stop_watching` (kanban-persistence) is now terminal: a subsequent `start_watching` call is a no-op and does not rearm the watcher. `is_watching` reports real armed/stopped state instead of a hardcoded `true`.
6. The navigation arms of `handle_board_detail_navigation_key` (kanban-tui) now go through `board_in_context()` instead of a mix of `active_board()` and `board_list.get_selected_board_id()`, so column/sprint up/down navigation counts the board actually open in Board Detail, not whatever board happens to be highlighted in the projects list. The load-bearing site is the `k` arm, which read the projects-list highlight; the `active_board()` swaps are no-ops today and are made for consistency. The `p` / SetBranchPrefix arm and the column handlers it delegates to still read `active_board()`; that is benign because Board Detail is only reachable with `active_board_id` set, and finishing that sweep is tracked on the card.

Notes for reviewers:

- Item 3 ships without a dedicated test: the arm lives inside `App::run`'s `tokio::select!` loop, which needs a live terminal and an event source: asserting the absence of a spin would require a wall-clock CPU probe rather than a deterministic assertion.
- The animation-guard test (`test_handle_animation_tick_does_not_rearchive_an_already_archived_card`) is a pin, not a red test: `ArchiveCards::execute` already skips ids with an existing archived marker, so the marker-count assertion was green even before the fix. The guard is still worth adding because without it, re-tick-ing an already-archived card still runs a redundant command batch and consumes `animation.archive_anchor`, moving the user's selection.

Each item is test-then-implementation, split into separate commits. `cargo test --all-features --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --all -- --check` are all green.

