### PR TITLE
feat(completion): default-status columns across CLI, MCP, TUI

### DIFF
--- a/.changeset/completion-feature-complete.md
+++ b/.changeset/completion-feature-complete.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Completion-column feature completeness across every surface. MCP `tool_create_board` gains `with_default_columns`, seeding the TODO/Doing/Complete template with matching default statuses like the CLI and TUI already do. The TUI create-column dialog can now set a column's `default_status` at creation instead of requiring the separate `s` popup afterwards. The board-settings column list marks the primary completion column (the first status=done column by position, where done cards actually file) distinctly from other done columns. CLI `board create --with-default-columns` now creates the board and its three columns as one atomic command batch, so a mid-seed failure can no longer leave a partial board and undo reverses the whole action in one step. Internally, the status/completion invariant is now encoded once: `CardMoveResult` carries placement only and the service derives the status sync via `target_status_for_column_move`, which drops its unused board parameter.

--- a/crates/kanban-cli/src/context.rs
+++ b/crates/kanban-cli/src/context.rs
@@ -93,6 +93,13 @@ impl CliContext {
         (field, order)
     }
 
+    pub fn execute_commands(
+        &mut self,
+        commands: Vec<kanban_domain::commands::Command>,
+    ) -> KanbanResult<()> {
+        self.inner.execute(commands)
+    }
+
     pub fn archive_cards_detailed(&mut self, ids: Vec<Uuid>) -> BatchOperationResult {
         self.inner.archive_cards_detailed(ids)
     }

--- a/crates/kanban-cli/src/handlers/board.rs
+++ b/crates/kanban-cli/src/handlers/board.rs
@@ -2,6 +2,7 @@ use crate::cli::{BoardAction, BoardUpdateArgs};
 use crate::context::CliContext;
 use crate::output;
 use kanban_core::{resolve_page_params, PaginatedList};
+use kanban_domain::commands::{BoardCommand, ColumnCommand, Command, CreateBoard, CreateColumn};
 use kanban_domain::{ArchivedFilter, BoardListFilter, BoardUpdate, FieldUpdate, KanbanOperations};
 use kanban_service::api::BoardResponse;
 
@@ -12,13 +13,20 @@ pub async fn handle(ctx: &mut CliContext, action: BoardAction) -> anyhow::Result
             card_prefix,
             with_default_columns,
         } => {
-            // Funnels through the Board factory via the name/card_prefix shim
-            // (KAN-792); the JSON edge projects the domain Board via BoardResponse.
-            let board = ctx.create_board(name, card_prefix)?;
             let board = if with_default_columns {
-                seed_default_columns(ctx, board.id)?
+                let board_id = uuid::Uuid::new_v4();
+                let position = ctx.list_boards()?.len() as i32;
+                ctx.execute_commands(build_create_board_batch(
+                    board_id,
+                    name,
+                    card_prefix,
+                    position,
+                ))?;
+                ctx.get_board(board_id)?.ok_or_else(|| {
+                    anyhow::anyhow!("board not found after creating it with default columns")
+                })?
             } else {
-                board
+                ctx.create_board(name, card_prefix)?
             };
             ctx.save().await?;
             output::output_success(BoardResponse::from(&board));
@@ -178,15 +186,31 @@ fn resolve_archived_board(ctx: &CliContext, raw: &str) -> Result<uuid::Uuid, Str
     }
 }
 
