### PR TITLE
KAN-1594 test(view,domain,service,tui,mcp): close eight local coverage gaps

### DIFF
--- a/.changeset/kan-1594-local-coverage-gaps.md
+++ b/.changeset/kan-1594-local-coverage-gaps.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+close eight local test-coverage gaps: rollback tiers, receipt guard, batch ambiguity, cycle-conflicting transfer, archived-board MCP resolution, and discriminating assertion fixes

--- a/crates/kanban-mcp/src/tools/card_crud.rs
+++ b/crates/kanban-mcp/src/tools/card_crud.rs
@@ -1847,4 +1847,189 @@ mod tests {
     async fn test_update_card_by_identifier_on_an_archived_board_still_mutates_it_on_sqlite() {
         assert_update_card_on_an_archived_board_still_mutates_it("test.sqlite").await;
     }
+
+    struct ArchivedBoardWithColumns {
+        seeded: Seeded,
+        column_ids: Vec<String>,
+        card_identifier: String,
+    }
+
+    async fn seed_archived_board_with_columns(
+        file_name: &str,
+        column_count: usize,
+    ) -> ArchivedBoardWithColumns {
+        let seeded = seeded_server(file_name).await;
+
+        let second_board = text_payload(
+            &seeded
+                .server
+                .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                    content: CreateBoardRequest {
+                        id: None,
+                        name: "Beta".to_string(),
+                        description: None,
+                        sprint_prefix: None,
+                        card_prefix: Some("BETA".to_string()),
+                        task_sort_field: None,
+                        task_sort_order: None,
+                        sprint_duration_days: None,
+                        task_list_view: None,
+                    },
+                    with_default_columns: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let second_board_id = second_board["id"].as_str().unwrap().to_string();
+
+        let mut column_ids = Vec::with_capacity(column_count);
+        for i in 0..column_count {
+            let column = text_payload(
+                &seeded
+                    .server
+                    .tool_create_column(Parameters(CreateColumnParams {
+                        board: second_board_id.clone(),
+                        content: kanban_service::api::CreateColumnRequest {
+                            id: None,
+                            name: format!("Column {i}"),
+                            wip_limit: None,
+                            default_status: None,
+                        },
+                    }))
+                    .await
+                    .unwrap(),
+            );
+            column_ids.push(column["id"].as_str().unwrap().to_string());
+        }
+
+        let card = text_payload(
+            &seeded
+                .server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: second_board_id.clone(),
+                    column: column_ids[0].clone(),
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Card on archived board".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let card_identifier = format!(
+            "{}-{}",
+            card["prefix"].as_str().unwrap(),
+            card["card_number"].as_u64().unwrap()
+        );
+
+        seeded
+            .server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: second_board_id,
+            }))
+            .await
+            .unwrap();
+
+        ArchivedBoardWithColumns {
+            seeded,
+            column_ids,
+            card_identifier,
+        }
+    }
+
+    async fn assert_move_card_on_an_archived_board_still_moves_it(file_name: &str) {
+        let fixture = seed_archived_board_with_columns(file_name, 2).await;
+
+        let moved = text_payload(
+            &fixture
+                .seeded
+                .server
+                .tool_move_card(Parameters(MoveCardRequest {
+                    card: fixture.card_identifier,
+                    column: fixture.column_ids[1].clone(),
+                    position: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(moved["column_id"], fixture.column_ids[1]);
+    }
+
+    #[tokio::test]
+    async fn test_move_card_by_identifier_on_an_archived_board_still_moves_it_on_json() {
+        assert_move_card_on_an_archived_board_still_moves_it("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_move_card_by_identifier_on_an_archived_board_still_moves_it_on_sqlite() {
+        assert_move_card_on_an_archived_board_still_moves_it("test.sqlite").await;
+    }
+
+    async fn assert_archive_card_on_an_archived_board_still_archives_it(file_name: &str) {
+        let fixture = seed_archived_board_with_columns(file_name, 1).await;
+
+        let archived = text_payload(
+            &fixture
+                .seeded
+                .server
+                .tool_archive_card(Parameters(ArchiveCardRequest {
+                    card: fixture.card_identifier,
+                }))
+                .await
+                .unwrap(),
+        );
+        assert!(archived["archived"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_archive_card_by_identifier_on_an_archived_board_still_archives_it_on_json() {
+        assert_archive_card_on_an_archived_board_still_archives_it("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_archive_card_by_identifier_on_an_archived_board_still_archives_it_on_sqlite() {
+        assert_archive_card_on_an_archived_board_still_archives_it("test.sqlite").await;
+    }
+
+    async fn assert_delete_card_on_an_archived_board_still_deletes_it(file_name: &str) {
+        let fixture = seed_archived_board_with_columns(file_name, 1).await;
+
+        let deleted = text_payload(
+            &fixture
+                .seeded
+                .server
+                .tool_delete_card(Parameters(DeleteCardRequest {
+                    card: fixture.card_identifier.clone(),
+                }))
+                .await
+                .unwrap(),
+        );
+        assert!(deleted["deleted"].as_str().is_some());
+
+        let err = fixture
+            .seeded
+            .server
+            .tool_delete_card(Parameters(DeleteCardRequest {
+                card: fixture.card_identifier,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn test_delete_card_by_identifier_on_an_archived_board_still_deletes_it_on_json() {
+        assert_delete_card_on_an_archived_board_still_deletes_it("test.json").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_delete_card_by_identifier_on_an_archived_board_still_deletes_it_on_sqlite() {
+        assert_delete_card_on_an_archived_board_still_deletes_it("test.sqlite").await;
+    }
 }

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -884,9 +884,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph_on_sqlite(
-    ) {
-        assert_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph("test.sqlite")
-            .await;
+    async fn test_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph_on_sqlite()
+    {
+        assert_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph(
+            "test.sqlite",
+        )
+        .await;
     }
 }

--- a/crates/kanban-mcp/src/tools/card_relations.rs
+++ b/crates/kanban-mcp/src/tools/card_relations.rs
@@ -653,7 +653,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_card_children_resolves_the_card_by_name_from_the_model() {
+    async fn test_list_card_children_resolves_the_card_by_identifier_from_the_model() {
         let seeded = seeded_server("test.json").await;
         seeded.handle.clear_ops();
 
@@ -717,5 +717,176 @@ mod tests {
         assert_ne!(not_found_err.code, fault_err.code);
         assert_ne!(not_found_err.message, fault_err.message);
         let _ = (&seeded.card_a_id, &seeded.card_b_id);
+    }
+
+    async fn assert_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph(
+        file_name: &str,
+    ) {
+        let seeded = seeded_server(file_name).await;
+
+        let second_board = text_payload(
+            &seeded
+                .server
+                .tool_create_board(Parameters(crate::requests::board::CreateBoardParams {
+                    content: CreateBoardRequest {
+                        id: None,
+                        name: "Beta".to_string(),
+                        description: None,
+                        sprint_prefix: None,
+                        card_prefix: Some("BETA".to_string()),
+                        task_sort_field: None,
+                        task_sort_order: None,
+                        sprint_duration_days: None,
+                        task_list_view: None,
+                    },
+                    with_default_columns: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let second_board_id = second_board["id"].as_str().unwrap().to_string();
+
+        let second_column = text_payload(
+            &seeded
+                .server
+                .tool_create_column(Parameters(CreateColumnParams {
+                    board: second_board_id.clone(),
+                    content: kanban_service::api::CreateColumnRequest {
+                        id: None,
+                        name: "TODO".to_string(),
+                        wip_limit: None,
+                        default_status: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let second_column_id = second_column["id"].as_str().unwrap().to_string();
+
+        let beta_a = text_payload(
+            &seeded
+                .server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: second_board_id.clone(),
+                    column: second_column_id.clone(),
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Beta A".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let beta_a_id = beta_a["id"].as_str().unwrap().to_string();
+        let beta_a_identifier = format!(
+            "{}-{}",
+            beta_a["prefix"].as_str().unwrap(),
+            beta_a["card_number"].as_u64().unwrap()
+        );
+
+        let beta_b = text_payload(
+            &seeded
+                .server
+                .tool_create_card(Parameters(CreateCardParams {
+                    board: second_board_id.clone(),
+                    column: second_column_id,
+                    sprint: None,
+                    content: kanban_service::api::CreateCardRequest {
+                        id: None,
+                        title: "Beta B".to_string(),
+                        description: None,
+                        priority: None,
+                        due_date: None,
+                        points: None,
+                        sprint_id: None,
+                    },
+                }))
+                .await
+                .unwrap(),
+        );
+        let beta_b_id = beta_b["id"].as_str().unwrap().to_string();
+        let beta_b_identifier = format!(
+            "{}-{}",
+            beta_b["prefix"].as_str().unwrap(),
+            beta_b["card_number"].as_u64().unwrap()
+        );
+
+        seeded
+            .server
+            .tool_archive_board(Parameters(crate::requests::board::ArchiveBoardRequest {
+                board: second_board_id,
+            }))
+            .await
+            .unwrap();
+
+        let set_response = text_payload(
+            &seeded
+                .server
+                .tool_set_card_parent(Parameters(SetCardParentRequest {
+                    parent: beta_a_identifier.clone(),
+                    child: beta_b_identifier.clone(),
+                }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(set_response["parent"], beta_a_id);
+        assert_eq!(set_response["child"], beta_b_id);
+
+        let children_after_set = text_payload(
+            &seeded
+                .server
+                .tool_list_card_children(Parameters(ListCardChildrenRequest {
+                    card: beta_a_identifier.clone(),
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let items_after_set = children_after_set["items"].as_array().unwrap();
+        assert_eq!(items_after_set.len(), 1);
+        assert_eq!(items_after_set[0]["id"], beta_b_id);
+
+        seeded
+            .server
+            .tool_remove_card_parent(Parameters(RemoveCardParentRequest {
+                parent: beta_a_identifier.clone(),
+                child: beta_b_identifier,
+            }))
+            .await
+            .unwrap();
+
+        let children_after_remove = text_payload(
+            &seeded
+                .server
+                .tool_list_card_children(Parameters(ListCardChildrenRequest {
+                    card: beta_a_identifier,
+                    page: None,
+                    page_size: None,
+                }))
+                .await
+                .unwrap(),
+        );
+        let items_after_remove = children_after_remove["items"].as_array().unwrap();
+        assert!(items_after_remove.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph_on_json() {
+        assert_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph("test.json")
+            .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph_on_sqlite(
+    ) {
+        assert_set_and_remove_card_parent_on_an_archived_board_still_mutate_the_graph("test.sqlite")
+            .await;
     }
 }

--- a/crates/kanban-mcp/src/tools/sprint.rs
+++ b/crates/kanban-mcp/src/tools/sprint.rs
@@ -563,8 +563,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sprint_tool_with_an_unloadable_sprint_list_errors_instead_of_reporting_not_found_on_json(
-    ) {
+    async fn test_sprint_tool_with_an_unloadable_sprint_list_errors_naming_the_collection_on_json()
+    {
         let seeded = seeded_server("test.json").await;
         seeded.handle.clear_ops();
         seeded.handle.fail("list_all_sprints");
@@ -578,11 +578,12 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("injected fault: list_all_sprints"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_sprint_tool_with_an_unloadable_sprint_list_errors_instead_of_reporting_not_found_on_sqlite(
+    async fn test_sprint_tool_with_an_unloadable_sprint_list_errors_naming_the_collection_on_sqlite(
     ) {
         let seeded = seeded_server("test.sqlite").await;
         seeded.handle.clear_ops();
@@ -597,6 +598,7 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("injected fault: list_all_sprints"));
         assert!(!err.message.to_lowercase().contains("not found"));
     }
 

--- a/crates/kanban-service/tests/resolve.rs
+++ b/crates/kanban-service/tests/resolve.rs
@@ -328,12 +328,7 @@ async fn test_resolve_card_ids_reports_ambiguous_for_a_bare_number_spanning_an_a
         .unwrap();
     let beta_col = ctx.create_column(beta.id, "TODO".into(), None).unwrap();
     let beta_card = ctx
-        .create_card(
-            beta.id,
-            beta_col.id,
-            "Beta card".into(),
-            Default::default(),
-        )
+        .create_card(beta.id, beta_col.id, "Beta card".into(), Default::default())
         .unwrap();
 
     assert_eq!(

--- a/crates/kanban-service/tests/resolve.rs
+++ b/crates/kanban-service/tests/resolve.rs
@@ -305,6 +305,66 @@ async fn test_resolve_card_ids_resolves_a_card_on_an_archived_board() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_card_ids_reports_ambiguous_for_a_bare_number_spanning_an_archived_board() {
+    use kanban_domain::{BatchResolutionCause, DomainError, KanbanError};
+    let (mut ctx, _dir) = open_ctx().await;
+
+    let alpha = ctx
+        .create_board("Alpha".into(), Some("ALPHA".into()))
+        .unwrap();
+    let alpha_col = ctx.create_column(alpha.id, "TODO".into(), None).unwrap();
+    let alpha_card = ctx
+        .create_card(
+            alpha.id,
+            alpha_col.id,
+            "Alpha card".into(),
+            Default::default(),
+        )
+        .unwrap();
+
+    let beta = ctx
+        .create_board("Beta".into(), Some("BETA".into()))
+        .unwrap();
+    let beta_col = ctx.create_column(beta.id, "TODO".into(), None).unwrap();
+    let beta_card = ctx
+        .create_card(
+            beta.id,
+            beta_col.id,
+            "Beta card".into(),
+            Default::default(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        alpha_card.card_number, beta_card.card_number,
+        "fixture sanity: distinct prefixes each start their counter at 1"
+    );
+
+    ctx.archive_board(beta.id).unwrap();
+
+    let bare_number = alpha_card.card_number.to_string();
+    let err = ctx
+        .resolve_card_ids(std::slice::from_ref(&bare_number))
+        .unwrap_err();
+    let KanbanError::Domain(DomainError::BatchResolutionFailed { entity, failures }) = err else {
+        panic!("expected BatchResolutionFailed");
+    };
+    assert_eq!(entity, "Card");
+    assert_eq!(failures.len(), 1);
+    let BatchResolutionCause::Ambiguous(matches) = &failures[0].cause else {
+        panic!(
+            "expected BatchResolutionCause::Ambiguous, got: {:?}",
+            failures[0].cause
+        );
+    };
+    let mut ids: Vec<_> = matches.iter().map(|m| m.id).collect();
+    ids.sort();
+    let mut expected = vec![alpha_card.id, beta_card.id];
+    expected.sort();
+    assert_eq!(ids, expected);
+}
+
 // ---------- require_same_board ----------
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/kanban-service/tests/transfer_pairs.rs
+++ b/crates/kanban-service/tests/transfer_pairs.rs
@@ -655,12 +655,8 @@ fn normalize(snapshot: &mut Snapshot) {
     snapshot.columns.sort_by_key(|c| c.id);
     snapshot.cards.sort_by_key(|c| c.id);
     snapshot.sprints.sort_by_key(|s| s.id);
-    snapshot
-        .archived_cards
-        .sort_by_key(|a| a.entity_id());
-    snapshot
-        .archived_boards
-        .sort_by_key(|a| a.entity_id());
+    snapshot.archived_cards.sort_by_key(|a| a.entity_id());
+    snapshot.archived_boards.sort_by_key(|a| a.entity_id());
     snapshot.prefixes.sort_by_key(|p| p.name.clone());
 }
 
@@ -697,7 +693,10 @@ async fn test_transfer_state_to_a_target_whose_graph_conflicts_leaves_the_target
             sprint_counter: 1,
         };
 
-        dst_ctx.data_store().upsert_prefix(unrelated_prefix).unwrap();
+        dst_ctx
+            .data_store()
+            .upsert_prefix(unrelated_prefix)
+            .unwrap();
         dst_ctx
             .data_store()
             .upsert_board(unrelated_board.clone())
@@ -744,7 +743,10 @@ async fn test_transfer_state_to_a_target_whose_graph_conflicts_leaves_the_target
         src_card_b.id = b_id;
         src_card_b.prefix = "src".into();
         src_card_b.card_number = 2;
-        src_ctx.data_store().upsert_board(src_board.clone()).unwrap();
+        src_ctx
+            .data_store()
+            .upsert_board(src_board.clone())
+            .unwrap();
         src_ctx
             .data_store()
             .upsert_column(src_column.clone())
@@ -756,9 +758,7 @@ async fn test_transfer_state_to_a_target_whose_graph_conflicts_leaves_the_target
             .modify_graph(Box::new(move |g| g.set_parent(b_id, a_id)))
             .unwrap();
 
-        let err = src_ctx
-            .transfer_state_to(&*dst_ctx.backend())
-            .unwrap_err();
+        let err = src_ctx.transfer_state_to(&*dst_ctx.backend()).unwrap_err();
         assert!(
             err.is_cycle_detected(),
             "expected a cycle-detected error on {dst_name}, got: {err}"

--- a/crates/kanban-service/tests/transfer_pairs.rs
+++ b/crates/kanban-service/tests/transfer_pairs.rs
@@ -602,6 +602,16 @@ async fn test_transfer_state_to_into_a_populated_target_is_an_upsert_not_a_wipe(
         let src_ctx = open_ctx(&in_memory_backend_factory(), &src_path).await;
         let fixture = seed_rich(src_ctx.data_store()).unwrap();
 
+        let src_edge_created = src_ctx
+            .data_store()
+            .get_graph()
+            .unwrap()
+            .blocks_edges()
+            .iter()
+            .find(|e| (e.source(), e.target()) == fixture.live_block_edge)
+            .unwrap()
+            .created_at();
+
         src_ctx
             .transfer_state_to(&*dst_ctx.backend())
             .unwrap_or_else(|e| panic!("transfer into populated {dst_name} failed: {e}"));
@@ -644,6 +654,19 @@ async fn test_transfer_state_to_into_a_populated_target_is_an_upsert_not_a_wipe(
         assert!(
             kept_blocks.contains(&(unrelated_card.id, unrelated_card_2.id)),
             "target's pre-existing block edge must survive the transfer on {dst_name}, got {kept_blocks:?}"
+        );
+
+        let dst_edge = store
+            .get_graph()
+            .unwrap()
+            .blocks_edges()
+            .iter()
+            .find(|e| (e.source(), e.target()) == fixture.live_block_edge)
+            .unwrap()
+            .created_at();
+        assert_ne!(
+            dst_edge, src_edge_created,
+            "merge_from regenerates timestamps on a non-empty target graph on {dst_name}"
         );
 
         assert_transfer_matches(&fixture, store);

--- a/crates/kanban-service/tests/transfer_pairs.rs
+++ b/crates/kanban-service/tests/transfer_pairs.rs
@@ -8,14 +8,14 @@ use kanban_backend_memory::InMemoryStore;
 use kanban_core::{AppConfig, Edge};
 use kanban_domain::commands::{BoardCommand, Command, CreateBoard};
 use kanban_domain::{
-    Archived, ArchivedBoard, ArchivedCard, Board, Card, Column, CommandBatch, CommandStore,
-    DataStore, KanbanResult, Prefix, Sprint, SprintLog,
+    Archived, ArchivedBoard, ArchivedCard, ArchivedEntity, Board, Card, Column, CommandBatch,
+    CommandStore, DataStore, KanbanResult, Prefix, Snapshot, Sprint, SprintLog,
 };
 use kanban_persistence_json::{JsonDataStore, JsonFileStore};
 use kanban_persistence_sqlite::SqliteBackend;
 use kanban_service::test_helpers::contract::assert_card_eq;
 use kanban_service::test_helpers::BackendFactory;
-use kanban_service::{KanbanBackend, KanbanContext, TransactionFn};
+use kanban_service::{read_full_snapshot, KanbanBackend, KanbanContext, TransactionFn};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -647,6 +647,158 @@ async fn test_transfer_state_to_into_a_populated_target_is_an_upsert_not_a_wipe(
         );
 
         assert_transfer_matches(&fixture, store);
+    }
+}
+
+fn normalize(snapshot: &mut Snapshot) {
+    snapshot.boards.sort_by_key(|b| b.id);
+    snapshot.columns.sort_by_key(|c| c.id);
+    snapshot.cards.sort_by_key(|c| c.id);
+    snapshot.sprints.sort_by_key(|s| s.id);
+    snapshot
+        .archived_cards
+        .sort_by_key(|a| a.entity_id());
+    snapshot
+        .archived_boards
+        .sort_by_key(|a| a.entity_id());
+    snapshot.prefixes.sort_by_key(|p| p.name.clone());
+}
+
+fn edge_pairs<E: Edge<NodeId = Uuid>>(edges: &[E]) -> Vec<(Uuid, Uuid)> {
+    let mut pairs: Vec<(Uuid, Uuid)> = edges.iter().map(|e| (e.source(), e.target())).collect();
+    pairs.sort_unstable();
+    pairs
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transfer_state_to_a_target_whose_graph_conflicts_leaves_the_target_unchanged() {
+    for (dst_name, dst_factory) in backends() {
+        let dir = TempDir::new().unwrap();
+        let dst_path = dir.path().join("dst.store");
+        let dst_ctx = open_ctx(&dst_factory, &dst_path).await;
+
+        let a_id = Uuid::new_v4();
+        let b_id = Uuid::new_v4();
+
+        let unrelated_board = Board::new("Unrelated", Some("unr"));
+        let unrelated_column = Column::new(unrelated_board.id, "Todo", 0);
+        let mut card_a = Card::new(unrelated_board.id, unrelated_column.id, "A", 0);
+        card_a.id = a_id;
+        card_a.prefix = "unr".into();
+        card_a.card_number = 1;
+        let mut card_b = Card::new(unrelated_board.id, unrelated_column.id, "B", 1);
+        card_b.id = b_id;
+        card_b.prefix = "unr".into();
+        card_b.card_number = 2;
+        let unrelated_sprint = Sprint::new(unrelated_board.id, 1, None, None::<String>);
+        let unrelated_prefix = Prefix {
+            name: "unr".into(),
+            card_counter: 2,
+            sprint_counter: 1,
+        };
+
+        dst_ctx.data_store().upsert_prefix(unrelated_prefix).unwrap();
+        dst_ctx
+            .data_store()
+            .upsert_board(unrelated_board.clone())
+            .unwrap();
+        dst_ctx
+            .data_store()
+            .upsert_column(unrelated_column.clone())
+            .unwrap();
+        dst_ctx.data_store().upsert_card(card_a.clone()).unwrap();
+        dst_ctx.data_store().upsert_card(card_b.clone()).unwrap();
+        dst_ctx
+            .data_store()
+            .upsert_sprint(unrelated_sprint.clone())
+            .unwrap();
+        dst_ctx
+            .data_store()
+            .modify_graph(Box::new(move |g| g.set_parent(a_id, b_id)))
+            .unwrap();
+        dst_ctx.save().await.unwrap();
+
+        let before = {
+            let mut s = read_full_snapshot(dst_ctx.data_store()).unwrap();
+            normalize(&mut s);
+            s
+        };
+
+        let src_path = dir.path().join("src.store");
+        let src_ctx = open_ctx(&in_memory_backend_factory(), &src_path).await;
+        src_ctx
+            .data_store()
+            .upsert_prefix(Prefix {
+                name: "src".into(),
+                card_counter: 2,
+                sprint_counter: 0,
+            })
+            .unwrap();
+        let src_board = Board::new("Src", Some("src"));
+        let src_column = Column::new(src_board.id, "Todo", 0);
+        let mut src_card_a = Card::new(src_board.id, src_column.id, "SrcA", 0);
+        src_card_a.id = a_id;
+        src_card_a.prefix = "src".into();
+        src_card_a.card_number = 1;
+        let mut src_card_b = Card::new(src_board.id, src_column.id, "SrcB", 1);
+        src_card_b.id = b_id;
+        src_card_b.prefix = "src".into();
+        src_card_b.card_number = 2;
+        src_ctx.data_store().upsert_board(src_board.clone()).unwrap();
+        src_ctx
+            .data_store()
+            .upsert_column(src_column.clone())
+            .unwrap();
+        src_ctx.data_store().upsert_card(src_card_a).unwrap();
+        src_ctx.data_store().upsert_card(src_card_b).unwrap();
+        src_ctx
+            .data_store()
+            .modify_graph(Box::new(move |g| g.set_parent(b_id, a_id)))
+            .unwrap();
+
+        let err = src_ctx
+            .transfer_state_to(&*dst_ctx.backend())
+            .unwrap_err();
+        assert!(
+            err.is_cycle_detected(),
+            "expected a cycle-detected error on {dst_name}, got: {err}"
+        );
+
+        let reopened = open_ctx(&dst_factory, &dst_path).await;
+        let after = {
+            let mut s = read_full_snapshot(reopened.data_store()).unwrap();
+            normalize(&mut s);
+            s
+        };
+
+        assert_eq!(before.boards, after.boards, "boards on {dst_name}");
+        assert_eq!(before.columns, after.columns, "columns on {dst_name}");
+        assert_eq!(before.cards, after.cards, "cards on {dst_name}");
+        assert_eq!(before.sprints, after.sprints, "sprints on {dst_name}");
+        assert_eq!(
+            before.archived_cards, after.archived_cards,
+            "archived cards on {dst_name}"
+        );
+        assert_eq!(
+            before.archived_boards, after.archived_boards,
+            "archived boards on {dst_name}"
+        );
+        assert_eq!(before.prefixes, after.prefixes, "prefixes on {dst_name}");
+        assert_eq!(
+            edge_pairs(before.graph.spawns_edges()),
+            edge_pairs(after.graph.spawns_edges()),
+            "spawns edges on {dst_name}"
+        );
+        assert_eq!(
+            edge_pairs(before.graph.blocks_edges()),
+            edge_pairs(after.graph.blocks_edges()),
+            "blocks edges on {dst_name}"
+        );
+        assert_eq!(
+            edge_pairs(before.graph.relates_edges()),
+            edge_pairs(after.graph.relates_edges()),
+            "relates edges on {dst_name}"
+        );
     }
 }
 

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -615,18 +615,11 @@ fn test_no_board_in_scope_leaves_restore_and_permanent_delete_animations_unstart
         "fixture sanity: board 2's archived tier is warm"
     );
 
-    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
-        list.set_selected_index(Some(0));
-    }
-    assert_eq!(
-        app.get_selected_card_id(),
-        Some(card2_id),
-        "fixture sanity: board 2's archived card must be selected before scope is cleared"
-    );
-
     app.selection.active_board_id = None;
     app.board_list.inner_mut().set_selected_index(None);
 
+    app.multi_select.selected_cards.insert(card_id);
+    app.multi_select.selected_cards.insert(card2_id);
     app.handle_restore_card();
     assert!(
         !app.animation.animating.contains_key(&card_id),
@@ -637,6 +630,8 @@ fn test_no_board_in_scope_leaves_restore_and_permanent_delete_animations_unstart
         "restore must not start an animation for board 2's card with no board in scope"
     );
 
+    app.multi_select.selected_cards.insert(card_id);
+    app.multi_select.selected_cards.insert(card2_id);
     app.handle_delete_card_permanent();
     assert!(
         !app.animation.animating.contains_key(&card_id),
@@ -648,12 +643,8 @@ fn test_no_board_in_scope_leaves_restore_and_permanent_delete_animations_unstart
     );
 
     app.selection.active_board_id = Some(board2.id);
-    app.board_list.inner_mut().set_selected_index(Some(0));
-    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
-        list.set_selected_index(Some(0));
-    }
-    assert_eq!(app.get_selected_card_id(), Some(card2_id));
-
+    app.multi_select.selected_cards.insert(card_id);
+    app.multi_select.selected_cards.insert(card2_id);
     app.handle_restore_card();
     assert!(
         app.animation.animating.contains_key(&card2_id),

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -654,4 +654,17 @@ fn test_no_board_in_scope_leaves_restore_and_permanent_delete_animations_unstart
         !app.animation.animating.contains_key(&card_id),
         "board 1's card must not animate off board 2's scope"
     );
+
+    app.animation.animating.clear();
+    app.multi_select.selected_cards.insert(card_id);
+    app.multi_select.selected_cards.insert(card2_id);
+    app.handle_delete_card_permanent();
+    assert!(
+        app.animation.animating.contains_key(&card2_id),
+        "permanent delete must start an animation for board 2's card once board 2 is back in scope"
+    );
+    assert!(
+        !app.animation.animating.contains_key(&card_id),
+        "board 1's card must not animate a permanent delete off board 2's scope"
+    );
 }

--- a/crates/kanban-tui/tests/archive_delete_tests.rs
+++ b/crates/kanban-tui/tests/archive_delete_tests.rs
@@ -574,18 +574,54 @@ fn test_no_board_in_scope_leaves_restore_and_permanent_delete_animations_unstart
     let card_id = card.id;
     app.ctx.archive_card(card_id).unwrap();
 
+    let board2 = app.ctx.create_board("Board 2".to_string(), None).unwrap();
+    let column2 = app
+        .ctx
+        .create_column(board2.id, "Todo".to_string(), None)
+        .unwrap();
+    let card2 = app
+        .ctx
+        .create_card(
+            board2.id,
+            column2.id,
+            "ArchiveMeToo".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let card2_id = card2.id;
+    app.ctx.archive_card(card2_id).unwrap();
+
     app.selection.active_board_id = Some(board.id);
     app.mode = AppMode::ArchivedCardsView;
-    app.reload_model();
-    app.prepare_frame();
+    app.refresh_view();
+
+    app.selection.active_board_id = Some(board2.id);
+    app.refresh_view();
+
+    assert_eq!(
+        app.model
+            .board_archived_cards_state(board.id)
+            .loaded()
+            .map(|v| v.len()),
+        Some(1),
+        "fixture sanity: board 1's archived tier stays warm"
+    );
+    assert_eq!(
+        app.model
+            .board_archived_cards_state(board2.id)
+            .loaded()
+            .map(|v| v.len()),
+        Some(1),
+        "fixture sanity: board 2's archived tier is warm"
+    );
 
     if let Some(list) = app.view.strategy.get_active_task_list_mut() {
         list.set_selected_index(Some(0));
     }
     assert_eq!(
         app.get_selected_card_id(),
-        Some(card_id),
-        "fixture sanity: the archived card must be selected before scope is cleared"
+        Some(card2_id),
+        "fixture sanity: board 2's archived card must be selected before scope is cleared"
     );
 
     app.selection.active_board_id = None;
@@ -594,12 +630,37 @@ fn test_no_board_in_scope_leaves_restore_and_permanent_delete_animations_unstart
     app.handle_restore_card();
     assert!(
         !app.animation.animating.contains_key(&card_id),
-        "restore must not start an animation with no board in scope"
+        "restore must not start an animation for board 1's card with no board in scope"
+    );
+    assert!(
+        !app.animation.animating.contains_key(&card2_id),
+        "restore must not start an animation for board 2's card with no board in scope"
     );
 
     app.handle_delete_card_permanent();
     assert!(
         !app.animation.animating.contains_key(&card_id),
-        "permanent delete must not start an animation with no board in scope"
+        "permanent delete must not start an animation for board 1's card with no board in scope"
+    );
+    assert!(
+        !app.animation.animating.contains_key(&card2_id),
+        "permanent delete must not start an animation for board 2's card with no board in scope"
+    );
+
+    app.selection.active_board_id = Some(board2.id);
+    app.board_list.inner_mut().set_selected_index(Some(0));
+    if let Some(list) = app.view.strategy.get_active_task_list_mut() {
+        list.set_selected_index(Some(0));
+    }
+    assert_eq!(app.get_selected_card_id(), Some(card2_id));
+
+    app.handle_restore_card();
+    assert!(
+        app.animation.animating.contains_key(&card2_id),
+        "restore must start an animation for board 2's card once board 2 is back in scope"
+    );
+    assert!(
+        !app.animation.animating.contains_key(&card_id),
+        "board 1's card must not animate off board 2's scope"
     );
 }

--- a/crates/kanban-tui/tests/delete_board_scope_tests.rs
+++ b/crates/kanban-tui/tests/delete_board_scope_tests.rs
@@ -76,7 +76,18 @@ async fn test_pressing_delete_after_navigating_off_the_active_board_opens_the_co
         )
         .unwrap();
     app.ctx
+        .create_card(
+            board2.id,
+            col2.id,
+            "Card 3".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx
         .create_sprint(board2.id, None, Some("Sprint 2".to_string()))
+        .unwrap();
+    app.ctx
+        .create_sprint(board2.id, None, Some("Sprint 3".to_string()))
         .unwrap();
 
     app.load_initial_state().await;
@@ -117,12 +128,12 @@ async fn test_pressing_delete_after_navigating_off_the_active_board_opens_the_co
 
     let output = render_to_string(&mut app, 140, 30);
     assert!(
-        output.contains("1 task(s)"),
+        output.contains("2 task(s)"),
         "expected board 2's task count, got:\n{}",
         output
     );
     assert!(
-        output.contains("1 sprint(s)"),
+        output.contains("2 sprint(s)"),
         "expected board 2's sprint count, got:\n{}",
         output
     );

--- a/crates/kanban-tui/tests/helpers.rs
+++ b/crates/kanban-tui/tests/helpers.rs
@@ -243,6 +243,7 @@ impl DataStore for CountingBackend {
     }
     fn list_archived_cards_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<ArchivedCard>> {
         self.record("list_archived_cards_by_board", vec![board_id]);
+        self.fault("list_archived_cards_by_board")?;
         self.inner.list_archived_cards_by_board(board_id)
     }
     fn insert_archived_card(&self, ac: ArchivedCard) -> KanbanResult<()> {
@@ -265,6 +266,7 @@ impl DataStore for CountingBackend {
     }
     fn list_archived_boards(&self) -> KanbanResult<Vec<ArchivedBoard>> {
         self.record("list_archived_boards", vec![]);
+        self.fault("list_archived_boards")?;
         self.inner.list_archived_boards()
     }
     fn insert_archived_board(&self, ab: ArchivedBoard) -> KanbanResult<()> {
@@ -282,6 +284,7 @@ impl DataStore for CountingBackend {
     }
     fn list_sprints_by_board(&self, board_id: Uuid) -> KanbanResult<Vec<Sprint>> {
         self.record("list_sprints_by_board", vec![board_id]);
+        self.fault("list_sprints_by_board")?;
         self.inner.list_sprints_by_board(board_id)
     }
     fn list_all_sprints(&self) -> KanbanResult<Vec<Sprint>> {
@@ -299,6 +302,7 @@ impl DataStore for CountingBackend {
     }
     fn get_graph(&self) -> KanbanResult<DependencyGraph> {
         self.record("get_graph", vec![]);
+        self.fault("get_graph")?;
         self.inner.get_graph()
     }
     fn set_graph(&self, graph: DependencyGraph) -> KanbanResult<()> {

--- a/crates/kanban-tui/tests/mutation_refetch_tests.rs
+++ b/crates/kanban-tui/tests/mutation_refetch_tests.rs
@@ -216,7 +216,23 @@ async fn test_delete_column_refetches_the_card_tier_because_the_batch_moved_card
         3,
         "the three cards moved out of c2 must all report c1"
     );
-    let _ = c3;
+
+    let untouched: Vec<_> = app
+        .model
+        .column_cards_state(c3.id)
+        .loaded()
+        .copied()
+        .unwrap_or(&[])
+        .iter()
+        .filter(|card| card.column_id == c3.id)
+        .collect();
+    let mut untouched_titles: Vec<_> = untouched.iter().map(|card| card.title.clone()).collect();
+    untouched_titles.sort();
+    assert_eq!(
+        untouched_titles,
+        vec!["M0".to_string(), "M1".to_string()],
+        "c3's own cards must be untouched by the c2 -> c1 move"
+    );
 }
 
 #[tokio::test]
@@ -272,6 +288,61 @@ async fn test_move_column_up_leaves_an_untouched_columns_card_scope_loaded() {
         "got {refetch:?}"
     );
     assert!(app.model.column_cards_state(c1.id).is_loaded());
+}
+
+#[tokio::test]
+async fn test_move_column_down_leaves_an_untouched_columns_card_scope_loaded() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let c1 = app
+        .ctx
+        .create_column(board.id, "C1".to_string(), Some(0))
+        .unwrap();
+    let c2 = app
+        .ctx
+        .create_column(board.id, "C2".to_string(), Some(1))
+        .unwrap();
+    let c3 = app
+        .ctx
+        .create_column(board.id, "C3".to_string(), Some(2))
+        .unwrap();
+    for (col, name) in [(&c1, "k1"), (&c2, "k2"), (&c3, "k3")] {
+        app.ctx
+            .create_card(
+                board.id,
+                col.id,
+                name.to_string(),
+                CreateCardOptions::default(),
+            )
+            .unwrap();
+    }
+
+    let ops = prime(&mut app).await;
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::BoardDetail;
+    select_column(&mut app, board.id, c1.id);
+    app.handle_move_column_down();
+
+    let refetch = refetch_ops(&ops);
+    assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
+    assert!(
+        has_op_with_id(&refetch, "list_columns_by_board", board.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c1.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        has_op_with_id(&refetch, "list_cards_by_column", c2.id),
+        "got {refetch:?}"
+    );
+    assert!(
+        !has_op_with_id(&refetch, "list_cards_by_column", c3.id),
+        "got {refetch:?}"
+    );
+    assert!(app.model.column_cards_state(c3.id).is_loaded());
 }
 
 #[tokio::test]
@@ -626,6 +697,9 @@ async fn test_create_card_refetches_the_card_tiers_named_by_its_inverse() {
     assert!(!has_op(&refetch, "get_graph"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_archived_cards"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_archived_boards"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_columns"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
+    assert!(!has_op(&refetch, "list_all_cards"), "got {refetch:?}");
 }
 
 #[tokio::test]

--- a/crates/kanban-tui/tests/reload_model_failure_tests.rs
+++ b/crates/kanban-tui/tests/reload_model_failure_tests.rs
@@ -2,8 +2,19 @@ mod helpers;
 
 use helpers::CountingBackend;
 use kanban_domain::{CreateCardOptions, KanbanOperations};
+use kanban_tui::app::mode::AppMode;
 use kanban_tui::components::BannerVariant;
 use kanban_tui::App;
+
+fn assert_error_banner(app: &App) {
+    let banner = app
+        .ui_state
+        .banner
+        .as_ref()
+        .expect("failed reload must set an error banner");
+    assert_eq!(banner.variant, BannerVariant::Error);
+    assert!(banner.message.contains("Failed to load from store"));
+}
 
 #[test]
 fn test_a_failed_reload_surfaces_an_error_to_the_user() {
@@ -73,6 +84,218 @@ fn test_a_failed_reload_leaves_the_previous_model_contents() {
         1
     );
     assert_eq!(app.model.boards_state().loaded_or_empty()[0].id, board.id);
+}
+
+#[test]
+fn test_a_failed_graph_read_rolls_back_to_the_previous_model() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Column".to_string(), None)
+        .unwrap();
+    let parent = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Parent".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let child = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Child".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    let (parent_id, child_id) = (parent.id, child.id);
+    app.ctx
+        .data_store()
+        .modify_graph(Box::new(move |g| g.set_parent(child_id, parent_id)))
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.selection.active_card_id = Some(child.id);
+    app.mode = AppMode::CardDetail;
+    app.reload_model();
+    assert_eq!(
+        app.model
+            .graph_state()
+            .loaded()
+            .map(|g| g.spawns_edges().len()),
+        Some(1),
+        "fixture sanity: one spawns edge seeded"
+    );
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "get_graph");
+    app.ctx.replace_backend(failing);
+    app.reload_model();
+
+    assert_error_banner(&app);
+    assert_eq!(
+        app.model
+            .graph_state()
+            .loaded()
+            .map(|g| g.spawns_edges().len()),
+        Some(1),
+        "the previous graph must survive a failed reload"
+    );
+}
+
+#[test]
+fn test_a_failed_scoped_column_read_rolls_back_to_the_previous_model() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    app.ctx
+        .create_column(board.id, "Column".to_string(), None)
+        .unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    assert_eq!(
+        app.model
+            .board_columns_state(board.id)
+            .loaded()
+            .map(|v| v.len()),
+        Some(1),
+        "fixture sanity: one column seeded"
+    );
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_columns_by_board");
+    app.ctx.replace_backend(failing);
+    app.reload_model();
+
+    assert_error_banner(&app);
+    assert_eq!(
+        app.model
+            .board_columns_state(board.id)
+            .loaded()
+            .map(|v| v.len()),
+        Some(1),
+        "the previous columns must survive a failed reload"
+    );
+}
+
+#[test]
+fn test_a_failed_scoped_sprint_read_rolls_back_to_the_previous_model() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Column".to_string(), None)
+        .unwrap();
+    app.ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.create_sprint(board.id, None, None).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.reload_model();
+    assert_eq!(
+        app.model
+            .board_sprints_state(board.id)
+            .loaded()
+            .map(|v| v.len()),
+        Some(1),
+        "fixture sanity: one sprint seeded"
+    );
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_sprints_by_board");
+    app.ctx.replace_backend(failing);
+    app.reload_model();
+
+    assert_error_banner(&app);
+    assert_eq!(
+        app.model
+            .board_sprints_state(board.id)
+            .loaded()
+            .map(|v| v.len()),
+        Some(1),
+        "the previous sprints must survive a failed reload"
+    );
+}
+
+#[test]
+fn test_a_failed_archived_board_read_rolls_back_to_the_previous_model() {
+    let mut app = App::test_default();
+    let live_board = app.ctx.create_board("Live".to_string(), None).unwrap();
+    let archived_board = app.ctx.create_board("Archived".to_string(), None).unwrap();
+    app.ctx.archive_board(archived_board.id).unwrap();
+
+    app.selection.active_board_id = Some(live_board.id);
+    app.mode = AppMode::ArchivedBoardsView;
+    app.reload_model();
+    assert_eq!(
+        app.model.archived_boards_state().loaded().map(|v| v.len()),
+        Some(1),
+        "fixture sanity: one archived board seeded"
+    );
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_archived_boards");
+    app.ctx.replace_backend(failing);
+    app.reload_model();
+
+    assert_error_banner(&app);
+    assert_eq!(
+        app.model.archived_boards_state().loaded().map(|v| v.len()),
+        Some(1),
+        "the previous archived boards must survive a failed reload"
+    );
+}
+
+#[test]
+fn test_a_failed_scoped_archived_card_read_rolls_back_to_the_previous_model() {
+    let mut app = App::test_default();
+    let board = app.ctx.create_board("Board".to_string(), None).unwrap();
+    let column = app
+        .ctx
+        .create_column(board.id, "Column".to_string(), None)
+        .unwrap();
+    let card = app
+        .ctx
+        .create_card(
+            board.id,
+            column.id,
+            "Card".to_string(),
+            CreateCardOptions::default(),
+        )
+        .unwrap();
+    app.ctx.archive_card(card.id).unwrap();
+
+    app.selection.active_board_id = Some(board.id);
+    app.mode = AppMode::ArchivedCardsView;
+    app.reload_model();
+    assert_eq!(
+        app.model
+            .board_archived_cards_state(board.id)
+            .loaded()
+            .map(|v| v.len()),
+        Some(1),
+        "fixture sanity: one archived card seeded"
+    );
+
+    let failing = CountingBackend::wrap_failing(app.ctx.backend(), "list_archived_cards_by_board");
+    app.ctx.replace_backend(failing);
+    app.reload_model();
+
+    assert_error_banner(&app);
+    assert_eq!(
+        app.model
+            .board_archived_cards_state(board.id)
+            .loaded()
+            .map(|v| v.len()),
+        Some(1),
+        "the previous archived cards must survive a failed reload"
+    );
 }
 
 #[test]

--- a/crates/kanban-tui/tests/sprint_dialog_refetch_tests.rs
+++ b/crates/kanban-tui/tests/sprint_dialog_refetch_tests.rs
@@ -734,7 +734,20 @@ async fn test_carry_over_sprint_refetches_the_card_tiers_not_the_sprint_list() {
     assert!(!has_op(&refetch, "snapshot"), "got {refetch:?}");
     assert!(has_op(&refetch, "list_cards_by_column"), "got {refetch:?}");
     assert!(!has_op(&refetch, "list_all_sprints"), "got {refetch:?}");
-    let _ = target;
+
+    let state = app.model.column_cards_state(c1.id);
+    let cards = state
+        .loaded()
+        .expect("card tier must be loaded after the carry-over refetch");
+    let moved = cards
+        .iter()
+        .find(|c| c.id == card.id)
+        .expect("the seeded card must still be present");
+    assert_eq!(
+        moved.sprint_id,
+        Some(target.id),
+        "the card must have been carried over onto the target sprint"
+    );
 }
 
 #[tokio::test]

--- a/crates/kanban-view/src/controller/mod.rs
+++ b/crates/kanban-view/src/controller/mod.rs
@@ -502,6 +502,11 @@ mod tests {
         let model_changed_block = prod.split("pub struct ModelChanged").next().unwrap();
         assert!(prod.contains("pub(crate) fn new()"));
         assert!(!prod.contains("pub fn new("));
+        assert!(prod.contains("pub(crate) fn unchanged()"));
+        assert!(
+            !prod.contains("pub fn unchanged("),
+            "a pub unchanged() would let an external caller mint a resync-skipping receipt"
+        );
         assert!(!model_changed_block.contains("derive(Debug, Default)"));
     }
 


### PR DESCRIPTION
## Summary

Test-only card closing eight local coverage gaps found across kanban-view, kanban-domain, kanban-service, kanban-tui and kanban-mcp. No production behaviour changes.

- Added a source-scanning guard extension pinning `ModelChanged::unchanged()` as `pub(crate)`, confirmed red against a widened `pub fn unchanged()`.
- Added five new `reload_model` rollback tests covering the graph, scoped columns, scoped sprints, archived boards, and scoped archived cards tiers, each asserting both the surfaced error and the surviving prior contents. `CountingBackend` in the tui test helpers gained fault hooks on `get_graph`, `list_sprints_by_board`, `list_archived_boards`, and `list_archived_cards_by_board`, since these previously recorded calls but never faulted, which would have made the new tests vacuous.
- Added a kanban-service test that reaches `BatchResolutionCause::Ambiguous` through real `resolve_card_ids` resolution of a bare card number that collides across a live board and a board archived through `KanbanOperations::archive_board`.
- Added a kanban-service test proving a cycle-conflicting `transfer_state_to` leaves the target's entire graph and every entity collection unchanged after reopening from disk, confirmed red against a transaction-less write. Also added an assertion that a transferred edge's `created_at` is regenerated on a non-empty target, per `merge_from`'s documented behaviour.
- Added archived-board pinning tests for MCP `tool_move_card`, `tool_archive_card`, `tool_delete_card`, and the `tool_set_card_parent`/`tool_remove_card_parent` pair, on both JSON and SQLite backends, following the repo's existing `_on_json`/`_on_sqlite` wrapper convention.
- Strengthened the sprint unloadable-list twins to assert the specific injected fault message, matching the existing column twins.
- Strengthened the no-board-in-scope animation guard test with a second board and a positive control routed through multi-select, so the test actually discriminates a regression that removes the archived-tier membership check. Recorded in the card's discrimination pass that the card's originally prescribed `unwrap_or_default()` mutation cannot make this test red on any fixture, since `Uuid::nil()` never keys an entry in `archived_cards_by_board`.
- Fixed several non-discriminating or missing assertions: a dropped `let _ = target;`/`let _ = c3;` binding each replaced with a real assertion, distinct per-board counts in a delete-board-scope test, a missing "move column down" twin, and rounding out the create-card refetch test's negative assertions, plus a stale test rename to match current identifier-based resolution.

## Test plan

- [x] `cargo test --all-features --workspace` (all crates green, zero failures)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Every new central assertion was mutation-checked: production behaviour reverted, test confirmed red, then restored
- [x] `.changeset/kan-1594-local-coverage-gaps.md` present with `bump: patch`
