### PR TITLE
KAN-1595 docs(server,backend-http,tui): document conditional requests, pin LF endings, rebuild a tautological test

### DIFF
--- a/.changeset/kan-1595-conditional-requests-docs-and-lf.md
+++ b/.changeset/kan-1595-conditional-requests-docs-and-lf.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+server: document the ETag / If-None-Match / If-Match protocol and the real /v1/graph empty body; repo: pin LF line endings; tui: rebuild a tautological relationship-resolution test on an independent expectation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/crates/kanban-backend-http/README.md
+++ b/crates/kanban-backend-http/README.md
@@ -18,6 +18,10 @@ of running them through its local command-execute-then-log path.
 Every other `DataStore`/`CommandStore` method (graph, sprints, prefixes,
 archive/restore, the command log) still declines under its own name — see
 `test_http_backend_stub_method_returns_unsupported_error` in `src/lib.rs`.
+`HttpDataStore::get_graph` is the one read that does more than deserialize:
+it parses `GET /v1/graph` straight into the domain `DependencyGraph`, whose
+`Deserialize` impl validates the DAG on parse (see
+[the server README's Graph section](../kanban-server/README.md#graph)).
 Returning `Some` from `remote_writes()` also arms a service-layer fence
 (`KanbanContext::execute_with_extra`): every mutation this crate does not
 implement now fails fast with an explicit "not supported over the HTTP

--- a/crates/kanban-backend-http/README.md
+++ b/crates/kanban-backend-http/README.md
@@ -15,9 +15,12 @@ way, and `KanbanBackend::remote_writes()` returns `Some(self)`, so
 `KanbanContext` diverts those nine operations straight to the server instead
 of running them through its local command-execute-then-log path.
 
-Every other `DataStore`/`CommandStore` method (graph, sprints, prefixes,
-archive/restore, the command log) still declines under its own name — see
-`test_http_backend_stub_method_returns_unsupported_error` in `src/lib.rs`.
+The remaining `DataStore`/`CommandStore` *writes* (graph mutations, sprint and
+prefix writes, the command log) still decline under their own name, see
+`test_http_backend_stub_method_returns_unsupported_error` in `src/lib.rs`. The
+reads in those families are implemented: `get_prefix`, `list_prefixes`,
+`get_sprint`, `list_sprints_by_board`, `list_archived_cards_by_board` and
+`get_graph` all go over the wire.
 `HttpDataStore::get_graph` is the one read that does more than deserialize:
 it parses `GET /v1/graph` straight into the domain `DependencyGraph`, whose
 `Deserialize` impl validates the DAG on parse (see

--- a/crates/kanban-backend-http/tests/sse_subscription.rs
+++ b/crates/kanban-backend-http/tests/sse_subscription.rs
@@ -1,7 +1,8 @@
-//! `HttpBackend`'s SSE subscription reconnects on drop with a doubling
-//! backoff (capped at 30s) between attempts, and `impl Drop for HttpBackend`
-//! shuts its Tokio runtime down in the background rather than blocking, so a
-//! backend dropped mid-backoff never stalls the caller waiting on the sleep.
+//! `HttpBackend`'s SSE subscription reconnects whenever the event stream ends
+//! or the connection fails, with a doubling backoff (capped at 30s) between
+//! attempts, and `impl Drop for HttpBackend` shuts its Tokio runtime down in
+//! the background rather than blocking, so a backend dropped mid-backoff
+//! never stalls the caller waiting on the sleep.
 
 use kanban_backend::KanbanBackend;
 use kanban_backend_http::HttpBackend;

--- a/crates/kanban-backend-http/tests/sse_subscription.rs
+++ b/crates/kanban-backend-http/tests/sse_subscription.rs
@@ -1,3 +1,8 @@
+//! `HttpBackend`'s SSE subscription reconnects on drop with a doubling
+//! backoff (capped at 30s) between attempts, and `impl Drop for HttpBackend`
+//! shuts its Tokio runtime down in the background rather than blocking, so a
+//! backend dropped mid-backoff never stalls the caller waiting on the sleep.
+
 use kanban_backend::KanbanBackend;
 use kanban_backend_http::HttpBackend;
 use kanban_core::ClientId;

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -263,7 +263,7 @@ Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event naming the en
 
 ## Conditional requests
 
-Every single-entity `GET` for boards, columns, cards and sprints (board-scoped and flat alike) responds with an `ETag`: `GET /v1/boards/{id}`, `GET /v1/boards/{board_id}/columns/{id}`, `GET /v1/boards/{board_id}/cards/{id}`, `GET /v1/cards/{id}`, `GET /v1/boards/{board_id}/sprints/{id}` and `GET /v1/sprints/{id}`. The tag is always strong: the response body's SHA-256 digest, truncated to its first 16 bytes, lowercase hex-encoded and quoted (34 characters total, e.g. `"0123456789abcdef0123456789abcdef"`). No route emits a weak (`W/`) tag.
+Every single-entity `GET` for boards, columns, cards and sprints (board-scoped and flat alike) responds with an `ETag`: `GET /v1/boards/{id}`, `GET /v1/boards/{board_id}/columns/{id}`, `GET /v1/columns/{id}`, `GET /v1/boards/{board_id}/cards/{id}`, `GET /v1/cards/{id}`, `GET /v1/boards/{board_id}/sprints/{id}` and `GET /v1/sprints/{id}`. The tag is always strong: the response body's SHA-256 digest, truncated to its first 16 bytes, lowercase hex-encoded and quoted (34 characters total, e.g. `"0123456789abcdef0123456789abcdef"`). No route emits a weak (`W/`) tag.
 
 `If-None-Match` short-circuits a `GET` that already holds the current representation: send a `304 Not Modified` with no body, but still carrying the `ETag` header. The header accepts a comma-separated list of tags or `*`; a match on any entry (`*` always matches) triggers the `304`. A `W/`-prefixed candidate is compared with its prefix stripped on both sides, so a weak client tag can still satisfy `If-None-Match` against a strong server tag.
 

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -182,8 +182,6 @@ Nine v1 write routes return the mutation's `Invalidation`: `POST /v1/boards`, `P
 | `GET` | `/v1/boards/{board_id}/columns` | List a board's columns. 404s if `board_id` doesn't exist (does not collapse into an empty list). Returns `Page<ColumnResponse>`; accepts `?page=&page_size=`. |
 | `GET` | `/v1/boards/{board_id}/columns/{id}` | Get a column by UUID. 404s if the column exists but belongs to a different board. |
 
-Column writes (create/update/delete) aren't implemented yet.
-
 ### Sprints
 
 | Method | Path | Description | Body |
@@ -221,7 +219,7 @@ The remaining card routes (get/create/replace/update/delete, and the flat `/v1/c
 
 | Method | Path | Description | Body |
 |---|---|---|---|
-| `GET` | `/v1/graph` | The whole workspace dependency graph as the domain `DependencyGraph` serde shape (`spawns`/`blocks`/`relates`, each `{"edges": [...]}`). Includes archived (tombstoned) edges and every edge's `created_at`, unlike the card-scoped route. Always `200`, `{}`-shaped empty graph when there are no edges, never `404`. | — |
+| `GET` | `/v1/graph` | The whole workspace dependency graph as the domain `DependencyGraph` serde shape (`spawns`/`blocks`/`relates`, each `{"edges": [...]}`). Includes archived (tombstoned) edges and every edge's `created_at`, unlike the card-scoped route. Always `200`, never `404`. With no edges the body is `{"spawns":{"edges":[]},"blocks":{"edges":[]},"relates":{"edges":[]}}`, not `{}`: all three sub-graphs are always present. | — |
 | `GET` | `/v1/cards/{id}/graph` | The card's dependency edges, scoped to that card: parents/children (spawns), blocked_by/blocks and related, plus `block_edges`/`related_edges` carrying each edge's severity/kind. Only active edges; archived edges are omitted. 404s if the card does not exist, rather than returning empty arrays. | — |
 | `POST` | `/v1/cards/{id}/children` | Attach cards as spawned children of `id`. `200` with the updated `CardGraphResponse`. 404 if `id` or any child is unknown; 409 `CYCLE_DETECTED` if the edge would create a cycle. | `{"children": [uuid, ...]}` |
 | `DELETE` | `/v1/cards/{id}/children/{child_id}` | Detach `child_id` as a spawned child of `id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |
@@ -229,6 +227,8 @@ The remaining card routes (get/create/replace/update/delete, and the flat `/v1/c
 | `DELETE` | `/v1/cards/{id}/blocks/{blocked_id}` | Remove the blocking edge from `id` to `blocked_id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |
 | `POST` | `/v1/cards/{id}/related` | Add an undirected relates edge between `id` and `other`. `200` with the updated `CardGraphResponse`. `kind` defaults to `general`. 409 `DUPLICATE_EDGE` if the edge already exists. | `{"other": uuid, "kind"?: "general"\|"duplicates"\|"mentioned_in"}` |
 | `DELETE` | `/v1/cards/{id}/related/{other_id}` | Remove the relates edge between `id` and `other_id`. `204` on success. 404 `EDGE_NOT_FOUND` if no such edge exists. | — |
+
+A client that parses `GET /v1/graph`'s body into the domain `DependencyGraph` gets the same cycle/self-reference guard the server itself enforces: `DagGraph`'s `Deserialize` impl (used by `spawns` and `blocks`) replays every edge through `add_edge_with_metadata`, so a body doctored to contain a cycle or a self-reference among active edges fails to deserialize. An edge that only completes a cycle through an archived (tombstoned) edge is accepted, since archived edges no longer constrain the DAG. `relates`, being undirected, has the equivalent guard against a self-reference edge.
 
 ### Transfer
 
@@ -261,6 +261,18 @@ Every write route (`POST`/`PUT`/`PATCH`) broadcasts a change event naming the en
 - Slicing is in-memory: the full collection is read from storage first, then windowed. There is no store-level `LIMIT`/`OFFSET`.
 - Other query params on `GET /v1/boards/{board_id}/cards` (`column_id`, `sprint_id`, `archived`) apply before pagination, so `total` reflects the filtered count, not the whole board.
 
+## Conditional requests
+
+Every single-entity `GET` for boards, columns, cards and sprints (board-scoped and flat alike) responds with an `ETag`: `GET /v1/boards/{id}`, `GET /v1/boards/{board_id}/columns/{id}`, `GET /v1/boards/{board_id}/cards/{id}`, `GET /v1/cards/{id}`, `GET /v1/boards/{board_id}/sprints/{id}` and `GET /v1/sprints/{id}`. The tag is always strong: the response body's SHA-256 digest, truncated to its first 16 bytes, lowercase hex-encoded and quoted (34 characters total, e.g. `"0123456789abcdef0123456789abcdef"`). No route emits a weak (`W/`) tag.
+
+`If-None-Match` short-circuits a `GET` that already holds the current representation: send a `304 Not Modified` with no body, but still carrying the `ETag` header. The header accepts a comma-separated list of tags or `*`; a match on any entry (`*` always matches) triggers the `304`. A `W/`-prefixed candidate is compared with its prefix stripped on both sides, so a weak client tag can still satisfy `If-None-Match` against a strong server tag.
+
+`If-Match` guards a write against a stale representation: `PUT`, `PATCH` and `DELETE` on `/v1/boards/{id}`; `PUT`, `PATCH` and `DELETE` on `/v1/boards/{board_id}/columns/{id}`; `PATCH` and `DELETE` on `/v1/columns/{id}`; `PUT` on `/v1/columns/{column_id}/cards/{id}`; `PATCH` and `DELETE` on `/v1/boards/{board_id}/cards/{id}`; `PATCH` and `DELETE` on `/v1/cards/{id}`; `PUT`, `PATCH` and `DELETE` on `/v1/boards/{board_id}/sprints/{id}`; `PATCH` and `DELETE` on `/v1/sprints/{id}`. No other route emits an ETag - not the collection GETs, not `/v1/cards/lookup`, `/v1/prefixes`, `/v1/export`, `/health` or `/v1/events`, not the graph routes, and not any write response. A missing `If-Match` header always proceeds without building the current representation. When present, the comparison is strong only: a `*` value fails if the target has no current representation at all, and a `W/`-prefixed candidate never matches, even the target's own tag. A stale or non-matching `If-Match` is a `412 PRECONDITION_FAILED`.
+
+Since no write response carries an `ETag`, a client that wants the new tag for its next conditional write must re-`GET` the entity after mutating it.
+
+CORS exposes the `ETag` header to browser clients whenever `KANBAN_CORS_ORIGINS` names an explicit origin list; the permissive (`*`) CORS mode does not expose it.
+
 ## Error Handling
 
 Every non-2xx response is a JSON `ApiError`:
@@ -276,7 +288,7 @@ Every non-2xx response is a JSON `ApiError`:
 | 400 | `BATCH_RESOLUTION_FAILED` |
 | 404 | `NOT_FOUND`, `NOT_FOUND_BY_NAME`, `EDGE_NOT_FOUND` |
 | 409 | `AMBIGUOUS`, `WIP_LIMIT_EXCEEDED`, `CONFLICT_DETECTED`, `ALREADY_EXISTS`, `UNSUPPORTED_VERSION`, `DEPENDENCY_ERROR`, `CYCLE_DETECTED`, `DUPLICATE_EDGE` |
-| 412 | `PRECONDITION_FAILED` |
+| 412 | `PRECONDITION_FAILED` (see [Conditional requests](#conditional-requests)) |
 | 422 | `VALIDATION_FAILED`, `SPRINT_BOARD_MISMATCH`, `SELF_REFERENCE` |
 | 500 | `IO_ERROR`, `SERIALIZATION_ERROR`, `DATABASE_ERROR`, `INTERNAL_ERROR` |
 

--- a/crates/kanban-server/README.md
+++ b/crates/kanban-server/README.md
@@ -2,7 +2,7 @@
 
 HTTP API server for kanban project management. Wraps `kanban-service` behind a REST interface so non-Rust clients (web UIs, scripts, other services) can read and write boards without going through the TUI, CLI, or MCP server.
 
-**Status: early / minimal.** Only boards and column reads are wired up so far — see [Endpoints](#endpoints). The bind address is configurable (see [Configuration](#configuration)); per-request logging is not. Still best treated as a development server rather than a hardened production deployment.
+**Status: early / minimal.** See [Endpoints](#endpoints) for what is wired up; reads and writes are covered across boards, columns, cards, sprints, the graph and transfer, with conditional-request guards on the entity writes. The bind address is configurable (see [Configuration](#configuration)); per-request logging is not. Still best treated as a development server rather than a hardened production deployment.
 
 ## Architecture
 
@@ -271,7 +271,7 @@ Every single-entity `GET` for boards, columns, cards and sprints (board-scoped a
 
 Since no write response carries an `ETag`, a client that wants the new tag for its next conditional write must re-`GET` the entity after mutating it.
 
-CORS exposes the `ETag` header to browser clients whenever `KANBAN_CORS_ORIGINS` names an explicit origin list; the permissive (`*`) CORS mode does not expose it.
+CORS exposes the `ETag` header to browser clients in both modes: an explicit `KANBAN_CORS_ORIGINS` list names it in `Access-Control-Expose-Headers`, and the permissive (`*`) mode exposes every header via a wildcard. With `KANBAN_CORS_ORIGINS` unset the server sends no CORS headers at all, so a browser client cannot read `ETag` cross-origin.
 
 ## Error Handling
 

--- a/crates/kanban-tui/src/app/query.rs
+++ b/crates/kanban-tui/src/app/query.rs
@@ -48,6 +48,10 @@ impl App {
     /// paired for a candidate search across both. `NotLoaded`/`Failed` on the
     /// live partition propagates; the archived half degrades to empty rather
     /// than gating, matching its behaviour outside the archived views.
+    /// Both partitions come from the controller, so a caller that filters
+    /// the result by its own derived `board_id` must have derived it from
+    /// the controller's scope board; any other id yields an empty candidate
+    /// set.
     pub(crate) fn board_candidate_cards(&self) -> LoadState<(&[Card], &[Card])> {
         self.controller.live_cards().map(|live| {
             (

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -1167,6 +1167,9 @@ pub async fn setup_app_with_json_file_and_save_worker(dir: &std::path::Path) -> 
 /// `model.archived_card_ids()` or a card's per-id/scoped state for an
 /// archived row without having navigated through the archived-cards view
 /// must call this first, or the tier stays `NotLoaded` and reads as empty.
+/// `Model::archived_card_ids()` is fed by the flat whole-store marker tier
+/// only, never by the by-board tier, which is why the backfill below is by
+/// hand.
 pub fn warm_archived_card_markers(app: &mut App) {
     let prior = app.mode.clone();
     app.mode = kanban_tui::app::mode::AppMode::ArchivedCardsView;

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -198,7 +198,7 @@ fn test_resolve_relationship_cards_omits_id_with_no_card() {
 }
 
 #[test]
-fn test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan() {
+fn test_resolve_relationship_cards_returns_live_archived_and_cross_board_bodies_in_input_order() {
     let mut app = App::test_default();
     let (board_b_id, column_b_id) = create_board_and_column(&mut app, "Board B");
     let (board_c_id, column_c_id) = create_board_and_column(&mut app, "Board C");
@@ -234,18 +234,26 @@ fn test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan() {
     ids.push(archived_parent);
     ids.push(Uuid::new_v4());
 
-    let expected: Vec<Uuid> = ids
-        .iter()
-        .filter_map(|id| app.model.card_by_id_state(*id).loaded().map(|c| c.id))
-        .collect();
-    assert_eq!(expected.len(), 3);
+    assert!(
+        !app.model
+            .graph_state()
+            .loaded()
+            .unwrap_or_else(|| Model::empty_graph())
+            .parents(subject)
+            .contains(&archived_parent),
+        "archiving a card archives its spawns edge, so it must be reintroduced by id"
+    );
 
     let actual: Vec<Uuid> = resolve_relationship_cards(&app.model, &ids)
         .iter()
         .map(|c| c.id)
         .collect();
 
-    assert_eq!(actual, expected);
+    assert_eq!(
+        actual,
+        vec![live_parent, cross_child, archived_parent],
+        "input order is preserved; the archived parent resolves from the per-id tier even though its spawns edge is archived, and the unknown id drops"
+    );
 }
 
 #[test]

--- a/crates/kanban-tui/tests/relationship_resolution_tests.rs
+++ b/crates/kanban-tui/tests/relationship_resolution_tests.rs
@@ -15,11 +15,8 @@ fn invalidate_graph(app: &mut App) {
         .invalidate(Invalidation::Entities(EntityIds::default().with_graph()));
 }
 
-/// `ViewScope` scopes the board-cards tier to the active board only, so a
-/// card on a different board (a cross-board `spawns` relative) never lands
-/// in `card_by_id_state` via `reload_model`/`prepare_frame`. Seed its body
-/// directly, the same way `warm_archived_card_markers` backfills the
-/// archived-marker tier.
+/// Seeds one card's per-id tier directly. Required for any card outside the
+/// active board, which `ViewScope`'s board-scoped card tier never reaches.
 fn warm_card_body(app: &mut App, card_id: Uuid) {
     let card = app.ctx.get_card(card_id).unwrap().unwrap();
     let _ = app.model.apply_resolved(kanban_domain::Resolved {


### PR DESCRIPTION
## Summary

Docs/infra/test-honesty slice of the KAN-1538/1541/1581 review harvest.

- Add a repo-root `.gitattributes` pinning `* text=auto eol=lf`. `git add --renormalize .` on a clean tree produced an empty diff, so nothing in the tree currently needs normalizing.
- Rebuild `test_resolve_relationship_cards_resolves_same_set_as_full_collection_scan` (renamed `test_resolve_relationship_cards_returns_live_archived_and_cross_board_bodies_in_input_order`), which built its expectation with the same `filter_map` the production code uses under the hood, so it could never fail. The new version asserts an independently derived literal order and adds an explicit check that the archived parent's `spawns` edge is absent from `graph.parents(subject)`, proving the archived id is resolved from the per-id tier rather than the graph. Mutation-checked by swapping two ids in the expected vector and confirming the assertion fails, then reverted before committing.
- Document the server's conditional-request protocol in `crates/kanban-server/README.md`: `ETag` construction, the exact routes that emit it, `If-None-Match`/304 semantics (including the weak-tag comparison), `If-Match`/412 semantics (including the absent-header short-circuit and the `*`-against-nothing failure), and the CORS caveat that only the explicit-origin-list mode exposes the header.
  - The route list for `If-Match` in this PR corrects the source card, which conflated `/v1/columns/{column_id}/cards/{id}` (which only registers `PUT`) with the board-scoped card routes (which register `PATCH`/`DELETE`).
  - While adding this section, found and removed a now-contradicted stale line: `Column writes (create/update/delete) aren't implemented yet.` The same README already lists the column write routes a few lines above, and this PR's new section documents `If-Match` on those same routes, so the sentence could not stay.
  - Corrected `GET /v1/graph`'s documented empty-graph body: it is `{"spawns":{"edges":[]},"blocks":{"edges":[]},"relates":{"edges":[]}}`, not `{}`.
  - Documented that a client-side `DependencyGraph` deserialization replays every edge through the same DAG cycle/self-reference guard the server enforces, with the archived-edge carve-out, and cross-referenced this from `crates/kanban-backend-http/README.md`.
- Added a module doc to `crates/kanban-backend-http/tests/sse_subscription.rs` recording the reconnect backoff and background-shutdown-on-drop behavior (no test added, this is a documentation-only note).
- Tightened three doc comments (`warm_archived_card_markers`, `warm_card_body`, `board_candidate_cards`) to state their real contracts rather than the vaguer prose they carried before.

## Deviation from the assigned card

The card's item 1 (a domain fix making `strip_test_modules` tolerate a trailing CR) was dropped. Its premise does not hold: Rust's `str::lines()` already treats `\r\n` as a single line terminator and strips both characters, so the cited sentinel check (`line == "}"`) already matches correctly on CRLF input. A red test built exactly as specified in the card passed at head with zero production changes, confirming there is no bug to fix. No change was made to `crates/kanban-domain/src/capabilities.rs`.

Two known-stale statements were left as-is per the card's scope, since nothing in this PR contradicts them: `crates/kanban-server/README.md:5` ("Only boards and column reads are wired up so far") and the sentence noting the remaining card routes aren't documented in the endpoint table yet.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`
- [x] `capability_guard` (all four crates) and `write_lock_guard` remain green
- [x] Mutation-checked the rebuilt relationship-resolution test
