### PR TITLE
KAN-1593 test(backend-http,tui,mcp): pin six already-shipped remote-path behaviours

### DIFF
--- a/.changeset/kan-1593-pin-remote-seams.md
+++ b/.changeset/kan-1593-pin-remote-seams.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Add tests pinning six already-shipped remote path behaviours: SSE CRLF tolerance and multi-data-line joining, graph tier invalidate and refetch over HttpBackend, an MCP graph-backed tool over an http locator, the startup scope's flat-tier avoidance over HttpBackend, and non-None optionals surviving the create wire in write parity. No production behaviour changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,6 +1684,7 @@ dependencies = [
  "kanban-persistence",
  "kanban-persistence-json",
  "kanban-persistence-sqlite",
+ "kanban-server",
  "kanban-service",
  "kanban-view",
  "pulldown-cmark",

--- a/crates/kanban-backend-http/src/events.rs
+++ b/crates/kanban-backend-http/src/events.rs
@@ -115,6 +115,44 @@ mod tests {
     }
 
     #[test]
+    fn test_sse_parser_accepts_crlf_line_endings() {
+        let frame = ChangeEventFrame::now(Uuid::new_v4(), Uuid::new_v4(), ClientId::nil());
+        let json = serde_json::to_string(&frame).unwrap();
+        let wire = format!("data: {json}\r\n\r\n");
+
+        let mut parser = super::SseParser::default();
+        let frames = parser.push(wire.as_bytes());
+
+        assert_eq!(frames.len(), 1, "a CRLF-delimited frame must parse");
+        assert_eq!(frames[0].writer_instance_id, frame.writer_instance_id);
+    }
+
+    #[test]
+    fn test_sse_parser_joins_consecutive_data_lines_with_a_newline() {
+        let frame = ChangeEventFrame::now(Uuid::new_v4(), Uuid::new_v4(), ClientId::nil());
+        let json = serde_json::to_string_pretty(&frame).unwrap();
+        let mut wire = String::new();
+        for line in json.lines() {
+            wire.push_str("data: ");
+            wire.push_str(line);
+            wire.push('\n');
+        }
+
+        let mut parser = super::SseParser::default();
+        let pending = parser.push(wire.as_bytes());
+
+        assert!(pending.is_empty(), "no blank line yet, so no frame yet");
+        assert_eq!(
+            parser.data, json,
+            "consecutive data lines must be rejoined with a newline, byte for byte"
+        );
+
+        let frames = parser.push(b"\n");
+        assert_eq!(frames.len(), 1, "multi-line data must parse as one payload");
+        assert_eq!(frames[0].writer_instance_id, frame.writer_instance_id);
+    }
+
+    #[test]
     fn test_next_backoff_doubles_and_caps_at_thirty_seconds() {
         assert_eq!(
             super::next_backoff(Duration::from_secs(1)),

--- a/crates/kanban-backend-http/tests/remote_reads.rs
+++ b/crates/kanban-backend-http/tests/remote_reads.rs
@@ -5,8 +5,8 @@ use kanban_api::{
 };
 use kanban_backend_http::HttpBackend;
 use kanban_domain::{
-    Board, Card, Column, DataStore, DependencyGraph, KanbanOperations, LoadState, Model,
-    NoProjections, Prefix, RelatesKind, Severity, Sprint,
+    Board, Card, Column, DataStore, DependencyGraph, EntityIds, Invalidation, KanbanOperations,
+    LoadState, Model, NoProjections, Prefix, RelatesKind, Severity, Sprint,
 };
 use kanban_server::test_helpers::TestServer;
 use kanban_service::{
@@ -946,6 +946,55 @@ async fn test_remote_graph_tier_resolves_loaded_and_serves_relation_children() {
         other => panic!("expected LoadState::Loaded, got {other:?}"),
     };
     assert_eq!(graph.children(parent), vec![child]);
+
+    drop(ctx);
+    drop(backend);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalidating_the_graph_tier_refetches_it_over_http_and_lands_loaded() {
+    let server = TestServer::start().await;
+    let board_id = seed_board(&server, "Invalidate Board").await;
+    let column_id = seed_column(&server, board_id, "Todo", None, None).await;
+    let parent = seed_card(&server, column_id, "Parent", None).await;
+    let child_a = seed_card(&server, column_id, "Child A", None).await;
+    let child_b = seed_card(&server, column_id, "Child B", None).await;
+    attach_children(&server, parent, &[child_a]).await;
+
+    let backend: Arc<dyn KanbanBackend> = Arc::new(HttpBackend::new(&server.base_url()).unwrap());
+    let ctx = KanbanContext::open(Arc::clone(&backend), AppConfig::default())
+        .await
+        .unwrap();
+
+    let mut model = Model::default();
+    ctx.sync(&GraphOnly, &mut model, &mut NoProjections);
+
+    let graph = match model.graph_state() {
+        LoadState::Loaded(graph) => graph,
+        other => panic!("expected LoadState::Loaded, got {other:?}"),
+    };
+    assert_eq!(graph.children(parent), vec![child_a]);
+
+    attach_children(&server, parent, &[child_b]).await;
+
+    let _ = model.invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
+    assert!(
+        model.graph_state().is_not_loaded(),
+        "graph:true must drop the tier"
+    );
+
+    ctx.sync(&GraphOnly, &mut model, &mut NoProjections);
+
+    let mut children = match model.graph_state() {
+        LoadState::Loaded(graph) => graph.children(parent),
+        other => panic!("expected the refetch to land Loaded, got {other:?}"),
+    };
+    children.sort();
+    let mut expected = vec![child_a, child_b];
+    expected.sort();
+    assert_eq!(children, expected);
 
     drop(ctx);
     drop(backend);

--- a/crates/kanban-backend-http/tests/write_parity.rs
+++ b/crates/kanban-backend-http/tests/write_parity.rs
@@ -2,7 +2,8 @@ use kanban_backend_http::HttpBackend;
 use kanban_domain::{
     ArchivedBoard, ArchivedCard, Board, BoardUpdate, Card, CardPriority, CardStatus, CardUpdate,
     Column, ColumnUpdate, CreateCardOptions, FieldUpdate, GraphOperations, KanbanOperations,
-    NewBoard, NewCard, NewColumn, Prefix, RelatesKind, Severity, Sprint,
+    NewBoard, NewCard, NewColumn, Prefix, RelatesKind, Severity, SortField, SortOrder, Sprint,
+    TaskListView,
 };
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
@@ -67,14 +68,20 @@ async fn ctx_over(server: &TestServer) -> KanbanContext {
 fn a_new_board(name: &str, prefix: Option<&str>) -> NewBoard {
     NewBoard {
         name: name.to_string(),
-        description: None,
-        sprint_prefix: None,
+        description: Some("parity fixture".to_string()),
+        sprint_prefix: Some("SPR".to_string()),
         card_prefix: prefix.map(str::to_string),
-        task_sort_field: None,
-        task_sort_order: None,
-        sprint_duration_days: None,
-        task_list_view: None,
+        task_sort_field: Some(SortField::Priority),
+        task_sort_order: Some(SortOrder::Descending),
+        sprint_duration_days: Some(14),
+        task_list_view: Some(TaskListView::ColumnView),
     }
+}
+
+fn fixed_due() -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339("2030-06-01T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc)
 }
 
 fn a_new_column(board_id: Uuid, name: &str) -> NewColumn {
@@ -130,7 +137,15 @@ fn snapshot(ctx: &KanbanContext) -> GraphSnapshot {
 
     let mut archived_card_rows: Vec<Card> = archived_cards
         .iter()
-        .map(|marker| ds.get_card(marker.entity_id).unwrap().unwrap())
+        .map(|marker| {
+            ds.get_card(marker.entity_id).unwrap().unwrap_or_else(|| {
+                panic!(
+                    "archived marker {} has no live card row; the reference-marker \
+                     model requires the row to outlive the marker",
+                    marker.entity_id
+                )
+            })
+        })
         .collect();
     archived_card_rows.sort_by_key(|c| c.id);
 
@@ -539,14 +554,27 @@ async fn lifecycle_parity(kind: Backend) {
     let (column_b, _) = remote
         .create_column_from_spec(None, a_new_column(board.id, "Doing"))
         .unwrap();
+    let (column_c, _) = remote
+        .create_column_from_spec(None, a_new_column(board.id, "Kept"))
+        .unwrap();
 
     let card_a_id = Uuid::new_v4();
     let card_b_id = Uuid::new_v4();
+    let card_c_id = Uuid::new_v4();
     let (card_a, _) = remote
         .create_card_from_spec(Some(card_a_id), a_new_card(column_a.id, "Card A"))
         .unwrap();
     let (card_b, _) = remote
         .create_card_from_spec(Some(card_b_id), a_new_card(column_a.id, "Card B"))
+        .unwrap();
+    let _ = remote
+        .create_card_from_spec(
+            Some(card_c_id),
+            NewCard {
+                due_date: Some(fixed_due()),
+                ..a_new_card(column_c.id, "Card C")
+            },
+        )
         .unwrap();
 
     let _ = remote
@@ -611,11 +639,23 @@ async fn lifecycle_parity(kind: Backend) {
     let (l_column_b, _) = local
         .create_column_from_spec(Some(column_b.id), a_new_column(l_board.id, "Doing"))
         .unwrap();
+    let (l_column_c, _) = local
+        .create_column_from_spec(Some(column_c.id), a_new_column(l_board.id, "Kept"))
+        .unwrap();
     let (l_card_a, _) = local
         .create_card_from_spec(Some(card_a_id), a_new_card(l_column_a.id, "Card A"))
         .unwrap();
     let (l_card_b, _) = local
         .create_card_from_spec(Some(card_b_id), a_new_card(l_column_a.id, "Card B"))
+        .unwrap();
+    let _ = local
+        .create_card_from_spec(
+            Some(card_c_id),
+            NewCard {
+                due_date: Some(fixed_due()),
+                ..a_new_card(l_column_c.id, "Card C")
+            },
+        )
         .unwrap();
 
     let _ = local

--- a/crates/kanban-mcp/tests/http_locator_smoke.rs
+++ b/crates/kanban-mcp/tests/http_locator_smoke.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "http")]
 
-use kanban_domain::KanbanOperations;
-use kanban_mcp::{CreateCardParams, KanbanMcpServer};
+use kanban_domain::{CreateCardOptions, GraphOperations, KanbanOperations};
+use kanban_mcp::{CreateCardParams, KanbanMcpServer, ListCardChildrenRequest};
 use kanban_server::test_helpers::TestServer;
 use kanban_service::{AppConfig, StoreManager};
 use rmcp::handler::server::wrapper::Parameters;
@@ -78,6 +78,71 @@ async fn test_tool_create_card_against_http_locator_succeeds() {
         card["title"], "Smoke",
         "server should hold the created card: {card:?}"
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_card_children_over_an_http_locator_resolves_the_graph_tier() {
+    let ids = Arc::new(Mutex::new(None::<(Uuid, Uuid)>));
+    let ids_for_seed = Arc::clone(&ids);
+
+    let server = TestServer::start_with(move |ctx| {
+        let board_id = ctx
+            .create_board("MCP Graph Board".to_string(), Some("KAN".to_string()))
+            .unwrap()
+            .id;
+        let column_id = ctx
+            .create_column(board_id, "To Do".to_string(), None)
+            .unwrap()
+            .id;
+        let parent_id = ctx
+            .create_card(
+                board_id,
+                column_id,
+                "Parent".to_string(),
+                CreateCardOptions::default(),
+            )
+            .unwrap()
+            .id;
+        let child_id = ctx
+            .create_card(
+                board_id,
+                column_id,
+                "Child".to_string(),
+                CreateCardOptions::default(),
+            )
+            .unwrap()
+            .id;
+        ctx.attach_children(parent_id, vec![child_id]).unwrap();
+        *ids_for_seed.lock().unwrap() = Some((parent_id, child_id));
+    })
+    .await;
+    let (parent_id, child_id) = ids.lock().unwrap().take().unwrap();
+
+    let store_manager = http_only_store_manager();
+    let mcp_server = KanbanMcpServer::new(&store_manager, &server.base_url(), AppConfig::default())
+        .await
+        .unwrap();
+
+    let result = mcp_server
+        .tool_list_card_children(Parameters(ListCardChildrenRequest {
+            card: parent_id.to_string(),
+            page: None,
+            page_size: None,
+        }))
+        .await
+        .unwrap();
+
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| c.as_text().map(|t| t.text.clone()))
+        .expect("tool result should carry a text content block");
+    let payload: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let items = payload["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], child_id.to_string());
 
     server.shutdown().await;
 }

--- a/crates/kanban-tui/Cargo.toml
+++ b/crates/kanban-tui/Cargo.toml
@@ -46,4 +46,5 @@ test-helpers = []
 [dev-dependencies]
 kanban-domain = { path = "../kanban-domain", features = ["test-helpers"] }
 kanban-service = { path = "../kanban-service", features = ["test-helpers"] }
+kanban-server = { path = "../kanban-server", features = ["test-helpers"] }
 tempfile = "3.13"

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -674,4 +674,50 @@ mod backend_parity {
             );
         }
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_the_startup_scope_never_reads_the_flat_tiers_over_http() {
+        let (snapshot, board1, _board2) = seed_non_trivial_snapshot().await;
+        let server = kanban_server::test_helpers::TestServer::start_with(move |ctx| {
+            kanban_service::write_full_snapshot(ctx.data_store(), snapshot).unwrap();
+        })
+        .await;
+
+        let backend: Arc<dyn kanban_service::KanbanBackend> =
+            Arc::new(kanban_backend_http::HttpBackend::new(&server.base_url()).unwrap());
+        let ctx = KanbanContext::open(backend, AppConfig::default())
+            .await
+            .unwrap();
+
+        let model = populate_scope(&ctx, board1);
+        let untouched_id = Uuid::new_v4();
+
+        assert!(
+            model.board_columns_state(untouched_id).is_not_loaded(),
+            "an unrelated board's column tier must stay unrequested over http"
+        );
+        assert!(
+            model.column_cards_state(untouched_id).is_not_loaded(),
+            "an unrelated column's card tier must stay unrequested over http"
+        );
+        assert!(
+            model.board_sprints_state(untouched_id).is_not_loaded(),
+            "an unrelated board's sprint tier must stay unrequested over http"
+        );
+        assert!(
+            model.board_columns_state(board1).is_loaded(),
+            "the scoped column tier must be loaded over http"
+        );
+        assert!(
+            model.board_cards_state(board1).is_loaded(),
+            "the scoped card tier must be loaded over http"
+        );
+        assert!(
+            model.board_sprints_state(board1).is_loaded(),
+            "the scoped sprint tier must be loaded over http"
+        );
+
+        drop(ctx);
+        server.shutdown().await;
+    }
 }

--- a/crates/kanban-tui/tests/startup_lazy_load_tests.rs
+++ b/crates/kanban-tui/tests/startup_lazy_load_tests.rs
@@ -448,13 +448,16 @@ mod backend_parity {
     /// in-memory context, so every backend under test is seeded from the
     /// exact same `Snapshot` value rather than three independently timed
     /// `create_*` calls that would drift in `created_at`/`updated_at`.
-    async fn seed_non_trivial_snapshot() -> (Snapshot, Uuid, Uuid) {
+    async fn seed_non_trivial_snapshot() -> (Snapshot, Uuid, Uuid, Uuid) {
         let backend: Arc<dyn kanban_service::KanbanBackend> = Arc::new(InMemoryStore::new());
         let mut ctx = KanbanContext::open(backend, AppConfig::default())
             .await
             .unwrap();
         let board1 = ctx.create_board("Board 1".to_string(), None).unwrap();
         let board2 = ctx.create_board("Board 2".to_string(), None).unwrap();
+        let board2_column = ctx
+            .create_column(board2.id, "Todo".to_string(), None)
+            .unwrap();
         let column = ctx
             .create_column(board1.id, "Todo".to_string(), None)
             .unwrap();
@@ -478,7 +481,7 @@ mod backend_parity {
         ctx.create_sprint(board1.id, None, Some("Sprint 1".to_string()))
             .unwrap();
         let snapshot = kanban_service::read_full_snapshot(ctx.data_store()).unwrap();
-        (snapshot, board1.id, board2.id)
+        (snapshot, board1.id, board2.id, board2_column.id)
     }
 
     async fn seed_empty_board_snapshot() -> (Snapshot, Uuid) {
@@ -525,7 +528,7 @@ mod backend_parity {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_startup_scope_reads_the_same_rows_on_every_backend() {
-        let (snapshot, board1, _board2) = seed_non_trivial_snapshot().await;
+        let (snapshot, board1, _board2, _board2_column) = seed_non_trivial_snapshot().await;
         let kinds = ["memory", "json", "sqlite"];
         let dirs = [
             tempfile::tempdir().unwrap(),
@@ -635,7 +638,7 @@ mod backend_parity {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_the_startup_scope_never_reads_the_flat_tiers_on_any_backend() {
-        let (snapshot, board1, _board2) = seed_non_trivial_snapshot().await;
+        let (snapshot, board1, board2, board2_column) = seed_non_trivial_snapshot().await;
         let kinds = ["memory", "json", "sqlite"];
         let dirs = [
             tempfile::tempdir().unwrap(),
@@ -646,18 +649,17 @@ mod backend_parity {
         for (kind, dir) in kinds.iter().zip(dirs.iter()) {
             let ctx = open_seeded(kind, dir, &snapshot).await;
             let model = populate_scope(&ctx, board1);
-            let untouched_id = Uuid::new_v4();
 
             assert!(
-                model.board_columns_state(untouched_id).is_not_loaded(),
+                model.board_columns_state(board2).is_not_loaded(),
                 "{kind}: an unrelated board's column tier must stay unrequested"
             );
             assert!(
-                model.column_cards_state(untouched_id).is_not_loaded(),
+                model.column_cards_state(board2_column).is_not_loaded(),
                 "{kind}: an unrelated column's card tier must stay unrequested"
             );
             assert!(
-                model.board_sprints_state(untouched_id).is_not_loaded(),
+                model.board_sprints_state(board2).is_not_loaded(),
                 "{kind}: an unrelated board's sprint tier must stay unrequested"
             );
             assert!(
@@ -677,7 +679,7 @@ mod backend_parity {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_the_startup_scope_never_reads_the_flat_tiers_over_http() {
-        let (snapshot, board1, _board2) = seed_non_trivial_snapshot().await;
+        let (snapshot, board1, board2, board2_column) = seed_non_trivial_snapshot().await;
         let server = kanban_server::test_helpers::TestServer::start_with(move |ctx| {
             kanban_service::write_full_snapshot(ctx.data_store(), snapshot).unwrap();
         })
@@ -690,18 +692,17 @@ mod backend_parity {
             .unwrap();
 
         let model = populate_scope(&ctx, board1);
-        let untouched_id = Uuid::new_v4();
 
         assert!(
-            model.board_columns_state(untouched_id).is_not_loaded(),
+            model.board_columns_state(board2).is_not_loaded(),
             "an unrelated board's column tier must stay unrequested over http"
         );
         assert!(
-            model.column_cards_state(untouched_id).is_not_loaded(),
+            model.column_cards_state(board2_column).is_not_loaded(),
             "an unrelated column's card tier must stay unrequested over http"
         );
         assert!(
-            model.board_sprints_state(untouched_id).is_not_loaded(),
+            model.board_sprints_state(board2).is_not_loaded(),
             "an unrelated board's sprint tier must stay unrequested over http"
         );
         assert!(


### PR DESCRIPTION
## Summary

Test-only card. No production source file is edited; the only non-test change is adding `kanban-server` (test-helpers) to `crates/kanban-tui/[dev-dependencies]`.

Pins six already-shipped remote-path behaviours that no test currently held:

1. SSE CRLF tolerance and multi-data-line joining (`crates/kanban-backend-http/src/events.rs`). The multi-line test asserts the parser's accumulated private buffer byte for byte (`parser.data == json`), not just that the frame parses. A behavioural JSON-parse assertion alone cannot distinguish a `'\n'` join from a `' '` join or from no separator at all: pretty-printed JSON is whitespace-insensitive between tokens, so it still parses the same way regardless of the separator used to rejoin its lines. Pinning the raw buffer is the only way to hold the join character itself.
2. The startup scope's flat-tier avoidance over `HttpBackend` (`crates/kanban-tui/tests/startup_lazy_load_tests.rs`), seeded through `TestServer::start_with` rather than a JSON-file round trip, so there is no save-debounce flush race to reason about.
3. The graph tier's invalidate/refetch cycle over HTTP, and an MCP tool that requires the graph tier (`wants_graph: true`), resolved against an `http` locator (`crates/kanban-backend-http/tests/remote_reads.rs`, `crates/kanban-mcp/tests/http_locator_smoke.rs`).
4. Non-None optionals surviving the create wire end to end in `write_parity` (`crates/kanban-backend-http/tests/write_parity.rs`): board sort/view/sprint-duration fields, a column's `wip_limit`, and a card's `due_date`, each carried by a fixture row that is created but never updated or deleted, so a dropped field on the wire cannot hide behind a subsequent overwrite.
5. A labelled panic in `write_parity`'s snapshot helper, naming the archived marker id instead of a bare `unwrap().unwrap()`, for easier diagnosis if the reference-marker invariant is ever violated. This item has no discrimination run: no fixture in this suite archives a card remotely, and production behaviour is out of scope for this card.

## Mutation verification

Every added or hardened assertion was checked RED by a targeted mutation, then reverted (no mutation is committed):

- `events.rs` `strip_suffix('\r')` removed -> CRLF test fails.
- `events.rs` join separator changed from `'\n'` to `' '` -> multi-line buffer assert fails.
- `events.rs` accumulate replaced by overwrite -> both multi-line assertions fail.
- `conversions_out/columns.rs` `wip_limit` forced `None` -> fails on the named `wip_limit` field, not a length/id mismatch.
- `conversions_out/cards.rs` `due_date` forced `None` -> fails on the named `due_date` field.
- `conversions_out/boards.rs` `sprint_duration_days` forced `None` -> fails on the named `sprint_duration_days` field.
- `model/invalidate.rs` `if ids.graph` made a no-op -> the `is_not_loaded` assertion between invalidation and resync fails.
- `card_relations.rs` `wants_graph: true` -> `false` for `ListCardChildrenRequest` -> the tool call returns the `require_loaded` "dependency graph" error (not a silently empty list).
- `kanban-tui` startup test: a scratch probe resolving board2's tiers flipped `board_columns_state(board2).is_not_loaded()` to failing, confirming the assertion shape distinguishes a requested tier from an unrequested one over HTTP (reverted, not committed).

## Test plan

- [x] `cargo test -p kanban-backend-http` green
- [x] `cargo test -p kanban-tui` green
- [x] `cargo test -p kanban-mcp` green (runs under the default `http` feature)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --all-features --workspace` green
- [x] `git diff origin/develop --stat` touches only `crates/*/tests/`, `crates/kanban-backend-http/src/events.rs` (test module only, verified with a targeted diff), `crates/kanban-tui/Cargo.toml` (one added dev-dependency line), `Cargo.lock`, and `.changeset/`