-fn seed_default_columns(
-    ctx: &mut CliContext,
+fn build_create_board_batch(
     board_id: uuid::Uuid,
-) -> anyhow::Result<kanban_domain::Board> {
-    for (name, default_status) in kanban_domain::DEFAULT_TEMPLATE_COLUMNS {
-        ctx.create_column_with_default_status(board_id, name.to_string(), None, default_status)?;
+    name: String,
+    card_prefix: Option<String>,
+    position: i32,
+) -> Vec<Command> {
+    let mut commands = vec![Command::Board(BoardCommand::Create(CreateBoard {
+        id: board_id,
+        name,
+        card_prefix,
+        position,
+    }))];
+    for (position, (name, default_status)) in kanban_domain::DEFAULT_TEMPLATE_COLUMNS
+        .into_iter()
+        .enumerate()
+    {
+        commands.push(Command::Column(ColumnCommand::Create(CreateColumn {
+            id: uuid::Uuid::new_v4(),
+            board_id,
+            name: name.to_string(),
+            position: position as i32,
+            default_status,
+        })));
     }
-    ctx.get_board(board_id)?
-        .ok_or_else(|| anyhow::anyhow!("board not found after seeding default columns"))
+    commands
 }
 
 async fn handle_update(
@@ -217,4 +241,46 @@ async fn handle_update(
     let board = ctx.update_board(uuid, updates)?;
     ctx.save().await?;
     Ok(board)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanban_domain::commands::{BoardCommand, ColumnCommand, Command};
+    use kanban_domain::CardStatus;
+
+    #[test]
+    fn test_build_create_board_batch_builds_board_then_template_columns_in_one_batch() {
+        let board_id = uuid::Uuid::new_v4();
+        let commands =
+            build_create_board_batch(board_id, "Board".to_string(), Some("KAN".to_string()), 2);
+
+        assert_eq!(commands.len(), 4);
+        match &commands[0] {
+            Command::Board(BoardCommand::Create(create)) => {
+                assert_eq!(create.id, board_id);
+                assert_eq!(create.name, "Board");
+                assert_eq!(create.card_prefix.as_deref(), Some("KAN"));
+                assert_eq!(create.position, 2);
+            }
+            other => panic!("expected board create first, got {:?}", other),
+        }
+
+        let expected = [
+            ("TODO", 0, Some(CardStatus::Todo)),
+            ("Doing", 1, Some(CardStatus::InProgress)),
+            ("Complete", 2, Some(CardStatus::Done)),
+        ];
+        for (command, (name, position, default_status)) in commands[1..].iter().zip(expected) {
+            match command {
+                Command::Column(ColumnCommand::Create(create)) => {
+                    assert_eq!(create.board_id, board_id);
+                    assert_eq!(create.name, name);
+                    assert_eq!(create.position, position);
+                    assert_eq!(create.default_status, default_status);
+                }
+                other => panic!("expected column create, got {:?}", other),
+            }
+        }
+    }
 }

--- a/crates/kanban-cli/tests/cli_integration.rs
+++ b/crates/kanban-cli/tests/cli_integration.rs
@@ -6011,21 +6011,22 @@ mod default_columns_tests {
             .clone();
         let json = parse_json_output(&String::from_utf8_lossy(&list_output));
         let items = json["data"]["items"].as_array().unwrap();
-        let names_and_positions: Vec<(String, i64)> = items
+        let columns: Vec<(String, i64, String)> = items
             .iter()
             .map(|c| {
                 (
                     c["name"].as_str().unwrap().to_string(),
                     c["position"].as_i64().unwrap(),
+                    c["default_status"].as_str().unwrap().to_string(),
                 )
             })
             .collect();
         assert_eq!(
-            names_and_positions,
+            columns,
             vec![
-                ("TODO".to_string(), 0),
-                ("Doing".to_string(), 1),
-                ("Complete".to_string(), 2),
+                ("TODO".to_string(), 0, "todo".to_string()),
+                ("Doing".to_string(), 1, "in_progress".to_string()),
+                ("Complete".to_string(), 2, "done".to_string()),
             ]
         );
     }

--- a/crates/kanban-domain/src/card_lifecycle.rs
+++ b/crates/kanban-domain/src/card_lifecycle.rs
@@ -61,13 +61,13 @@ pub struct CompletionToggleResult {
     pub new_position: i32,
 }
 
-/// Result of computing a column move.
+/// Result of computing a column move. Carries only placement: the status
+/// sync is the service layer's job, derived via
+/// [`target_status_for_column_move`] when the move commits.
 #[derive(Debug, Clone)]
 pub struct CardMoveResult {
     pub target_column_id: Uuid,
     pub new_position: i32,
-    /// If Some, the card's status should be changed to this value.
-    pub new_status: Option<CardStatus>,
 }
 
 fn column_is_completion(columns: &[Column], column_id: Uuid) -> bool {
@@ -124,36 +124,22 @@ pub fn compute_completion_toggle(
     columns: &[Column],
     cards: &[Card],
 ) -> Option<CompletionToggleResult> {
-    let completion_col_id = primary_completion_column_id(board.id, columns)?;
-
-    if card.status == CardStatus::Done {
-        if column_is_completion(columns, card.column_id) {
-            let target_col_id = uncomplete_target_column(card, board, columns)?;
-            let new_position = next_position_in_column(cards, target_col_id);
-            Some(CompletionToggleResult {
-                new_status: CardStatus::Todo,
-                target_column_id: target_col_id,
-                new_position,
-            })
-        } else {
-            None
-        }
-    } else if column_is_completion(columns, card.column_id) {
-        None
+    let new_status = if card.status == CardStatus::Done {
+        CardStatus::Todo
     } else {
-        let new_position = next_position_in_column(cards, completion_col_id);
-        Some(CompletionToggleResult {
-            new_status: CardStatus::Done,
-            target_column_id: completion_col_id,
-            new_position,
-        })
-    }
+        CardStatus::Done
+    };
+    let target_column_id = target_column_for_status(card, new_status, board, columns)?;
+    Some(CompletionToggleResult {
+        new_status,
+        target_column_id,
+        new_position: next_position_in_column(cards, target_column_id),
+    })
 }
 
 /// Compute the result of moving a card left or right between columns.
 ///
 /// Returns `None` if there is no column in that direction.
-/// Includes a status change if moving to/from the completion column.
 pub fn compute_card_column_move(
     card: &Card,
     board: &Board,
@@ -182,23 +168,9 @@ pub fn compute_card_column_move(
     let target_col = sorted[target_idx];
     let new_position = next_position_in_column(cards, target_col.id);
 
-    let is_moving_to_completion = column_is_completion(columns, target_col.id);
-    let is_moving_from_completion = column_is_completion(columns, card.column_id);
-    let new_status = if is_moving_to_completion && card.status != CardStatus::Done {
-        Some(CardStatus::Done)
-    } else if !is_moving_to_completion
-        && is_moving_from_completion
-        && card.status == CardStatus::Done
-    {
-        Some(CardStatus::Todo)
-    } else {
-        None
-    };
-
     Some(CardMoveResult {
         target_column_id: target_col.id,
         new_position,
-        new_status,
     })
 }
 
@@ -235,10 +207,8 @@ pub fn target_column_for_status(
 pub fn target_status_for_column_move(
     card: &Card,
     new_column_id: Uuid,
-    board: &Board,
     columns: &[Column],
 ) -> Option<CardStatus> {
-    let _ = board;
     let moving_to_completion = column_is_completion(columns, new_column_id);
     let was_in_completion = column_is_completion(columns, card.column_id);
 
@@ -390,7 +360,7 @@ mod tests {
         let mut card = test_card(&board, last, "In Decision", 0);
         card.status = CardStatus::Todo;
         assert_eq!(
-            target_status_for_column_move(&card, last.id, &board, &cols),
+            target_status_for_column_move(&card, last.id, &cols),
             None,
             "moving into the non-configured last column must not set Done"
         );
@@ -414,7 +384,7 @@ mod tests {
         card.column_id = last.id;
 
         assert_eq!(
-            target_status_for_column_move(&card, last.id, &board, &cols),
+            target_status_for_column_move(&card, last.id, &cols),
             None,
             "a board with no completion column configured must not infer \
              completion from column position"
@@ -435,7 +405,7 @@ mod tests {
         card.status = CardStatus::Done;
         card.column_id = cols[2].id;
         assert_eq!(
-            target_status_for_column_move(&card, cols[0].id, &board, &cols),
+            target_status_for_column_move(&card, cols[0].id, &cols),
             None,
             "moves must never restatus a card when the list is empty"
         );
@@ -683,7 +653,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result.target_column_id, cols[1].id);
-        assert_eq!(result.new_status, Some(CardStatus::Done));
+        assert_eq!(
+            target_status_for_column_move(&card, result.target_column_id, &cols),
+            Some(CardStatus::Done)
+        );
     }
 
     #[test]
@@ -703,7 +676,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result.target_column_id, cols[0].id);
-        assert_eq!(result.new_status, Some(CardStatus::Todo));
+        assert_eq!(
+            target_status_for_column_move(&card, result.target_column_id, &cols),
+            Some(CardStatus::Todo)
+        );
     }
 
     #[test]
@@ -753,7 +729,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result.target_column_id, cols[1].id);
-        assert_eq!(result.new_status, None);
+        assert_eq!(
+            target_status_for_column_move(&card, result.target_column_id, &cols),
+            None
+        );
     }
 
     #[test]
@@ -849,7 +828,7 @@ mod tests {
         cols[2].default_status = Some(CardStatus::Done);
         let card = test_card(&board, &cols[0], "Task", 0);
 
-        let status = target_status_for_column_move(&card, cols[2].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[2].id, &cols);
         assert_eq!(status, Some(CardStatus::Done));
     }
 
@@ -860,7 +839,7 @@ mod tests {
         cols[2].default_status = Some(CardStatus::Done);
         let card = test_card(&board, &cols[0], "Task", 0);
 
-        let status = target_status_for_column_move(&card, cols[3].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[3].id, &cols);
         assert_eq!(status, None);
     }
 
@@ -872,7 +851,7 @@ mod tests {
         let mut card = test_card(&board, &cols[2], "Task", 0);
         card.status = CardStatus::Done;
 
-        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[1].id, &cols);
         assert_eq!(status, Some(CardStatus::Todo));
     }
 
@@ -885,7 +864,7 @@ mod tests {
         let mut card = test_card(&board, &cols[2], "Task", 0);
         card.status = CardStatus::Done;
 
-        let status = target_status_for_column_move(&card, cols[3].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[3].id, &cols);
         assert_eq!(status, None);
     }
 
@@ -905,7 +884,7 @@ mod tests {
         let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Todo;
 
-        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[1].id, &cols);
         assert_eq!(status, Some(CardStatus::InProgress));
     }
 
@@ -915,7 +894,7 @@ mod tests {
         let mut card = test_card(&board, &cols[2], "Task", 0);
         card.status = CardStatus::Done;
 
-        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[1].id, &cols);
         assert_eq!(status, Some(CardStatus::InProgress));
     }
 
@@ -925,7 +904,7 @@ mod tests {
         let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Blocked;
 
-        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[1].id, &cols);
         assert_eq!(status, None);
     }
 
@@ -935,7 +914,7 @@ mod tests {
         let mut card = test_card(&board, &cols[1], "Task", 0);
         card.status = CardStatus::InProgress;
 
-        let status = target_status_for_column_move(&card, cols[0].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[0].id, &cols);
         assert_eq!(status, None);
     }
 
@@ -950,7 +929,7 @@ mod tests {
         let mut card = test_card(&board, todo, "Task", 0);
         card.status = CardStatus::Todo;
         assert_eq!(
-            target_status_for_column_move(&card, doing.id, &board, &cols),
+            target_status_for_column_move(&card, doing.id, &cols),
             Some(CardStatus::InProgress),
             "TODO -> Doing must promote to in_progress"
         );
@@ -958,7 +937,7 @@ mod tests {
         card.status = CardStatus::InProgress;
         card.column_id = doing.id;
         assert_eq!(
-            target_status_for_column_move(&card, complete.id, &board, &cols),
+            target_status_for_column_move(&card, complete.id, &cols),
             Some(CardStatus::Done),
             "Doing -> Complete must set done"
         );
@@ -966,7 +945,7 @@ mod tests {
         card.status = CardStatus::Done;
         card.column_id = complete.id;
         assert_eq!(
-            target_status_for_column_move(&card, doing.id, &board, &cols),
+            target_status_for_column_move(&card, doing.id, &cols),
             Some(CardStatus::InProgress),
             "Complete -> Doing must uncomplete then promote to in_progress"
         );
@@ -980,7 +959,7 @@ mod tests {
         let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Blocked;
 
-        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[1].id, &cols);
         assert_eq!(
             status, None,
             "a blocked card moved into an in-progress column must stay blocked"
@@ -994,7 +973,7 @@ mod tests {
         let mut card = test_card(&board, &cols[0], "Task", 0);
         card.status = CardStatus::Todo;
 
-        let status = target_status_for_column_move(&card, cols[1].id, &board, &cols);
+        let status = target_status_for_column_move(&card, cols[1].id, &cols);
         assert_eq!(status, None);
     }
 

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -10,9 +10,9 @@ pub use error::{KanbanMcpError, KanbanMcpResult};
 pub use server::McpServer;
 
 pub use requests::board::{
-    ArchiveBoardRequest, CreateBoardRequest, DeleteArchivedBoardRequest, DeleteBoardRequest,
-    GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, SetBoardSortRequest,
-    UpdateBoardRequest,
+    ArchiveBoardRequest, CreateBoardParams, CreateBoardRequest, DeleteArchivedBoardRequest,
+    DeleteBoardRequest, GetBoardRequest, ListBoardsRequest, RestoreBoardRequest,
+    SetBoardSortRequest, UpdateBoardRequest,
 };
 pub use requests::card::{
     ArchiveCardRequest, ArchiveCardsRequest, AssignCardToSprintRequest, AssignCardsToSprintRequest,

--- a/crates/kanban-mcp/src/requests/board.rs
+++ b/crates/kanban-mcp/src/requests/board.rs
@@ -8,6 +8,16 @@ use serde::Deserialize;
 pub use kanban_service::api::CreateBoardRequest;
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CreateBoardParams {
+    #[serde(flatten)]
+    pub content: CreateBoardRequest,
+    #[schemars(
+        description = "Seed the board with the standard template columns (TODO, Doing, Complete) with default statuses todo, in_progress, done"
+    )]
+    pub with_default_columns: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetBoardRequest {
     #[schemars(description = "UUID or name of the board to retrieve")]
     pub board: String,

--- a/crates/kanban-mcp/src/requests/mod.rs
+++ b/crates/kanban-mcp/src/requests/mod.rs
@@ -4,7 +4,9 @@ pub mod column;
 pub mod sprint;
 pub mod transfer;
 
-pub use board::{CreateBoardRequest, DeleteBoardRequest, GetBoardRequest, UpdateBoardRequest};
+pub use board::{
+    CreateBoardParams, CreateBoardRequest, DeleteBoardRequest, GetBoardRequest, UpdateBoardRequest,
+};
 pub use card::{
     ArchiveCardRequest, ArchiveCardsRequest, AssignCardToSprintRequest, AssignCardsToSprintRequest,
     CreateCardParams, DeleteCardRequest, GetCardBranchNameRequest, GetCardGitCheckoutRequest,

--- a/crates/kanban-mcp/src/tools/board.rs
+++ b/crates/kanban-mcp/src/tools/board.rs
@@ -1,10 +1,10 @@
 use crate::helpers::{
-    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, mutating_op,
-    parse_archived_selector, parse_board_sort_field, parse_sort_field, parse_sort_order,
-    to_call_tool_result, to_call_tool_result_json, McpResolve,
+    core_err_to_mcp, kanban_err_to_mcp, locked_read, locked_write, parse_archived_selector,
+    parse_board_sort_field, parse_sort_field, parse_sort_order, to_call_tool_result,
+    to_call_tool_result_json, McpResolve,
 };
 use crate::requests::board::{
-    ArchiveBoardRequest, CreateBoardRequest, DeleteArchivedBoardRequest, DeleteBoardRequest,
+    ArchiveBoardRequest, CreateBoardParams, DeleteArchivedBoardRequest, DeleteBoardRequest,
     GetBoardRequest, ListBoardsRequest, RestoreBoardRequest, SetBoardSortRequest,
     UpdateBoardRequest,
 };
@@ -23,16 +23,39 @@ use uuid::Uuid;
 
 #[tool_router(router = board_router, vis = "pub(crate)")]
 impl KanbanMcpServer {
-    #[tool(description = "Create a new kanban board")]
+    #[tool(
+        description = "Create a new kanban board. Pass with_default_columns=true to seed the standard template columns (TODO, Doing, Complete) with default statuses todo, in_progress, done."
+    )]
     pub async fn tool_create_board(
         &self,
-        Parameters(req): Parameters<CreateBoardRequest>,
+        Parameters(req): Parameters<CreateBoardParams>,
     ) -> Result<CallToolResult, McpError> {
         // Funnel through the Board factory: split the shared DTO into its
         // optional client id + content spec, then create-from-spec. The JSON
         // edge projects the resulting domain Board via BoardResponse.
-        let (id, spec) = req.into_new_board();
-        let board = mutating_op!(self.ctx, create_board_from_spec, id, spec)?;
+        let (id, spec) = req.content.into_new_board();
+        let seed_columns = req.with_default_columns.unwrap_or(false);
+        let board = locked_write(&self.ctx, |ctx| {
+            let board = ctx
+                .create_board_from_spec(id, spec)
+                .map_err(kanban_err_to_mcp)?;
+            if seed_columns {
+                for (name, default_status) in kanban_domain::DEFAULT_TEMPLATE_COLUMNS {
+                    ctx.create_column_from_spec(
+                        None,
+                        kanban_domain::NewColumn {
+                            board_id: board.id,
+                            name: name.to_string(),
+                            wip_limit: None,
+                            default_status,
+                        },
+                    )
+                    .map_err(kanban_err_to_mcp)?;
+                }
+            }
+            Ok::<_, McpError>(board)
+        })
+        .await?;
         to_call_tool_result(&BoardResponse::from(&board))
     }
 

--- a/crates/kanban-mcp/tests/integration.rs
+++ b/crates/kanban-mcp/tests/integration.rs
@@ -779,7 +779,7 @@ async fn require_same_board_rejects_cross_board_on_mcp() {
 // ============================================================================
 
 use kanban_mcp::{
-    ArchiveBoardRequest, AssignCardToSprintRequest, CarryOverSprintCardsRequest,
+    ArchiveBoardRequest, AssignCardToSprintRequest, CarryOverSprintCardsRequest, CreateBoardParams,
     CreateBoardRequest, CreateCardParams, CreateColumnParams, CreateSprintParams,
     DeleteArchivedBoardRequest, GetBoardRequest, GetCardRequest, GetColumnRequest,
     GetSprintRequest, KanbanMcpServer, ListBoardsRequest, ListColumnsRequest, ListSprintsRequest,
@@ -805,17 +805,20 @@ async fn setup_server() -> (KanbanMcpServer, TempDir) {
 /// Minimal-path board-create request: just name + card_prefix, the only fields
 /// these seed-helpers need. The shared `CreateBoardRequest` carries the full
 /// create spec; the remaining fields default to `None`.
-fn board_req(name: &str, card_prefix: Option<String>) -> CreateBoardRequest {
-    CreateBoardRequest {
-        id: None,
-        name: name.to_string(),
-        description: None,
-        sprint_prefix: None,
-        card_prefix,
-        task_sort_field: None,
-        task_sort_order: None,
-        sprint_duration_days: None,
-        task_list_view: None,
+fn board_req(name: &str, card_prefix: Option<String>) -> CreateBoardParams {
+    CreateBoardParams {
+        content: CreateBoardRequest {
+            id: None,
+            name: name.to_string(),
+            description: None,
+            sprint_prefix: None,
+            card_prefix,
+            task_sort_field: None,
+            task_sort_order: None,
+            sprint_duration_days: None,
+            task_list_view: None,
+        },
+        with_default_columns: None,
     }
 }
 
@@ -931,6 +934,65 @@ async fn test_mcp_update_column_sets_default_status() {
         .unwrap();
     let body = text_payload(&result);
     assert_eq!(body["default_status"], "in_progress");
+}
+
+async fn list_column_items(server: &KanbanMcpServer, board: &str) -> Vec<Value> {
+    let result = server
+        .tool_list_columns(Parameters(ListColumnsRequest {
+            board: board.to_string(),
+            page: None,
+            page_size: None,
+        }))
+        .await
+        .unwrap();
+    text_payload(&result)["items"]
+        .as_array()
+        .expect("items array")
+        .clone()
+}
+
+#[tokio::test]
+async fn test_create_board_with_default_columns_seeds_template_columns() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(CreateBoardParams {
+            with_default_columns: Some(true),
+            ..board_req("B", None)
+        }))
+        .await
+        .unwrap();
+
+    let items = list_column_items(&server, "B").await;
+    let expected = [
+        ("TODO", "todo"),
+        ("Doing", "in_progress"),
+        ("Complete", "done"),
+    ];
+    assert_eq!(items.len(), expected.len());
+    for (position, (name, default_status)) in expected.iter().enumerate() {
+        assert_eq!(items[position]["name"], *name);
+        assert_eq!(items[position]["position"], position);
+        assert_eq!(items[position]["default_status"], *default_status);
+    }
+}
+
+#[tokio::test]
+async fn test_create_board_without_default_columns_flag_creates_no_columns() {
+    let (server, _tmp) = setup_server().await;
+    server
+        .tool_create_board(Parameters(board_req("Omitted", None)))
+        .await
+        .unwrap();
+    server
+        .tool_create_board(Parameters(CreateBoardParams {
+            with_default_columns: Some(false),
+            ..board_req("Explicit", None)
+        }))
+        .await
+        .unwrap();
+
+    assert!(list_column_items(&server, "Omitted").await.is_empty());
+    assert!(list_column_items(&server, "Explicit").await.is_empty());
 }
 
 #[tokio::test]
@@ -1568,7 +1630,7 @@ async fn test_mcp_create_board_uses_shared_dto() {
 
     // The shared DTO carries the full create spec (not just name/card_prefix):
     // a client passing extra fields must have them applied through the factory.
-    let req: CreateBoardRequest = serde_json::from_value(serde_json::json!({
+    let req: CreateBoardParams = serde_json::from_value(serde_json::json!({
         "name": "Roadmap",
         "card_prefix": "KAN",
         "sprint_prefix": "SPR",

--- a/crates/kanban-service/src/context/cards_batch.rs
+++ b/crates/kanban-service/src/context/cards_batch.rs
@@ -147,15 +147,11 @@ impl KanbanContext {
         let Some(column) = self.backend.get_column(new_column_id)? else {
             return Ok(None);
         };
-        let Some(board) = self.backend.get_board(column.board_id)? else {
-            return Ok(None);
-        };
-        let columns = self.backend.list_columns_by_board(board.id)?;
+        let columns = self.backend.list_columns_by_board(column.board_id)?;
         Ok(
             kanban_domain::card_lifecycle::target_status_for_column_move(
                 &card,
                 new_column_id,
-                &board,
                 &columns,
             ),
         )

--- a/crates/kanban-tui/src/app/dialog_input.rs
+++ b/crates/kanban-tui/src/app/dialog_input.rs
@@ -12,6 +12,13 @@ pub enum CreateCardFocus {
     Sprint,
 }
 
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CreateColumnFocus {
+    #[default]
+    Name,
+    Status,
+}
+
 pub struct DialogInputState {
     pub import_files: Vec<String>,
     pub import_selection: SelectionState,
@@ -24,6 +31,7 @@ pub struct DialogInputState {
     pub carry_over_source_sprint_id: Option<Uuid>,
     pub create_card_sprint_picker: SprintPicker,
     pub create_card_focus: CreateCardFocus,
+    pub create_column_focus: CreateColumnFocus,
     pub create_card_column_input: InputState,
     create_card_column_editable: bool,
     create_card_sprint_visible: bool,
@@ -52,6 +60,7 @@ impl Default for DialogInputState {
             carry_over_source_sprint_id: None,
             create_card_sprint_picker: SprintPicker::with_filter(SprintFilter::ActiveOnly),
             create_card_focus: CreateCardFocus::default(),
+            create_column_focus: CreateColumnFocus::default(),
             create_card_column_input: InputState::default(),
             create_card_column_editable: false,
             create_card_sprint_visible: true,
@@ -104,6 +113,21 @@ impl DialogInputState {
 
     pub fn reset_create_card_focus(&mut self) {
         self.create_card_focus = CreateCardFocus::Title;
+    }
+
+    pub fn create_column_focus_is_name(&self) -> bool {
+        self.create_column_focus == CreateColumnFocus::Name
+    }
+
+    pub fn toggle_create_column_focus(&mut self) {
+        self.create_column_focus = match self.create_column_focus {
+            CreateColumnFocus::Name => CreateColumnFocus::Status,
+            CreateColumnFocus::Status => CreateColumnFocus::Name,
+        };
+    }
+
+    pub fn reset_create_column_focus(&mut self) {
+        self.create_column_focus = CreateColumnFocus::Name;
     }
 
     pub fn prime_create_card_column_field(&mut self, name: String, editable: bool) {

--- a/crates/kanban-tui/src/handlers/column_handlers.rs
+++ b/crates/kanban-tui/src/handlers/column_handlers.rs
@@ -14,6 +14,10 @@ impl App {
                 if self.active_board().is_some() {
                     self.open_dialog(DialogMode::CreateColumn);
                     self.input.clear();
+                    self.dialog_input.default_status_selection.set(Some(
+                        kanban_view::selection_dialog::popup_index_of_default_status(None),
+                    ));
+                    self.dialog_input.reset_create_column_focus();
                 }
             }
         }
@@ -243,12 +247,19 @@ impl App {
                     .unwrap_or(-1)
                     + 1;
 
+                let default_status = self
+                    .dialog_input
+                    .default_status_selection
+                    .get()
+                    .and_then(kanban_view::selection_dialog::default_status_at_popup_index)
+                    .flatten();
+
                 let cmd = Command::Column(ColumnCommand::Create(CreateColumn {
                     id: uuid::Uuid::new_v4(),
                     board_id,
                     name: column_name.clone(),
                     position,
-                    default_status: None,
+                    default_status,
                 }));
 
                 let prior_column_count = self
@@ -441,30 +452,61 @@ impl App {
         }
     }
 
+    fn close_create_column_dialog(&mut self) {
+        self.pop_mode();
+        self.focus.board_focus = BoardFocus::Columns;
+        self.input.clear();
+        self.dialog_input.default_status_selection.clear();
+        self.dialog_input.reset_create_column_focus();
+    }
+
     pub fn handle_create_column_dialog(&mut self, key_code: KeyCode) {
+        // Enter always submits and Tab always toggles focus, regardless of
+        // which sub-field currently has focus.
         match key_code {
             KeyCode::Esc => {
-                self.pop_mode();
-                self.focus.board_focus = BoardFocus::Columns;
-                self.input.clear();
+                self.close_create_column_dialog();
+                return;
             }
             KeyCode::Enter => {
                 self.create_column();
-                self.pop_mode();
-                self.focus.board_focus = BoardFocus::Columns;
-                self.input.clear();
+                self.close_create_column_dialog();
+                return;
             }
-            KeyCode::Char(c) => {
-                self.input.insert_char(c);
+            KeyCode::Tab => {
+                self.dialog_input.toggle_create_column_focus();
+                return;
             }
-            KeyCode::Backspace => {
-                self.input.backspace();
+            _ => {}
+        }
+
+        if self.dialog_input.create_column_focus_is_name() {
+            match key_code {
+                KeyCode::Char(c) => {
+                    self.input.insert_char(c);
+                }
+                KeyCode::Backspace => {
+                    self.input.backspace();
+                }
+                KeyCode::Left => {
+                    self.input.move_left();
+                }
+                KeyCode::Right => {
+                    self.input.move_right();
+                }
+                _ => {}
             }
-            KeyCode::Left => {
-                self.input.move_left();
+            return;
+        }
+
+        match key_code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.dialog_input
+                    .default_status_selection
+                    .next(kanban_view::selection_dialog::DEFAULT_STATUS_POPUP_ORDER.len());
             }
-            KeyCode::Right => {
-                self.input.move_right();
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.dialog_input.default_status_selection.prev();
             }
             _ => {}
         }

--- a/crates/kanban-tui/src/keybindings/dialog_modes.rs
+++ b/crates/kanban-tui/src/keybindings/dialog_modes.rs
@@ -89,6 +89,48 @@ impl KeybindingProvider for DialogInputProvider {
     }
 }
 
+pub struct CreateColumnDialogProvider;
+
+impl KeybindingProvider for CreateColumnDialogProvider {
+    fn get_context(&self) -> KeybindingContext {
+        KeybindingContext::new(
+            "Create Column - Input Dialog",
+            vec![
+                Keybinding::new(
+                    "ESC",
+                    "cancel",
+                    "Cancel and close dialog",
+                    KeybindingAction::Escape,
+                ),
+                Keybinding::new(
+                    "Enter",
+                    "confirm",
+                    "Create column",
+                    KeybindingAction::SelectItem,
+                ),
+                Keybinding::new(
+                    "Tab",
+                    "switch field",
+                    "Switch between name and default status",
+                    KeybindingAction::NavigateRight,
+                ),
+                Keybinding::new(
+                    "Type",
+                    "input",
+                    "Enter column name",
+                    KeybindingAction::EditCard,
+                ),
+                Keybinding::new(
+                    "j/↓ k/↑",
+                    "status",
+                    "Choose default status (when selector focused)",
+                    KeybindingAction::NavigateDown,
+                ),
+            ],
+        )
+    }
+}
+
 pub struct DialogSelectionProvider {
     dialog_name: String,
 }

--- a/crates/kanban-tui/src/keybindings/registry.rs
+++ b/crates/kanban-tui/src/keybindings/registry.rs
@@ -3,9 +3,10 @@ use super::{
     card_detail::CardDetailProvider,
     card_list::CardListProvider,
     dialog_modes::{
-        ConfirmSprintPrefixCollisionProvider, ConflictResolutionProvider, DeleteConfirmProvider,
-        DialogInputProvider, DialogSelectionProvider, ErrorLogProvider,
-        ExternalChangeDetectedProvider, FilterOptionsProvider, SearchModeProvider,
+        ConfirmSprintPrefixCollisionProvider, ConflictResolutionProvider,
+        CreateColumnDialogProvider, DeleteConfirmProvider, DialogInputProvider,
+        DialogSelectionProvider, ErrorLogProvider, ExternalChangeDetectedProvider,
+        FilterOptionsProvider, SearchModeProvider,
     },
     normal_mode::{
         ArchivedBoardsViewProvider, ArchivedCardsViewProvider, NormalModeBoardsProvider,
@@ -73,7 +74,7 @@ impl KeybindingRegistry {
                 DialogMode::SetColumnDefaultStatus => {
                     Box::new(DialogSelectionProvider::new("Set Default Status"))
                 }
-                DialogMode::CreateColumn => Box::new(DialogInputProvider::new("Create Column")),
+                DialogMode::CreateColumn => Box::new(CreateColumnDialogProvider),
                 DialogMode::ExportBoard => Box::new(DialogInputProvider::new("Export Project")),
                 DialogMode::ExportAll => Box::new(DialogInputProvider::new("Export All Projects")),
                 DialogMode::SetCardPoints => Box::new(DialogInputProvider::new("Set Points")),

--- a/crates/kanban-tui/src/ui/board_detail.rs
+++ b/crates/kanban-tui/src/ui/board_detail.rs
@@ -260,6 +260,12 @@ fn render_board_columns_list(
         let all_cards = app.model.live_cards();
         let is_focused = app.focus.board_focus == BoardFocus::Columns;
         let viewport_height = area.height.saturating_sub(2) as usize;
+        let primary_completion_id =
+            kanban_domain::completion_derivation::primary_completion_column(
+                board.id,
+                app.model.columns(),
+            )
+            .map(|c| c.id);
 
         // Refreshed here rather than relying on a handler having run first:
         // jumping straight to the Columns panel (key '5') sets focus without
@@ -297,14 +303,8 @@ fn render_board_columns_list(
                 Span::styled(&column.name, base_style),
                 Span::styled(format!(" ({})", card_count), label_text()),
             ];
-            if let Some(status) = column.default_status {
-                spans.push(Span::styled(
-                    format!(
-                        " [{}]",
-                        kanban_view::selection_dialog::default_status_label(Some(status))
-                    ),
-                    label_text(),
-                ));
+            if let Some(suffix) = column_status_suffix(column, primary_completion_id) {
+                spans.push(Span::styled(format!(" {}", suffix), label_text()));
             }
 
             column_lines.push(Line::from(spans));
@@ -313,6 +313,20 @@ fn render_board_columns_list(
 
     let columns = Paragraph::new(column_lines).block(columns_config.block());
     frame.render_widget(columns, area);
+}
+
+fn column_status_suffix(
+    column: &kanban_domain::Column,
+    primary_completion_id: Option<uuid::Uuid>,
+) -> Option<String> {
+    let status = column.default_status?;
+    let label = kanban_view::selection_dialog::default_status_label(Some(status));
+    let star = if primary_completion_id == Some(column.id) {
+        "*"
+    } else {
+        ""
+    };
+    Some(format!("[{}{}]", label, star))
 }
 
 fn columns_empty_state_message(total_columns: usize) -> &'static str {
@@ -326,6 +340,47 @@ fn columns_empty_state_message(total_columns: usize) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kanban_domain::{CardStatus, Column};
+    use uuid::Uuid;
+
+    fn make_column(default_status: Option<CardStatus>) -> Column {
+        let mut col = Column::new(Uuid::new_v4(), "col", 0);
+        col.default_status = default_status;
+        col
+    }
+
+    #[test]
+    fn test_column_status_suffix_for_primary_completion_column_is_done_starred() {
+        let col = make_column(Some(CardStatus::Done));
+        assert_eq!(
+            column_status_suffix(&col, Some(col.id)),
+            Some("[Done*]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_column_status_suffix_for_secondary_done_column_is_done() {
+        let col = make_column(Some(CardStatus::Done));
+        assert_eq!(
+            column_status_suffix(&col, Some(Uuid::new_v4())),
+            Some("[Done]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_column_status_suffix_for_in_progress_column_is_unstarred_label() {
+        let col = make_column(Some(CardStatus::InProgress));
+        assert_eq!(
+            column_status_suffix(&col, Some(Uuid::new_v4())),
+            Some("[In Progress]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_column_status_suffix_without_default_status_is_none() {
+        let col = make_column(None);
+        assert_eq!(column_status_suffix(&col, Some(Uuid::new_v4())), None);
+    }
 
     #[test]
     fn test_columns_empty_state_message_when_board_has_no_columns() {

--- a/crates/kanban-tui/src/ui/dialogs/columns.rs
+++ b/crates/kanban-tui/src/ui/dialogs/columns.rs
@@ -1,16 +1,90 @@
 use crate::app::App;
 use crate::components::*;
 use crate::theme::*;
-use ratatui::{widgets::ListItem, Frame};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    Frame,
+};
 
 pub(crate) fn render_create_column_popup(app: &App, frame: &mut Frame) {
-    render_input_popup(
-        frame,
-        "Create New Column",
-        "Column Name:",
-        app.input.as_str(),
-        app.input.cursor_byte_offset(),
+    let statuses = kanban_view::selection_dialog::DEFAULT_STATUS_POPUP_ORDER;
+    let dialog_height = (1 + 3 + 1 + statuses.len() + 2 + 6) as u16;
+    let area = centered_rect_abs(60, dialog_height, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title("Create New Column")
+        .borders(Borders::ALL)
+        .style(Style::default().bg(Color::Black));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    let name_focused = app.dialog_input.create_column_focus_is_name();
+    let unfocused_border = Style::default().fg(Color::DarkGray);
+
+    frame.render_widget(
+        Paragraph::new("Column Name:").style(Style::default().fg(Color::Yellow)),
+        chunks[0],
     );
+
+    let input = Paragraph::new(app.input.as_str())
+        .style(crate::theme::normal_text())
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(if name_focused {
+                    crate::theme::focused_border()
+                } else {
+                    unfocused_border
+                }),
+        );
+    frame.render_widget(input, chunks[1]);
+    if name_focused {
+        let cursor_x = chunks[1].x + app.input.cursor_byte_offset() as u16 + 1;
+        let cursor_y = chunks[1].y + 1;
+        frame.set_cursor_position((cursor_x, cursor_y));
+    }
+
+    frame.render_widget(
+        Paragraph::new("Default Status (Tab to switch, j/k to select):")
+            .style(Style::default().fg(Color::Yellow)),
+        chunks[2],
+    );
+
+    let selected = app.dialog_input.default_status_selection.get();
+    let items: Vec<ListItem> = statuses
+        .iter()
+        .enumerate()
+        .map(|(idx, (_, label))| {
+            let style = if Some(idx) == selected {
+                bold_highlight()
+            } else {
+                normal_text()
+            };
+            ListItem::new(*label).style(style)
+        })
+        .collect();
+    let list = List::new(items).block(Block::default().borders(Borders::ALL).border_style(
+        if name_focused {
+            unfocused_border
+        } else {
+            crate::theme::focused_border()
+        },
+    ));
+    frame.render_widget(list, chunks[3]);
 }
 
 pub(crate) fn render_rename_column_popup(app: &App, frame: &mut Frame) {

--- a/crates/kanban-tui/tests/column_default_status_tests.rs
+++ b/crates/kanban-tui/tests/column_default_status_tests.rs
@@ -147,6 +147,125 @@ fn test_column_edit_dialog_clears_default_status() {
 }
 
 #[test]
+fn test_create_column_dialog_status_selection_creates_column_with_chosen_default_status() {
+    let mut app = App::test_default();
+    let (_todo, _doing, _done) = setup_board_with_columns(&mut app);
+    let board_id = app.selection.active_board_id.unwrap();
+
+    app.focus.board_focus = BoardFocus::Columns;
+    app.handle_create_column_key();
+    assert_eq!(
+        app.mode,
+        AppMode::Dialog(DialogMode::CreateColumn),
+        "dialog must open"
+    );
+
+    for ch in "Review".chars() {
+        app.handle_create_column_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_column_dialog(KeyCode::Tab);
+    let done_idx =
+        kanban_view::selection_dialog::popup_index_of_default_status(Some(CardStatus::Done));
+    for _ in 0..done_idx {
+        app.handle_create_column_dialog(KeyCode::Down);
+    }
+    app.handle_create_column_dialog(KeyCode::Enter);
+
+    let columns = app
+        .ctx
+        .data_store()
+        .list_columns_by_board(board_id)
+        .unwrap();
+    let created = columns
+        .iter()
+        .find(|c| c.name == "Review")
+        .expect("column created");
+    assert_eq!(
+        created.default_status,
+        Some(CardStatus::Done),
+        "the status chosen in the create dialog must be persisted on the new column"
+    );
+    assert_eq!(app.mode, AppMode::Normal, "dialog closes after Enter");
+}
+
+#[test]
+fn test_create_column_dialog_untouched_status_selector_creates_column_with_no_default_status() {
+    let mut app = App::test_default();
+    let (_todo, _doing, _done) = setup_board_with_columns(&mut app);
+    let board_id = app.selection.active_board_id.unwrap();
+
+    app.focus.board_focus = BoardFocus::Columns;
+    app.handle_create_column_key();
+
+    for ch in "Backlog".chars() {
+        app.handle_create_column_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_column_dialog(KeyCode::Enter);
+
+    let columns = app
+        .ctx
+        .data_store()
+        .list_columns_by_board(board_id)
+        .unwrap();
+    let created = columns
+        .iter()
+        .find(|c| c.name == "Backlog")
+        .expect("column created");
+    assert_eq!(
+        created.default_status, None,
+        "name + Enter without touching the selector must keep default_status None"
+    );
+}
+
+#[test]
+fn test_create_column_dialog_tab_cycles_focus_between_name_and_status() {
+    let mut app = App::test_default();
+    let (_todo, _doing, _done) = setup_board_with_columns(&mut app);
+
+    app.focus.board_focus = BoardFocus::Columns;
+    app.handle_create_column_key();
+    assert!(
+        app.dialog_input.create_column_focus_is_name(),
+        "dialog opens with the name field focused"
+    );
+
+    for ch in "Col".chars() {
+        app.handle_create_column_dialog(KeyCode::Char(ch));
+    }
+    app.handle_create_column_dialog(KeyCode::Tab);
+    assert!(
+        !app.dialog_input.create_column_focus_is_name(),
+        "Tab moves focus to the status selector"
+    );
+
+    app.handle_create_column_dialog(KeyCode::Char('j'));
+    assert_eq!(
+        app.input.as_str(),
+        "Col",
+        "keys pressed while the selector is focused must not edit the name"
+    );
+    assert_eq!(
+        app.dialog_input.default_status_selection.get(),
+        Some(1),
+        "'j' navigates the status selector down from the seeded (none) entry"
+    );
+
+    app.handle_create_column_dialog(KeyCode::Tab);
+    assert!(
+        app.dialog_input.create_column_focus_is_name(),
+        "Tab cycles focus back to the name field"
+    );
+
+    app.handle_create_column_dialog(KeyCode::Esc);
+    assert_eq!(app.mode, AppMode::Normal, "Esc closes the dialog");
+    assert_eq!(
+        app.dialog_input.default_status_selection.get(),
+        None,
+        "closing the dialog clears the seeded selection"
+    );
+}
+
+#[test]
 fn test_column_default_status_change_is_undoable() {
     let mut app = App::test_default();
     let (_todo, doing, _done) = setup_board_with_columns(&mut app);


### PR DESCRIPTION
## Summary
Completion-column feature completeness across every surface:

- MCP `tool_create_board` gains `with_default_columns`, seeding the TODO/Doing/Complete template with matching default statuses like the CLI and TUI already do
- TUI create-column dialog can now set a column's `default_status` at creation, instead of requiring the separate `s` popup afterwards
- Board-settings column list marks the primary completion column (the first status=done column by position, where done cards actually file) distinctly from other done columns
- CLI `board create --with-default-columns` now creates the board and its three columns as one atomic command batch, so a mid-seed failure can no longer leave a partial board, and undo reverses the whole action in one step
- Internally, the status/completion invariant is encoded once: `CardMoveResult` now carries placement only, and the service derives the status sync via `target_status_for_column_move`, which drops its unused board parameter
- Unrelated build fix: force `yuva420p` pixel format before vp9-encoding the landing page demo GIF, since newer ffmpeg's libvpx-vp9 encoder rejects the GIF's native `gbrap` format instead of auto-converting it

## Test plan
- [x] `cargo test -p kanban-cli -p kanban-mcp -p kanban-tui -p kanban-domain`
- [x] `nix build .#kanban-web`